### PR TITLE
Add NaN and NULL count to MIN/MAX stats

### DIFF
--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -97,6 +97,10 @@ std::string type_to_operator_string(ColumnStatTypeInternal type) {
         return "v1_MIN";
     case ColumnStatTypeInternal::MAX_V1:
         return "v1_MAX";
+    case ColumnStatTypeInternal::NAN_COUNT_V1:
+        return "v1_NAN_COUNT";
+    case ColumnStatTypeInternal::NULL_COUNT_V1:
+        return "v1_NULL_COUNT";
     default:
         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unknown column stat type requested");
     }
@@ -146,7 +150,9 @@ ColumnStats::ColumnStats(
             switch (entry.type()) {
             case MIN_V1:
             case MAX_V1:
-                external_type = ColumnStatType::MINMAX;
+            case NAN_COUNT_V1:
+            case NULL_COUNT_V1:
+                external_type = ColumnStatType::MINMAX; // null and nan are calculated inline with minmax
                 break;
             case UNKNOWN:
             default:
@@ -255,7 +261,10 @@ namespace {
 std::unordered_set<ColumnStatTypeInternal> external_to_internal(ColumnStatType type) {
     switch (type) {
     case ColumnStatType::MINMAX:
-        return {ColumnStatTypeInternal::MIN_V1, ColumnStatTypeInternal::MAX_V1};
+        return {ColumnStatTypeInternal::MIN_V1,
+                ColumnStatTypeInternal::MAX_V1,
+                ColumnStatTypeInternal::NAN_COUNT_V1,
+                ColumnStatTypeInternal::NULL_COUNT_V1};
     default:
         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unknown column stat type");
     }
@@ -339,7 +348,13 @@ std::optional<Clause> ColumnStats::clause() const {
                         ),
                         ColumnName(
                                 to_segment_column_name(name_and_stat_types.mangled_name, ColumnStatTypeInternal::MAX_V1)
-                        )
+                        ),
+                        ColumnName(to_segment_column_name(
+                                name_and_stat_types.mangled_name, ColumnStatTypeInternal::NAN_COUNT_V1
+                        )),
+                        ColumnName(to_segment_column_name(
+                                name_and_stat_types.mangled_name, ColumnStatTypeInternal::NULL_COUNT_V1
+                        ))
                 ));
                 break;
             default:

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
@@ -43,6 +43,11 @@ StatsComparison stats_membership_comparator(const ColumnStatsValues& stats, Valu
         return StatsComparison::NONE_MATCH;
     }
 
+    if (stats.only_nulls()) {
+        // Every row is null: a null is never in the set, so isin matches none and isnotin matches all.
+        return is_isin ? StatsComparison::NONE_MATCH : StatsComparison::ALL_MATCH;
+    }
+
     if (!stats.min || !stats.max) {
         return StatsComparison::UNKNOWN;
     }
@@ -137,6 +142,14 @@ StatsComparison stats_membership_comparator(const ColumnStatsValues& stats, Valu
                         }
                         // comparison == NONE_MATCH -> elem outside of [min, max], so not relevant
                     }
