### PR TITLE
Quality 11961775873: Remove processing pipeline scheduling kill switches

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -59,8 +59,7 @@ class AsyncStore : public Store {
     ) :
         library_(std::move(library)),
         codec_(std::make_shared<proto::encoding::VariantCodec>(codec)),
-        encoding_version_(encoding_version),
-        window_processing_pipeline_reads_(ConfigsMap::instance()->get_int("Storage.WindowProcessingReads", 1) == 1) {}
+        encoding_version_(encoding_version) {}
 
     folly::Future<entity::VariantKey> write(
             stream::KeyType key_type, VersionId version_id, const StreamId& stream_id, IndexValue start_index,
@@ -428,38 +427,22 @@ class AsyncStore : public Store {
             std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
     ) override {
         ARCTICDB_RUNTIME_DEBUG(log::version(), "Reading {} keys", ranges_and_keys.size());
-        // Window the reads by default (but with a kill switch) for reasons detailed in the PR description:
-        // https://github.com/man-group/ArcticDB/pull/3086
+        // Window the reads for reasons detailed in the PR description https://github.com/man-group/ArcticDB/pull/3086
         // x2 IO threadpool size is a balance to keep the IO workers busy, without reading data in faster than we can
         // process it
-        // TODO 11961775873: remove this kill switch
-        if (window_processing_pipeline_reads_) {
-            return folly::window(
-                    std::move(ranges_and_keys),
-                    [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
-                        const auto key = ranges_and_key.key_;
-                        return read_and_continue(
-                                key,
-                                library_,
-                                storage::ReadKeyOpts{},
-                                DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
-                        );
-                    },
-                    2 * async::TaskScheduler::instance()->io_thread_count()
-            );
-        } else {
-            std::vector<folly::Future<pipelines::SegmentAndSlice>> output;
-            for (auto&& ranges_and_key : ranges_and_keys) {
-                const auto key = ranges_and_key.key_;
-                output.emplace_back(read_and_continue(
-                        key,
-                        library_,
-                        storage::ReadKeyOpts{},
-                        DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
-                ));
-            }
-            return output;
-        }
+        return folly::window(
+                std::move(ranges_and_keys),
+                [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
+                    const auto key = ranges_and_key.key_;
+                    return read_and_continue(
+                            key,
+                            library_,
+                            storage::ReadKeyOpts{},
+                            DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+                    );
+                },
+                2 * async::TaskScheduler::instance()->io_thread_count()
+        );
     }
 
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {
@@ -533,7 +516,6 @@ class AsyncStore : public Store {
     std::shared_ptr<storage::Library> library_;
     std::shared_ptr<arcticdb::proto::encoding::VariantCodec> codec_;
     const EncodingVersion encoding_version_;
-    const bool window_processing_pipeline_reads_;
 };
 
 } // namespace arcticdb::async

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -766,10 +766,6 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
         std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>&& id_to_pos,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses
 ) {
-    // TODO 11961775873: remove this kill switch
-    static const bool process_on_cpu_executor = ConfigsMap::instance()->get_int("Storage.ProcessOnCpuExecutor", 1) == 1;
-    auto* processing_executor = process_on_cpu_executor ? dynamic_cast<folly::Executor*>(&async::cpu_executor())
-                                                        : dynamic_cast<folly::Executor*>(&async::io_executor());
     // Used to make sure each entity is only added into the component manager once
     auto slice_added_mtx = std::make_shared<std::vector<std::mutex>>(num_segments);
     auto slice_added = std::make_shared<std::vector<bool>>(num_segments, false);
@@ -793,10 +789,10 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
             );
         }
 
-        // Switch to the CPU executor by default (but with a kill switch) for reasons detailed in the PR description:
+        // Switch to the CPU executor for reasons detailed in the PR description
         // https://github.com/man-group/ArcticDB/pull/3086
         futures->emplace_back(folly::collect(local_futs)
-                                      .via(processing_executor)
+                                      .via(&async::cpu_executor())
                                       .thenValueInline([component_manager,
                                                         segment_fetch_counts,
                                                         id_to_pos,


### PR DESCRIPTION
#### Reference Issues/PRs
[11961775873](https://man312219.monday.com/boards/7852509418/pulses/11961775873)

#### What does this implement or fix?
https://github.com/man-group/ArcticDB/pull/3086 made 2 changes to how work scheduling happens in the processing pipeline:

1. Window segment reads from disk
2. Switch to the CPU executor for processing

In case either of these proved problematic for users, they each came with an environment variable to allow reverting to the old behaviour. This change has been released internally to Man for 3 weeks and externally for 2 weeks without complaint, so this PR just removes the kill switches.