### PR TITLE
Skip azure test that does parallel reads with forking

### DIFF
--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -60,12 +60,23 @@ def _read_and_assert_symbol(args):
             time.sleep(0.5)  # Make sure the writes have finished, especially azurite.
 
 
-def test_parallel_reads(local_object_version_store):
+@pytest.mark.parametrize(
+    "store_factory",
+    [
+        "s3_store_factory",
+        pytest.param(
+            "azure_store_factory",
+            marks=pytest.mark.skip(reason="Azure SDK's CurlConnectionPool is global and is not fork-safe. Monday ref 12128961896"),
+        ),
+    ],
+)
+def test_parallel_reads(store_factory, request):
+    lib = request.getfixturevalue(store_factory)()
     symbols = ["XXX"] * 20
-    p = Pool(10)
-    local_object_version_store.write(symbols[0], df("test1"))
+    lib.write(symbols[0], df("test1"))
     time.sleep(0.1)  # Make sure the writes have finished, especially azurite.
-    p.map(_read_and_assert_symbol, [(local_object_version_store, s, idx) for idx, s in enumerate(symbols)])
+    p = Pool(10)
+    p.map(_read_and_assert_symbol, [(lib, s, idx) for idx, s in enumerate(symbols)])
     p.close()
     p.join()
 
@@ -77,7 +88,7 @@ def test_parallel_reads_arctic(storage_name, request, lib_name):
     ac = Arctic(storage.arctic_uri)
     try:
         lib = ac.create_library(lib_name)
-        symbols = [f"{i}" for i in range(1)]
+        symbols = [f"{i}" for i in range(10)]
         for s in symbols:
             lib.write(s, df("test1"))
         p = Pool(10)

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -66,7 +66,9 @@ def _read_and_assert_symbol(args):
         "s3_store_factory",
         pytest.param(
             "azure_store_factory",
-            marks=pytest.mark.skip(reason="Azure SDK's CurlConnectionPool is global and is not fork-safe. Monday ref 12128961896"),
+            marks=pytest.mark.skip(
+                reason="Azure SDK's CurlConnectionPool is global and is not fork-safe. Monday ref 12128961896"
+            ),
         ),
     ],
 )


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Currently forking with azure storage doesn't work.

* This closes 11975991632 by just skipping the test.
* Opened 12128961896 for the future work with the actual fix.
* (unrelated) Fixes a nearby test to actually test parallel reads

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