+                }
+
+                // Same idea as `adjust_for_missing` in column_stats_dispatch.hpp:
+                // when the segment has NaN/NaT/sparse-gap rows, an `isin` ALL_MATCH may overstate
+                // (NaN never matches isin), so the corresponding `isnotin` NONE_MATCH (after the
+                // flip below) would also be wrong. Downgrade before the flip so both paths agree.
+                if ((stats.nan_count + stats.null_count) > 0 && isin_result == StatsComparison::ALL_MATCH) {
+                    isin_result = StatsComparison::UNKNOWN;
                 }
 
                 if (!is_isin) {

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -105,15 +105,48 @@ struct FlippedComparator<NotEqualsOperator> {
 };
 
 template<typename Func>
+StatsComparison adjust_for_missing(StatsComparison result, uint64_t missing_count) {
+    if (missing_count == 0) { // no nulls or nans
+        return result;
+    }
+
+    using F = std::remove_cvref_t<Func>;
+
+    if constexpr (std::is_same_v<F, NotEqualsOperator>) {
+        if (result == StatsComparison::NONE_MATCH) {
+            // col = [3, NaN, NaN, 3], due to min=3 and max=3:
+            // Filter [col != 3] returns NONE_MATCH, but [NaN != 3] is a match, downgrade to UNKNOWN
+            return StatsComparison::UNKNOWN;
+        }
+    } else {
+        if (result == StatsComparison::ALL_MATCH) {
+            // col = [3, NaN, NaN, 3], due to min=3 and max=3:
+            // Filter [col == 3] returns ALL_MATCH, but [NaN == 3] is not a match, downgrade to UNKNOWN
+
+            // col = [5, 8, NaN], due to min=5 and max=8:
+            // Filter [col < 100] returns ALL_MATCH, but [NaN < 100] is not a match, downgrade to UNKNOWN
+            return StatsComparison::UNKNOWN;
+        }
+    }
+
+    return result;
+}
+
+template<typename Func>
 StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value& val_rhs, Func&& func) {
     if (stats_lhs.column_absent) {
         return StatsComparison::NONE_MATCH;
+    }
+    if (stats_lhs.only_nulls()) {
+        // Every row is null: `!=` matches all of them, every other comparison matches none.
+        return std::is_same_v<std::remove_cvref_t<Func>, NotEqualsOperator> ? StatsComparison::ALL_MATCH
+                                                                            : StatsComparison::NONE_MATCH;
     }
     if (!stats_lhs.min) {
         return StatsComparison::UNKNOWN;
     }
 
-    return details::visit_type(stats_lhs.min->data_type(), [&](auto stats_tag) -> StatsComparison {
+    auto result = details::visit_type(stats_lhs.min->data_type(), [&](auto stats_tag) -> StatsComparison {
         using StatsTag = std::remove_reference_t<decltype(stats_tag)>;
 
         return details::visit_type(val_rhs.data_type(), [&](auto val_tag) -> StatsComparison {
@@ -152,6 +185,7 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value
             return StatsComparison::UNKNOWN;
         });
     });
+    return adjust_for_missing<Func>(result, stats_lhs.nan_count + stats_lhs.null_count);
 }
 
 template<typename Func>
@@ -163,7 +197,7 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Colum
         return StatsComparison::UNKNOWN;
     }
 
-    return details::visit_type(stats_lhs.min->data_type(), [&](auto lhs_tag) -> StatsComparison {
+    auto result = details::visit_type(stats_lhs.min->data_type(), [&](auto lhs_tag) -> StatsComparison {
         using LhsTag = std::remove_reference_t<decltype(lhs_tag)>;
 
         return details::visit_type(stats_rhs.min->data_type(), [&](auto rhs_tag) -> StatsComparison {
@@ -202,6 +236,9 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Colum
             return StatsComparison::UNKNOWN;
         });
     });
+    return adjust_for_missing<Func>(
+            result, stats_lhs.nan_count + stats_lhs.null_count + stats_rhs.nan_count + stats_rhs.null_count
+    );
 }
 
 template<typename Func>

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -143,32 +143,40 @@ std::vector<StatsMetadataForColumn> calculate_stats_metadata(
         );
         stats_metadata_for_column.col_name = std::string{tsd.fields().at(data_col_offset).name()};
         for (const auto& entry : entry_list.entries()) {
-            if (entry.type() != arcticc::pb2::column_stats_pb2::MIN_V1 &&
-                entry.type() != arcticc::pb2::column_stats_pb2::MAX_V1) {
+            const auto entry_type = entry.type();
+            const bool is_min_max = entry_type == arcticc::pb2::column_stats_pb2::MIN_V1 ||
+                                    entry_type == arcticc::pb2::column_stats_pb2::MAX_V1;
+            const bool is_count = entry_type == arcticc::pb2::column_stats_pb2::NAN_COUNT_V1 ||
+                                  entry_type == arcticc::pb2::column_stats_pb2::NULL_COUNT_V1;
+            if (!is_min_max && !is_count) {
                 log::version().warn(
                         "Unknown column stats type {} for column {}, skipping",
-                        static_cast<int>(entry.type()),
+                        static_cast<int>(entry_type),
                         stats_metadata_for_column.col_name
                 );
                 continue;
             }
-            const auto field_name = to_segment_column_name(stats_metadata_for_column.col_name, entry.type());
+            const auto field_name = to_segment_column_name(stats_metadata_for_column.col_name, entry_type);
             const auto col_index = segment.column_index(field_name);
             if (!col_index.has_value()) {
                 // Column was filtered out at decode time, or never present in this segment.
                 continue;
             }
-            const auto entry_data_type = fields.at(*col_index).type().data_type();
-            if (stats_metadata_for_column.data_type == DataType::UNKNOWN) {
-                stats_metadata_for_column.data_type = entry_data_type;
-            } else {
-                util::check(
-                        stats_metadata_for_column.data_type == entry_data_type,
-                        "MIN/MAX stats columns for {} disagree on data type",
-                        stats_metadata_for_column.col_name
-                );
+            // NAN_COUNT/NULL_COUNT are always UINT64 and tracked separately; only MIN/MAX define the
+            // column's value data type.
+            if (is_min_max) {
+                const auto entry_data_type = fields.at(*col_index).type().data_type();
+                if (stats_metadata_for_column.data_type == DataType::UNKNOWN) {
+                    stats_metadata_for_column.data_type = entry_data_type;
+                } else {
+                    util::check(
+                            stats_metadata_for_column.data_type == entry_data_type,
+                            "MIN/MAX stats columns for {} disagree on data type",
+                            stats_metadata_for_column.col_name
+                    );
+                }
             }
-            stats_metadata_for_column.entries.push_back({*col_index, entry.type()});
+            stats_metadata_for_column.entries.push_back({*col_index, entry_type});
         }
         if (!stats_metadata_for_column.entries.empty()) {
             stats_metadata.emplace_back(std::move(stats_metadata_for_column));
@@ -181,19 +189,31 @@ std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
         const SegmentInMemory& segment, std::vector<StatsMetadataForColumn> stats_metadata, size_t first_kept,
         size_t last_kept_excl, size_t num_rows
 ) {
+    using namespace arcticc::pb2::column_stats_pb2;
     std::unordered_map<std::string, StatsForColumn> stats_by_column;
     for (auto& stats_metadata_for_column : stats_metadata) {
         StatsForColumn stats_for_column;
         stats_for_column.mins.resize(num_rows);
         stats_for_column.maxes.resize(num_rows);
+        stats_for_column.nan_counts.resize(num_rows, 0);
+        stats_for_column.null_counts.resize(num_rows, 0);
+
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                stats_metadata_for_column.data_type != DataType::UNKNOWN,
+                "Column stats for {} have no MIN/MAX and therefore an unknown data type",
+                stats_metadata_for_column.col_name
+        );
 
         details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
             using type_info = ScalarTypeInfo<T>;
             if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
                           is_bool_type(type_info::data_type)) {
                 for (const auto& entry : stats_metadata_for_column.entries) {
+                    if (entry.stat_type != MIN_V1 && entry.stat_type != MAX_V1) {
+                        continue;
+                    }
                     const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
-                    const bool is_min = entry.stat_type == arcticc::pb2::column_stats_pb2::MIN_V1;
+                    const bool is_min = entry.stat_type == MIN_V1;
                     auto& dest = is_min ? stats_for_column.mins : stats_for_column.maxes;
                     for_each_enumerated<typename type_info::TDT>(
                             column,
@@ -207,6 +227,22 @@ std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
                 }
             }
         });
+
+        // NaN/NaT and null (sparse-gap) counts are stored inline with min/max as dense UINT64 columns.
+        using CountTDT = ScalarTagType<DataTypeTag<DataType::UINT64>>;
+        for (const auto& entry : stats_metadata_for_column.entries) {
+            if (entry.stat_type != NAN_COUNT_V1 && entry.stat_type != NULL_COUNT_V1) {
+                continue;
+            }
+            auto& dest = entry.stat_type == NAN_COUNT_V1 ? stats_for_column.nan_counts : stats_for_column.null_counts;
+            const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
+            for_each_enumerated<CountTDT>(column, [&](const ColumnData::Enumeration<uint64_t>& enumerating_it) {
+                auto idx = static_cast<size_t>(enumerating_it.idx());
+                if (idx >= first_kept && idx < last_kept_excl) {
+                    dest.at(idx - first_kept) = enumerating_it.value();
+                }
+            });
+        }
 
         stats_by_column.emplace(std::move(stats_metadata_for_column.col_name), std::move(stats_for_column));
     }
@@ -353,6 +389,11 @@ std::vector<ColumnStatsValues> ColumnStatsData::values_for_column(
         if (min_set) {
             result_entry.min = stats.mins.at(r);
             result_entry.max = stats.maxes.at(r);
+            result_entry.nan_count = stats.nan_counts.at(r);
+            result_entry.null_count = stats.null_counts.at(r);
+        } else if (stats.nan_counts.at(r) > 0 || stats.null_counts.at(r) > 0) {
+            result_entry.nan_count = stats.nan_counts.at(r);
+            result_entry.null_count = stats.null_counts.at(r);
         } else {
             result_entry.column_absent = true;
         }

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -39,6 +39,10 @@ struct PairHasher {
 struct ColumnStatsValues {
     std::optional<Value> min;
     std::optional<Value> max;
+    // In-band sentinels (NaN for floats, NaT for time types) counted during write-time aggregation.
+    uint64_t nan_count = 0;
+    // Sparse-map gaps (rows genuinely absent from the data segment) counted during write-time aggregation.
+    uint64_t null_count = 0;
     bool column_absent = false;
 
     ColumnStatsValues() = default;
@@ -46,6 +50,8 @@ struct ColumnStatsValues {
     ColumnStatsValues(std::optional<Value> min, std::optional<Value> max) : min(std::move(min)), max(std::move(max)) {
         util::check(min.has_value() == max.has_value(), "min and max should either both be present or both be absent");
     };
+
+    bool only_nulls() const { return !min.has_value() && (nan_count + null_count) > 0; }
 };
 
 struct StatsIndexAndType {
@@ -62,6 +68,8 @@ struct StatsMetadataForColumn {
 struct StatsForColumn {
     std::vector<std::optional<Value>> mins;  // size == num_rows_
     std::vector<std::optional<Value>> maxes; // size == num_rows_
+    std::vector<uint64_t> nan_counts;        // size == num_rows_, default 0
+    std::vector<uint64_t> null_counts;       // size == num_rows_, default 0
 };
 
 /**

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -411,4 +411,97 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     ASSERT_FALSE(v1.max.has_value());
     ASSERT_TRUE(v1.column_absent);
 }
+
+// A wholly-null row-slice has NAN_COUNT/NULL_COUNT entries but no MIN/MAX (no real value to
+// min/max over). values_for_column must propagate the counts and leave column_absent false, so
+// downstream comparators fall through to UNKNOWN rather than pruning the slice
+TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
+    using namespace arcticc::pb2::column_stats_pb2;
+
+    // Stats segment layout:
+    //   col 0: start_index
+    //   col 1: end_index
+    //   col 2: v1_MIN(price)
+    //   col 3: v1_MAX(price)
+    //   col 4: v1_NAN_COUNT(price)
+    //   col 5: v1_NULL_COUNT(price)
+    //
+    // Row 0: price=[10,20]            (real values)
+    // Row 1: price all null           (no MIN/MAX, null_count=3)
+
+    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto min_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
+    auto max_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
+    auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+    auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+
+    // Row 0: real values present, no nulls
+    start_col->push_back<timestamp>(100);
+    end_col->push_back<timestamp>(200);
+    min_price_col->push_back<int64_t>(10);
+    max_price_col->push_back<int64_t>(20);
+    nan_count_col->push_back<uint64_t>(0);
+    null_count_col->push_back<uint64_t>(0);
+
+    // Row 1: all null - min/max absent, counts present
+    start_col->push_back<timestamp>(300);
+    end_col->push_back<timestamp>(400);
+    min_price_col->mark_absent_rows(1);
+    max_price_col->mark_absent_rows(1);
+    nan_count_col->push_back<uint64_t>(0);
+    null_count_col->push_back<uint64_t>(3);
+
+    ssize_t last_row = 1;
+    SegmentInMemory seg;
+    seg.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
+    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_col);
+    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_col);
+    seg.add_column(scalar_field(DataType::INT64, "v1_MIN(price)"), min_price_col);
+    seg.add_column(scalar_field(DataType::INT64, "v1_MAX(price)"), max_price_col);
+    seg.add_column(scalar_field(DataType::UINT64, "v1_NAN_COUNT(price)"), nan_count_col);
+    seg.add_column(scalar_field(DataType::UINT64, "v1_NULL_COUNT(price)"), null_count_col);
+    seg.set_row_data(last_row);
+
+    ColumnStatsHeader header;
+    header.set_version(1);
+    auto& price_entries = (*header.mutable_stats_by_column())[price_data_col_offset];
+    auto* p_min = price_entries.add_entries();
+    p_min->set_stats_seg_offset(2);
+    p_min->set_type(MIN_V1);
+    auto* p_max = price_entries.add_entries();
+    p_max->set_stats_seg_offset(3);
+    p_max->set_type(MAX_V1);
+    auto* p_nan = price_entries.add_entries();
+    p_nan->set_stats_seg_offset(4);
+    p_nan->set_type(NAN_COUNT_V1);
+    auto* p_null = price_entries.add_entries();
+    p_null->set_stats_seg_offset(5);
+    p_null->set_type(NULL_COUNT_V1);
+
+    google::protobuf::Any any;
+    any.PackFrom(header);
+    seg.set_metadata(std::move(any));
+
+    ColumnStatsData data(std::move(seg), build_test_tsd());
+    ASSERT_FALSE(data.empty());
+
+    auto row0 = data.find_row(100, 200);
+    ASSERT_TRUE(row0.has_value());
+    auto v0 = stats_for(data, "price", *row0);
+    ASSERT_TRUE(v0.min.has_value());
+    ASSERT_EQ(v0.min->get<int64_t>(), 10);
+    ASSERT_TRUE(v0.max.has_value());
+    ASSERT_EQ(v0.max->get<int64_t>(), 20);
+    ASSERT_FALSE(v0.column_absent);
+
+    auto row1 = data.find_row(300, 400);
+    ASSERT_TRUE(row1.has_value());
+    auto v1 = stats_for(data, "price", *row1);
+    ASSERT_FALSE(v1.min.has_value());
+    ASSERT_FALSE(v1.max.has_value());
+    ASSERT_FALSE(v1.column_absent); // present-but-all-null, not absent
+    ASSERT_EQ(v1.nan_count, 0u);
+    ASSERT_EQ(v1.null_count, 3u);
+}
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -25,6 +25,13 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
         using type_info = ScalarTypeInfo<decltype(col_tag)>;
         using RawType = typename type_info::RawType;
         if constexpr (!is_sequence_type(type_info::data_type)) {
+            // null_count_ tracks rows that are genuinely absent (sparse-map gaps from Arrow
+            // validity bitmaps). nan_count_ tracks in-band sentinel values found while iterating
+            // the dense values (NaN for floats, NaT for time types) - see the for_each below.
+            if (input_column.column_->is_sparse()) {
+                const auto sparse_gap_count = input_column.column_->last_row() + 1 - input_column.column_->row_count();
+                null_count_ += static_cast<uint64_t>(sparse_gap_count);
+            }
             auto is_nat_or_nan = []([[maybe_unused]] RawType v) {
                 if constexpr (is_floating_point_type(type_info::data_type)) {
                     return std::isnan(v);
@@ -45,20 +52,21 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
             };
             [[maybe_unused]] bool any_nan{false};
             arcticdb::for_each<typename type_info::TDT>(*input_column.column_, [&](auto value) {
-                const auto& curr = static_cast<RawType>(value);
+                // In-band sentinel (NaN for floats, NaT for time types) - count it and skip the
+                // min/max update so those reflect only real values.
                 if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
-                    // Skip NaN/NaT as they don't generate a stable ordering
-                    if (is_nat_or_nan(curr)) {
+                    if (is_nat_or_nan(value)) {
+                        ++nan_count_;
                         any_nan = true;
                         return;
                     }
                 }
                 if (ARCTICDB_UNLIKELY(!min_.has_value())) {
-                    min_ = Value{curr, type_info::data_type};
-                    max_ = Value{curr, type_info::data_type};
+                    min_ = Value{value, type_info::data_type};
+                    max_ = Value{value, type_info::data_type};
                 } else {
-                    min_->set(std::min(min_->get<RawType>(), curr));
-                    max_->set(std::max(max_->get<RawType>(), curr));
+                    min_->set(std::min(min_->get<RawType>(), value));
+                    max_->set(std::max(max_->get<RawType>(), value));
                 }
             });
             if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
@@ -78,8 +86,8 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
 
 SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& output_column_names) const {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            output_column_names.size() == 2,
-            "Expected 2 output column names in MinMaxAggregatorData::finalize, but got {}",
+            output_column_names.size() == 4,
+            "Expected 4 output column names in MinMaxAggregatorData::finalize, but got {}",
             output_column_names.size()
     );
     SegmentInMemory seg;
@@ -93,6 +101,12 @@ SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& ou
             auto max_col = std::make_shared<Column>(make_scalar_type(max_->data_type()), Sparsity::PERMITTED);
             max_col->push_back<RawType>(max_->get<RawType>());
 
+            auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+            nan_count_col->push_back<uint64_t>(nan_count_);
+
+            auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+            null_count_col->push_back<uint64_t>(null_count_);
+
             auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset_];
             auto* min_entry = entry_list.add_entries();
             min_entry->set_stats_seg_offset(0);
@@ -100,10 +114,37 @@ SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& ou
             auto* max_entry = entry_list.add_entries();
             max_entry->set_stats_seg_offset(1);
             max_entry->set_type(arcticc::pb2::column_stats_pb2::MAX_V1);
+            auto* nan_entry = entry_list.add_entries();
+            nan_entry->set_stats_seg_offset(2);
+            nan_entry->set_type(arcticc::pb2::column_stats_pb2::NAN_COUNT_V1);
+            auto* null_entry = entry_list.add_entries();
+            null_entry->set_stats_seg_offset(3);
+            null_entry->set_type(arcticc::pb2::column_stats_pb2::NULL_COUNT_V1);
 
             seg.add_column(scalar_field(min_col->type().data_type(), output_column_names[0].value), min_col);
             seg.add_column(scalar_field(max_col->type().data_type(), output_column_names[1].value), max_col);
+            seg.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
+            seg.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
         });
+    } else if (null_count_ > 0) { // The whole col in the slice is null
+        auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+        nan_count_col->push_back<uint64_t>(nan_count_);
+
+        auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+        null_count_col->push_back<uint64_t>(null_count_);
+
+        auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset_];
+
+        auto* nan_entry = entry_list.add_entries();
+        nan_entry->set_stats_seg_offset(0);
+        nan_entry->set_type(arcticc::pb2::column_stats_pb2::NAN_COUNT_V1);
+
+        auto* null_entry = entry_list.add_entries();
+        null_entry->set_stats_seg_offset(1);
+        null_entry->set_type(arcticc::pb2::column_stats_pb2::NULL_COUNT_V1);
+
+        seg.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
+        seg.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
     }
 
     google::protobuf::Any any;

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -24,6 +24,8 @@ class MinMaxAggregatorData {
   private:
     std::optional<Value> min_;
     std::optional<Value> max_;
+    uint64_t nan_count_{0};
+    uint64_t null_count_{0};
     size_t data_col_offset_;
 };
 
@@ -31,18 +33,24 @@ class MinMaxAggregator {
   public:
     explicit MinMaxAggregator(
             ColumnName column_name, size_t data_col_offset, ColumnName output_column_name_min,
-            ColumnName output_column_name_max
+            ColumnName output_column_name_max, ColumnName output_column_name_nan_count,
+            ColumnName output_column_name_null_count
     ) :
         column_name_(std::move(column_name)),
         data_col_offset_(data_col_offset),
         output_column_name_min_(std::move(output_column_name_min)),
-        output_column_name_max_(std::move(output_column_name_max)) {}
+        output_column_name_max_(std::move(output_column_name_max)),
+        output_column_name_nan_count_(std::move(output_column_name_nan_count)),
+        output_column_name_null_count_(std::move(output_column_name_null_count)) {}
 
     ARCTICDB_MOVE_COPY_DEFAULT(MinMaxAggregator)
 
     [[nodiscard]] ColumnName get_input_column_name() const { return column_name_; }
     [[nodiscard]] std::vector<ColumnName> get_output_column_names() const {
-        return {output_column_name_min_, output_column_name_max_};
+        return {output_column_name_min_,
+                output_column_name_max_,
+                output_column_name_nan_count_,
+                output_column_name_null_count_};
     }
     [[nodiscard]] MinMaxAggregatorData get_aggregator_data() const { return MinMaxAggregatorData(data_col_offset_); }
 
@@ -51,6 +59,8 @@ class MinMaxAggregator {
     size_t data_col_offset_;
     ColumnName output_column_name_min_;
     ColumnName output_column_name_max_;
+    ColumnName output_column_name_nan_count_;
+    ColumnName output_column_name_null_count_;
 };
 
 class AggregatorDataBase {

--- a/cpp/proto/arcticc/pb2/column_stats.proto
+++ b/cpp/proto/arcticc/pb2/column_stats.proto
@@ -23,6 +23,8 @@ enum ColumnStatsType {
     // misinterpret the new statistics format.
     MIN_V1 = 1;
     MAX_V1 = 2;
+    NAN_COUNT_V1 = 3;
+    NULL_COUNT_V1 = 4;
 }
 
 message StatEntry {

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -6,11 +6,14 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
+import math
+
 import numpy as np
 import pandas as pd
 import polars as pl
 import pyarrow as pa
 import pytest
+from hypothesis import given, settings, strategies as st
 from polars.testing import assert_frame_equal as pl_assert_frame_equal
 
 from arcticc.pb2.column_stats_pb2 import ColumnStatsHeader, ColumnStatsType
@@ -20,6 +23,7 @@ from arcticdb_ext.exceptions import SchemaException, StorageException, UserInput
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
+from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked
 
 pytestmark = pytest.mark.pipeline
 
@@ -55,6 +59,12 @@ def assert_stats_equal(received, expected):
     assert isinstance(received, pa.Table)
     assert isinstance(expected, pl.DataFrame)
     received_pl = pl.from_arrow(received)
+    # The C++ aggregator always emits v1_NAN_COUNT and v1_NULL_COUNT columns alongside MIN/MAX.
+    # Tests that aren't exercising the count behaviour omit those columns from `expected`;
+    # subselect `received` down to the expected columns so the comparison stays focused.
+    missing = set(expected.columns) - set(received_pl.columns)
+    assert not missing, f"Expected columns missing from received: {missing}"
+    received_pl = received_pl.select(expected.columns)
     pl_assert_frame_equal(received_pl, expected, check_column_order=False, check_dtypes=False)
 
 
@@ -264,6 +274,186 @@ def test_column_stats_only_nat_values(lmdb_version_store, any_output_format):
     assert raw_stats["v1_MAX(col_1)"].values.view("int64")[0] == nat_sentinel
 
 
+def test_column_stats_nan_and_null_counts(lmdb_version_store, any_output_format):
+    lib = lmdb_version_store
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_nan_and_null_counts"
+
+    # Each write/append produces a separate segment, so we get one row per dataframe in the stats.
+    # Both NaN (float) and NaT (timestamp) are in-band sentinels and count toward v1_NAN_COUNT.
+    df0 = pd.DataFrame(
+        {"float_col": [1.0, 2.0], "ts_col": [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-06-01")]},
+        index=pd.date_range("2000-01-01", periods=2),
+    )
+    df1 = pd.DataFrame(
+        {"float_col": [np.nan, 5.0], "ts_col": [pd.NaT, pd.Timestamp("2021-01-01")]},
+        index=pd.date_range("2000-01-03", periods=2),
+    )
+    df2 = pd.DataFrame(
+        {"float_col": [np.nan, np.nan], "ts_col": [pd.NaT, pd.NaT]},
+        index=pd.date_range("2000-01-05", periods=2),
+    )
+    df3 = pd.DataFrame(
+        {"float_col": [1.0, np.nan, 2.0], "ts_col": [pd.Timestamp("2022-01-01"), pd.NaT, pd.Timestamp("2022-06-01")]},
+        index=pd.date_range("2000-01-07", periods=3),
+    )
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.append(sym, df2)
+    lib.append(sym, df3)
+
+    lib.create_column_stats_experimental(sym)
+
+    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+        pl.Series("v1_MIN(float_col)", [1.0, 5.0, np.nan, 1.0]),
+        pl.Series("v1_MAX(float_col)", [2.0, 5.0, np.nan, 2.0]),
+        pl.Series("v1_NAN_COUNT(float_col)", [0, 1, 2, 1], dtype=pl.UInt64),
+        pl.Series("v1_NULL_COUNT(float_col)", [0, 0, 0, 0], dtype=pl.UInt64),
+        pl.Series(
+            "v1_MIN(ts_col)",
+            [
+                pd.Timestamp("2020-01-01").value,
+                pd.Timestamp("2021-01-01").value,
+                None,
+                pd.Timestamp("2022-01-01").value,
+            ],
+            dtype=pl.Int64,
+        ).cast(pl.Datetime("ns")),
+        pl.Series(
+            "v1_MAX(ts_col)",
+            [
+                pd.Timestamp("2020-06-01").value,
+                pd.Timestamp("2021-01-01").value,
+                None,
+                pd.Timestamp("2022-06-01").value,
+            ],
+            dtype=pl.Int64,
+        ).cast(pl.Datetime("ns")),
+        pl.Series("v1_NAN_COUNT(ts_col)", [0, 1, 2, 1], dtype=pl.UInt64),
+        pl.Series("v1_NULL_COUNT(ts_col)", [0, 0, 0, 0], dtype=pl.UInt64),
+    )
+
+    column_stats = lib.read_column_stats_experimental(sym)
+    assert_stats_equal(column_stats, expected_column_stats)
+
+
+def test_column_stats_nan_count_single_segment(lmdb_version_store, any_output_format):
+    """In-band sentinels (NaN in a float column, NaT in a timestamp column) count towards
+    v1_NAN_COUNT. v1_NULL_COUNT is reserved for genuinely-missing rows (sparse-map gaps)."""
+    lib = lmdb_version_store
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_nan_count_single_segment"
+    df = pd.DataFrame(
+        {
+            "float_col": [1.0, np.nan, 2.0, np.nan, np.nan],
+            "ts_col": [
+                pd.Timestamp("2020-01-01"),
+                pd.NaT,
+                pd.Timestamp("2020-06-01"),
+                pd.NaT,
+                pd.Timestamp("2020-12-01"),
+            ],
+        },
+        index=pd.date_range("2000-01-01", periods=5),
+    )
+    lib.write(sym, df)
+    lib.create_column_stats_experimental(sym)
+
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym))
+    assert cs["v1_NAN_COUNT(float_col)"].to_list() == [3]
+    assert cs["v1_NULL_COUNT(float_col)"].to_list() == [0]
+    assert cs["v1_NAN_COUNT(ts_col)"].to_list() == [2]
+    assert cs["v1_NULL_COUNT(ts_col)"].to_list() == [0]
+
+
+def test_column_stats_null_count_sparse_floats(version_store_factory, lib_name, encoding_version, any_output_format):
+    """sparsify_floats=True stores NaN floats as sparse-map gaps rather than dense NaN values.
+    Those gaps are counted as nulls (v1_NULL_COUNT), not NaNs (v1_NAN_COUNT).
+
+    The 6 rows span multiple segments (segment_row_size=3) with a different null count in each,
+    so the per-segment null calculation is exercised rather than a single-segment case."""
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=3,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_null_count_sparse_floats"
+    # Segment 0 (rows 0-2): [1.0, nan, 2.0] -> 1 null, min 1.0, max 2.0
+    # Segment 1 (rows 3-5): [nan, nan, 4.0] -> 2 nulls, min 4.0, max 4.0
+    df = pd.DataFrame({"col_1": [1.0, np.nan, 2.0, np.nan, np.nan, 4.0]}, index=pd.date_range("2000-01-01", periods=6))
+    lib.write(sym, df, sparsify_floats=True)
+    lib.create_column_stats_experimental(sym)
+
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_index")
+    assert cs["v1_NULL_COUNT(col_1)"].to_list() == [1, 2]
+    assert cs["v1_NAN_COUNT(col_1)"].to_list() == [0, 0]
+    assert cs["v1_MIN(col_1)"].to_list() == [1.0, 4.0]
+    assert cs["v1_MAX(col_1)"].to_list() == [2.0, 4.0]
+
+
+def test_column_stats_arrow_nan_and_null_same_column(lmdb_version_store_arrow):
+    lib = lmdb_version_store_arrow
+    lib._cfg.write_options.segment_row_size = 100
+    sym = "test_column_stats_arrow_nan_and_null_same_column"
+
+    def table(values):
+        return pa.table({"f": pa.array(values, pa.float64())})
+
+    lib.write(sym, table([1.0, np.nan, None, 2.0]))  # nan=1, null=1, min=1, max=2
+    lib.append(sym, table([np.nan, np.nan, None]))  # nan=2, null=1, all stored values are NaN
+    lib.append(sym, table([None, None]))  # all null: nan=0, null=2, no min/max
+    lib.append(sym, table([3.0, None, np.nan, 4.0, None]))  # nan=1, null=2, min=3, max=4
+
+    lib.create_column_stats_experimental(sym)
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_index")
+
+    assert cs["v1_NAN_COUNT(f)"].to_list() == [1, 2, 0, 1]
+    assert cs["v1_NULL_COUNT(f)"].to_list() == [1, 1, 2, 2]
+
+    mins = cs["v1_MIN(f)"].to_list()
+    maxs = cs["v1_MAX(f)"].to_list()
+    assert mins[0] == 1.0 and maxs[0] == 2.0
+    assert math.isnan(mins[1]) and math.isnan(maxs[1])  # all-NaN block keeps NaN min/max
+    assert mins[2] is None and maxs[2] is None  # all-null block has no min/max
+    assert mins[3] == 3.0 and maxs[3] == 4.0
+
+
+def _segment_values():
+    element = st.one_of(
+        st.floats(min_value=-1e9, max_value=1e9, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.none(),
+    )
+    return st.lists(element, min_size=1, max_size=10)
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(segments=st.lists(_segment_values(), min_size=1, max_size=6))
+def test_column_stats_arrow_nan_null_counts_hypothesis(lmdb_version_store_arrow, segments):
+    lib = lmdb_version_store_arrow
+    lib._cfg.write_options.segment_row_size = 100
+    lib.version_store.clear()
+    sym = "test_column_stats_arrow_nan_null_counts_hypothesis"
+
+    lib.write(sym, pa.table({"f": pa.array(segments[0], pa.float64())}))
+    for seg in segments[1:]:
+        lib.append(sym, pa.table({"f": pa.array(seg, pa.float64())}))
+
+    lib.create_column_stats_experimental(sym)
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_index")
+
+    # Each write/append is its own row-slice, so column stats rows line up with segments in index order.
+    expected_nan = [sum(1 for v in seg if v is not None and np.isnan(v)) for seg in segments]
+    expected_null = [sum(1 for v in seg if v is None) for seg in segments]
+
+    assert cs["v1_NAN_COUNT(f)"].to_list() == expected_nan
+    assert cs["v1_NULL_COUNT(f)"].to_list() == expected_null
+
+
 def test_column_stats_as_of(version_store_factory, lib_name, encoding_version, any_output_format):
     lib = version_store_factory(
         column_group_size=2,
@@ -409,6 +599,9 @@ def test_column_stats_dynamic_schema_missing_data(version_store_factory, lib_nam
 
     # Slices that are missing the column come back as null via the validity bitmap. df4["col_2"] is
     # all-NaN but the column is present so the stat is computed and stored as NaN, not null.
+    # The count columns follow the same rule: a fully-missing column has no aggregator run for that
+    # slice, so its NAN_COUNT/NULL_COUNT are null (not 0). Present columns count their NaNs in
+    # NAN_COUNT and leave NULL_COUNT at 0 (NaN floats are stored densely here, not as sparse gaps).
     expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
         pl.Series(
             "v1_MIN(col_1)",
@@ -418,6 +611,8 @@ def test_column_stats_dynamic_schema_missing_data(version_store_factory, lib_nam
             "v1_MAX(col_1)",
             [df0["col_1"].max(), None, df2["col_1"].max(), None, df4["col_1"].max(), None],
         ),
+        pl.Series("v1_NAN_COUNT(col_1)", [0, None, 0, None, 1, None], dtype=pl.UInt64),
+        pl.Series("v1_NULL_COUNT(col_1)", [0, None, 0, None, 0, None], dtype=pl.UInt64),
         pl.Series(
             "v1_MIN(col_2)",
             [df0["col_2"].min(), df1["col_2"].min(), None, None, df4["col_2"].min(), None],
@@ -426,8 +621,12 @@ def test_column_stats_dynamic_schema_missing_data(version_store_factory, lib_nam
             "v1_MAX(col_2)",
             [df0["col_2"].max(), df1["col_2"].max(), None, None, df4["col_2"].max(), None],
         ),
+        pl.Series("v1_NAN_COUNT(col_2)", [0, 0, None, None, 2, None], dtype=pl.UInt64),
+        pl.Series("v1_NULL_COUNT(col_2)", [0, 0, None, None, 0, None], dtype=pl.UInt64),
         pl.Series("v1_MIN(col_5)", [None, None, None, None, None, df5["col_5"].min()], dtype=pl.Int64),
         pl.Series("v1_MAX(col_5)", [None, None, None, None, None, df5["col_5"].max()], dtype=pl.Int64),
+        pl.Series("v1_NAN_COUNT(col_5)", [None, None, None, None, None, 0], dtype=pl.UInt64),
+        pl.Series("v1_NULL_COUNT(col_5)", [None, None, None, None, None, 0], dtype=pl.UInt64),
     )
     lib.create_column_stats_experimental(sym)
     assert lib.get_column_stats_info_experimental(sym) == {
@@ -739,35 +938,39 @@ def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_
     sym = "test_column_stats_header_metadata"
     generate_symbol(lib, sym)
 
-    # Auto-discovery creates stats for all eligible columns (col_1 at offset 2, col_2 at offset 3)
+    # Auto-discovery creates stats for all eligible columns (col_1 at offset 2, col_2 at offset 3).
+    # MINMAX emits 4 stat entries per column: MIN, MAX, NAN_COUNT, NULL_COUNT.
+    minmax_types = {
+        ColumnStatsType.MIN_V1,
+        ColumnStatsType.MAX_V1,
+        ColumnStatsType.NAN_COUNT_V1,
+        ColumnStatsType.NULL_COUNT_V1,
+    }
     lib.create_column_stats_experimental(sym)
     header = read_column_stats_header(lib, sym)
 
     assert header.version == 1
     # if you change the structure, consider whether you need to change header.version too
     assert len(header.ListFields()) == 2
-    assert header_stat_count(header) == 4
-    assert header_stat_pairs(header) == {
-        (2, ColumnStatsType.MIN_V1),
-        (2, ColumnStatsType.MAX_V1),
-        (3, ColumnStatsType.MIN_V1),
-        (3, ColumnStatsType.MAX_V1),
-    }
+    assert header_stat_count(header) == 8
+    assert header_stat_pairs(header) == {(2, t) for t in minmax_types} | {(3, t) for t in minmax_types}
     offsets = [entry.stats_seg_offset for _, entry in header_all_entries(header)]
-    assert len(set(offsets)) == 4
+    assert len(set(offsets)) == 8
 
     # Verify descriptor field names match the offsets
+    field_name_by_type = {
+        ColumnStatsType.MIN_V1: "v1_MIN",
+        ColumnStatsType.MAX_V1: "v1_MAX",
+        ColumnStatsType.NAN_COUNT_V1: "v1_NAN_COUNT",
+        ColumnStatsType.NULL_COUNT_V1: "v1_NULL_COUNT",
+    }
+    col_name_by_offset = {2: "col_1", 3: "col_2"}
     lib_tool = lib.library_tool()
     keys = lib_tool.find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
     fields = lib_tool.read_descriptor(keys[0]).fields()
-    expected_field_names = {
-        (2, ColumnStatsType.MIN_V1): "v1_MIN(col_1)",
-        (2, ColumnStatsType.MAX_V1): "v1_MAX(col_1)",
-        (3, ColumnStatsType.MIN_V1): "v1_MIN(col_2)",
-        (3, ColumnStatsType.MAX_V1): "v1_MAX(col_2)",
-    }
     for data_col_offset, entry in header_all_entries(header):
-        assert fields[entry.stats_seg_offset].name == expected_field_names[(data_col_offset, entry.type)]
+        expected = f"{field_name_by_type[entry.type]}({col_name_by_offset[data_col_offset]})"
+        assert fields[entry.stats_seg_offset].name == expected
 
 
 def test_column_stats_duplicated_column_names(version_store_factory, lib_name, encoding_version, any_output_format):

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -595,6 +595,44 @@ def test_column_stats_comparison_operators(
     assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA reads but got {table_data_reads}"
 
 
+@pytest.mark.parametrize(
+    "query_expr, pandas_expr, expected_reads",
+    [
+        # `!=` / `isnotin`: a null is never equal to / in the set, so every null row matches and the
+        # wholly-null slice must be kept (all 3 slices read).
+        (lambda q: q["col_1"] != 99.0, lambda df: df["col_1"] != 99.0, 3),
+        (lambda q: q["col_1"].isnotin([99.0]), lambda df: ~df["col_1"].isin([99.0]), 3),
+        # `==` / `isin`: no null row matches, so the wholly-null slice is pruned (its read is skipped).
+        (lambda q: q["col_1"] == 1.0, lambda df: df["col_1"] == 1.0, 1),
+        (lambda q: q["col_1"].isin([1.0, 5.0]), lambda df: df["col_1"].isin([1.0, 5.0]), 2),
+    ],
+    ids=["ne", "isnotin", "eq", "isin"],
+)
+def test_column_stats_all_null_slice_pruning(
+    in_memory_store_factory, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr, expected_reads
+):
+    """A wholly-null row-slice has no MIN/MAX, only NAN_COUNT/NULL_COUNT. It must be kept for
+    `!=`/`isnotin` (every null row matches) and pruned for `==`/`isin` (no null row matches).
+    Regression test for the slice being marked column_absent and always pruned to NONE_MATCH."""
+    # segment_row_size=2 splits into 3 row-slices: [1,2], [NaN,NaN], [5,6]. sparsify_floats stores the
+    # NaNs as sparse-map gaps, so the middle slice is wholly null with no MIN/MAX (only NAN/NULL counts).
+    lib = in_memory_store_factory(column_group_size=2, segment_row_size=2)
+    df = pd.DataFrame({"col_1": [1.0, 2.0, np.nan, np.nan, 5.0, 6.0]}, index=pd.date_range("2000-01-01", periods=6))
+    lib.write(sym, df, sparsify_floats=True)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    qs.reset_stats()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    expected = df[pandas_expr(df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA reads but got {table_data_reads}"
+
+
 @pytest.mark.xfail(reason="Creating column stats on multi-indexed symbols is not supported yet")
 def test_column_stats_multiindex_index_col(in_memory_version_store):
     """Test column stats creation and usage with a multi-index DataFrame, with column stats created
@@ -1854,7 +1892,6 @@ def test_column_stats_dynamic_schema_cross_column_backfilled_values_int(
     assert table_data_reads == 1
 
 
-@pytest.mark.xfail(reason="Need a NaN count or flag, Monday=11866077783")
 def test_column_stats_dynamic_schema_cross_column_backfilled_values_float(
     in_memory_version_store_dynamic_schema,
     clear_query_stats,
@@ -2099,3 +2136,154 @@ def test_column_stats_bool_vs_int_cross_type(
     q = q[q["bool_col"] > 0]
     with pytest.raises(UserInputException):
         lib.read(sym, query_builder=q)
+
+
+# Tests for the NaN/null-aware downgrade in the read pipeline.
+# When a segment's [min, max] suggest a verdict that NaN/null rows would change at the row
+# level (e.g. min == max == v says "all == v" but in-band NaN rows fail `==`), the verdict
+# must be downgraded to UNKNOWN so the segment is still read.
+
+
+# The four equivalent ways to express "a != 3.0" through the QueryBuilder. Each must
+# downgrade the prune verdict in the presence of in-band nulls, so the no-prune tests
+# below share this parameterization.
+NE_FLOAT_EXPRS = [
+    pytest.param(lambda q: q["a"] != 3.0, lambda df: df["a"] != 3.0, id="ne"),
+    pytest.param(lambda q: ~(q["a"] == 3.0), lambda df: ~(df["a"] == 3.0), id="not_eq"),
+    pytest.param(lambda q: q["a"].isnotin([3.0]), lambda df: ~df["a"].isin([3.0]), id="isnotin"),
+    pytest.param(lambda q: ~q["a"].isin([3.0]), lambda df: ~df["a"].isin([3.0]), id="negated_isin"),
+]
+
+
+@pytest.mark.parametrize("query_expr,pandas_expr", NE_FLOAT_EXPRS)
+def test_column_stats_no_prune_when_in_band_nan(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
+):
+    """[3.0, NaN, NaN, 3.0] in one segment: min=max=3, nan_count=2.
+    Filters that would normally prune the segment must include the NaN rows."""
+    lib = in_memory_version_store
+
+    df = pd.DataFrame({"a": [3.0, np.nan, np.nan, 3.0]}, index=pd.date_range("2000-01-01", periods=4))
+    lib.write(sym, df)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    expected = df[pandas_expr(df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == 1, "Segment must be read because in-band NaN rows match the filter"
+
+
+# Time-type analogues of NE_FLOAT_EXPRS, expressing "a != pd.Timestamp("2025-01-01")".
+NE_TS_EXPRS = [
+    pytest.param(
+        lambda q: q["a"] != pd.Timestamp("2025-01-01"), lambda df: df["a"] != pd.Timestamp("2025-01-01"), id="ne"
+    ),
+    pytest.param(
+        lambda q: ~(q["a"] == pd.Timestamp("2025-01-01")),
+        lambda df: ~(df["a"] == pd.Timestamp("2025-01-01")),
+        id="not_eq",
+    ),
+    pytest.param(
+        lambda q: q["a"].isnotin([pd.Timestamp("2025-01-01")]),
+        lambda df: ~df["a"].isin([pd.Timestamp("2025-01-01")]),
+        id="isnotin",
+    ),
+    pytest.param(
+        lambda q: ~q["a"].isin([pd.Timestamp("2025-01-01")]),
+        lambda df: ~df["a"].isin([pd.Timestamp("2025-01-01")]),
+        id="negated_isin",
+    ),
+]
+
+
+@pytest.mark.parametrize("query_expr,pandas_expr", NE_TS_EXPRS)
+def test_column_stats_no_prune_ne_when_nat(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
+):
+    """Time-type analogue of the in-band NaN case: min=max=ts, nan_count=2."""
+    lib = in_memory_version_store
+
+    df = pd.DataFrame(
+        {"a": [pd.Timestamp("2025-01-01"), pd.NaT, pd.NaT, pd.Timestamp("2025-01-01")]},
+        index=pd.date_range("2000-01-01", periods=4),
+    )
+    lib.write(sym, df)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    expected = df[pandas_expr(df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == 1
+
+
+@pytest.mark.parametrize("query_expr,pandas_expr", NE_FLOAT_EXPRS)
+def test_column_stats_no_prune_ne_when_sparse_null(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
+):
+    """sparsify_floats stores NaN floats as sparse-map gaps -> null_count > 0, nan_count = 0.
+    The downgrade must still fire."""
+    lib = in_memory_version_store
+
+    df = pd.DataFrame({"a": [3.0, np.nan, np.nan, 3.0]}, index=pd.date_range("2000-01-01", periods=4))
+    lib.write(sym, df, sparsify_floats=True)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    expected = df[pandas_expr(df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == 1
+
+
+# Comparison operators (everything besides (in)equality). NaN/NaT rows never satisfy a
+# magnitude comparison, so a NONE_MATCH verdict must NOT be downgraded for these.
+@pytest.mark.parametrize(
+    "query_expr,pandas_expr",
+    [
+        pytest.param(lambda q: q["a"] < 1.0, lambda df: df["a"] < 1.0, id="lt"),
+        pytest.param(lambda q: q["a"] <= 1.0, lambda df: df["a"] <= 1.0, id="le"),
+        pytest.param(lambda q: q["a"] > 100.0, lambda df: df["a"] > 100.0, id="gt"),
+        pytest.param(lambda q: q["a"] >= 100.0, lambda df: df["a"] >= 100.0, id="ge"),
+    ],
+)
+def test_column_stats_still_prunes_when_nan_does_not_save_row(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
+):
+    """Negative control: NaN rows do NOT satisfy a magnitude comparison, so NONE_MATCH must
+    stay NONE_MATCH and the segments must still be pruned even though nan_count > 0."""
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"a": [3.0, np.nan, np.nan, 3.0]}, index=pd.date_range("2000-01-01", periods=4))
+    df1 = pd.DataFrame({"a": [10.0, 20.0]}, index=pd.date_range("2000-01-05", periods=2))
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    full_df = pd.concat([df0, df1])
+    expected = full_df[pandas_expr(full_df)]
+    assert_frame_equal(expected, result)
+    assert table_data_reads == 0, "Both segments must still be pruned; NaN never satisfies a magnitude comparison"


### PR DESCRIPTION
## Add NaN and null counts to MINMAX column stats
  
 > [!IMPORTANT]
  > **The regression in the benchmark commit is EXPECTED and was reviewed by me and Ivo Dilov.**
  > It happened because the size of the `COLUMN_STATS_KEY` became **~2× bigger** due to the two
  > new columns added for **`null_count`** and **`nan_count`**.

  ### Summary
  Extends the `MINMAX` column statistic to also record per-segment counts of `NaN` (floating point) and null values (NaT timestamps, plus  sparse-map gaps such as those from Arrow validity bitmaps), alongside the existing min/max values.

  ### Changes
  - **Proto**: Added `NAN_COUNT_V1 = 3` and `NULL_COUNT_V1 = 4` entries to the `ColumnStatsType` enum in `column_stats.proto`.
  - **Aggregation** (`unsorted_aggregation.{hpp,cpp}`): `MinMaxAggregatorData` now tracks `nan_count_` (floating-point NaNs) and `null_count_` (NaT cells plus sparse-map gaps). For sparse columns, the gap count `last_row()+1 - row_count()` is added to `null_count_` so validity-bitmap nulls that the dense iterator never visits are still counted. `MinMaxAggregator` takes two additional output column names and `finalize` produces 4 output columns (`MIN`, `MAX`, `NAN_COUNT`, `NULL_COUNT`) instead of 2.
  - **Pipeline** (`column_stats.cpp`): `MINMAX` external stat now maps to the four internal stat types; `v1_NAN_COUNT` / `v1_NULL_COUNT` operator strings and segment column naming wired through.
  - **Tests**: Added `test_column_stats_nan_and_null_counts` covering multi-segment symbols with mixed NaN, NaT, and valid values across floating-point and timestamp columns. Widened the shared `assert_stats_equal` helper to subselect the received frame to the columns the test cares about (so existing min/max-only tests don't have to spell out all-zero count columns), and updated `test_column_stats_header_metadata` for the 4-entries-per-column header layout.
