### PR TITLE
Fix CMake includes to work when ArcticDB is built as a subdirectory

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -12,8 +12,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake" ${CMAKE_MODULE_PATH})
 project(arcticdb VERSION 0.0.1)
 
-include(${CMAKE_SOURCE_DIR}/CMake/compiler_cache.cmake)
-include(${CMAKE_SOURCE_DIR}/CMake/pdb_generation.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/compiler_cache.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/CMake/pdb_generation.cmake)
 
 enable_testing()
 


### PR DESCRIPTION
## Summary

PR #3121 (\"Switch to using /Zi format for MSVC...\") added two `include()` calls at the top of `cpp/CMakeLists.txt`:

```cmake
include(${CMAKE_SOURCE_DIR}/CMake/compiler_cache.cmake)
include(${CMAKE_SOURCE_DIR}/CMake/pdb_generation.cmake)
```

`CMAKE_SOURCE_DIR` is the top-level CMake source directory of the build invocation, not the directory of the CMakeLists.txt being processed. When ArcticDB is consumed as a subdirectory via `add_subdirectory(ArcticDB/cpp)` from a parent project, `CMAKE_SOURCE_DIR` is the parent project root, and these includes fail:

```
CMake Error at ArcticDB/cpp/CMakeLists.txt:15 (include):
  include could not find requested file:
    <parent>/CMake/compiler_cache.cmake
```

The subsequent `set_arcticdb_compiler_cache()` call (line 51) is then undefined.

This breaks the **ArcticDB Enterprise** build, which embeds ArcticDB via `add_subdirectory(ArcticDB/cpp)`. The standalone ArcticDB build is unaffected because there `CMAKE_SOURCE_DIR == CMAKE_CURRENT_SOURCE_DIR`.

## Fix

Use `CMAKE_CURRENT_SOURCE_DIR` instead, matching the pattern already used two lines above for `CMAKE_MODULE_PATH`. This is also robust to future changes that invoke ArcticDB from any other root.

## Test plan

- [x] Standalone ArcticDB CMake configure still works (no behavioral change).
- [x] ArcticDB Enterprise build configures and builds end-to-end on Linux with this patch applied.