### PR TITLE
Route AWS SDK S3 logs to stderr by default

### DIFF
--- a/cpp/CMake/CpuCount.cmake
+++ b/cpp/CMake/CpuCount.cmake
@@ -7,8 +7,8 @@ if(NOT DEFINED ENV{CMAKE_BUILD_PARALLEL_LEVEL} OR "$ENV{CMAKE_BUILD_PARALLEL_LEV
         set(ENV{CMAKE_BUILD_PARALLEL_LEVEL} 2)
     else()
         cmake_host_system_information(RESULT _physical_mb QUERY TOTAL_PHYSICAL_MEMORY)
-        # C++ compiler processes can use up to 3GB each; cap parallelism to avoid OOM
-        math(EXPR _mem_jobs "${_physical_mb} / 3000")
+        # C++ compiler processes can use up to 5GB each; cap parallelism to avoid OOM
+        math(EXPR _mem_jobs "${_physical_mb} / 5000")
         if(${_mem_jobs} LESS 1)
             set(_mem_jobs 1)
         endif()

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -49,6 +49,7 @@ struct Loggers::Impl {
     std::unique_ptr<spdlog::logger> message_;
     std::unique_ptr<spdlog::logger> symbol_;
     std::unique_ptr<spdlog::logger> snapshot_;
+    std::unique_ptr<spdlog::logger> s3_;
     std::shared_ptr<spdlog::details::thread_pool> thread_pool_;
     std::optional<spdlog::details::periodic_worker> periodic_worker_;
 
@@ -85,6 +86,8 @@ spdlog::logger& message() { return Loggers::instance().message(); }
 spdlog::logger& symbol() { return Loggers::instance().symbol(); }
 
 spdlog::logger& snapshot() { return Loggers::instance().snapshot(); }
+
+spdlog::logger& s3() { return Loggers::instance().s3(); }
 
 namespace fs = std::filesystem;
 
@@ -124,6 +127,8 @@ spdlog::logger& Loggers::symbol() { return impl_->logger_ref(impl_->symbol_); }
 
 spdlog::logger& Loggers::snapshot() { return impl_->logger_ref(impl_->snapshot_); }
 
+spdlog::logger& Loggers::s3() { return impl_->logger_ref(impl_->s3_); }
+
 spdlog::logger& Loggers::root() { return impl_->logger_ref(impl_->root_); }
 
 void Loggers::flush_all() {
@@ -139,6 +144,7 @@ void Loggers::flush_all() {
     message().flush();
     symbol().flush();
     snapshot().flush();
+    s3().flush();
 }
 
 void Loggers::destroy_instance() { loggers_instance_.reset(); }
@@ -255,6 +261,7 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig& conf, bool
     check_and_configure("message", "root", impl_->message_);
     check_and_configure("symbol", "root", impl_->symbol_);
     check_and_configure("snapshot", "root", impl_->snapshot_);
+    check_and_configure("s3", "root", impl_->s3_);
 
     if (auto flush_sec = util::as_opt(conf.flush_interval_seconds()).value_or(1); flush_sec != 0) {
         impl_->periodic_worker_.emplace(

--- a/cpp/arcticdb/log/log.hpp
+++ b/cpp/arcticdb/log/log.hpp
@@ -59,6 +59,7 @@ class Loggers {
     spdlog::logger& message();
     spdlog::logger& symbol();
     spdlog::logger& snapshot();
+    spdlog::logger& s3();
 
     void flush_all();
 
@@ -80,5 +81,6 @@ spdlog::logger& schedule();
 spdlog::logger& message();
 spdlog::logger& symbol();
 spdlog::logger& snapshot();
+spdlog::logger& s3();
 
 } // namespace arcticdb::log

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -37,7 +37,7 @@
 
 namespace py = pybind11;
 
-enum class LoggerId { ROOT, STORAGE, IN_MEM, CODEC, VERSION, MEMORY, TIMINGS, LOCK, SCHEDULE, SYMBOL, SNAPSHOT };
+enum class LoggerId { ROOT, STORAGE, IN_MEM, CODEC, VERSION, MEMORY, TIMINGS, LOCK, SCHEDULE, SYMBOL, SNAPSHOT, S3 };
 
 void register_log(py::module&& log) {
     log.def(
@@ -69,6 +69,7 @@ void register_log(py::module&& log) {
             .value("SCHEDULE", LoggerId::SCHEDULE)
             .value("SYMBOL", LoggerId::SYMBOL)
             .value("SNAPSHOT", LoggerId::SNAPSHOT)
+            .value("S3", LoggerId::S3)
             .export_values();
     auto choose_logger = [&](LoggerId log_id) -> decltype(arcticdb::log::storage()) /* logger ref */ {
         switch (log_id) {
@@ -94,6 +95,8 @@ void register_log(py::module&& log) {
             return arcticdb::log::symbol();
         case LoggerId::SNAPSHOT:
             return arcticdb::log::snapshot();
+        case LoggerId::S3:
+            return arcticdb::log::s3();
         default:
             arcticdb::util::raise_rte("Unsupported logger id");
         }

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -13,18 +13,29 @@
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/ec2_utils.hpp>
 #include <cstdlib>
+#include <iostream>
 
 namespace arcticdb::storage::s3 {
 
-S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level) : log_level_(log_level), options_() {
+void StdErrLogSystem::ProcessFormattedStatement(Aws::String&& statement) { std::cerr << statement; }
+
+void StdErrLogSystem::Flush() { std::cerr.flush(); }
+
+S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level, bool log_to_file) :
+    log_level_(log_level),
+    options_() {
     // Use correct URI encoding rather than legacy compat one in AWS SDK. PURE S3 needs this to handle symbol names
     // that have special characters (eg ':').
     options_.httpOptions.compliantRfc3986Encoding = true;
 
     if (log_level_ > Aws::Utils::Logging::LogLevel::Off) {
-        Aws::Utils::Logging::InitializeAWSLogging(
-                Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>("v", log_level, "aws_sdk_")
-        );
+        if (log_to_file) {
+            Aws::Utils::Logging::InitializeAWSLogging(
+                    Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>("v", log_level, "aws_sdk_")
+            );
+        } else {
+            Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<StdErrLogSystem>("v", log_level));
+        }
     }
     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Begin initializing AWS API");
     Aws::InitAPI(options_);
@@ -49,7 +60,8 @@ S3ApiInstance::~S3ApiInstance() {
 
 void S3ApiInstance::init() {
     auto log_level = ConfigsMap::instance()->get_int("AWS.LogLevel", 0);
-    S3ApiInstance::instance_ = std::make_shared<S3ApiInstance>(Aws::Utils::Logging::LogLevel(log_level));
+    auto log_to_file = ConfigsMap::instance()->get_int("AWS.LogToFile", 0) != 0;
+    S3ApiInstance::instance_ = std::make_shared<S3ApiInstance>(Aws::Utils::Logging::LogLevel(log_level), log_to_file);
 }
 
 std::shared_ptr<S3ApiInstance> S3ApiInstance::instance() {

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -12,14 +12,61 @@
 #include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/ec2_utils.hpp>
-#include <cstdlib>
-#include <iostream>
+#include <cstdarg>
+#include <vector>
 
 namespace arcticdb::storage::s3 {
 
-void StdErrLogSystem::ProcessFormattedStatement(Aws::String&& statement) { std::cerr << statement; }
+namespace {
+spdlog::level::level_enum to_spdlog_level(Aws::Utils::Logging::LogLevel log_level) {
+    switch (log_level) {
+    case Aws::Utils::Logging::LogLevel::Fatal:
+        return spdlog::level::critical;
+    case Aws::Utils::Logging::LogLevel::Error:
+        return spdlog::level::err;
+    case Aws::Utils::Logging::LogLevel::Warn:
+        return spdlog::level::warn;
+    case Aws::Utils::Logging::LogLevel::Info:
+        return spdlog::level::info;
+    case Aws::Utils::Logging::LogLevel::Debug:
+        return spdlog::level::debug;
+    case Aws::Utils::Logging::LogLevel::Trace:
+        return spdlog::level::trace;
+    default:
+        return spdlog::level::off;
+    }
+}
+} // namespace
 
-void StdErrLogSystem::Flush() { std::cerr.flush(); }
+void SpdlogLogSystem::Log(Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format_str, ...) {
+    va_list args;
+    va_start(args, format_str);
+    vaLog(log_level, tag, format_str, args);
+    va_end(args);
+}
+
+void SpdlogLogSystem::vaLog(
+        Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format_str, va_list args
+) {
+    va_list args_copy;
+    va_copy(args_copy, args);
+    const int length = std::vsnprintf(nullptr, 0, format_str, args_copy);
+    va_end(args_copy);
+    if (length < 0) {
+        return;
+    }
+    std::vector<char> buffer(static_cast<size_t>(length) + 1);
+    std::vsnprintf(buffer.data(), buffer.size(), format_str, args);
+    log::s3().log(to_spdlog_level(log_level), "[{}] {}", tag, buffer.data());
+}
+
+void SpdlogLogSystem::LogStream(
+        Aws::Utils::Logging::LogLevel log_level, const char* tag, const Aws::OStringStream& message_stream
+) {
+    log::s3().log(to_spdlog_level(log_level), "[{}] {}", tag, message_stream.str());
+}
+
+void SpdlogLogSystem::Flush() { log::s3().flush(); }
 
 S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level, bool log_to_file) :
     log_level_(log_level),
@@ -34,7 +81,7 @@ S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level, bool log_t
                     Aws::MakeShared<Aws::Utils::Logging::DefaultLogSystem>("v", log_level, "aws_sdk_")
             );
         } else {
-            Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<StdErrLogSystem>("v", log_level));
+            Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<SpdlogLogSystem>("v", log_level));
         }
     }
     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Begin initializing AWS API");

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -9,14 +9,26 @@
 #pragma once
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/logging/FormattedLogSystem.h>
 #include <memory>
 #include <mutex>
 
 namespace arcticdb::storage::s3 {
 
+class StdErrLogSystem : public Aws::Utils::Logging::FormattedLogSystem {
+  public:
+    explicit StdErrLogSystem(Aws::Utils::Logging::LogLevel log_level) : FormattedLogSystem(log_level) {}
+    void Flush() override;
+
+  protected:
+    void ProcessFormattedStatement(Aws::String&& statement) override;
+};
+
 class S3ApiInstance {
   public:
-    S3ApiInstance(Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Off);
+    S3ApiInstance(
+            Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Off, bool log_to_file = false
+    );
     ~S3ApiInstance();
 
     static std::shared_ptr<S3ApiInstance> instance_;

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -9,19 +9,30 @@
 #pragma once
 
 #include <aws/core/Aws.h>
-#include <aws/core/utils/logging/FormattedLogSystem.h>
+#include <aws/core/utils/logging/LogSystemInterface.h>
+#include <atomic>
 #include <memory>
 #include <mutex>
 
 namespace arcticdb::storage::s3 {
 
-class StdErrLogSystem : public Aws::Utils::Logging::FormattedLogSystem {
+// Routes AWS SDK log messages into ArcticDB's `s3` spdlog logger so they are ordered with, and formatted like, the
+// rest of ArcticDB's logging. Implementing LogSystemInterface directly (rather than deriving from FormattedLogSystem)
+// keeps each message's AWS severity on every path, including the printf-style Log/vaLog path where vaLog receives the
+// level. The severity is mapped to the equivalent spdlog level.
+class SpdlogLogSystem : public Aws::Utils::Logging::LogSystemInterface {
   public:
-    explicit StdErrLogSystem(Aws::Utils::Logging::LogLevel log_level) : FormattedLogSystem(log_level) {}
+    explicit SpdlogLogSystem(Aws::Utils::Logging::LogLevel log_level) : log_level_(log_level) {}
+
+    Aws::Utils::Logging::LogLevel GetLogLevel() const override { return log_level_.load(); }
+    void Log(Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format_str, ...) override;
+    void vaLog(Aws::Utils::Logging::LogLevel log_level, const char* tag, const char* format_str, va_list args) override;
+    void LogStream(Aws::Utils::Logging::LogLevel log_level, const char* tag, const Aws::OStringStream& message_stream)
+            override;
     void Flush() override;
 
-  protected:
-    void ProcessFormattedStatement(Aws::String&& statement) override;
+  private:
+    std::atomic<Aws::Utils::Logging::LogLevel> log_level_;
 };
 
 class S3ApiInstance {

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -17,8 +17,12 @@
 #include <arcticdb/storage/test/common.hpp>
 #include <arcticdb/util/test/gtest_utils.hpp>
 
+#include <arcticdb/log/log.hpp>
+
 #include <aws/core/Aws.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
+
+#include <spdlog/sinks/ostream_sink.h>
 
 #include <sstream>
 
@@ -454,19 +458,44 @@ TEST_F(S3StorageFixture, test_list_directory_bucket_failure) {
     ASSERT_FALSE(store.directory_bucket());
 }
 
-TEST(S3LogSystem, StdErrLogSystemWritesToStdErr) {
+TEST(S3LogSystem, RoutesToSpdlogWithLevelAndTag) {
     using namespace arcticdb::storage::s3;
-    StdErrLogSystem log_system(Aws::Utils::Logging::LogLevel::Info);
+    using Aws::Utils::Logging::LogLevel;
+
+    auto& logger = arcticdb::log::s3();
+    const auto saved_level = logger.level();
 
     std::ostringstream captured;
-    auto* old_buf = std::cerr.rdbuf(captured.rdbuf());
+    auto sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(captured);
+    sink->set_pattern("%l|%v");
+    logger.sinks().push_back(sink);
+    logger.set_level(spdlog::level::trace);
 
-    Aws::OStringStream message;
-    message << "hello-from-aws-sdk";
-    log_system.LogStream(Aws::Utils::Logging::LogLevel::Info, "TestTag", message);
+    SpdlogLogSystem log_system(LogLevel::Trace);
+    for (auto [aws_level, tag] :
+         {std::pair{LogLevel::Fatal, "FatalTag"},
+          {LogLevel::Error, "ErrorTag"},
+          {LogLevel::Warn, "WarnTag"},
+          {LogLevel::Info, "InfoTag"},
+          {LogLevel::Debug, "DebugTag"},
+          {LogLevel::Trace, "TraceTag"}}) {
+        Aws::OStringStream message;
+        message << "msg-" << tag;
+        log_system.LogStream(aws_level, tag, message);
+    }
+    // The printf-style Log path must keep the per-message level too.
+    log_system.Log(LogLevel::Error, "FmtTag", "value=%d", 42);
     log_system.Flush();
 
-    std::cerr.rdbuf(old_buf);
+    logger.sinks().pop_back();
+    logger.set_level(saved_level);
 
-    ASSERT_NE(captured.str().find("hello-from-aws-sdk"), std::string::npos);
+    const auto out = captured.str();
+    ASSERT_NE(out.find("critical|[FatalTag] msg-FatalTag"), std::string::npos);
+    ASSERT_NE(out.find("error|[ErrorTag] msg-ErrorTag"), std::string::npos);
+    ASSERT_NE(out.find("warning|[WarnTag] msg-WarnTag"), std::string::npos);
+    ASSERT_NE(out.find("info|[InfoTag] msg-InfoTag"), std::string::npos);
+    ASSERT_NE(out.find("debug|[DebugTag] msg-DebugTag"), std::string::npos);
+    ASSERT_NE(out.find("trace|[TraceTag] msg-TraceTag"), std::string::npos);
+    ASSERT_NE(out.find("error|[FmtTag] value=42"), std::string::npos);
 }

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -18,6 +18,9 @@
 #include <arcticdb/util/test/gtest_utils.hpp>
 
 #include <aws/core/Aws.h>
+#include <aws/core/utils/memory/stl/AWSStringStream.h>
+
+#include <sstream>
 
 struct EnvFunctionShim : ::testing::Test {
     std::unordered_set<const char*> env_vars_to_unset{};
@@ -449,4 +452,21 @@ TEST_F(S3StorageFixture, test_list_directory_bucket_failure) {
     }
     ASSERT_THROW(list_in_store(store, KeyType::TABLE_DATA, prefix), UnexpectedS3ErrorException);
     ASSERT_FALSE(store.directory_bucket());
+}
+
+TEST(S3LogSystem, StdErrLogSystemWritesToStdErr) {
+    using namespace arcticdb::storage::s3;
+    StdErrLogSystem log_system(Aws::Utils::Logging::LogLevel::Info);
+
+    std::ostringstream captured;
+    auto* old_buf = std::cerr.rdbuf(captured.rdbuf());
+
+    Aws::OStringStream message;
+    message << "hello-from-aws-sdk";
+    log_system.LogStream(Aws::Utils::Logging::LogLevel::Info, "TestTag", message);
+    log_system.Flush();
+
+    std::cerr.rdbuf(old_buf);
+
+    ASSERT_NE(captured.str().find("hello-from-aws-sdk"), std::string::npos);
 }

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -93,6 +93,7 @@ ac = Arctic("s3://localhost:9000:my-bucket?access=minioadmin&secret=minioadmin")
 - **Batch operations**: Multiple keys read/written in parallel
 - **Retry logic**: Automatic retry on transient failures
 - **Path prefix**: Organize data under a prefix within the bucket
+- **AWS SDK logging**: `AWS.LogLevel` config enables AWS SDK logs (`s3_api.cpp:S3ApiInstance`). Default sink is stderr via `s3_api.cpp:StdErrLogSystem`; set `AWS.LogToFile` to write to a file in the cwd via `DefaultLogSystem` instead.
 
 ## Azure Blob Storage
 

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -93,7 +93,7 @@ ac = Arctic("s3://localhost:9000:my-bucket?access=minioadmin&secret=minioadmin")
 - **Batch operations**: Multiple keys read/written in parallel
 - **Retry logic**: Automatic retry on transient failures
 - **Path prefix**: Organize data under a prefix within the bucket
-- **AWS SDK logging**: `AWS.LogLevel` config enables AWS SDK logs (`s3_api.cpp:S3ApiInstance`). Default sink is stderr via `s3_api.cpp:StdErrLogSystem`; set `AWS.LogToFile` to write to a file in the cwd via `DefaultLogSystem` instead.
+- **AWS SDK logging**: AWS SDK logs are routed into the `s3` spdlog stream via `s3_api.cpp:SpdlogLogSystem` (per-message severity mapped to spdlog levels, AWS tag preserved as a `[tag]` prefix), so they interleave with ArcticDB's own logs. The effective level is reconciled in Python (`tools.py:_reconcile_aws_log_level`): the more verbose of `ARCTICDB_s3_loglevel` and the deprecated `ARCTICDB_AWS_LogLevel_int` drives both the AWS SDK emission (`AWS.LogLevel` config, read in `S3ApiInstance::init`) and the `s3` stream level. The `s3` stream is opt-in: defaults to `CRITICAL`, ignores `ARCTICDB_all_loglevel`. Set `AWS.LogToFile` to write to a file in the cwd via `DefaultLogSystem` instead.
 
 ## Azure Blob Storage
 

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -155,7 +155,8 @@ There are two ways to configure log levels:
 
 If both environment variables are set, and `set_log_level` is called, then the latter takes priority.
 
-S3 logging can also be enabled by setting the environment variable `ARCTICDB_AWS_LogLevel_int=6`, which will output all S3 logs to a file in the present working directory. 
+S3 logging can also be enabled by setting the environment variable `ARCTICDB_AWS_LogLevel_int=6`, which by default outputs all S3 logs to `stderr` (alongside ArcticDB's own logging). 
+To write these S3 logs to a file in the present working directory instead, additionally set `ARCTICDB_AWS_LogToFile_int=1`. 
 See the [AWS documentation](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/logging.html) for more details.
 
 ### Logging destinations

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -155,9 +155,17 @@ There are two ways to configure log levels:
 
 If both environment variables are set, and `set_log_level` is called, then the latter takes priority.
 
-S3 logging can also be enabled by setting the environment variable `ARCTICDB_AWS_LogLevel_int=6`, which by default outputs all S3 logs to `stderr` (alongside ArcticDB's own logging). 
-To write these S3 logs to a file in the present working directory instead, additionally set `ARCTICDB_AWS_LogToFile_int=1`. 
+AWS SDK (S3) logging is controlled by the `s3` log stream: set `ARCTICDB_s3_loglevel=DEBUG` (for
+example). Because AWS SDK output is very noisy, the `s3` stream is opt-in: it defaults to `CRITICAL` and is *not*
+affected by `ARCTICDB_all_loglevel`. Raise it explicitly with `ARCTICDB_s3_loglevel` to see S3 logs.
+
+To write these S3 logs to a file in the present working directory instead, set `ARCTICDB_AWS_LogToFile_int=1`.
 See the [AWS documentation](https://docs.aws.amazon.com/sdk-for-cpp/v1/developer-guide/logging.html) for more details.
+
+!!! note "Deprecated"
+    The older `ARCTICDB_AWS_LogLevel_int=<0-6>` variable still works but is deprecated and logs a warning. When both are
+    set, the more verbose of `ARCTICDB_AWS_LogLevel_int` and `ARCTICDB_s3_loglevel` is used for both the AWS SDK and the
+    `s3` stream. Prefer `ARCTICDB_s3_loglevel`.
 
 ### Logging destinations
 

--- a/python/arcticdb/config.py
+++ b/python/arcticdb/config.py
@@ -207,7 +207,12 @@ def make_loggers_config(
         sink.file.path = file_output_path
 
     for logger_name in logger_by_name:
-        level_to_set = specific_log_levels.get(logger_name, default_level)
+        # The s3 stream carries AWS SDK output, which is very noisy. It ignores the global default level
+        # (so ARCTICDB_all_loglevel does not enable it) and stays quiet unless explicitly enabled.
+        if logger_name == "s3":
+            level_to_set = specific_log_levels.get("s3", "CRITICAL")
+        else:
+            level_to_set = specific_log_levels.get(logger_name, default_level)
         logger = log_cfgs.logger_by_id[logger_name]
         if console_output:
             logger.sink_ids.append("console")

--- a/python/arcticdb/log.py
+++ b/python/arcticdb/log.py
@@ -55,6 +55,7 @@ logger_by_name = {
     "schedule": _Logger(_LoggerId.SCHEDULE),
     "symbol": _Logger(_LoggerId.SYMBOL),
     "snapshot": _Logger(_LoggerId.SNAPSHOT),
+    "s3": _Logger(_LoggerId.S3),
 }
 
 for key, value in logger_by_name.items():

--- a/python/arcticdb/tools.py
+++ b/python/arcticdb/tools.py
@@ -62,14 +62,16 @@ def set_config_from_env_vars(env_vars: Dict[str, str]):
                 if var_type == _TYPE_STR:
                     set_config_string(config_name, v)
                 elif var_type == _TYPE_INT:
-                    set_config_int(config_name, int(v))
                     if config_name == "AWS.LOGLEVEL":
+                        # Set later in _reconcile_aws_log_level
                         if 0 <= int(v) < len(_AWS_LOG_LEVELS):
                             aws_log_level_env = int(v)
                         else:
                             storage_log.error(
                                 f"Ignoring ARCTICDB_AWS_LogLevel_int={v}: must be in 0..{len(_AWS_LOG_LEVELS) - 1}"
                             )
+                    else:
+                        set_config_int(config_name, int(v))
                 elif var_type == _TYPE_FLOAT:
                     set_config_double(config_name, float(v))
                 elif var_type == _TYPE_LOGLEVEL:

--- a/python/arcticdb/tools.py
+++ b/python/arcticdb/tools.py
@@ -6,10 +6,9 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
-import logging
-
 from typing import Dict
 from arcticdb.config import set_log_level, Defaults
+from arcticdb.log import storage as storage_log
 
 from arcticdb_ext import set_config_int, set_config_string, set_config_double
 
@@ -22,6 +21,14 @@ _TYPE_STR = "STR"
 _TYPE_LOGLEVEL = "LOGLEVEL"
 _DEFAULT_TYPE = _TYPE_STR
 _TYPE_SET = {_TYPE_INT, _TYPE_FLOAT, _TYPE_STR, _TYPE_LOGLEVEL}
+
+# AWS SDK verbosity (Aws::Utils::Logging::LogLevel) by increasing verbosity, paired with the equivalent ArcticDB log
+# level name used for the `s3` spdlog stream. Index == AWS LogLevel integer.
+_AWS_LOG_LEVELS = ["OFF", "CRITICAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"]
+
+
+def _aws_level_int_from_name(name: str) -> int:
+    return _AWS_LOG_LEVELS.index(name.upper())
 
 
 def set_config_from_env_vars(env_vars: Dict[str, str]):
@@ -37,6 +44,7 @@ def set_config_from_env_vars(env_vars: Dict[str, str]):
 
     log_level_changes = {}
     default_log_level = Defaults.DEFAULT_LOG_LEVEL
+    aws_log_level_env = None
     for k, v in env_vars.items():
         k = k.upper()
         start_index = None
@@ -55,6 +63,13 @@ def set_config_from_env_vars(env_vars: Dict[str, str]):
                     set_config_string(config_name, v)
                 elif var_type == _TYPE_INT:
                     set_config_int(config_name, int(v))
+                    if config_name == "AWS.LOGLEVEL":
+                        if 0 <= int(v) < len(_AWS_LOG_LEVELS):
+                            aws_log_level_env = int(v)
+                        else:
+                            storage_log.error(
+                                f"Ignoring ARCTICDB_AWS_LogLevel_int={v}: must be in 0..{len(_AWS_LOG_LEVELS) - 1}"
+                            )
                 elif var_type == _TYPE_FLOAT:
                     set_config_double(config_name, float(v))
                 elif var_type == _TYPE_LOGLEVEL:
@@ -63,12 +78,39 @@ def set_config_from_env_vars(env_vars: Dict[str, str]):
                     else:
                         log_level_changes[config_name.lower()] = v.upper()
                 else:
-                    logging.error("Invalid type for env var %s (value %s), type used %s", k, v, var_type)
+                    storage_log.error(f"Invalid type for env var {k} (value {v}), type used {var_type}")
             except Exception as e:
-                logging.error(
+                storage_log.error(
                     f"Error setting env var {k} to value {v} using type {var_type} and config name {config_name}"
                     f" Exception: {e}"
                 )
 
+    _reconcile_aws_log_level(aws_log_level_env, log_level_changes)
+
     if log_level_changes or default_log_level != Defaults.DEFAULT_LOG_LEVEL:
         set_log_level(default_level=default_log_level, specific_log_levels=log_level_changes)
+
+
+def _reconcile_aws_log_level(aws_log_level_env, log_level_changes):
+    """
+    AWS SDK logging and the `s3` spdlog stream share a single level, the more verbose of
+    ``ARCTICDB_AWS_LogLevel_int`` (deprecated) and ``ARCTICDB_s3_loglevel``.
+    When neither is set, AWS logging stays off (the `s3` stream defaults to CRITICAL).
+    """
+    s3_requested = log_level_changes.get("s3")
+    if aws_log_level_env is None and s3_requested is None:
+        return
+
+    aws_from_s3 = 0
+    if s3_requested is not None and s3_requested.upper() in _AWS_LOG_LEVELS:
+        aws_from_s3 = _aws_level_int_from_name(s3_requested)
+    effective = max(aws_log_level_env or 0, aws_from_s3)
+
+    log_level_changes["s3"] = _AWS_LOG_LEVELS[effective]
+    set_config_int("AWS.LogLevel", effective)
+
+    if aws_log_level_env is not None:
+        storage_log.warn(
+            "ARCTICDB_AWS_LogLevel_int is deprecated. Use ARCTICDB_s3_loglevel (e.g. ARCTICDB_s3_loglevel=DEBUG) to "
+            "control S3/AWS SDK logging, which is now routed through ArcticDB's `s3` log stream."
+        )

--- a/python/tests/unit/arcticdb/test_env_vars.py
+++ b/python/tests/unit/arcticdb/test_env_vars.py
@@ -36,12 +36,80 @@ def test_get_normal(prefix, key, value, mocks):
 
 @pytest.mark.parametrize("key, value", [("a_int", "a"), ("a_float", "aa")])
 def test_bad_format(key, value, mocks):
-    with patch(_MODULE + ".logging") as log_mock:
+    with patch(_MODULE + ".storage_log") as log_mock:
         set_config_from_env_vars({_ARCTICDB_ENV_VAR_PREFIX + key: value})
         log_mock.error.assert_called()
 
     for setter in mocks.values():
         setter.assert_not_called()
+
+
+@pytest.fixture()
+def log_mocks():
+    with patch(_MODULE + ".set_config_int") as s_int, patch(_MODULE + ".set_log_level") as s_log:
+        with patch(_MODULE + ".storage_log") as s_storage_log:
+            yield {"set_config_int": s_int, "set_log_level": s_log, "storage_log": s_storage_log}
+
+
+def _aws_log_level_set_to(mock):
+    for call in mock.call_args_list:
+        if call.args and call.args[0] == "AWS.LogLevel":
+            return call.args[1]
+    return None
+
+
+def test_s3_loglevel_drives_aws_emission(log_mocks):
+    set_config_from_env_vars({"ARCTICDB_s3_loglevel": "DEBUG"})
+
+    assert _aws_log_level_set_to(log_mocks["set_config_int"]) == 5  # Debug
+    _, kwargs = log_mocks["set_log_level"].call_args
+    assert kwargs["specific_log_levels"]["s3"] == "DEBUG"
+    log_mocks["storage_log"].warn.assert_not_called()
+
+
+def test_deprecated_aws_var_warns_and_sets_s3(log_mocks):
+    set_config_from_env_vars({"ARCTICDB_AWS_LogLevel_int": "6"})
+
+    assert _aws_log_level_set_to(log_mocks["set_config_int"]) == 6  # Trace
+    _, kwargs = log_mocks["set_log_level"].call_args
+    assert kwargs["specific_log_levels"]["s3"] == "TRACE"
+    log_mocks["storage_log"].warn.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "s3_level, aws_int, expected_int, expected_s3",
+    [
+        ("WARN", 5, 5, "DEBUG"),  # AWS (Debug) more verbose than s3 (Warn) -> AWS wins
+        ("DEBUG", 2, 5, "DEBUG"),  # s3 (Debug) more verbose than AWS (Error) -> s3 wins
+        ("TRACE", 6, 6, "TRACE"),  # equal verbosity
+    ],
+)
+def test_more_verbose_of_the_two_wins(log_mocks, s3_level, aws_int, expected_int, expected_s3):
+    set_config_from_env_vars({"ARCTICDB_s3_loglevel": s3_level, "ARCTICDB_AWS_LogLevel_int": str(aws_int)})
+
+    assert _aws_log_level_set_to(log_mocks["set_config_int"]) == expected_int
+    _, kwargs = log_mocks["set_log_level"].call_args
+    assert kwargs["specific_log_levels"]["s3"] == expected_s3
+    log_mocks["storage_log"].warn.assert_called_once()
+
+
+@pytest.mark.parametrize("bad_value", ["7", "99", "-1"])
+def test_out_of_range_aws_log_level_is_ignored(log_mocks, bad_value):
+    set_config_from_env_vars({"ARCTICDB_AWS_LogLevel_int": bad_value})
+
+    # The raw value is still forwarded to ConfigsMap, but it does not feed into the reconciled effective level.
+    assert _aws_log_level_set_to(log_mocks["set_config_int"]) is None
+    log_mocks["storage_log"].error.assert_called()
+    log_mocks["set_log_level"].assert_not_called()
+
+
+def test_no_s3_or_aws_var_does_not_touch_aws_log_level(log_mocks):
+    set_config_from_env_vars({"ARCTICDB_version_loglevel": "DEBUG"})
+
+    assert _aws_log_level_set_to(log_mocks["set_config_int"]) is None
+    _, kwargs = log_mocks["set_log_level"].call_args
+    assert "s3" not in kwargs["specific_log_levels"]
+    log_mocks["storage_log"].warn.assert_not_called()
 
 
 @pytest.mark.parametrize("input_val", ["y", "yes", "t", "true", "on", "1", "YES", "True", "ON"])

--- a/python/tests/unit/arcticdb/test_env_vars.py
+++ b/python/tests/unit/arcticdb/test_env_vars.py
@@ -53,7 +53,7 @@ def log_mocks():
 
 def _aws_log_level_set_to(mock):
     for call in mock.call_args_list:
-        if call.args and call.args[0] == "AWS.LogLevel":
+        if call.args and call.args[0].upper() == "AWS.LOGLEVEL":
             return call.args[1]
     return None
 
@@ -97,7 +97,6 @@ def test_more_verbose_of_the_two_wins(log_mocks, s3_level, aws_int, expected_int
 def test_out_of_range_aws_log_level_is_ignored(log_mocks, bad_value):
     set_config_from_env_vars({"ARCTICDB_AWS_LogLevel_int": bad_value})
 
-    # The raw value is still forwarded to ConfigsMap, but it does not feed into the reconciled effective level.
     assert _aws_log_level_set_to(log_mocks["set_config_int"]) is None
     log_mocks["storage_log"].error.assert_called()
     log_mocks["set_log_level"].assert_not_called()


### PR DESCRIPTION
AWS SDK logging (enabled via ARCTICDB_AWS_LogLevel) previously wrote only to a file in the current working directory via DefaultLogSystem. It now defaults to stderr, alongside ArcticDB's own logging. Set `ARCTICDB_AWS_LogToFile_int=1` to restore the file sink.

Since this is now a normal spdlog logger, I've changed the config flag to `ARCTICDB_s3_loglevel=DEBUG`. `ARCTICDB_AWS_LogLevel_int=6` is still supported but is deprecated. If both are set we take the most verbose. We exclude the S3 logger from the `ARCTICDB_ALL_loglevel=DEBUG` flag because it is so verbose, and it can also log out access keys.

This is particular useful to see these logs in short-lived containers, or containers running in a directory with no write permissions.

The default log level for AWS is 0 (off) so this won't expose extra logs to users who haven't opt-ed in to AWS logging.

Example log lines with debug AWS logging enabled:

```
--- AWS init handoff: storage -> s3 ---
     17:20260604 12:06:07.526478 1545540 D arcticdb.s3 | [FileSystemUtils] Home directory is missing the final / appending one to normalize
     18:20260604 12:06:07.526484 1545540 D arcticdb.s3 | [FileSystemUtils] Final Home Directory is /users/is/aseaton/
     19:20260604 12:06:07.526491 1545540 I arcticdb.s3 | [Aws::Config::AWSConfigFileProfileConfigLoader] Initializing config loader against fileName /users/is/aseaton/.aws/config and using profilePrefix = 1
     
     --- a PUT request, levels D/W/E, tags preserved (credential-loader noise skipped) ---
     10:20260604 12:06:07.525068 1545540 D arcticdb.storage | Begin initializing AWS API
     162:20260604 12:06:07.789636 1545540 D arcticdb.s3 | [CURL] (HeaderOut) HEAD /test-s3-bucket-1780571146-1/_arctic_cfg/cref/%2AsUt%2Ademo HTTP/1.1
     178:20260604 12:06:07.792286 1545540 D arcticdb.s3 | [CURL] (HeaderIn) HTTP/1.1 404 NOT FOUND
     203:20260604 12:06:07.792775 1545540 D arcticdb.s3 | [AWSClient] Request returned error. Attempting to generate appropriate error codes from response
     204:20260604 12:06:07.792832 1545540 E arcticdb.s3 | [AWSXmlClient] HTTP response code: 404
     217:20260604 12:06:07.792990 1545540 W arcticdb.s3 | [AWSClient] If the signature check failed. This could be because of a time skew. Attempting to adjust the signer.
     268:20260604 12:06:07.799336 1545540 D arcticdb.s3 | [CURL] (HeaderOut) PUT /test-s3-bucket-1780571146-1/_arctic_cfg/cref/%2AsUt%2Ademo HTTP/1.1
     283:20260604 12:06:07.800032 1545540 D arcticdb.s3 | [CURL] (HeaderIn) HTTP/1.1 100 Continue
     287:20260604 12:06:07.800151 1545540 D arcticdb.s3 | [CURL] (HeaderIn) HTTP/1.1 100 Continue
     294:20260604 12:06:07.802813 1545540 D arcticdb.s3 | [CURL] (HeaderIn) HTTP/1.1 200 OK
     387:20260604 12:06:07.809275 1545540 D arcticdb.s3 | [CURL] (HeaderIn) HTTP/1.1 200 OK
     422:20260604 12:06:07.809831 1545540 D arcticdb.s3 | [AWSClient] Request returned successful response.
     488:20260604 12:06:07.821258 1545540 D arcticdb.s3 | [CURL] (HeaderOut) GET /test-s3-bucket-1780571146-1/demo1780571167793346816/vref/%2AsUt%2Asym HTTP/1.1
     504:20260604 12:06:07.824845 1545540 D arcticdb.s3 | [CURL] (HeaderIn) HTTP/1.1 404 NOT FOUND
```

Confirmed this logging does not show up without the dedicated config options, even with the "all" logger set to debug.

If using the old flag we get:

```
WARNING:root:ARCTICDB_AWS_LogLevel_int is deprecated. Use ARCTICDB_s3_loglevel (e.g. ARCTICDB_s3_loglevel=DEBUG) to control S3/AWS SDK logging, which is now routed through ArcticDB's `s3` log stream.
INFO:werkzeug:ESC[31mESC[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.ESC[0m
 * Running on all addresses (0.0.0.0)
 * Running on http://127.0.0.1:12208
 * Running on http://10.220.129.2:12208
INFO:werkzeug:ESC[33mPress CTRL+C to quitESC[0m
INFO:werkzeug:127.0.0.1 - - [04/Jun/2026 12:17:20] "GET / HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [04/Jun/2026 12:17:20] "GET /whoami HTTP/1.1" 200 -
INFO:werkzeug:127.0.0.1 - - [04/Jun/2026 12:17:20] "PUT /test-s3-bucket-1780571819-1 HTTP/1.1" 200 -
20260604 12:17:20.704798 1615593 I arcticdb.s3 | [GlobalEnumOverflowContainer] Initialized AWS-CRT-CPP with version 0.29.7
20260604 12:17:20.704864 1615593 T arcticdb.s3 | [FileSystemUtils] Checking HOME for the home directory.
20260604 12:17:20.704875 1615593 D arcticdb.s3 | [FileSystemUtils] Environment value for variable HOME is /users/is/aseaton
20260604 12:17:20.704888 1615593 D arcticdb.s3 | [FileSystemUtils] Home directory is missing the final / appending one to normalize
```