### PR TITLE
Partial implementation insertion for numeric columns

### DIFF
--- a/cpp/arcticdb/column_store/column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.cpp
@@ -168,8 +168,8 @@ class ColumnDataRandomAccessorDense {
     ChunkedBufferRandomAccessor<TDT> chunked_buffer_random_accessor_;
 };
 
-template<typename TDT>
-requires(util::instantiation_of<TDT, TypeDescriptorTag> && (TDT::dimension() == Dimension::Dim0))
+template<util::type_descriptor_tag TDT>
+requires(TDT::dimension() == Dimension::Dim0)
 ColumnDataRandomAccessor<TDT> random_accessor(ColumnData* parent) {
     bool sparse = parent->bit_vector() != nullptr;
     if (parent->buffer().num_blocks() == 1) {

--- a/cpp/arcticdb/column_store/column_data_random_accessor.hpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.hpp
@@ -15,7 +15,7 @@
 
 namespace arcticdb {
 
-template<typename TDT>
+template<util::type_descriptor_tag TDT>
 struct IColumnDataRandomAccessor {
     template<class Base>
     struct Interface : Base {
@@ -28,10 +28,10 @@ struct IColumnDataRandomAccessor {
     using Members = folly::PolyMembers<&T::at, &T::ptr_at>;
 };
 
-template<typename TDT>
+template<util::type_descriptor_tag TDT>
 using ColumnDataRandomAccessor = folly::Poly<IColumnDataRandomAccessor<TDT>>;
 
-template<typename TDT>
-requires(util::instantiation_of<TDT, TypeDescriptorTag> && (TDT::dimension() == Dimension::Dim0))
+template<util::type_descriptor_tag TDT>
+requires(TDT::dimension() == Dimension::Dim0)
 ColumnDataRandomAccessor<TDT> random_accessor(ColumnData* parent);
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -32,6 +32,10 @@
 
 namespace arcticdb {
 
+struct MergeUpdateInsertedRowsEntity {
+    size_t inserted_rows;
+};
+
 using ResampleOrigin = std::variant<std::string, timestamp>;
 
 using RangesAndKey = pipelines::RangesAndKey;
@@ -893,8 +897,9 @@ struct MergeUpdateClause {
 
   private:
     bool update_and_insert(
-            const std::span<const NativeTensor> source_tensors, const StreamDescriptor& source_descriptor,
-            const ProcessingUnit& proc, const std::span<const std::vector<size_t>> rows_to_update
+            const std::optional<NativeTensor>& index_tensor, const std::span<const NativeTensor> source_tensors,
+            const StreamDescriptor& source_descriptor, const ProcessingUnit& proc,
+            const std::span<const std::vector<size_t>> rows_to_update, size_t num_matched_rows
     ) const;
 
     /// Filter segments which will be affected by the merge. The complexity is O(m * log(n)) where n is the number
@@ -904,17 +909,17 @@ struct MergeUpdateClause {
     /// @return Vector of size equal to the number of source data rows that are within the row slice being
     /// processed. Each element is a vector of the rows from the target data that has the same index as the
     /// corresponding source row
-    std::vector<std::vector<size_t>> filter_index_match(
+    std::pair<std::vector<std::vector<size_t>>, size_t> filter_index_match(
             const Column& target_index, const std::span<const timestamp> source_index, const ProcessingUnit& proc
     ) const;
 
-    std::vector<std::vector<size_t>> filter_on_additional_columns_match(
+    std::pair<std::vector<std::vector<size_t>>, size_t> filter_on_additional_columns_match(
             const StreamDescriptor& source_descriptor, const StreamDescriptor& target_descriptor,
             const std::span<const NativeTensor> source_tensors, ProcessingUnit& proc,
-            std::optional<std::vector<std::vector<size_t>>>&& index_match
+            std::optional<std::vector<std::vector<size_t>>>&& index_match, size_t num_matched_rows
     ) const;
 
-    std::vector<std::vector<size_t>> initialize_rows_to_update_for_rowrange_indexed_data(
+    std::pair<std::vector<std::vector<size_t>>, size_t> initialize_rows_to_update_for_rowrange_indexed_data(
             ProcessingUnit& proc, const StreamDescriptor& source_descriptor
     ) const;
 

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -52,8 +52,7 @@ void filter_selected_ranges_and_keys_and_reindex_entities(
     ranges_and_keys = std::move(new_ranges_and_keys);
 }
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 position_t write_py_string_to_pool_or_throw(
         PyObject* const py_string_object, const size_t row_in_segment, const RowRange& row_range,
         std::optional<ScopedGILLock>& gil_lock, StringPool& new_string_pool, const std::string_view column_name
@@ -68,8 +67,7 @@ position_t write_py_string_to_pool_or_throw(
     );
 }
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 void rebuild_sequence_column_in_new_pool(
         Column& target_column, const StringPool& old_string_pool, StringPool& new_string_pool,
         const util::BitSet* rows_to_add_in_new_pool = nullptr
@@ -95,81 +93,8 @@ void rebuild_sequence_column_in_new_pool(
     }
 }
 
-/// When merge update is performed on a string column the string pool is rebuild from scratch, thus we must iterate over
-/// all rows in the column. When the column is a part of a timeseries all target rows stored in rows_to_update will be
-/// ordered (i.e. sorted(flatten(rows_to_update)) = true). This means we can iterate over the target column row and
-/// at the same time forward iterate on the source rows. It's a nested loop but the complexity is O(n + m + k)
-/// where n is the total number of rows in the target, m are the rows in the source, and k are the total matches between
-/// source and target (i.e. sum(rows_to_update[i] for i in range(len(rows_to_update))))
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
-bool merge_update_string_column_timeseries(
-        Column& target_column, const std::span<const std::vector<size_t>> rows_to_update, const Field& target_field,
-        const RowRange& row_range, const StringPool& target_string_pool,
-        const std::span<PyObject* const> source_column_view, StringPool& new_string_pool
-) {
-    bool is_column_changed = false;
-    if constexpr (is_fixed_string_type(TDT::data_type())) {
-        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                "Fixed string sequences are not supported for merge update"
-        );
-    } else if constexpr (is_dynamic_string_type(TDT::data_type())) {
-        // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
-        // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
-        // If such a string is encountered in a column, then the GIL will be held until that whole column has
-        // been processed, on the assumption that if a column has one such string it will probably have many.
-        std::optional<ScopedGILLock> gil_lock;
-        // TODO: Create new column in case of insertion
-        auto source_row_it = rows_to_update.begin();
-        auto next_target_row_to_update = source_row_it->begin();
-        // TODO: Handle sparse target columns Monday 10756321294
-        arcticdb::for_each_enumerated<TDT>(target_column, [&](auto row) {
-            source_row_it = std::find_if(
-                    source_row_it,
-                    rows_to_update.end(),
-                    [&, new_row = false](const std::vector<size_t>& vec) mutable {
-                        // TODO: Handle inserts. Empty vec means insert.
-                        next_target_row_to_update = std::find_if(
-                                new_row ? vec.begin() : next_target_row_to_update,
-                                vec.end(),
-                                [&](const int64_t target_row_to_update) { return target_row_to_update >= row.idx(); }
-                        );
-                        if (next_target_row_to_update == vec.end()) {
-                            new_row = true;
-                        }
-                        return next_target_row_to_update != vec.end();
-                    }
-            );
-            const bool current_target_row_is_matched = source_row_it != rows_to_update.end() &&
-                                                       next_target_row_to_update != source_row_it->end() &&
-                                                       static_cast<int64_t>(*next_target_row_to_update) == row.idx();
-            if (current_target_row_is_matched) {
-                is_column_changed = true;
-                const auto py_string_object = source_column_view[source_row_it - rows_to_update.begin()];
-                row.value() = write_py_string_to_pool_or_throw<TDT>(
-                        py_string_object, row.idx(), row_range, gil_lock, new_string_pool, target_field.name()
-                );
-            } else {
-                if (is_a_string(row.value())) {
-                    const std::string_view string_in_target = target_string_pool.get_const_view(row.value());
-                    const OffsetString offset_in_new_pool = new_string_pool.get(string_in_target);
-                    row.value() = offset_in_new_pool.offset();
-                }
-            }
-        });
-    }
-    return is_column_changed;
-}
-
-/// When merge update is performed on a string column the string pool is rebuild from scratch, thus we must iterate over
-/// all rows in the column. When the column is *not* part of a timeseries the rows in rows_to_update are in random
-/// order. To avoid having quadratic complexity (i.e. O(n * k) where n are the rows in the target and k are all matches
-/// i.e. sum(rows_to_update[i] for i in range(len(rows_to_update)))) we invert the loops and iterate over all
-/// rows_to_update perform the update and then add additional loop over all rows in target to rebuild the string pool.
-/// Asymptotically this will yield the same complexity as the timeseries case but practically is a bit slower.
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
-bool merge_update_string_column_rowrange(
+template<util::type_descriptor_tag TDT>
+bool merge_update_string_column(
         Column& target_column, const std::span<const std::vector<size_t>> rows_to_update, const Field& target_field,
         const RowRange& row_range, const StringPool& target_string_pool,
         const std::span<PyObject* const> source_column_view, StringPool& new_string_pool
@@ -213,8 +138,7 @@ struct MergeUpdateStringColumnFlags {
     bool data_not_changed = false;
 };
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 bool merge_update_string_column(
         Column& target_column, const MergeUpdateStringColumnFlags& flags,
         const std::span<const std::vector<size_t>> rows_to_update, const Field& target_field, const RowRange& row_range,
@@ -224,29 +148,17 @@ bool merge_update_string_column(
     if (flags.data_not_changed) {
         rebuild_sequence_column_in_new_pool<TDT>(target_column, target_string_pool, new_string_pool);
         return false;
-    } else {
-        if (flags.is_timeseries) {
-            return merge_update_string_column_timeseries<TDT>(
-                    target_column,
-                    rows_to_update,
-                    target_field,
-                    row_range,
-                    target_string_pool,
-                    source_column_view,
-                    new_string_pool
-            );
-        } else {
-            return merge_update_string_column_rowrange<TDT>(
-                    target_column,
-                    rows_to_update,
-                    target_field,
-                    row_range,
-                    target_string_pool,
-                    source_column_view,
-                    new_string_pool
-            );
-        }
     }
+
+    return merge_update_string_column<TDT>(
+            target_column,
+            rows_to_update,
+            target_field,
+            row_range,
+            target_string_pool,
+            source_column_view,
+            new_string_pool
+    );
 }
 
 struct NaNAwareFloatComparator {
@@ -271,7 +183,8 @@ struct NaNAwareFloatHasher {
 };
 
 template<
-        typename SourceTDT, typename TargetTDT, typename SourceValueRawType = TargetTDT::DataTypeTag::raw_type,
+        util::type_descriptor_tag SourceTDT, util::type_descriptor_tag TargetTDT,
+        typename SourceValueRawType = TargetTDT::DataTypeTag::raw_type,
         typename TargetValueRawType = TargetTDT::DataTypeTag::raw_type>
 requires std::same_as<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>
 std::variant<bool, convert::StringEncodingError> are_merge_values_matching(
@@ -305,8 +218,7 @@ std::variant<bool, convert::StringEncodingError> are_merge_values_matching(
     }
 }
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 auto map_column_values_to_rows(const ColumnWithStrings& column) {
     constexpr static bool is_target_sequence_type = is_sequence_type(TDT::data_type());
     constexpr static bool is_target_floating_point_type = is_floating_point_type(TDT::data_type());
@@ -333,6 +245,141 @@ auto map_column_values_to_rows(const ColumnWithStrings& column) {
     return target_values;
 }
 
+template<util::type_descriptor_tag TargetColumnTypeDescriptorTag, typename SourceRawType>
+Column merge(
+        const Column& target_index, const std::span<const timestamp> source_index, const Column& target,
+        const std::span<const SourceRawType> source_data, const std::span<const std::vector<size_t>> rows_to_update,
+        const size_t num_rows_to_insert, const MergeStrategy strategy
+) {
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            source_index.size() == source_data.size(),
+            "Source data size must match the index size"
+    );
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            source_index.size() == rows_to_update.size(),
+            "For each source data row in the segment there must be exactly one vector of target rows that must be "
+            "updated by that source row."
+    );
+    using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+    if constexpr (!is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+        Column new_column(
+                target.type(),
+                target.row_count() + num_rows_to_insert,
+                AllocationType::PRESIZED,
+                Sparsity::NOT_PERMITTED
+        );
+        ColumnData new_column_data = new_column.data();
+        auto new_column_it = new_column_data.begin<TargetColumnTypeDescriptorTag>();
+        auto new_data = random_accessor<TargetColumnTypeDescriptorTag>(&new_column_data);
+
+        ColumnData target_index_data = target_index.data();
+        auto target_index_it = target_index_data.begin<IndexType>();
+        const auto target_index_end = target_index_data.end<IndexType>();
+
+        ColumnData target_column_data = target.data();
+        auto target_data = random_accessor<TargetColumnTypeDescriptorTag>(&target_column_data);
+        size_t target_row_idx = 0;
+
+        size_t source_row_idx = 0;
+
+        size_t new_column_row_idx = 0;
+
+        // Stable merge target and source into the new column. If there is a sequence of repeated index values and new
+        // rows must be inserted, the new rows will appear after the rows from the target
+        while (target_index_it != target_index_end && source_row_idx < source_index.size()) {
+            // Target index values are smaller than the source index value. If the index is different, it's impossible
+            // to perform an update. Just copy the target data to the output buffer
+            while (target_index_it != target_index_end && *target_index_it < source_index[source_row_idx]) {
+                *new_column_it++ = target_data[target_row_idx++];
+                ++new_column_row_idx;
+                ++target_index_it;
+            }
+
+            // Target index values are equal to the source index values. Since the index is matching, it's possible to
+            // perform both an update and an insert. First, copy all target values to the output buffer and then append
+            // the new values. In case rows_to_update[source_row_idx] is not empty, then an update must happen. The
+            // update is performed in place in the new output buffer. It is crucial to take into account that the
+            // indexes in rows_to_update[source_row_idx] are pointing to rows in the original column (before any
+            // insertions happened)
+
+            // Source and target index values are equal. Copy the target data first.
+            const timestamp equal_run_index_value = *target_index_it;
+            // Since the index is ordered, no index in source_index[source_row_idx] can be less than target_row_idx.
+            // The number of inserted is used to correct for the fact that rows_to_update[source_row_idx] refers rows
+            // in the original column.
+            const size_t inserted_rows = new_column_row_idx - target_row_idx;
+            while (target_index_it != target_index_end && *target_index_it == equal_run_index_value &&
+                   source_index[source_row_idx] == equal_run_index_value) {
+                *new_column_it++ = target_data[target_row_idx++];
+                ++new_column_row_idx;
+                ++target_index_it;
+            }
+
+            // For each source row equal to the target row, there are two options.
+            // * source_index[source_row_idx] is non-empty -> the output buffer must be updated using inserted_rows as
+            //   an offset
+            // * source_index[source_row_idx] is empty -> insertion must happen by appending to the end of the output
+            //   buffer.
+            while (source_row_idx < source_index.size() && source_index[source_row_idx] == equal_run_index_value) {
+                if (rows_to_update[source_row_idx].empty()) {
+                    *new_column_it++ = source_data[source_row_idx];
+                    ++new_column_row_idx;
+                } else if (strategy.matched == MergeAction::UPDATE) {
+                    for (const size_t target_row_to_update : rows_to_update[source_row_idx]) {
+                        new_data[target_row_to_update + inserted_rows] = source_data[source_row_idx];
+                    }
+                }
+                ++source_row_idx;
+            }
+
+            if (target_index_it == target_index_end) {
+                break;
+            }
+
+            // Target index values are larger than the source index value. Append the source data to the output buffer.
+            while (source_row_idx < source_index.size() && *target_index_it > source_index[source_row_idx]) {
+                *new_column_it++ = source_data[source_row_idx++];
+                ++new_column_row_idx;
+            }
+        }
+        // Not all target rows were processed, copy the rest
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                static_cast<position_t>(target_row_idx) <= target.row_count(),
+                "Cannot consume more target rows than there are in the target column"
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                static_cast<position_t>(target_row_idx) >= target.row_count() ||
+                        new_column_it != new_column_data.end<TargetColumnTypeDescriptorTag>(),
+                "There are {} target rows to insert but the output buffer is exhausted",
+                target.row_count() - static_cast<position_t>(target_row_idx)
+        );
+        while (static_cast<position_t>(target_row_idx) < target.row_count()) {
+            *new_column_it++ = target_data[target_row_idx++];
+        }
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                source_row_idx >= source_index.size() ||
+                        new_column_it != new_column_data.end<TargetColumnTypeDescriptorTag>(),
+                "There are {} source rows to insert but the output buffer is exhausted",
+                source_index.size() - source_row_idx
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                source_row_idx <= source_index.size(),
+                "Cannot consume more source rows than there are in the source column"
+        );
+        // Not all source rows were processed, copy the rest
+        std::copy(source_data.begin() + source_row_idx, source_data.end(), new_column_it);
+        return new_column;
+    } else {
+        internal::raise<ErrorCode::E_NOT_IMPLEMENTED>("Insertion is not implemented for string columns yet");
+    }
+}
+
 } // namespace
 
 namespace arcticdb {
@@ -348,9 +395,6 @@ MergeUpdateClause::MergeUpdateClause(
     strategy_(strategy),
     source_(std::move(source)) {
     std::erase_if(on_, [&](const std::string& column) { return !on_set_.insert(column).second; });
-    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-            strategy_.not_matched_by_target == MergeAction::DO_NOTHING, "Merge cannot perform insertion at the moment"
-    );
 }
 
 std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys
@@ -389,16 +433,27 @@ std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing_log
         ranges_and_keys.clear();
         return {};
     }
-    std::span index(static_cast<const IndexType::DataTypeTag::raw_type*>(index_tensor.data()), source_->num_rows);
+
+    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
+            strategy_.not_matched_by_target == MergeAction::DO_NOTHING ||
+                    !(source_ends_before_first_row_slice || source_starts_after_the_last_row_slice),
+            "Insertion is not implemented for cases when the value to be inserted does not lie within the "
+            "boundaries of a segment"
+    );
+
+    std::span index(index_tensor.data(), source_->num_rows);
+    // TODO: Needed only to track if there are source rows not contained in any segment.
+    std::pair<size_t, size_t> spanned_source_row_range{0, 0};
     for (size_t row_slice_idx = 0; row_slice_idx < offsets.size(); ++row_slice_idx) {
-        // TODO: Add logic for insertion.
+        // TODO: Add logic for insertion when the source index value is not contained in any segment
         const TimestampRange& time_range = ranges_and_keys[offsets[row_slice_idx].front()].key_.time_range();
         if (source_start_end_for_row_range_.contains(time_range)) {
             row_slices_to_keep.push_back(row_slice_idx);
             continue;
         }
-        const auto source_range_start = std::ranges::lower_bound(index, time_range.first);
+        const auto source_range_start = ranges::lower_bound(index, time_range.first);
         if (source_range_start == index.end()) {
+            // All remaining row ranges start after the last index value of the source, thus not match is possible.
             break;
         }
         if (*source_range_start < time_range.second) {
@@ -406,10 +461,23 @@ std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing_log
             const std::pair<size_t, size_t> source_row_range = {
                     source_range_start - index.begin(), source_range_end - index.begin()
             };
+            internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
+                    strategy_.not_matched_by_target == MergeAction::DO_NOTHING ||
+                            spanned_source_row_range.first <= source_row_range.second,
+                    "Insertion is not implemented for cases when the value to be inserted does not lie within the "
+                    "boundaries of any segment segment"
+            );
+            spanned_source_row_range.second = std::max(spanned_source_row_range.second, source_row_range.second);
             source_start_end_for_row_range_.insert({time_range, source_row_range});
             row_slices_to_keep.push_back(row_slice_idx);
         }
     }
+    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
+            strategy_.not_matched_by_target == MergeAction::DO_NOTHING ||
+                    spanned_source_row_range == std::pair{0, source_->num_rows},
+            "Insertion is not implemented for cases when the value to be inserted does not lie within the "
+            "boundaries of a segment"
+    );
     filter_selected_ranges_and_keys_and_reindex_entities(row_slices_to_keep, offsets, ranges_and_keys);
     return offsets;
 }
@@ -436,40 +504,52 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
             std::shared_ptr<RowRange>,
             std::shared_ptr<ColRange>,
             std::shared_ptr<AtomKey>>(*component_manager_, std::move(entity_ids));
-    // TODO: Add exception handling two source rows matching the same target row. This should be done in the
-    // function
-    //  handling the "on" parameter matching multiple columns. Monday 10655943156
-    auto matched = [&]() -> std::optional<std::vector<std::vector<size_t>>> {
+    auto [matched, num_matched_rows] = [&]() -> std::pair<std::optional<std::vector<std::vector<size_t>>>, size_t> {
         std::optional<std::vector<std::vector<size_t>>> result;
+        size_t matched_count = 0;
         if (source_->has_index()) {
             using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
             const TypedTensor<IndexType::DataTypeTag::raw_type> index_tensor(source_->opt_index_tensor().value());
-            result.emplace(filter_index_match(
+            auto [index_match, matched_rows_count] = filter_index_match(
                     proc.segments_->front()->column(0), std::span(index_tensor.data(), source_->num_rows), proc
-            ));
+            );
+            result.emplace(std::move(index_match));
+            matched_count += matched_rows_count;
         }
-        return result;
+        return {result, matched_count};
     }();
     // TODO: Source and target descriptor can differ for dynamic schema
-    matched = filter_on_additional_columns_match(
-            source_->desc(), source_->desc(), source_->field_tensors(), proc, std::move(matched)
+
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            !source_->has_segment(), "Arrow format is not supported as input for merge update"
     );
-    if (source_->has_segment()) {
-        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Arrow format is not supported as input for merge update"
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            source_->has_tensors(), "Input frame does not contain neither a segment nor tensors"
+    );
+    std::tie(matched, num_matched_rows) = filter_on_additional_columns_match(
+            source_->desc(), source_->desc(), source_->field_tensors(), proc, std::move(matched), num_matched_rows
+    );
+    if (update_and_insert(
+                source_->opt_index_tensor(), source_->field_tensors(), source_->desc(), proc, *matched, num_matched_rows
+        )) {
+        const size_t entity_count = proc.segments_->size();
+        const size_t inserted_rows_count = matched->size() - num_matched_rows;
+        return component_manager_->add_entities(
+                std::move(*proc.segments_),
+                std::move(*proc.row_ranges_),
+                std::move(*proc.col_ranges_),
+                std::vector<EntityFetchCount>(entity_count, 1),
+                std::vector(entity_count, MergeUpdateInsertedRowsEntity{inserted_rows_count})
         );
-    } else if (source_->has_tensors()) {
-        if (update_and_insert(source_->field_tensors(), source_->desc(), proc, *matched)) {
-            return push_entities(*component_manager_, std::move(proc));
-        }
-    } else {
-        internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Input frame does not contain neither a segment nor tensors");
     }
+
     return {};
 }
 
-std::vector<std::vector<size_t>> MergeUpdateClause::initialize_rows_to_update_for_rowrange_indexed_data(
-        ProcessingUnit& proc, const StreamDescriptor& source_descriptor
-) const {
+std::pair<std::vector<std::vector<size_t>>, size_t> MergeUpdateClause::
+        initialize_rows_to_update_for_rowrange_indexed_data(
+                ProcessingUnit& proc, const StreamDescriptor& source_descriptor
+        ) const {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !on_.empty(),
             "MergeUpdate requires at least one column in the \"on\" parameter when the DataFrame is not a "
@@ -485,13 +565,14 @@ std::vector<std::vector<size_t>> MergeUpdateClause::initialize_rows_to_update_fo
     result.resize(source_->num_rows);
     const size_t source_field_position = field_index_for_matching_on_column(column_name, source_descriptor);
     const Field& source_field = source_descriptor.field(source_field_position);
+    size_t num_matched_rows = 0;
     details::visit_type(source_field.type().data_type(), [&](auto source_field_dt) {
         using SourceTDT = ScalarTagType<std::decay_t<decltype(source_field_dt)>>;
         using SourceRawType = typename SourceTDT::DataTypeTag::raw_type;
         const ColumnWithStrings target_column = std::get<ColumnWithStrings>(proc.get(ColumnName{column_name}));
         details::visit_type(target_column.column_->type().data_type(), [&](auto target_field_dt) {
             using TargetTDT = ScalarTagType<decltype(target_field_dt)>;
-            if constexpr (std::is_same_v<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>) {
+            if constexpr (std::same_as<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>) {
                 using SourceType =
                         std::conditional_t<is_sequence_type(SourceTDT::data_type()), PyObject* const, SourceRawType>;
                 auto target_values_to_rows = map_column_values_to_rows<TargetTDT>(target_column);
@@ -525,6 +606,7 @@ std::vector<std::vector<size_t>> MergeUpdateClause::initialize_rows_to_update_fo
                     } else {
                         result[source_row_idx] = target_values_to_rows[source_value];
                     }
+                    num_matched_rows += !result[source_row_idx].empty();
                 }
             } else {
                 schema::raise<ErrorCode::E_DESCRIPTOR_MISMATCH>(
@@ -535,7 +617,7 @@ std::vector<std::vector<size_t>> MergeUpdateClause::initialize_rows_to_update_fo
             }
         });
     });
-    return result;
+    return std::pair{std::move(result), num_matched_rows};
 }
 
 std::pair<size_t, size_t> MergeUpdateClause::get_source_start_end(const ProcessingUnit& proc) const {
@@ -555,8 +637,9 @@ std::pair<size_t, size_t> MergeUpdateClause::get_source_start_end(const Processi
 }
 
 bool MergeUpdateClause::update_and_insert(
-        const std::span<const NativeTensor> source_tensors, const StreamDescriptor& source_descriptor,
-        const ProcessingUnit& proc, const std::span<const std::vector<size_t>> rows_to_update
+        const std::optional<NativeTensor>& index_tensor, const std::span<const NativeTensor> source_tensors,
+        const StreamDescriptor& source_descriptor, const ProcessingUnit& proc,
+        const std::span<const std::vector<size_t>> rows_to_update, size_t num_matched_rows
 ) const {
     const std::span<const std::shared_ptr<SegmentInMemory>> target_segments = *proc.segments_;
     const std::span<const std::shared_ptr<RowRange>> row_ranges = *proc.row_ranges_;
@@ -564,22 +647,58 @@ bool MergeUpdateClause::update_and_insert(
     const auto [source_row_start, source_row_end] = get_source_start_end(proc);
     bool row_slice_changed = false;
     const bool is_timeseries = source_->desc().index().type() == IndexDescriptor::Type::TIMESTAMP;
-    util::BitSet matched_target_rows(row_ranges.front()->diff());
-    // TODO: This can be inlined in the loop iterating over all columns to avoid iterating the source one more
-    // time. The loop structure makes it not intuitive. The performance cost must be evaluated. Monday: 10655963947
-    for (size_t source_row_idx = 0; source_row_idx < rows_to_update.size(); ++source_row_idx) {
-        for (const size_t target_row : rows_to_update[source_row_idx]) {
-            user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                    !matched_target_rows[target_row],
-                    "Multiple source rows match the same target row. This is not allowed as it's not clear which "
-                    "source row should be used for the update. Target row is {}, the second source row to match it is "
-                    "{}",
-                    target_row,
-                    source_row_idx + source_row_start
-            );
-            matched_target_rows[target_row] = true;
+
+    if (strategy_.update_only() && num_matched_rows == 0) {
+        return false;
+    }
+
+    if (strategy_.insert_only() && rows_to_update.size() == num_matched_rows) {
+        return false;
+    }
+
+    if (strategy_.matched == MergeAction::UPDATE && num_matched_rows > 0) {
+        // TODO: This can be inlined in the loop iterating over all columns to avoid iterating the source one more
+        // time. The loop structure makes it not intuitive. The performance cost must be evaluated. Monday: 10655963947
+        util::BitSet matched_target_rows(row_ranges.front()->diff());
+        for (size_t source_row_idx = 0; source_row_idx < rows_to_update.size(); ++source_row_idx) {
+            for (const size_t target_row : rows_to_update[source_row_idx]) {
+                user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                        !matched_target_rows[target_row],
+                        "Multiple source rows match the same target row. This is not allowed as it's not clear which "
+                        "source row should be used for the update. Target row is {}, the second source row to match it "
+                        "is {}",
+                        target_row,
+                        source_row_idx + source_row_start
+                );
+                matched_target_rows[target_row] = true;
+            }
         }
     }
+
+    const size_t rows_to_insert =
+            strategy_.not_matched_by_target == MergeAction::INSERT ? rows_to_update.size() - num_matched_rows : 0;
+
+    std::optional<Column> new_index = [&] {
+        std::optional<Column> result;
+        if (rows_to_insert > 0 && is_timeseries) {
+            using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+            const std::span source_data(
+                    static_cast<const timestamp*>(index_tensor->data()) + source_row_start,
+                    source_row_end - source_row_start
+            );
+            result.emplace(merge<IndexType>(
+                    target_segments[0]->column(0),
+                    source_data,
+                    target_segments[0]->column(0),
+                    source_data,
+                    rows_to_update,
+                    rows_to_insert,
+                    strategy_
+            ));
+        }
+        return result;
+    }();
+
     // Update one column at a time to increase cache coherency and to avoid calling visit_field for each row
     // being updated
     for (size_t segment_idx = 0; segment_idx < target_segments.size(); ++segment_idx) {
@@ -603,8 +722,7 @@ bool MergeUpdateClause::update_and_insert(
                 user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                         util::is_cstyle_array<RawType>(source_tensors[column_position_in_source]),
                         "Fortran-style arrays are not supported by merge update yet. Column \"{}\" has data type "
-                        "{} of "
-                        "size {} bytes but the stride is {} bytes",
+                        "{} of size {} bytes but the stride is {} bytes",
                         target_field.name(),
                         target_field.type(),
                         sizeof(RawType),
@@ -624,56 +742,69 @@ bool MergeUpdateClause::update_and_insert(
                 internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                         !rows_to_update.empty(), "There must be at least one source row inside the target row slice."
                 );
-                if constexpr (is_sequence_type(DataTypeTag::data_type)) {
-                    // String columns are always recreated from scratch regardless if an update or insert is
-                    // happening. This is done because the string pool must be updated. With data read from disk,
-                    // the map_ member of the pool is not populated. Which means that the mapping between a string
-                    // and offset in the pool is missing. To get it, we need to rebuild the pool anyway.
-                    segment_contains_string_column = true;
-                    const MergeUpdateStringColumnFlags column_update_flags{
-                            .is_timeseries = is_timeseries,
-                            .data_not_changed = on_set_.contains(target_field.name()) && strategy_.update_only()
-                    };
-                    row_slice_changed |= merge_update_string_column<ScalarType>(
-                            target_column,
-                            column_update_flags,
-                            rows_to_update,
-                            target_field,
-                            *row_ranges[segment_idx],
-                            target_segment.string_pool(),
-                            source_data,
-                            new_string_pool
-                    );
-                } else {
-                    if (is_update_only() && on_set_.contains(target_field.name())) {
-                        return;
-                    }
-                    ColumnData target_column_data = target_column.data();
-                    if (is_timeseries) {
-                        auto target_row_to_update_it = target_column_data.begin<ScalarType>();
-                        size_t target_row_to_update_idx = 0;
-                        for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
-                            // TODO: Handle insert. Empty rows_to_update[source_row_idx] means that update must be done
-                            row_slice_changed |= !rows_to_update[source_row_idx].empty();
-                            for (const size_t target_row_idx : rows_to_update[source_row_idx]) {
-                                const size_t rows_to_skip = target_row_idx - target_row_to_update_idx;
-                                std::advance(target_row_to_update_it, rows_to_skip);
-                                *target_row_to_update_it = source_data[source_row_idx];
-                                target_row_to_update_idx = target_row_idx;
-                            }
-                        }
+
+                if (strategy_.update_only() || rows_to_insert == 0) {
+                    if constexpr (is_sequence_type(DataTypeTag::data_type)) {
+                        // String columns are always recreated from scratch regardless if an update or insert is
+                        // happening. This is done because the string pool must be updated. With data read from disk,
+                        // the map_ member of the pool is not populated. Which means that the mapping between a string
+                        // and offset in the pool is missing. To get it, we need to rebuild the pool anyway.
+                        segment_contains_string_column = true;
+                        const MergeUpdateStringColumnFlags column_update_flags{
+                                .is_timeseries = is_timeseries,
+                                .data_not_changed = on_set_.contains(target_field.name()) && strategy_.update_only()
+                        };
+                        row_slice_changed |= merge_update_string_column<ScalarType>(
+                                target_column,
+                                column_update_flags,
+                                rows_to_update,
+                                target_field,
+                                *row_ranges[segment_idx],
+                                target_segment.string_pool(),
+                                source_data,
+                                new_string_pool
+                        );
                     } else {
+                        if (on_set_.contains(target_field.name())) {
+                            return;
+                        }
+                        ColumnData target_column_data = target_column.data();
                         auto target = random_accessor<ScalarType>(&target_column_data);
                         for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
-                            // TODO: Handle insert. Empty rows_to_update[source_row_idx] means that update must be done
                             row_slice_changed |= !rows_to_update[source_row_idx].empty();
                             for (const size_t target_row_idx : rows_to_update[source_row_idx]) {
                                 target[target_row_idx] = source_data[source_row_idx];
                             }
                         }
                     }
+                } else {
+                    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
+                            is_timeseries, "Merge update with insertion is implemented only for timeseries"
+                    );
+                    const std::span source_index(
+                            static_cast<const timestamp*>(index_tensor->data()) + source_row_start,
+                            source_row_end - source_row_start
+                    );
+                    const Column& target_index = target_segment.column(0);
+                    target_segment.column(column_index_in_slice) = merge<ScalarType>(
+                            target_index,
+                            source_index,
+                            target_column,
+                            source_data,
+                            rows_to_update,
+                            rows_to_insert,
+                            strategy_
+                    );
+                    row_slice_changed = true;
                 }
             });
+        }
+        if (rows_to_insert > 0) {
+            if (new_index) {
+                const bool is_last_segment = segment_idx == target_segments.size() - 1;
+                target_segment.column(0) = is_last_segment ? std::move(*new_index) : new_index->clone();
+            }
+            target_segment.set_row_data(target_segment.row_count() + rows_to_insert - 1);
         }
         if (segment_contains_string_column) {
             target_segment.set_string_pool(std::make_shared<StringPool>(std::move(new_string_pool)));
@@ -693,7 +824,7 @@ bool MergeUpdateClause::update_and_insert(
 ///
 /// Complexity: $$O(m * log_2(n) + n)$$ where: m is the count of source rows in the bounds of the segment, n is the
 /// number of target rows in the segment.
-std::vector<std::vector<size_t>> MergeUpdateClause::filter_index_match(
+std::pair<std::vector<std::vector<size_t>>, size_t> MergeUpdateClause::filter_index_match(
         const Column& target_index, const std::span<const timestamp> source_index, const ProcessingUnit& proc
 ) const {
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
@@ -712,7 +843,7 @@ std::vector<std::vector<size_t>> MergeUpdateClause::filter_index_match(
     size_t source_row = source_row_start;
     const size_t source_rows_in_row_slice = source_row_end - source_row;
     std::vector<std::vector<size_t>> matched_rows(source_rows_in_row_slice);
-    size_t target_row = 0;
+    size_t target_row = 0, num_matched_rows = 0;
     // This loop can be inverted so that if source_row_end - source_row_start is > len(target) the complexity becomes
     // O(n * log_2(m)) where: m is the count of source rows in the bounds of the segment, n is the number of target rows
     // in the segment.
@@ -729,6 +860,7 @@ std::vector<std::vector<size_t>> MergeUpdateClause::filter_index_match(
         }
         target_row = *target_match_it;
         while (target_row < last_target_row_to_consider && target_index_accessor.at(target_row) == source_ts) {
+            num_matched_rows += matched_rows[source_row - source_row_start].empty();
             matched_rows[source_row - source_row_start].push_back(target_row);
             ++target_row;
         }
@@ -737,18 +869,19 @@ std::vector<std::vector<size_t>> MergeUpdateClause::filter_index_match(
         while (++source_row < source_row_end && source_index[source_row] == source_ts) {
             const size_t source_row_offset = source_row - source_row_start;
             matched_rows[source_row_offset] = matched_rows[source_row_offset - 1];
+            num_matched_rows += !matched_rows[source_row_offset].empty();
         }
     }
-    return matched_rows;
+    return std::pair{std::move(matched_rows), num_matched_rows};
 }
 
 /// Complexity: $$O(c * n * m)$$ m is the count of source rows in the bounds of the segment, n is the  number of target
 /// rows in the segment. c is the number of columns in MergeUpdateClause::on_. It can be reached if the data in source
 /// and target is the same up to the very last column in MergeUpdateClause::on_.
-std::vector<std::vector<size_t>> MergeUpdateClause::filter_on_additional_columns_match(
+std::pair<std::vector<std::vector<size_t>>, size_t> MergeUpdateClause::filter_on_additional_columns_match(
         const StreamDescriptor& source_descriptor, const StreamDescriptor& target_descriptor,
         const std::span<const NativeTensor> source_tensors, ProcessingUnit& proc,
-        std::optional<std::vector<std::vector<size_t>>>&& index_match
+        std::optional<std::vector<std::vector<size_t>>>&& index_match, size_t num_matched_rows
 ) const {
     ranges::subrange on = on_;
     std::vector<std::vector<size_t>> matched_rows;
@@ -769,11 +902,12 @@ std::vector<std::vector<size_t>> MergeUpdateClause::filter_on_additional_columns
                 source_index_type,
                 target_index_type
         );
-        matched_rows = initialize_rows_to_update_for_rowrange_indexed_data(proc, source_descriptor);
+        std::tie(matched_rows, num_matched_rows) =
+                initialize_rows_to_update_for_rowrange_indexed_data(proc, source_descriptor);
         on = on.next();
     }
     if (on.empty()) {
-        return matched_rows;
+        return std::pair{std::move(matched_rows), num_matched_rows};
     }
     const auto [source_row_start, source_row_end] = get_source_start_end(proc);
     // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
@@ -812,25 +946,33 @@ std::vector<std::vector<size_t>> MergeUpdateClause::filter_on_additional_columns
                         if constexpr (std::same_as<std::decay_t<SourceDataTypeTag>, std::decay_t<TargetDataTypeTag>>) {
                             auto target_accessor = random_accessor<TargetTDT>(&target_data);
                             for (size_t source_row_idx = 0; source_row_idx < matched_rows.size(); ++source_row_idx) {
-                                std::erase_if(matched_rows[source_row_idx], [&](const size_t target_row_idx) {
-                                    const TargetRawType target_value = target_accessor.at(target_row_idx);
-                                    const auto& source_value = source_data[source_row_idx];
-                                    auto are_values_equal = are_merge_values_matching<SourceTDT, TargetTDT>(
-                                            source_value, target_value, *target_column.string_pool_, scoped_gil_lock
-                                    );
-                                    if constexpr (is_sequence_type(TargetDataTypeTag::data_type)) {
-                                        return util::variant_match(
-                                                are_values_equal,
-                                                [](const bool equal) { return !equal; },
-                                                [&](convert::StringEncodingError& err) -> bool {
-                                                    err.row_index_in_slice_ = source_row_idx;
-                                                    err.raise(column_name, source_row_start);
-                                                }
+                                if (!matched_rows.empty()) {
+                                    std::erase_if(matched_rows[source_row_idx], [&](const size_t target_row_idx) {
+                                        const TargetRawType target_value = target_accessor.at(target_row_idx);
+                                        const auto& source_value = source_data[source_row_idx];
+                                        auto are_values_equal = are_merge_values_matching<SourceTDT, TargetTDT>(
+                                                source_value, target_value, *target_column.string_pool_, scoped_gil_lock
                                         );
-                                    } else {
-                                        return !std::get<bool>(are_values_equal);
-                                    }
-                                });
+                                        if constexpr (is_sequence_type(TargetDataTypeTag::data_type)) {
+                                            return util::variant_match(
+                                                    are_values_equal,
+                                                    [](const bool equal) { return !equal; },
+                                                    [&](convert::StringEncodingError& err) -> bool {
+                                                        err.row_index_in_slice_ = source_row_idx;
+                                                        err.raise(column_name, source_row_start);
+                                                    }
+                                            );
+                                        } else {
+                                            return !std::get<bool>(are_values_equal);
+                                        }
+                                    });
+                                    ARCTICDB_DEBUG_CHECK(
+                                            ErrorCode::E_ASSERTION_FAILURE,
+                                            num_matched_rows > 0 || !matched_rows[source_row_idx].empty(),
+                                            ""
+                                    );
+                                    num_matched_rows -= matched_rows[source_row_idx].empty();
+                                }
                             }
                         } else {
                             internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
@@ -844,7 +986,7 @@ std::vector<std::vector<size_t>> MergeUpdateClause::filter_on_additional_columns
             );
         });
     }
-    return matched_rows;
+    return std::pair{std::move(matched_rows), num_matched_rows};
 }
 
 const ClauseInfo& MergeUpdateClause::clause_info() const { return clause_info_; }

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -128,6 +128,18 @@ class ComponentManager {
         return get_entities_impl<Args...>(ids, false);
     }
 
+    template<typename ProcessComponents>
+    void process_entities(ProcessComponents&& process_fn) {
+        using ArgTypes = util::function_arg_types<std::decay_t<ProcessComponents>>::args_t;
+        using NoRefArgs = decltype([]<typename... Ts>(std::tuple<Ts...>*) {
+            return std::tuple<std::remove_reference_t<Ts>...>{};
+        }(static_cast<ArgTypes*>(nullptr)));
+        return [&]<typename... Args>(std::tuple<Args...>*) {
+            auto view = registry_.view<Args...>();
+            return view.each(std::forward<ProcessComponents>(process_fn));
+        }(static_cast<NoRefArgs*>(nullptr));
+    }
+
   private:
     void decrement_entity_fetch_count(EntityId id);
     void update_entity_fetch_count(EntityId id, EntityFetchCount count);

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -60,6 +60,7 @@ inline std::unordered_map<ErrorCategory, const char*> get_error_category_names()
     ERROR_CODE(1003, E_RUNTIME_ERROR)                                                                                  \
     ERROR_CODE(1004, E_STORED_CONFIG_ERROR)                                                                            \
     ERROR_CODE(1005, E_NOT_SUPPORTED)                                                                                  \
+    ERROR_CODE(1006, E_NOT_IMPLEMENTED)                                                                                \
     ERROR_CODE(2000, E_INCOMPATIBLE_OBJECTS)                                                                           \
     ERROR_CODE(2001, E_UNIMPLEMENTED_INPUT_TYPE)                                                                       \
     ERROR_CODE(2002, E_UPDATE_NOT_SUPPORTED)                                                                           \

--- a/cpp/arcticdb/util/type_traits.hpp
+++ b/cpp/arcticdb/util/type_traits.hpp
@@ -27,4 +27,31 @@ concept instantiation_of = is_instantiation_of_v<T, TT>;
 
 template<typename T, typename... U>
 concept any_of = std::disjunction_v<std::is_same<T, U>...>;
+
+template<typename T>
+concept type_descriptor_tag = instantiation_of<T, entity::TypeDescriptorTag>;
+
+template<typename T>
+struct function_arg_types : function_arg_types<decltype(&std::decay_t<T>::operator())> {};
+
+// Free function
+template<typename ReturnType, typename... Args>
+struct function_arg_types<ReturnType (*)(Args...)> {
+    using args_t = std::tuple<Args...>;
+    using return_t = ReturnType;
+};
+
+// Member method
+template<typename ClassType, typename ReturnType, typename... Args>
+struct function_arg_types<ReturnType (ClassType::*)(Args...)> {
+    using args_t = std::tuple<Args...>;
+    using return_t = ReturnType;
+};
+
+template<typename ClassType, typename ReturnType, typename... Args>
+struct function_arg_types<ReturnType (ClassType::*)(Args...) const> {
+    using args_t = std::tuple<Args...>;
+    using return_t = ReturnType;
+};
+
 } // namespace arcticdb::util

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -2535,13 +2535,14 @@ VersionedItem LocalVersionedEngine::merge_internal(
         const WriteOptions write_options = get_write_options();
         VersionedItem versioned_item = merge_update_impl(
                                                store(),
-                                               VersionedItem{*update_info.previous_index_key_},
+                                               update_info,
                                                read_options,
                                                write_options,
                                                IndexPartialKey{stream_id, update_info.next_version_id_},
                                                std::move(on),
                                                strategy,
-                                               std::move(source)
+                                               std::move(source),
+                                               get_de_dup_map(stream_id, update_info.previous_index_key_, write_options)
         )
                                                .get();
         write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);

--- a/cpp/arcticdb/version/merge_options.cpp
+++ b/cpp/arcticdb/version/merge_options.cpp
@@ -16,4 +16,8 @@ bool MergeStrategy::update_only() const {
 bool MergeStrategy::insert_only() const {
     return matched == MergeAction::DO_NOTHING && not_matched_by_target == MergeAction::INSERT;
 }
+
+bool MergeStrategy::insert() const { return not_matched_by_target == MergeAction::INSERT; }
+
+bool MergeStrategy::update() const { return matched == MergeAction::UPDATE; }
 } // namespace arcticdb

--- a/cpp/arcticdb/version/merge_options.hpp
+++ b/cpp/arcticdb/version/merge_options.hpp
@@ -17,6 +17,8 @@ struct MergeStrategy {
     bool operator==(const MergeStrategy&) const = default;
     bool update_only() const;
     bool insert_only() const;
+    bool insert() const;
+    bool update() const;
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -42,6 +42,7 @@
 #include <arcticdb/util/format_date.hpp>
 #include <iterator>
 #include <aws/core/utils/stream/ResponseStream.h>
+#include <mongocxx/result/update.hpp>
 
 namespace arcticdb::version_store {
 
@@ -3001,18 +3002,18 @@ folly::Future<ReadVersionOutput> read_frame_for_version(
 
 folly::Future<std::vector<SliceAndKey>> read_modify_write_data_keys(
         const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
-        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context
+        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
+        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto write_clause_processing_structure = read_query->clauses_.empty()
                                                      ? ProcessingStructure::ROW_SLICE
                                                      : read_query->clauses_.back()->clause_info().output_structure_;
-    read_query->clauses_.push_back(std::make_shared<Clause>(WriteClause(
-            target_partial_index_key, std::make_shared<DeDupMap>(), store, write_clause_processing_structure
-    )));
+    read_query->clauses_.push_back(std::make_shared<Clause>(
+            WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
+    ));
 
-    auto component_manager = std::make_shared<ComponentManager>();
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
-            .thenValue([component_manager,
+            .thenValue([component_manager = std::move(component_manager),
                         pipeline_context,
                         read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
                 generate_output_schema_and_save_to_pipeline(*pipeline_context, *read_query);
@@ -3039,7 +3040,15 @@ folly::Future<VersionedItem> read_modify_write_impl(
         const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
         std::optional<proto::descriptors::UserDefinedMetadata>&& user_meta_proto
 ) {
-    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
+    return read_modify_write_data_keys(
+                   store,
+                   read_query,
+                   read_options,
+                   target_partial_index_key,
+                   pipeline_context,
+                   std::make_shared<ComponentManager>(),
+                   std::make_shared<DeDupMap>()
+    )
             .thenValue([&](std::vector<SliceAndKey>&& data_keys_and_slices) {
                 ARCTICDB_DEBUG_CHECK(
                         ErrorCode::E_ASSERTION_FAILURE,
@@ -3077,20 +3086,44 @@ folly::Future<VersionedItem> read_modify_write_impl(
 }
 
 folly::Future<VersionedItem> merge_update_impl(
-        const std::shared_ptr<Store>& store, const VersionIdentifier& version_info, const ReadOptions& read_options,
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
-        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source
+        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
+        std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto read_query = std::make_shared<ReadQuery>();
     const StreamDescriptor& source_descriptor = source->desc();
     auto merge_update_clause = std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source));
     read_query->clauses_.push_back(merge_update_clause);
-    VersionIdentifier resolved = version_info;
+    VersionIdentifier resolved = VersionedItem{*update_info.previous_index_key_};
     if (auto* vi = std::get_if<VersionedItem>(&resolved)) {
         resolved = std::make_shared<IndexInformation>(read_index_key_without_column_stats(store, vi->key_));
     }
     std::shared_ptr<PipelineContext> pipeline_context =
             setup_pipeline_context(store, std::move(resolved), *read_query, read_options);
+    // The target is empty.
+    if (pipeline_context->rows_ == 0) {
+        if (strategy.insert()) {
+            return write_dataframe_impl(store, update_info.next_version_id_, source, write_options, de_dup_map);
+        } else if (strategy.update_only()) {
+            const TimeseriesDescriptor tsd = make_timeseries_descriptor(
+                    0,
+                    pipeline_context->descriptor(),
+                    std::move(*pipeline_context->norm_meta_),
+                    pipeline_context->user_meta_ ? std::make_optional(std::move(source->user_meta)) : std::nullopt,
+                    std::nullopt,
+                    std::nullopt,
+                    write_options.bucketize_dynamic
+            );
+            return index::write_index(
+                    index_type_from_descriptor(pipeline_context->descriptor()),
+                    tsd,
+                    std::vector<SliceAndKey>{},
+                    target_partial_index_key,
+                    store
+            );
+        }
+    }
     // TODO: Rely on modify_schema for this https://man312219.monday.com/boards/7852509418/pulses/10997979275
     schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
             columns_match(pipeline_context->descriptor(), source_descriptor),
@@ -3102,6 +3135,11 @@ folly::Future<VersionedItem> merge_update_impl(
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !write_options.dynamic_schema, "Cannot merge update with dynamic schema"
     );
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            strategy.not_matched_by_target != MergeAction::INSERT ||
+                    pipeline_context->descriptor().index().type() == IndexDescriptor::Type::TIMESTAMP,
+            "Merge update with INSERT strategy is not implemented for ROWRANGE indexes yet."
+    );
     const IndexDescriptor::Type index_type = pipeline_context->descriptor().index().type();
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             (index_type == IndexDescriptor::Type::TIMESTAMP &&
@@ -3112,23 +3150,45 @@ folly::Future<VersionedItem> merge_update_impl(
     );
     folly::poly_cast<MergeUpdateClause>(*merge_update_clause).fake_index_name_ =
             index_type == IndexDescriptor::Type::TIMESTAMP && is_fake_index_name(*pipeline_context->norm_meta_);
-    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
+    auto component_manager = std::make_shared<ComponentManager>();
+    return read_modify_write_data_keys(
+                   store,
+                   read_query,
+                   read_options,
+                   target_partial_index_key,
+                   pipeline_context,
+                   component_manager,
+                   std::move(de_dup_map)
+    )
             .thenValue([pipeline_context = std::move(pipeline_context),
+                        component_manager = std::move(component_manager),
                         store,
                         write_options,
                         source = std::move(source),
                         target_partial_index_key](std::vector<SliceAndKey>&& data_keys_and_slices) {
                 // TODO: This needs to be changed to account for the INSERT option of merge update. Insert can
                 // create new segments and shift row slices.
+                ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
+                component_manager->process_entities([&](const MergeUpdateInsertedRowsEntity& inserted_rows,
+                                                        const std::shared_ptr<RowRange>& row_range) {
+                    inserted_rows_per_row_range.emplace(*row_range, inserted_rows.inserted_rows);
+                });
+                size_t total_inserted_rows_count = 0;
                 ranges::sort(data_keys_and_slices);
                 std::vector<SliceAndKey> merged_ranges_and_keys;
                 auto new_slice = data_keys_and_slices.begin();
-                for (SliceAndKey& slice : pipeline_context->slice_and_keys_) {
-                    if (new_slice != data_keys_and_slices.end() && new_slice->slice_ == slice.slice_) {
+                for (SliceAndKey& old_slice : pipeline_context->slice_and_keys_) {
+                    if (new_slice != data_keys_and_slices.end() && new_slice->slice_ == old_slice.slice_) {
+                        const size_t inserted_row_count = inserted_rows_per_row_range[new_slice->slice_.row_range];
+                        new_slice->slice().row_range.first += total_inserted_rows_count;
+                        total_inserted_rows_count += inserted_row_count;
+                        new_slice->slice().row_range.second += total_inserted_rows_count;
                         merged_ranges_and_keys.push_back(std::move(*new_slice));
                         ++new_slice;
                     } else {
-                        merged_ranges_and_keys.push_back(std::move(slice));
+                        old_slice.slice().row_range.first += total_inserted_rows_count;
+                        old_slice.slice().row_range.second += total_inserted_rows_count;
+                        merged_ranges_and_keys.push_back(std::move(old_slice));
                     }
                 }
                 pipeline_context->slice_and_keys_.clear();
@@ -3231,13 +3291,18 @@ folly::Future<std::optional<VersionedItem>> compact_data_impl(
             std::make_shared<IndexInformation>(read_index_key_without_column_stats(store, versioned_item.key_));
     std::shared_ptr<PipelineContext> pipeline_context =
             setup_pipeline_context(store, std::move(resolved), *read_query, {});
-    return read_modify_write_data_keys(store, read_query, ReadOptions{}, target_partial_index_key, pipeline_context)
+    return read_modify_write_data_keys(
+                   store,
+                   read_query,
+                   ReadOptions{},
+                   target_partial_index_key,
+                   pipeline_context,
+                   std::make_shared<ComponentManager>(),
+                   std::make_shared<DeDupMap>()
+    )
             .thenValue(
-                    [pipeline_context = std::move(pipeline_context),
-                     store,
-                     write_options,
-                     target_partial_index_key,
-                     read_query](std::vector<SliceAndKey>&& slices_and_keys
+                    [pipeline_context = std::move(pipeline_context), store, write_options, target_partial_index_key](
+                            std::vector<SliceAndKey>&& slices_and_keys
                     ) -> folly::Future<std::optional<VersionedItem>> {
                         if (slices_and_keys.empty()) {
                             return folly::makeFuture(std::optional<VersionedItem>());

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -197,9 +197,10 @@ folly::Future<VersionedItem> read_modify_write_impl(
 );
 
 folly::Future<VersionedItem> merge_update_impl(
-        const std::shared_ptr<Store>& store, const VersionIdentifier& version_info, const ReadOptions& read_options,
+        const std::shared_ptr<Store>& store, const UpdateInfo& version_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
-        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source
+        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
+        std::shared_ptr<DeDupMap> de_dup_map
 );
 
 folly::Future<CompactDataInfo> compact_data_explain_plan_impl(

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -156,10 +156,8 @@ def dataframe_dump_to_log(label_for_df, df: pd.DataFrame):
     we could use to reproduce something or further analyze failures caused by
     a problems in test code or arctic
     """
-    print("-" * 80)
-    if SHORTER_LOGS:
-        print("No full dataframes dumps when shorter logs is activated")
-    else:
+    if not SHORTER_LOGS:
+        print("-" * 80)
         if isinstance(df, pd.DataFrame):
             print("dataframe : , ", label_for_df)
             print(df.to_csv())

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -1037,8 +1037,32 @@ class TestMergeTimeseriesUpdate:
         with pytest.raises(UserInputException, match="E_DUPLICATE_COLUMN") as exc_info:
             lib.merge_experimental("sym", source, strategy=self.strategy, on=["my_duplicated_column"])
 
+    def test_on_colum_reorders_matched_rows(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 0, 0, 1, 1], "b": [1, 2, 3, 4, 5], "c": ["a", "b", "c", "d", "e"]},
+            index=pd.DatetimeIndex([pd.Timestamp(0)] * 5),
+        )
+        # The test matches on column "a". Note the order of the columns of a. This means that
+        # source[0]: updates target [1, 2]
+        # source[1]: updates target []
+        # source[2]: updates target [0, 3, 4]
+        # Meaning that flatten(rows_to_be_updated) is not a sorted list
+        source = pd.DataFrame(
+            {"a": [0, 2, 1], "b": [100, 200, 300], "c": ["A", "B", "C"]}, index=pd.DatetimeIndex([pd.Timestamp(0)] * 3)
+        )
+        expected = pd.DataFrame(
+            {"a": [1, 0, 0, 1, 1], "b": [300, 100, 100, 300, 300], "c": ["C", "A", "A", "C", "C"]},
+            index=pd.DatetimeIndex([pd.Timestamp(0)] * 5),
+        )
+        generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a"])
+
 
 class TestMergeTimeseriesInsert:
+
+    def setup_method(self):
+        self.strategy = MergeStrategy("do_nothing", "insert")
+
     @pytest.mark.parametrize(
         "strategy",
         (MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), MergeStrategy("do_nothing", "insert")),
@@ -1118,24 +1142,10 @@ class TestMergeTimeseriesInsert:
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
-    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library, monkeypatch):
+    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
-        write_vit = lib.write("sym", target)
-        monkeypatch.setattr(
-            lib,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=write_vit.version + 1,
-                metadata=write_vit.metadata,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
-        )
+        lib.write("sym", target)
         source = pd.DataFrame(
             {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]}, index=pd.date_range("2024-01-01", periods=3)
         )
@@ -1144,31 +1154,13 @@ class TestMergeTimeseriesInsert:
         )
         assert merge_vit.version == 1
 
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=target,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(read_vit, merge_vit)
         assert_frame_equal(read_vit.data, target)
 
         lt = lib._dev_tools.library_tool()
-        monkeypatch.setattr(
-            lt,
-            "find_keys_for_symbol",
-            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 1, KeyType.TABLE_INDEX: 1, KeyType.VERSION: 2}),
-        )
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
     def test_index_and_column(self, lmdb_library, monkeypatch):
@@ -1241,74 +1233,280 @@ class TestMergeTimeseriesInsert:
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_does_not_throw_when_target_row_is_matched_more_than_once_when_matched_is_do_nothing(
-        self, lmdb_library, monkeypatch
-    ):
+    def test_does_not_throw_when_target_row_is_matched_more_than_once_when_matched_is_do_nothing(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target)
 
         source = pd.DataFrame(
-            {"a": [1, 2, 4], "b": [1.0, 2.0, 4.0]},
+            {"a": [1, 2, 40], "b": [1.0, 2.0, 40.0]},
             index=pd.DatetimeIndex(
                 [
                     pd.Timestamp("2024-01-01"),  # Matches first row of target
                     pd.Timestamp("2024-01-01"),  # Also matches first row of target
-                    pd.Timestamp("2024-01-04"),
+                    pd.Timestamp("2024-01-02 00:00:01"),
                 ]
             ),
         )
 
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
         lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
         expected = pd.DataFrame(
-            {"a": [1, 2, 3, 4], "b": [1.0, 2.0, 3.0, 4.0]}, index=pd.date_range("2024-01-01", periods=4)
+            {
+                "a": [
+                    1,
+                    2,
+                    40,
+                    3,
+                ],
+                "b": [1.0, 2.0, 40.0, 3.0],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),
+                    pd.Timestamp("2024-01-02"),
+                    pd.Timestamp("2024-01-02 00:00:01"),
+                    pd.Timestamp("2024-01-03"),
+                ]
+            ),
         )
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_target_is_empty(self, lmdb_library, monkeypatch):
+    def test_target_is_empty(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
-        write_vit = lib.write("sym", target)
-
+        write_vit = lib.write("sym", target, metadata={"meta": "data"})
+        assert write_vit.version == 0
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        monkeypatch.setattr(
-            lib.__class__,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=1,
-                metadata=None,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
+        merge_vit = lib.merge_experimental(
+            "sym", source, strategy=MergeStrategy("do_nothing", "insert"), metadata={"new_meta": "new_data"}
         )
-        merge_vit = lib.merge_experimental("sym", source, strategy=MergeStrategy("do_nothing", "insert"))
+        assert merge_vit.version == 1
         expected = source
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=expected,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
         read_vit = lib.read("sym")
+        assert read_vit.metadata == {"new_meta": "new_data"}
         assert_vit_equals_except_data(merge_vit, read_vit)
         assert_frame_equal(read_vit.data, expected)
 
+    def test_insert_within_single_segment(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", target)
+        source = pd.DataFrame(
+            {"a": [100, 200, 300, 400], "b": [100.0, 200.0, 300.0, 400.0]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(2),
+                    pd.Timestamp(2),
+                    pd.Timestamp(6),
+                    pd.Timestamp(9),
+                ]
+            ),
+        )
+        lib.merge_experimental("sym", source, self.strategy)
+        expected = pd.concat([target, source]).sort_index()
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 1, 100], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 2, 3, 4, 5, 100, 6], "b": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 300.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_first_equal_run_Insert_in_second_equal_run.",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 3], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 100, 2, 3, 4, 5, 6], "b": [0.0, 1.0, 200, 2.0, 3.0, 4.0, 5.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_second_equal_run_Insert_in_first.",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 1, 2, 5, 200, 4, 3], "b": [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                        ]
+                    ),
+                ),
+                pd.DataFrame(
+                    {
+                        "a": [0, 1, 100, 2, 3, 4, 5, 200, 6],
+                        "b": [0.0, 1.0, 200.0, 2.0, 3.0, 4.0, 5.0, 600.0, 6.0],
+                    },
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_both_equal_index_runs_and_insert_in_both.",
+            ),
+        ],
+    )
+    def test_within_single_segment_match_on_column(self, lmdb_library, source, expected):
+        lib = lmdb_library
+        index = pd.DatetimeIndex(
+            [
+                pd.Timestamp(0),
+                pd.Timestamp(0),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(6),
+            ]
+        )
+        target = pd.DataFrame({"a": range(len(index)), "b": np.linspace(0, len(index) - 1, len(index))}, index=index)
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pd.DataFrame({"a": [10], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp(0)])),
+            pd.DataFrame({"a": [10], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp(5)])),
+            pd.DataFrame({"a": [10], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp(10)])),
+            pd.DataFrame(
+                {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])
+            ),
+            pd.DataFrame(
+                {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(10)])
+            ),
+            pd.DataFrame(
+                {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(5), pd.Timestamp(10)])
+            ),
+            pd.DataFrame(
+                {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]},
+                index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+            ),
+        ],
+    )
+    def test_within_single_segment_matched_rows_stay_the_same(self, lmdb_library, source):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, self.strategy)
+        assert_frame_equal(lib.read("sym").data, target)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                pd.DataFrame({"a": [10], "b": [20.0], "c": [True]}, index=pd.DatetimeIndex([pd.Timestamp(2)])),
+                id="Insert_single_row_in_first_segment",
+            ),
+            pytest.param(
+                pd.DataFrame({"a": [10], "b": [20.0], "c": [True]}, index=pd.DatetimeIndex([pd.Timestamp(21)])),
+                id="Insert_single_row_in_second_segment",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [10, 100], "b": [20.0, 200.0], "c": [False, True]},
+                    index=pd.DatetimeIndex([pd.Timestamp(6), pd.Timestamp(26)]),
+                ),
+                id="Insert_single_value_in_both_segments",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {
+                        "a": [10, 20, 30, 40, 50, 1000, 2000],
+                        "b": [60.0, 70.0, 80.0, 90.0, 100.0, 3000, 4000],
+                        "c": [True, False, False, True, True, True, False],
+                    },
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(1),
+                            pd.Timestamp(2),
+                            pd.Timestamp(3),
+                            pd.Timestamp(7),
+                            pd.Timestamp(9),
+                            pd.Timestamp(21),
+                            pd.Timestamp(26),
+                        ]
+                    ),
+                ),
+                id="Insert_multiple_values_in_both_segments",
+            ),
+        ],
+    )
+    def test_within_two_segments(self, lmdb_library, source):
+        lib = lmdb_library
+        seg0 = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": [True, False, True]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", seg0)
+        seg1 = pd.DataFrame(
+            {"a": [4, 5, 6], "b": [4.0, 5.0, 6.0], "c": [False, True, False]},
+            index=pd.DatetimeIndex([pd.Timestamp(20), pd.Timestamp(25), pd.Timestamp(30)]),
+        )
+        lib.append("sym", seg1)
+        lib.merge_experimental("sym", source, self.strategy)
+        expected = pd.concat([seg0, seg1, source]).sort_index()
+        assert_frame_equal(lib.read("sym").data, expected)
+
 
 class TestMergeTimeseriesUpdateAndInsert:
+
+    def setup_method(self):
+        self.strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
 
     @pytest.mark.parametrize(
         "strategy",
@@ -1609,64 +1807,148 @@ class TestMergeTimeseriesUpdateAndInsert:
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_target_is_empty(self, lmdb_library, monkeypatch):
+    def test_target_is_empty(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
         write_vit = lib.write("sym", target)
-
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        monkeypatch.setattr(
-            lib.__class__,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=1,
-                metadata=None,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
-        )
         merge_vit = lib.merge_experimental("sym", source)
         expected = source
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=expected,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(merge_vit, read_vit)
         assert_frame_equal(read_vit.data, expected)
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_throws_when_target_row_is_matched_more_than_once(self, lmdb_library):
-        lib = lmdb_library
-        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
-        lib.write("sym", target)
-
-        source = pd.DataFrame(
-            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
-            index=pd.DatetimeIndex(
-                [
-                    pd.Timestamp("2024-01-01"),  # Matches first row of target
-                    pd.Timestamp("2024-01-01"),  # Also matches first row of target
-                    pd.Timestamp("2024-01-03"),
-                ]
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0)])
+                ),
+                id="No_unmatched",
             ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(2)]),
+                ),
+                id="Contains_unmatched",
+            ),
+        ],
+    )
+    def test_throws_when_target_row_is_matched_more_than_once(self, lmdb_library, source):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
         )
-        strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
+        lib.write("sym", target)
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge_experimental("sym", source, strategy=self.strategy)
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 1, 100], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 2, 3, 4, 5, 100, 6], "b": [100.0, 200.0, 2.0, 3.0, 4.0, 5.0, 300.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_first_equal_run_Insert_in_second_equal_run",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 3], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 100, 2, 3, 4, 5, 6], "b": [100.0, 1.0, 200, 2.0, 300.0, 4.0, 5.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_second_equal_run_Insert_in_first",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 1, 2, 5, 200, 4, 3], "b": [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                        ]
+                    ),
+                ),
+                pd.DataFrame(
+                    {
+                        "a": [0, 1, 100, 2, 3, 4, 5, 200, 6],
+                        "b": [100.0, 300.0, 200.0, 400.0, 800.0, 700.0, 500.0, 600.0, 6.0],
+                    },
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_both_equal_index_runs_and_insert_in_both",
+            ),
+        ],
+    )
+    def test_within_single_segment_match_on_column(self, lmdb_library, source, expected):
+        lib = lmdb_library
+        index = pd.DatetimeIndex(
+            [
+                pd.Timestamp(0),
+                pd.Timestamp(0),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(6),
+            ]
+        )
+        target = pd.DataFrame({"a": range(len(index)), "b": np.linspace(0, len(index) - 1, len(index))}, index=index)
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        assert_frame_equal(lib.read("sym").data, expected)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Phase one of insertion has some limitations that are going to be addressed in future PRs. The limitations are:
* Works for timeseries only
* String columns are not supported
* Does not support a single value spanning multiple segments
* Can insert only if the source index value lies in the middle of some existing segment, e.g. if there are 3 segments [5, 20) [20, 25) [30, 50) source rows with indexes 0, 4, 26, 29, 55 cannot be inserted
* Segments are not sliced. Insertion can produce large segments.

Matching on multiple columns is supported.

The algorithm is merges two sorted lists in O(m + n) where m is the size of the segment and n is the size of the source data that lies within this segment.

This PR also handles mixed strategy update on match and insert when source row is not matched
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
