### PR TITLE
WIP Enhancement 12036593840: append compact_data_inline

### DIFF
--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -241,22 +241,34 @@ struct TypedTensor : public NativeTensor {
         // The new column shape * the column stride tells us how far to move the data pointer from the origin
 
         ptr = reinterpret_cast<const uint8_t*>(tensor.data()) + (slice_num * stride_offset);
-        check_ptr_within_bounds(tensor, slice_num, stride_offset);
+        check_ptr_within_bounds(tensor, slice_num * stride_offset);
+    }
+
+    TypedTensor(const NativeTensor& tensor, size_t row, ssize_t nvalues) :
+        NativeTensor(
+                nvalues * itemsize(), tensor.ndim(), tensor.strides(), tensor.shape(), tensor.data_type(),
+                tensor.elsize(), nullptr, tensor.expanded_dim()
+        ) {
+        util::check(ndim() <= 1, "TypedTensor rows ctor should not be called with dim 2 data");
+        shapes_[0] = nvalues;
+        // The new column shape * the column stride tells us how far to move the data pointer from the origin
+        ptr = reinterpret_cast<const uint8_t*>(tensor.data()) + (row * strides(0));
+        check_ptr_within_bounds(tensor, row);
     }
 
     const T* data() const { return static_cast<const T*>(NativeTensor::data()); }
 
   private:
-    void check_ptr_within_bounds(const NativeTensor& tensor, ssize_t slice_num, ssize_t stride_offset) {
+    void check_ptr_within_bounds(const NativeTensor& tensor, size_t rows) {
         if (tensor.extent(0) == 0) {
             // For empty tensors, we can't perform the normal bounds check
             // Just ensure we're not trying to access beyond the first element
-            util::check(slice_num == 0, "Cannot put slice pointer at position {} in an empty tensor", slice_num);
+            util::check(rows == 0, "Cannot put slice pointer at position {} in an empty tensor", rows);
         } else {
             util::check(
                     ptr < static_cast<const uint8_t*>(tensor.ptr) + std::abs(tensor.extent(0)),
                     "Tensor overflow, cannot put slice pointer at byte {} in a tensor of {} bytes",
-                    slice_num * stride_offset,
+                    rows,
                     tensor.extent(0)
             );
         }

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -69,10 +69,7 @@ TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
             pipeline_context->total_rows_,
             pipeline_context->descriptor(),
             std::move(*pipeline_context->norm_meta_),
-            pipeline_context->user_meta_ ? std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>(
-                                                   std::move(*pipeline_context->user_meta_)
-                                           )
-                                         : std::nullopt,
+            pipeline_context->release_user_defined_metadata(),
             std::move(prev_key),
             std::nullopt,
             bucketize_dynamic

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -86,11 +86,10 @@ TimeseriesDescriptor index_descriptor_from_frame(
 
 template<typename RawType>
 RawType* flatten_tensor(
-        std::optional<ChunkedBuffer>& flattened_buffer, size_t rows_to_write, const NativeTensor& tensor,
-        size_t slice_num, size_t regular_slice_size
+        std::optional<ChunkedBuffer>& flattened_buffer, size_t rows_to_write, const NativeTensor& tensor, size_t row
 ) {
     flattened_buffer = ChunkedBuffer::presized(rows_to_write * sizeof(RawType));
-    TypedTensor<RawType> t(tensor, slice_num, regular_slice_size, rows_to_write);
+    TypedTensor<RawType> t(tensor, row, rows_to_write);
     util::FlattenHelper flattener{t};
     auto dst = reinterpret_cast<RawType*>(flattened_buffer->data());
     flattener.flatten(dst, reinterpret_cast<RawType const*>(t.data()));
@@ -134,8 +133,7 @@ std::variant<position_t, convert::StringEncodingError> add_py_string_to_pool(
 
 template<typename AggregatorType, typename TagType, typename RawType>
 std::optional<convert::StringEncodingError> set_sequence_type(
-        AggregatorType& agg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        size_t slice_num, size_t regular_slice_size
+        AggregatorType& agg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row
 ) {
     constexpr auto dt = TagType::DataTypeTag::data_type;
     const auto c_style = util::is_cstyle_array<RawType>(tensor);
@@ -156,8 +154,7 @@ std::optional<convert::StringEncodingError> set_sequence_type(
         auto ptr_data = static_cast<PyObject**>(data);
         ptr_data += row;
         if (!c_style)
-            ptr_data =
-                    flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, slice_num, regular_slice_size);
+            ptr_data = flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, row);
 
         // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
         // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
@@ -185,7 +182,7 @@ std::optional<convert::StringEncodingError> set_sequence_type(
 template<typename AggregatorType, typename TagType, typename RawType>
 void set_integral_scalar_type(
         AggregatorType& agg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        size_t slice_num, size_t regular_slice_size, bool sparsify_floats
+        bool sparsify_floats
 ) {
     constexpr auto dt = TagType::DataTypeTag::data_type;
     auto ptr = tensor.template ptr_cast<RawType>(row);
@@ -210,7 +207,7 @@ void set_integral_scalar_type(
                     sizeof(RawType)
             );
 
-            TypedTensor<RawType> t(tensor, slice_num, regular_slice_size, rows_to_write);
+            TypedTensor<RawType> t(tensor, row, rows_to_write);
             agg.set_array(col, t);
         }
     }
@@ -218,8 +215,7 @@ void set_integral_scalar_type(
 
 template<typename AggregatorType, typename TagType, typename RawType>
 void set_bool_object_type(
-        AggregatorType& agg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        size_t slice_num, size_t regular_slice_size
+        AggregatorType& agg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row
 ) {
     const auto c_style = util::is_cstyle_array<RawType>(tensor);
     std::optional<ChunkedBuffer> flattened_buffer;
@@ -229,7 +225,7 @@ void set_bool_object_type(
     ptr_data += row;
 
     if (!c_style)
-        ptr_data = flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, slice_num, regular_slice_size);
+        ptr_data = flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, row);
 
     util::BitSet bitset = util::scan_object_type_to_sparse(ptr_data, rows_to_write);
 
@@ -325,7 +321,7 @@ std::optional<convert::StringEncodingError> set_array_type(
 template<typename Aggregator>
 std::optional<convert::StringEncodingError> aggregator_set_data(
         const TypeDescriptor& type_desc, const entity::NativeTensor& tensor, Aggregator& agg, size_t col,
-        size_t rows_to_write, size_t row, size_t slice_num, size_t regular_slice_size, bool sparsify_floats
+        size_t rows_to_write, size_t row, bool sparsify_floats
 ) {
     return type_desc.visit_tag([&](auto tag) {
         using TagType = std::decay_t<decltype(tag)>;
@@ -344,22 +340,18 @@ std::optional<convert::StringEncodingError> aggregator_set_data(
             normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(
                     tag.dimension() == Dimension::Dim0, "Multidimensional string types are not supported."
             );
-            auto maybe_error = set_sequence_type<Aggregator, TagType, RawType>(
-                    agg, tensor, col, rows_to_write, row, slice_num, regular_slice_size
-            );
+            auto maybe_error = set_sequence_type<Aggregator, TagType, RawType>(agg, tensor, col, rows_to_write, row);
             if (maybe_error)
                 return maybe_error;
         } else if constexpr ((is_numeric_type(dt) || is_bool_type(dt)) && tag.dimension() == Dimension::Dim0) {
             set_integral_scalar_type<Aggregator, TagType, RawType>(
-                    agg, tensor, col, rows_to_write, row, slice_num, regular_slice_size, sparsify_floats
+                    agg, tensor, col, rows_to_write, row, sparsify_floats
             );
         } else if constexpr (is_bool_object_type(dt)) {
             normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(
                     tag.dimension() == Dimension::Dim0, "Multidimensional nullable booleans are not supported"
             );
-            set_bool_object_type<Aggregator, TagType, RawType>(
-                    agg, tensor, col, rows_to_write, row, slice_num, regular_slice_size
-            );
+            set_bool_object_type<Aggregator, TagType, RawType>(agg, tensor, col, rows_to_write, row);
         } else if constexpr (is_array_type(TypeDescriptor(tag))) {
             auto maybe_error =
                     set_array_type<Aggregator, TagType, RawType>(type_desc, agg, tensor, col, rows_to_write, row);

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -63,7 +63,7 @@ bool InputFrame::has_index() const { return desc().index().field_count() != 0ULL
 
 bool InputFrame::empty() const { return num_rows == 0; }
 
-timestamp InputFrame::index_value_at(size_t row) {
+timestamp InputFrame::index_value_at(size_t row) const {
     util::check(has_index(), "InputFrame::index_value_at should only be called on timeseries data");
     return util::variant_match(
             input_data,

--- a/cpp/arcticdb/pipeline/input_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_frame.hpp
@@ -66,7 +66,7 @@ struct InputFrame {
     void set_offset(ssize_t off) const;
     bool has_index() const;
     bool empty() const;
-    timestamp index_value_at(size_t row);
+    timestamp index_value_at(size_t row) const;
     void set_index_range();
     void set_bucketize_dynamic(bool bucketize);
     bool has_segment() const;

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -45,6 +45,14 @@ bool PipelineContext::only_index_columns_selected() const {
     return overall_column_bitset_->count() == 1 && (*overall_column_bitset_)[0];
 }
 
+std::optional<proto::descriptors::UserDefinedMetadata> PipelineContext::release_user_defined_metadata() {
+    if (index_segment_reader_.has_value()) {
+        return std::move(*index_segment_reader_->mutable_tsd().mutable_proto().mutable_user_meta());
+    } else {
+        return std::nullopt;
+    }
+}
+
 const std::optional<util::BitSet>& PipelineContextRow::get_selected_columns() const {
     return parent_->selected_columns_;
 }

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -10,6 +10,7 @@
 
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/util/bitset.hpp>
 #include <memory>
 
@@ -111,8 +112,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     VersionId version_id_ = 0;
     size_t total_rows_ = 0;
     size_t rows_ = 0;
+    std::optional<index::IndexSegmentReader> index_segment_reader_;
     std::shared_ptr<arcticdb::proto::descriptors::NormalizationMetadata> norm_meta_;
-    std::unique_ptr<arcticdb::proto::descriptors::UserDefinedMetadata> user_meta_;
     std::vector<SliceAndKey> slice_and_keys_;
     util::BitSet fetch_index_;
     std::vector<std::shared_ptr<StringPool>> string_pools_;
@@ -182,7 +183,7 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
         swap(left.stream_id_, right.stream_id_);
         swap(left.version_id_, right.version_id_);
         swap(left.total_rows_, right.total_rows_);
-        swap(left.norm_meta_, right.norm_meta_);
+        swap(left.index_segment_reader_, right.index_segment_reader_);
         swap(left.fetch_index_, right.fetch_index_);
         swap(left.string_pools_, right.string_pools_);
         swap(left.selected_columns_, right.selected_columns_);
@@ -231,6 +232,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     }
 
     bool only_index_columns_selected() const;
+
+    std::optional<proto::descriptors::UserDefinedMetadata> release_user_defined_metadata();
 };
 
 } // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -13,7 +13,7 @@
 
 namespace arcticdb::pipelines {
 
-std::pair<int64_t, int64_t> get_index_and_field_count(const arcticdb::pipelines::InputFrame& frame) {
+std::pair<size_t, size_t> get_index_and_field_count(const arcticdb::pipelines::InputFrame& frame) {
     return {frame.desc().index().field_count(), frame.desc().fields().size()};
 }
 
@@ -56,25 +56,59 @@ std::pair<size_t, size_t> get_first_and_last_row(const arcticdb::pipelines::Inpu
 }
 
 std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::InputFrame& frame) const {
+    const auto [first_row, last_row] = get_first_and_last_row(frame);
+    std::vector<RowRange> row_ranges;
+    for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
+        auto rdist = std::min(last_row - r, row_per_slice_);
+        row_ranges.emplace_back(r, r + rdist);
+    }
+    std::vector<ColRange> col_ranges;
     const auto [index_count, total_field_count] = get_index_and_field_count(frame);
-    auto field_count = total_field_count - index_count;
+    auto start_col = index_count;
+    do {
+        auto col_count = std::min(total_field_count - start_col, col_per_slice_);
+        col_ranges.emplace_back(start_col, start_col + col_count);
+        start_col += col_count;
+    } while (start_col < total_field_count);
+    if (row_ranges.empty() || col_ranges.empty()) {
+        return {};
+    } else {
+        return SpecificSlicer{std::move(row_ranges), std::move(col_ranges)}(frame);
+    }
+}
+
+SpecificSlicer::SpecificSlicer(std::vector<RowRange>&& row_ranges, std::vector<ColRange>&& col_ranges) :
+    row_ranges_(row_ranges),
+    col_ranges_(col_ranges) {
+    util::check(
+            !row_ranges_.empty() && !col_ranges_.empty(), "Expected non-empty row and col ranges in SpecificSlicer ctor"
+    );
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            std::ranges::is_sorted(row_ranges_) && std::ranges::is_sorted(col_ranges_),
+            "SpecificSlicer ctor expects sorted input row and col ranges"
+    );
+}
+
+std::vector<FrameSlice> SpecificSlicer::operator()(const arcticdb::pipelines::InputFrame& frame) const {
+    util::check(
+            row_ranges_.front().first >= frame.offset && row_ranges_.back().second <= frame.offset + frame.num_rows,
+            "SpecificSlicer expected row ranges to lie within input frame"
+    );
     auto fields_pos = std::begin(frame.desc().fields());
-    std::advance(fields_pos, index_count);
+    std::advance(fields_pos, col_ranges_.front().first);
 
     auto id = frame.desc().id();
     auto index = frame.desc().index();
 
     std::vector<FrameSlice> slices;
-    slices.reserve((field_count + col_per_slice_ - 1) / col_per_slice_);
-
-    const auto [first_row, last_row] = get_first_and_last_row(frame);
-
+    slices.reserve(row_ranges_.size() * col_ranges_.size());
     // order of the frame slices is used in the mark_index_slices impl. If slices are not grouped and ordered the same
     // way, one will need to modify the mark_index_slices method to use two passes instead of one
-    auto col = index_count;
-    do {
+    auto col = col_ranges_.front().first;
+    for (const auto& col_range : col_ranges_) {
         auto fields_next = fields_pos;
-        auto distance = std::min(size_t(std::distance(fields_pos, std::end(frame.desc().fields()))), col_per_slice_);
+        auto distance = std::min(size_t(std::distance(fields_pos, std::end(frame.desc().fields()))), col_range.diff());
         std::advance(fields_next, distance);
 
         // systematically writing the index in the column group
@@ -87,14 +121,18 @@ std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::Input
         }
 
         auto desc = std::make_shared<StreamDescriptor>(id, index, current_fields);
-        for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
-            auto rdist = std::min(last_row - r, row_per_slice_);
-            slices.push_back(FrameSlice(desc, ColRange{col, col + distance}, RowRange{r, r + rdist}));
+        for (const auto& row_range : row_ranges_) {
+            slices.push_back(FrameSlice(desc, ColRange{col, col + distance}, row_range));
         }
-
-        col += col_per_slice_;
+        col += col_range.diff();
         fields_pos = fields_next;
-    } while (fields_pos != std::end(frame.desc().fields()));
+    }
+    util::check(
+            slices.size() == row_ranges_.size() * col_ranges_.size(),
+            "SpecificSlicer produced wrong number of slices {} != {}",
+            slices.size(),
+            row_ranges_.size() * col_ranges_.size()
+    );
     return slices;
 }
 

--- a/cpp/arcticdb/pipeline/slicing.hpp
+++ b/cpp/arcticdb/pipeline/slicing.hpp
@@ -28,11 +28,20 @@ class FixedSlicer {
 
     std::vector<FrameSlice> operator()(const InputFrame& frame) const;
 
-    auto row_per_slice() const { return row_per_slice_; }
-
   private:
     size_t col_per_slice_;
     size_t row_per_slice_;
+};
+
+class SpecificSlicer {
+  public:
+    SpecificSlicer(std::vector<RowRange>&& row_ranges, std::vector<ColRange>&& col_ranges);
+
+    std::vector<FrameSlice> operator()(const InputFrame& frame) const;
+
+  private:
+    std::vector<RowRange> row_ranges_;
+    std::vector<ColRange> col_ranges_;
 };
 
 class HashedSlicer {
@@ -45,8 +54,6 @@ class HashedSlicer {
 
     size_t num_buckets() const { return num_buckets_; }
 
-    auto row_per_slice() const { return row_per_slice_; }
-
   private:
     size_t num_buckets_;
     size_t row_per_slice_;
@@ -54,7 +61,7 @@ class HashedSlicer {
 
 class NoSlicing {};
 
-using SlicingPolicy = std::variant<NoSlicing, FixedSlicer, HashedSlicer>;
+using SlicingPolicy = std::variant<NoSlicing, FixedSlicer, SpecificSlicer, HashedSlicer>;
 
 SlicingPolicy get_slicing_policy(const WriteOptions& options, const arcticdb::pipelines::InputFrame& frame);
 

--- a/cpp/arcticdb/pipeline/test/test_rollback.cpp
+++ b/cpp/arcticdb/pipeline/test/test_rollback.cpp
@@ -96,7 +96,7 @@ TestTensorFrame append_with_three_segments(version_store::PythonVersionStore& st
     constexpr size_t update_val{1};
     auto append_frame =
             get_test_frame<TimeseriesIndex>(stream_id, get_test_timeseries_fields(), 30, start_index, update_val);
-    store.append_internal(stream_id, append_frame.frame_, false, false, false);
+    store.append_internal(stream_id, append_frame.frame_, false, false, false, false);
     start_index += 30; // To avoid sameappends
     return append_frame;
 }

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -30,16 +30,12 @@ using namespace arcticdb::stream;
 namespace ranges = std::ranges;
 
 WriteToSegmentTask::WriteToSegmentTask(
-        std::shared_ptr<InputFrame> frame, FrameSlice slice, const SlicingPolicy& slicing,
-        folly::Function<PartialKey(const FrameSlice&)>&& partial_key_gen, size_t slice_num_for_column, Index index,
-        bool sparsify_floats
+        std::shared_ptr<InputFrame> frame, FrameSlice slice,
+        folly::Function<PartialKey(const FrameSlice&)>&& partial_key_gen, bool sparsify_floats
 ) :
     frame_(std::move(frame)),
     slice_(std::move(slice)),
-    slicing_(slicing),
     partial_key_gen_(std::move(partial_key_gen)),
-    slice_num_for_column_(slice_num_for_column),
-    index_(std::move(index)),
     sparsify_floats_(sparsify_floats) {
     slice_.check_magic();
 }
@@ -50,6 +46,7 @@ std::tuple<PartialKey, SegmentInMemory, FrameSlice> WriteToSegmentTask::operator
     magic_.check();
     auto key = partial_key_gen_(slice_);
     auto seg = frame_->has_segment() ? slice_segment() : slice_tensors();
+    seg.set_row_data((slice_.rows().second - slice_.rows().first) - 1);
     seg.descriptor().set_id(key.stream_id);
     return {std::move(key), std::move(seg), std::move(slice_)};
 }
@@ -75,7 +72,6 @@ SegmentInMemory WriteToSegmentTask::slice_segment() const {
                 std::make_shared<Column>(slice_column(frame, col_idx, offset, seg.string_pool()))
         );
     }
-    seg.set_row_data((slice_.rows().second - slice_.rows().first) - 1);
     return seg;
 }
 
@@ -344,7 +340,7 @@ Column WriteToSegmentTask::slice_column(
 }
 
 SegmentInMemory WriteToSegmentTask::slice_tensors() const {
-    return util::variant_match(index_, [this](auto& idx) {
+    return util::variant_match(frame_->index, [this](auto& idx) {
         using IdxType = std::decay_t<decltype(idx)>;
         using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
 
@@ -356,12 +352,6 @@ SegmentInMemory WriteToSegmentTask::slice_tensors() const {
                 *slice_.desc()
         };
 
-        auto regular_slice_size = util::variant_match(
-                slicing_,
-                [&](const NoSlicing&) { return slice_.row_range.second - slice_.row_range.first; },
-                [&](const auto& slicer) { return slicer.row_per_slice(); }
-        );
-
         // Offset is used for index value in row-count index
         auto offset_in_frame = slice_begin_pos(slice_, *frame_);
         agg.set_offset(offset_in_frame);
@@ -371,15 +361,7 @@ SegmentInMemory WriteToSegmentTask::slice_tensors() const {
             const auto& opt_index_tensor = frame_->opt_index_tensor();
             util::check(opt_index_tensor.has_value(), "Got null index tensor in WriteToSegmentTask");
             auto opt_error = aggregator_set_data(
-                    frame_->desc().fields(0).type(),
-                    *opt_index_tensor,
-                    agg,
-                    0,
-                    rows_to_write,
-                    offset_in_frame,
-                    slice_num_for_column_,
-                    regular_slice_size,
-                    false
+                    frame_->desc().fields(0).type(), *opt_index_tensor, agg, 0, rows_to_write, offset_in_frame, false
             );
             if (opt_error.has_value()) {
                 opt_error->raise(frame_->desc().fields(0).name(), offset_in_frame);
@@ -392,15 +374,7 @@ SegmentInMemory WriteToSegmentTask::slice_tensors() const {
             auto& fd = slice_.non_index_field(col);
             auto& tensor = field_tensors[slice_.absolute_field_col(col)];
             auto opt_error = aggregator_set_data(
-                    fd.type(),
-                    tensor,
-                    agg,
-                    abs_col,
-                    rows_to_write,
-                    offset_in_frame,
-                    slice_num_for_column_,
-                    regular_slice_size,
-                    sparsify_floats_
+                    fd.type(), tensor, agg, abs_col, rows_to_write, offset_in_frame, sparsify_floats_
             );
             if (opt_error.has_value()) {
                 opt_error->raise(fd.name(), offset_in_frame);
@@ -417,24 +391,6 @@ SegmentInMemory WriteToSegmentTask::slice_tensors() const {
     });
 }
 
-std::vector<std::pair<FrameSlice, size_t>> get_slice_and_rowcount(const std::vector<FrameSlice>& slices) {
-    std::vector<std::pair<FrameSlice, size_t>> slice_and_rowcount;
-    slice_and_rowcount.reserve(slices.size());
-    size_t slice_num_for_column = 0;
-    std::optional<size_t> first_row;
-    for (const auto& slice : slices) {
-        if (!first_row)
-            first_row = slice.row_range.first;
-
-        if (slice.row_range.first == *first_row)
-            slice_num_for_column = 0;
-
-        slice_and_rowcount.emplace_back(slice, slice_num_for_column);
-        ++slice_num_for_column;
-    }
-    return slice_and_rowcount;
-}
-
 int64_t write_window_size() {
     return ConfigsMap::instance()->get_int(
             "VersionStore.BatchWriteWindow", int64_t(2 * async::TaskScheduler::instance()->io_thread_count())
@@ -442,27 +398,19 @@ int64_t write_window_size() {
 }
 
 folly::SemiFuture<std::vector<folly::Try<SliceAndKey>>> write_slices(
-        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, const SlicingPolicy& slicing,
-        TypedStreamVersion&& key, const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map, bool sparsify_floats
+        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, TypedStreamVersion&& key,
+        const std::shared_ptr<stream::StreamSink>& sink, const std::shared_ptr<DeDupMap>& de_dup_map,
+        bool sparsify_floats
 ) {
     ARCTICDB_SAMPLE(WriteSlices, 0)
 
-    auto slice_and_rowcount = get_slice_and_rowcount(slices);
-
     int64_t write_window = write_window_size();
     auto window = folly::window(
-            std::move(slice_and_rowcount),
-            [de_dup_map, frame, slicing, key = std::move(key), sink, sparsify_floats](auto&& slice) {
-                return async::submit_cpu_task(WriteToSegmentTask(
-                                                      frame,
-                                                      slice.first,
-                                                      slicing,
-                                                      get_partial_key_gen(frame, key),
-                                                      slice.second,
-                                                      frame->index,
-                                                      sparsify_floats
-                                              ))
+            std::move(slices),
+            [de_dup_map, frame, key = std::move(key), sink, sparsify_floats](auto&& slice) {
+                return async::submit_cpu_task(
+                               WriteToSegmentTask(frame, slice, get_partial_key_gen(frame, key), sparsify_floats)
+                )
                         .then([sink, de_dup_map](auto&& ks) {
                             return sink->async_write(std::forward<decltype(ks)>(ks), de_dup_map);
                         });
@@ -484,7 +432,7 @@ folly::Future<std::vector<SliceAndKey>> slice_and_write(
 
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
     TypedStreamVersion tsv{std::move(key.id), key.version_id, KeyType::TABLE_DATA};
-    return write_slices(frame, std::move(slices), slicing, std::move(tsv), sink, de_dup_map, sparsify_floats)
+    return write_slices(frame, std::move(slices), std::move(tsv), sink, de_dup_map, sparsify_floats)
             .via(&async::cpu_executor())
             .thenValue([sink](std::vector<folly::Try<SliceAndKey>>&& ks) {
                 return rollback_slices_on_quota_exceeded(std::move(ks), sink);
@@ -508,33 +456,14 @@ folly::Future<entity::AtomKey> write_frame(
 
 folly::Future<AtomKey> append_frame(
         IndexPartialKey&& key, const std::shared_ptr<InputFrame>& frame, const SlicingPolicy& slicing,
-        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema,
-        bool ignore_sort_order
+        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema
 ) {
     ARCTICDB_SAMPLE_DEFAULT(AppendFrame)
-    util::variant_match(
-            frame->index,
-            [&index_segment_reader, &frame, ignore_sort_order](const TimeseriesIndex&) {
-                util::check(frame->has_index(), "Cannot append timeseries without index");
-                if (index_segment_reader.tsd().total_rows() != 0 && frame->num_rows != 0) {
-                    auto first_index = NumericIndex{frame->index_value_at(0)};
-                    auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
-                    util::check(
-                            ignore_sort_order || prev - 1 <= first_index,
-                            "Can't append dataframe with start index {} to existing sequence ending at {}",
-                            util::format_timestamp(first_index),
-                            util::format_timestamp(prev)
-                    );
-                }
-            },
-            [](const auto&) {
-                // Do whatever, but you can't range search it
-            }
-    );
-
     auto existing_slices = unfiltered_index(index_segment_reader);
+    const auto tsd =
+            index::get_merged_tsd(frame->num_rows + frame->offset, dynamic_schema, index_segment_reader.tsd(), frame);
     auto keys_fut = slice_and_write(frame, slicing, IndexPartialKey{key}, store);
-    return std::move(keys_fut).thenValue([dynamic_schema,
+    return std::move(keys_fut).thenValue([tsd = std::move(tsd),
                                           slices_to_write = std::move(existing_slices),
                                           frame = frame,
                                           index_segment_reader = std::move(index_segment_reader),
@@ -546,9 +475,6 @@ folly::Future<AtomKey> append_frame(
                 std::make_move_iterator(std::end(slice_and_keys_to_append))
         );
         ranges::sort(slices_to_write);
-        const auto tsd = index::get_merged_tsd(
-                frame->num_rows + frame->offset, dynamic_schema, index_segment_reader.tsd(), frame
-        );
         return index::write_index(
                 index_type_from_descriptor(tsd.as_stream_descriptor()), tsd, std::move(slices_to_write), key, store
         );

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -14,6 +14,7 @@
 #include <arcticdb/stream/index.hpp>
 #include <folly/futures/Future.h>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/storage/store.hpp>
@@ -27,17 +28,13 @@ struct WriteToSegmentTask : public async::BaseTask {
   public:
     std::shared_ptr<InputFrame> frame_;
     const FrameSlice slice_;
-    const SlicingPolicy slicing_;
     folly::Function<PartialKey(const FrameSlice&)> partial_key_gen_;
-    size_t slice_num_for_column_;
-    Index index_;
     bool sparsify_floats_;
     util::MagicNum<'W', 's', 'e', 'g'> magic_;
 
     WriteToSegmentTask(
-            std::shared_ptr<InputFrame> frame, FrameSlice slice, const SlicingPolicy& slicing,
-            folly::Function<PartialKey(const FrameSlice&)>&& partial_key_gen, size_t slice_num_for_column, Index index,
-            bool sparsify_floats
+            std::shared_ptr<InputFrame> frame, FrameSlice slice,
+            folly::Function<PartialKey(const FrameSlice&)>&& partial_key_gen, bool sparsify_floats = false
     );
 
     std::tuple<PartialKey, SegmentInMemory, FrameSlice> operator()();
@@ -57,9 +54,9 @@ folly::Future<std::vector<SliceAndKey>> slice_and_write(
 int64_t write_window_size();
 
 folly::SemiFuture<std::vector<folly::Try<SliceAndKey>>> write_slices(
-        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, const SlicingPolicy& slicing,
-        TypedStreamVersion&& partial_key, const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map, bool sparsify_floats
+        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, TypedStreamVersion&& partial_key,
+        const std::shared_ptr<stream::StreamSink>& sink, const std::shared_ptr<DeDupMap>& de_dup_map,
+        bool sparsify_floats
 );
 
 folly::Future<entity::AtomKey> write_frame(
@@ -70,8 +67,7 @@ folly::Future<entity::AtomKey> write_frame(
 
 folly::Future<entity::AtomKey> append_frame(
         IndexPartialKey&& key, const std::shared_ptr<InputFrame>& frame, const SlicingPolicy& slicing,
-        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema,
-        bool ignore_sort_order
+        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema
 );
 
 enum class AffectedSegmentPart { START, END };
@@ -95,8 +91,6 @@ folly::Future<SliceAndKey> async_rewrite_partial_segment(
 std::vector<SliceAndKey> flatten_and_fix_rows(
         const std::array<std::vector<SliceAndKey>, 5>& groups, size_t& global_count
 );
-
-std::vector<std::pair<FrameSlice, size_t>> get_slice_and_rowcount(const std::vector<FrameSlice>& slices);
 
 template<typename T>
 requires std::is_same_v<T, SliceAndKey> || std::is_same_v<T, std::vector<SliceAndKey>>

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -939,10 +939,12 @@ struct CompactDataClause {
     ClauseInfo clause_info_;
     std::shared_ptr<ComponentManager> component_manager_;
     uint64_t rows_per_segment_;
+    std::shared_ptr<InputFrame> frame_;
     uint64_t min_rows_per_segment_;
     uint64_t max_rows_per_segment_;
+    bool dynamic_schema_;
 
-    explicit CompactDataClause(uint64_t rows_per_segment);
+    CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<InputFrame> frame = std::shared_ptr<InputFrame>());
     ARCTICDB_MOVE_COPY_DEFAULT(CompactDataClause)
 
     [[nodiscard]] std::vector<std::vector<size_t>> structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys);
@@ -955,7 +957,7 @@ struct CompactDataClause {
 
     [[nodiscard]] const ClauseInfo& clause_info() const;
 
-    void set_processing_config(const ProcessingConfig&);
+    void set_processing_config(const ProcessingConfig& processing_config);
 
     void set_component_manager(std::shared_ptr<ComponentManager> component_manager);
 
@@ -968,5 +970,10 @@ struct CompactDataClause {
     [[nodiscard]] bool row_ranges_all_acceptable_lengths(const std::set<RowRange>& row_ranges) const;
 
     [[nodiscard]] std::set<RowRange> structure_row_ranges(const std::set<RowRange>& row_ranges) const;
+
+  private:
+    void add_segment_from_frame(
+            const ProcessingUnit& proc, size_t col_range_start, std::vector<SegmentInMemory>& segments
+    ) const;
 };
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/clause_compact_data.cpp
+++ b/cpp/arcticdb/processing/clause_compact_data.cpp
@@ -11,14 +11,19 @@
 #include <cstdint>
 #include <set>
 
+#include <arcticdb/column_store/column_reslicer.hpp>
 #include <arcticdb/column_store/segment_reslicer.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/input_frame.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
 #include <arcticdb/processing/clause_utils.hpp>
 #include <arcticdb/util/collection_utils.hpp>
 
 namespace arcticdb {
 
-CompactDataClause::CompactDataClause(uint64_t rows_per_segment) : rows_per_segment_(rows_per_segment) {
+CompactDataClause::CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<InputFrame> frame) :
+    rows_per_segment_(rows_per_segment),
+    frame_(std::move(frame)) {
     // Magic range of +-33% chosen so that:
     // - 2 row slices with < min_rows_per_segment_ cannot be combined into one row slice with > max_rows_per_segment_
     // - 1 row slice with a little more than max_rows_per_segment_ when split in half will still have
@@ -102,10 +107,22 @@ std::vector<std::vector<size_t>> CompactDataClause::structure_for_processing(std
     for (const auto& range_and_key : ranges_and_keys) {
         row_ranges.insert(range_and_key.row_range());
     }
+    if (frame_) {
+        // frame_ is non null when we have arrived here via the compact_data_inline argument to append[_batch]
+        // In this case, we treat the frame being appended as if it is ONE row-slice (even if it is larger than the
+        // library's default slicing policy). A consequence of this is that the resulting structure on-disk may not be
+        // identical to calling append with compact_data_inline=false, followed by an explicit compact_data call.
+        // However, the invariant that all row-slices will have rows_per_segments+-33% will be maintained in both cases
+        util::check(
+                frame_->offset == row_ranges.rbegin()->second,
+                "CompactDataClause expects the input frame offset to match the end of the existing data"
+        );
+        row_ranges.emplace(frame_->offset, frame_->offset + frame_->num_rows);
+    }
     // The greedy algorithm in structure_row_ranges can reslice data where all segments have an acceptable number of
     // rows, which is not desirable, so short-circuit out if this is the case
     if (row_ranges_all_acceptable_lengths(row_ranges)) {
-        log::version().info("No work to do in CompactDataClause, data is already compacted");
+        log::version().debug("No work to do in CompactDataClause, existing data is already compacted");
         ranges_and_keys.clear();
         return {};
     }
@@ -126,7 +143,7 @@ std::vector<std::vector<size_t>> CompactDataClause::structure_for_processing(std
             }
     );
     if (ranges_and_keys.empty()) {
-        log::version().info("No work to do in CompactDataClause, data is already compacted");
+        log::version().debug("No work to do in CompactDataClause, existing data is already compacted");
         return {};
     }
     // Order by column slice (i.e. all segments in first column slice from top to bottom, then second column slice, etc)
@@ -184,6 +201,12 @@ std::vector<EntityId> CompactDataClause::process(std::vector<EntityId>&& entity_
             proc.row_ranges_->back()->second
     );
     std::vector<SegmentInMemory> segments = util::extract_from_pointers(std::move(*proc.segments_));
+    // Presence of frame implies we are doing inline compaction in append. The second condition means we are processing
+    // the last row-slice of the existing data, and so it must be combined with the frame
+    if (frame_ && frame_->offset == proc.row_ranges_->back()->second) {
+        add_segment_from_frame(proc, col_range_start, segments);
+    }
+
     SegmentReslicer reslicer{max_rows_per_segment_};
     segments = reslicer.reslice_segments(std::move(segments));
 
@@ -214,9 +237,42 @@ std::vector<EntityId> CompactDataClause::process(std::vector<EntityId>&& entity_
     return push_entities(*component_manager_, std::move(proc));
 }
 
+void CompactDataClause::add_segment_from_frame(
+        const ProcessingUnit& proc, size_t col_range_start, std::vector<SegmentInMemory>& segments
+) const {
+    uint64_t total_rows_without_frame = std::accumulate(
+            segments.cbegin(),
+            segments.cend(),
+            uint64_t(0),
+            [](uint64_t n, const SegmentInMemory& segment) { return n + segment.row_count(); }
+    );
+    auto total_rows = total_rows_without_frame + (frame_ ? frame_->num_rows : 0);
+    ReslicingInfo reslicing_info{total_rows, max_rows_per_segment_};
+    // Work out how many rows of the frame we need to combine with segments from disk
+    uint64_t row_count{0};
+    for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+        row_count += reslicing_info.rows_in_slice(idx);
+        if (row_count > total_rows_without_frame) {
+            break;
+        }
+    }
+    const SpecificSlicer slicer{
+            {RowRange{frame_->offset, frame_->offset + (row_count - total_rows_without_frame)}},
+            {ColRange{
+                    col_range_start, dynamic_schema_ ? frame_->desc().field_count() : proc.col_ranges_->front()->second
+            }}
+    };
+    // There is a check in SpecificSlicer that exactly 1 slice will be produced in this case
+    const auto frame_slice = std::move(slicer(*frame_)[0]);
+    WriteToSegmentTask write_to_segment_task{frame_, frame_slice, [](const FrameSlice&) { return PartialKey{}; }};
+    segments.emplace_back(std::get<SegmentInMemory>(write_to_segment_task()));
+}
+
 const ClauseInfo& CompactDataClause::clause_info() const { return clause_info_; }
 
-void CompactDataClause::set_processing_config(const ProcessingConfig&) {}
+void CompactDataClause::set_processing_config(const ProcessingConfig& processing_config) {
+    dynamic_schema_ = processing_config.dynamic_schema_;
+}
 
 void CompactDataClause::set_component_manager(std::shared_ptr<ComponentManager> component_manager) {
     component_manager_ = std::move(component_manager);

--- a/cpp/arcticdb/storage/file/file_store.hpp
+++ b/cpp/arcticdb/storage/file/file_store.hpp
@@ -69,26 +69,19 @@ void write_dataframe_to_file_internal(
     auto slices = slice(*frame, slicing);
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
 
-    auto slice_and_rowcount = get_slice_and_rowcount(slices);
-    auto key_seg_futs = folly::collect(folly::window(
-                                               std::move(slice_and_rowcount),
-                                               [frame,
-                                                slicing,
-                                                key = std::move(partial_key),
-                                                sparsify_floats = options.sparsify_floats](auto&& slice) {
-                                                   return async::submit_cpu_task(pipelines::WriteToSegmentTask(
-                                                           frame,
-                                                           slice.first,
-                                                           slicing,
-                                                           get_partial_key_gen(frame, key),
-                                                           slice.second,
-                                                           frame->index,
-                                                           sparsify_floats
-                                                   ));
-                                               },
-                                               write_window_size()
-                                       ))
-                                .via(&async::io_executor());
+    auto key_seg_futs =
+            folly::collect(folly::window(
+                                   std::move(slices),
+                                   [frame,
+                                    key = std::move(partial_key),
+                                    sparsify_floats = options.sparsify_floats](auto&& slice) {
+                                       return async::submit_cpu_task(pipelines::WriteToSegmentTask(
+                                               frame, slice, get_partial_key_gen(frame, key), sparsify_floats
+                                       ));
+                                   },
+                                   write_window_size()
+                           ))
+                    .via(&async::io_executor());
     auto segments = std::move(key_seg_futs).get();
 
     auto data_size = max_data_size(segments, codec_opts, encoding_version);

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -151,7 +151,6 @@ SegmentInMemory incomplete_segment_from_tensor_frame(
     );
 
     auto offset_in_frame = 0;
-    auto slice_num_for_column = 0;
     const auto num_rows = frame->num_rows;
     auto index_tensor = frame->opt_index_tensor();
     const bool has_index = frame->has_index();
@@ -206,8 +205,6 @@ SegmentInMemory incomplete_segment_from_tensor_frame(
                             0,
                             num_rows,
                             offset_in_frame,
-                            slice_num_for_column,
-                            num_rows,
                             allow_sparse
                     );
 
@@ -226,8 +223,6 @@ SegmentInMemory incomplete_segment_from_tensor_frame(
                             dest_col,
                             num_rows,
                             offset_in_frame,
-                            slice_num_for_column,
-                            num_rows,
                             allow_sparse
                     );
                     if (opt_error.has_value()) {
@@ -403,7 +398,6 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     }
 
     util::check(!slices.empty(), "Unexpected empty slice in write_incomplete_frame");
-    auto slice_and_rowcount = get_slice_and_rowcount(slices);
 
     IndexPartialKey key{stream_id, VersionId(0)};
     auto de_dup_map = std::make_shared<DeDupMap>();
@@ -412,32 +406,25 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     arcticdb::proto::descriptors::NormalizationMetadata norm_meta = frame->norm_meta;
     auto user_meta = frame->user_meta;
     auto bucketize_dynamic = frame->bucketize_dynamic;
-    bool sparsify_floats{false};
 
     TypedStreamVersion typed_stream_version{stream_id, VersionId{0}, KeyType::APPEND_DATA};
     return folly::collect(
                    folly::window(
-                           std::move(slice_and_rowcount),
+                           std::move(slices),
                            [frame,
-                            slicing_policy,
                             key = std::move(key),
                             store,
-                            sparsify_floats,
                             typed_stream_version = std::move(typed_stream_version),
                             bucketize_dynamic,
                             de_dup_map,
                             desc,
                             norm_meta,
                             user_meta](auto&& slice) {
-                               return async::submit_cpu_task(WriteToSegmentTask(
-                                                                     frame,
-                                                                     slice.first,
-                                                                     slicing_policy,
-                                                                     get_partial_key_gen(frame, typed_stream_version),
-                                                                     slice.second,
-                                                                     frame->index,
-                                                                     sparsify_floats
-                                                             ))
+                               return async::submit_cpu_task(
+                                              WriteToSegmentTask(
+                                                      frame, slice, get_partial_key_gen(frame, typed_stream_version)
+                                              )
+                               )
                                        .thenValue([store, de_dup_map, bucketize_dynamic, desc, norm_meta, user_meta](
                                                           std::tuple<PartialKey, SegmentInMemory, FrameSlice>&& ks
                                                   ) {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1368,20 +1368,12 @@ CompactDataInfo LocalVersionedEngine::compact_data_explain_plan_internal(
             .get();
 }
 
-VersionedItem LocalVersionedEngine::compact_data_internal(
-        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
+VersionedItem LocalVersionedEngine::maybe_compact_data_and_write_version(
+        const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
+        std::optional<CompactDataFrame> compact_data_frame
 ) {
-    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
-    py::gil_scoped_release release_gil;
-    UpdateInfo update_info = compact_data_preamble(stream_id);
-    auto versioned_item = compact_data_impl(
-                                  store(),
-                                  VersionedItem{*update_info.previous_index_key_},
-                                  get_write_options(),
-                                  IndexPartialKey{stream_id, update_info.next_version_id_},
-                                  rows_per_segment.value_or(get_write_options().segment_row_size)
-    )
-                                  .get();
+    auto versioned_item =
+            compact_data_impl(store(), update_info, get_write_options(), rows_per_segment, compact_data_frame).get();
     if (versioned_item.has_value()) {
         write_version_and_prune_previous(
                 prune_previous_versions, versioned_item->key_, update_info.previous_index_key_
@@ -1392,6 +1384,17 @@ VersionedItem LocalVersionedEngine::compact_data_internal(
         // return is for the existing version
         return {std::move(*update_info.previous_index_key_)};
     }
+}
+
+VersionedItem LocalVersionedEngine::compact_data_internal(
+        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
+    py::gil_scoped_release release_gil;
+    UpdateInfo update_info = compact_data_preamble(stream_id);
+    return maybe_compact_data_and_write_version(
+            update_info, rows_per_segment.value_or(get_write_options().segment_row_size), prune_previous_versions
+    );
 }
 
 bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) {
@@ -1862,27 +1865,48 @@ std::vector<std::variant<folly::Unit, DataError>> LocalVersionedEngine::batch_de
 
 VersionedItem LocalVersionedEngine::append_internal(
         const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool upsert, bool prune_previous_versions,
-        bool validate_index
+        bool validate_index, bool compact_data_inline
 ) {
     py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
 
+    // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data_inline is true,
+    // but also when it isn't. However, ther ead-modify-write pipeline is all built around the PipelineContext class
+    // which assumes an existing version. Better if we just make the FixedSlicer smarter so that it's logic is more like
+    // ReslicingInfo
     if (update_info.previous_index_key_.has_value()) {
-        if (frame->empty()) {
-            ARCTICDB_RUNTIME_DEBUG(
-                    log::version(),
-                    "Appending an empty item to existing data has no effect. \n"
-                    "No new version has been created for symbol='{}', "
-                    "and the last version is returned",
-                    stream_id
+        auto compact_data_frame = frame->empty() ? std::optional<CompactDataFrame>()
+                                                 : std::make_optional<CompactDataFrame>(
+                                                           frame, validate_index, cfg().write_options().empty_types()
+                                                   );
+        if (compact_data_inline) {
+            return maybe_compact_data_and_write_version(
+                    update_info, get_write_options().segment_row_size, prune_previous_versions, compact_data_frame
             );
-            return VersionedItem(*std::move(update_info.previous_index_key_));
+        } else {
+            if (frame->empty() && !compact_data_inline) {
+                ARCTICDB_RUNTIME_DEBUG(
+                        log::version(),
+                        "Appending an empty item to existing data has no effect. \n"
+                        "No new version has been created for symbol='{}', "
+                        "and the last version is returned",
+                        stream_id
+                );
+                return VersionedItem(*std::move(update_info.previous_index_key_));
+            }
+            auto versioned_item = append_impl(
+                    store(),
+                    update_info,
+                    frame,
+                    get_write_options(),
+                    validate_index,
+                    cfg().write_options().empty_types()
+            );
+            write_version_and_prune_previous(
+                    prune_previous_versions, versioned_item.key_, update_info.previous_index_key_
+            );
+            return versioned_item;
         }
-        auto versioned_item = append_impl(
-                store(), update_info, frame, get_write_options(), validate_index, cfg().write_options().empty_types()
-        );
-        write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
-        return versioned_item;
     } else {
         if (upsert) {
             auto write_options = get_write_options();

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -132,7 +132,7 @@ class LocalVersionedEngine : public VersionedEngine {
 
     VersionedItem append_internal(
             const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool upsert,
-            bool prune_previous_versions, bool validate_index
+            bool prune_previous_versions, bool validate_index, bool compact_data_inline
     ) override;
 
     VersionedItem delete_range_internal(
@@ -340,6 +340,11 @@ class LocalVersionedEngine : public VersionedEngine {
 
     CompactDataInfo compact_data_explain_plan_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
+    ) override;
+
+    VersionedItem maybe_compact_data_and_write_version(
+            const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
+            std::optional<CompactDataFrame> compact_data_frame = std::nullopt
     ) override;
 
     VersionedItem compact_data_internal(

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -641,12 +641,12 @@ TEST(VersionStore, AppendRefKeyOptimisation) {
 
     // Append v0
     auto test_frame_0 = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.append_internal(symbol, std::move(test_frame_0.frame_), true, false, false);
+    version_store.append_internal(symbol, std::move(test_frame_0.frame_), true, false, false, false);
 
     // Append v1
     start_val += num_rows;
     auto test_frame_1 = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.append_internal(symbol, std::move(test_frame_1.frame_), false, false, false);
+    version_store.append_internal(symbol, std::move(test_frame_1.frame_), false, false, false, false);
 
     // Snapshot and delete
     std::cout << "Snap" << std::endl;
@@ -659,7 +659,7 @@ TEST(VersionStore, AppendRefKeyOptimisation) {
     // Append v2
     start_val += num_rows;
     auto test_frame_2 = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.append_internal(symbol, std::move(test_frame_2.frame_), false, false, false);
+    version_store.append_internal(symbol, std::move(test_frame_2.frame_), false, false, false, false);
 
     uint64_t version_id = 1;
     // Test that v1 is visible when deleted versions are included

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -135,7 +135,7 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     return write_frame(std::move(partial_key), frame, slicing_policy, store, de_dup_map, sparsify_floats);
 }
 
-void sorted_data_check_append(const InputFrame& frame, index::IndexSegmentReader& index_segment_reader) {
+void sorted_data_check_append(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
     if (!index_is_not_timeseries_or_is_sorted_ascending(frame)) {
         sorting::raise<ErrorCode::E_UNSORTED_DATA>(
                 "When calling append with validate_index enabled, input data must be sorted"
@@ -148,6 +148,90 @@ void sorted_data_check_append(const InputFrame& frame, index::IndexSegmentReader
     );
 }
 
+void check_index_match(const Index& index, const IndexDescriptorImpl& desc) {
+    if (std::holds_alternative<TimeseriesIndex>(index))
+        util::check(
+                desc.type() == IndexDescriptor::Type::TIMESTAMP || desc.type() == IndexDescriptor::Type::EMPTY,
+                "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries"
+        );
+    else
+        util::check(
+                desc.type() == IndexDescriptorImpl::Type::ROWCOUNT,
+                "Index mismatch, cannot update a timeseries with a non-timeseries-indexed frame"
+        );
+}
+
+void check_update_data_is_sorted(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
+    bool is_time_series = std::holds_alternative<stream::TimeseriesIndex>(frame.index);
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            is_time_series, "When calling update, the input data must be a time series."
+    );
+    bool input_data_is_sorted =
+            frame.desc().sorted() == SortedValue::ASCENDING || frame.desc().sorted() == SortedValue::UNKNOWN;
+    // If changing this error message, the corresponding message in _normalization.py::restrict_data_to_date_range_only
+    // should also be updated
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            input_data_is_sorted, "When calling update, the input data must be sorted."
+    );
+    bool existing_data_is_sorted = index_segment_reader.sorted() == SortedValue::ASCENDING ||
+                                   index_segment_reader.sorted() == SortedValue::UNKNOWN;
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            existing_data_is_sorted, "When calling update, the existing data must be sorted."
+    );
+}
+
+static void check_can_append(
+        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
+        const WriteOptions& write_options, bool validate_index, bool empty_types
+) {
+    util::check(
+            update_info.previous_index_key_.has_value(),
+            "Cannot append as there is no previous index key to append into"
+    );
+    util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
+    fix_descriptor_mismatch_or_throw(APPEND, write_options.dynamic_schema, index_segment_reader, frame, empty_types);
+    if (validate_index) {
+        sorted_data_check_append(frame, index_segment_reader);
+    }
+    util::variant_match(
+            frame.index,
+            [&index_segment_reader, &frame, &write_options](const TimeseriesIndex&) {
+                util::check(frame.has_index(), "Cannot append timeseries without index");
+                if (index_segment_reader.tsd().total_rows() != 0 && frame.num_rows != 0) {
+                    auto first_index = NumericIndex{frame.index_value_at(0)};
+                    auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
+                    util::check(
+                            write_options.ignore_sort_order || prev - 1 <= first_index,
+                            "Can't append dataframe with start index {} to existing sequence "
+                            "ending at {}",
+                            util::format_timestamp(first_index),
+                            util::format_timestamp(prev)
+                    );
+                }
+            },
+            [](const auto&) {
+                // Do whatever, but you can't range search it
+            }
+    );
+}
+
+static void check_can_update(
+        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
+        bool dynamic_schema, bool empty_types
+) {
+    util::check(
+            update_info.previous_index_key_.has_value(),
+            "Cannot update as there is no previous index key to update into"
+    );
+    util::check_rte(!index_segment_reader.is_pickled(), "Cannot update to pickled data");
+    check_index_match(frame.index, index_segment_reader.tsd().index());
+    const auto index_desc = index_segment_reader.tsd().index();
+    util::check(index::is_timeseries_index(index_desc), "Update not supported for non-timeseries indexes");
+    check_update_data_is_sorted(frame, index_segment_reader);
+    (void)check_and_mark_slices(index_segment_reader, false, std::nullopt);
+    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame, empty_types);
+}
+
 folly::Future<AtomKey> async_append_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const std::shared_ptr<InputFrame>& frame,
         const WriteOptions& options, bool validate_index, bool empty_types
@@ -158,16 +242,12 @@ folly::Future<AtomKey> async_append_impl(
     );
     const StreamId stream_id = frame->desc().id();
     ARCTICDB_DEBUG(log::version(), "append stream_id: {} , version_id: {}", stream_id, update_info.next_version_id_);
+    // This is reading the index key synchronously in an async function. Should use async_get_index_reader instead
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto row_offset = index_segment_reader.tsd().total_rows();
-    util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
+    check_can_append(*frame, index_segment_reader, update_info, options, validate_index, empty_types);
     frame->set_offset(static_cast<ssize_t>(row_offset));
-    fix_descriptor_mismatch_or_throw(APPEND, options.dynamic_schema, index_segment_reader, *frame, empty_types);
-    if (validate_index) {
-        sorted_data_check_append(*frame, index_segment_reader);
-    }
-
     frame->set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, *frame);
     return append_frame(
@@ -176,8 +256,7 @@ folly::Future<AtomKey> async_append_impl(
             slicing_arg,
             index_segment_reader,
             store,
-            options.dynamic_schema,
-            options.ignore_sort_order
+            options.dynamic_schema
     );
 }
 
@@ -202,19 +281,6 @@ namespace {
 bool is_before(const IndexRange& a, const IndexRange& b) { return a.start_ < b.start_; }
 
 bool is_after(const IndexRange& a, const IndexRange& b) { return a.end_ > b.end_; }
-
-void check_index_match(const Index& index, const IndexDescriptorImpl& desc) {
-    if (std::holds_alternative<TimeseriesIndex>(index))
-        util::check(
-                desc.type() == IndexDescriptor::Type::TIMESTAMP || desc.type() == IndexDescriptor::Type::EMPTY,
-                "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries"
-        );
-    else
-        util::check(
-                desc.type() == IndexDescriptorImpl::Type::ROWCOUNT,
-                "Index mismatch, cannot update a timeseries with a non-timeseries-indexed frame"
-        );
-}
 
 /// Represents all slices which are intersecting (but not overlapping) with range passed to update
 /// First member is a vector of all segments intersecting with the first row-slice of the update range
@@ -418,25 +484,6 @@ VersionedItem delete_range_impl(
     return versioned_item;
 }
 
-void check_update_data_is_sorted(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
-    bool is_time_series = std::holds_alternative<stream::TimeseriesIndex>(frame.index);
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(
-            is_time_series, "When calling update, the input data must be a time series."
-    );
-    bool input_data_is_sorted =
-            frame.desc().sorted() == SortedValue::ASCENDING || frame.desc().sorted() == SortedValue::UNKNOWN;
-    // If changing this error message, the corresponding message in _normalization.py::restrict_data_to_date_range_only
-    // should also be updated
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(
-            input_data_is_sorted, "When calling update, the input data must be sorted."
-    );
-    bool existing_data_is_sorted = index_segment_reader.sorted() == SortedValue::ASCENDING ||
-                                   index_segment_reader.sorted() == SortedValue::UNKNOWN;
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(
-            existing_data_is_sorted, "When calling update, the existing data must be sorted."
-    );
-}
-
 struct UpdateRanges {
     IndexRange front;
     IndexRange back;
@@ -469,23 +516,6 @@ static UpdateRanges compute_update_ranges(
                 return {};
             }
     );
-}
-
-static void check_can_update(
-        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
-        bool dynamic_schema, bool empty_types
-) {
-    util::check(
-            update_info.previous_index_key_.has_value(),
-            "Cannot update as there is no previous index key to update into"
-    );
-    util::check_rte(!index_segment_reader.is_pickled(), "Cannot update pickled data");
-    check_index_match(frame.index, index_segment_reader.tsd().index());
-    const auto index_desc = index_segment_reader.tsd().index();
-    util::check(index::is_timeseries_index(index_desc), "Update not supported for non-timeseries indexes");
-    check_update_data_is_sorted(frame, index_segment_reader);
-    (void)check_and_mark_slices(index_segment_reader, false, std::nullopt);
-    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame, empty_types);
 }
 
 static std::shared_ptr<std::vector<SliceAndKey>> get_keys_affected_by_update(
@@ -557,6 +587,10 @@ folly::Future<AtomKey> async_update_impl(
                         update_info.previous_index_key_->version_id()
                 );
                 frame->set_bucketize_dynamic(index_segment_reader.bucketize_dynamic());
+                // This also checks that types are compatible, so create with a dummy row-count here, and then modify
+                // the row count later once it is known. This avoids orphaning data keys if this function throws
+                // because of incompatible schemas
+                auto tsd = index::get_merged_tsd(1, dynamic_schema, index_segment_reader.tsd(), frame);
                 return slice_and_write(
                                frame,
                                get_slicing_policy(options, *frame),
@@ -569,8 +603,8 @@ folly::Future<AtomKey> async_update_impl(
                                     query,
                                     frame,
                                     dynamic_schema,
-                                    index_segment_reader = std::move(index_segment_reader
-                                    )](std::vector<SliceAndKey>&& new_slice_and_keys) mutable {
+                                    index_segment_reader = std::move(index_segment_reader),
+                                    tsd = std::move(tsd)](std::vector<SliceAndKey>&& new_slice_and_keys) mutable {
                             std::sort(std::begin(new_slice_and_keys), std::end(new_slice_and_keys));
                             auto affected_keys =
                                     get_keys_affected_by_update(index_segment_reader, *frame, query, dynamic_schema);
@@ -602,7 +636,7 @@ folly::Future<AtomKey> async_update_impl(
                                                 affected_keys = std::move(affected_keys),
                                                 index_segment_reader = std::move(index_segment_reader),
                                                 frame,
-                                                dynamic_schema,
+                                                tsd = std::move(tsd),
                                                 update_info,
                                                 store](IntersectingSegments&& intersecting_segments) mutable {
                                         auto [flattened_slice_and_keys, row_count] = get_slice_and_keys_for_update(
@@ -612,9 +646,7 @@ folly::Future<AtomKey> async_update_impl(
                                                 std::move(intersecting_segments),
                                                 std::move(*new_slice_and_keys_ptr)
                                         );
-                                        auto tsd = index::get_merged_tsd(
-                                                row_count, dynamic_schema, index_segment_reader.tsd(), frame
-                                        );
+                                        tsd.set_total_rows(row_count);
                                         return index::write_index(
                                                 index_type_from_descriptor(tsd.as_stream_descriptor()),
                                                 std::move(tsd),
@@ -1325,17 +1357,21 @@ void check_can_perform_processing(
             (!read_query.columns && !read_query.row_range &&
              std::holds_alternative<std::monostate>(read_query.row_filter) && read_query.clauses_.empty());
     const bool is_numpy_array = pipeline_context->norm_meta_ && pipeline_context->norm_meta_->has_np();
+    // We do not support processing over numpy arrays in general, but compact_data (either directly, or via the
+    // compact_data_inline argument to append[_batch]) must work with numpy arrays as well as Series/DataFrames
+    const bool is_compaction =
+            !read_query.clauses_.empty() && folly::poly_type(*read_query.clauses_.front()) == typeid(CompactDataClause);
     if (!is_query_empty) {
-        // Exception for filterig pickled data is skipped for now for backward compatibility
+        // Exception for filtering pickled data is skipped for now for backward compatibility
         if (pipeline_context->multi_key_) {
             schema::raise<ErrorCode::E_OPERATION_NOT_SUPPORTED_WITH_RECURSIVE_NORMALIZED_DATA>(
                     "Cannot perform processing such as row/column filtering, projection, aggregation, resampling, "
                     "etc.. on recursively normalized data"
             );
-        } else if (is_numpy_array) {
+        } else if (is_numpy_array && !is_compaction) {
             schema::raise<ErrorCode::E_OPERATION_NOT_SUPPORTED_WITH_NUMPY_ARRAY>(
                     "Cannot perform processing such as row/column filtering, projection, aggregation, resampling, "
-                    "etc.. on recursively numpy array"
+                    "etc.. on numpy array"
             );
         }
     }
@@ -1345,18 +1381,18 @@ static void read_indexed_keys_to_pipeline(
         const std::shared_ptr<PipelineContext>& pipeline_context, ReadQuery& read_query,
         const ReadOptions& read_options, IndexInformation& index_information
 ) {
-    auto maybe_reader = get_index_segment_reader(pipeline_context, std::move(index_information.index_));
-    if (!maybe_reader)
+    pipeline_context->index_segment_reader_ =
+            get_index_segment_reader(pipeline_context, std::move(index_information.index_));
+    if (!pipeline_context->index_segment_reader_)
         return;
 
-    auto index_segment_reader = std::move(*maybe_reader);
-    ARCTICDB_DEBUG(log::version(), "Read index segment with {} keys", index_segment_reader.size());
-    check_can_read_index_only_if_required(index_segment_reader, read_query);
-    add_index_columns_to_query(read_query, index_segment_reader.tsd());
+    ARCTICDB_DEBUG(log::version(), "Read index segment with {} keys", pipeline_context->index_segment_reader_->size());
+    check_can_read_index_only_if_required(*pipeline_context->index_segment_reader_, read_query);
+    add_index_columns_to_query(read_query, pipeline_context->index_segment_reader_->tsd());
 
-    const auto& tsd = index_segment_reader.tsd();
+    const auto& tsd = pipeline_context->index_segment_reader_->tsd();
     read_query.convert_to_positive_row_filter(static_cast<int64_t>(tsd.total_rows()));
-    const bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
+    const bool bucketize_dynamic = pipeline_context->index_segment_reader_->bucketize_dynamic();
     pipeline_context->desc_ = tsd.as_stream_descriptor();
 
     const bool dynamic_schema = opt_false(read_options.dynamic_schema());
@@ -1369,14 +1405,12 @@ static void read_indexed_keys_to_pipeline(
         queries.push_back(create_column_stats_filter(std::move(data), tsd, std::move(query_metadata)));
     }
 
-    pipeline_context->slice_and_keys_ = filter_index(index_segment_reader, combine_filter_functions(queries));
+    pipeline_context->slice_and_keys_ =
+            filter_index(*pipeline_context->index_segment_reader_, combine_filter_functions(queries));
     pipeline_context->total_rows_ = pipeline_context->calc_rows();
-    pipeline_context->rows_ = index_segment_reader.tsd().total_rows();
+    pipeline_context->rows_ = pipeline_context->index_segment_reader_->tsd().total_rows();
     pipeline_context->norm_meta_ = std::make_unique<arcticdb::proto::descriptors::NormalizationMetadata>(
-            std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_normalization())
-    );
-    pipeline_context->user_meta_ = std::make_unique<arcticdb::proto::descriptors::UserDefinedMetadata>(
-            std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_user_meta())
+            pipeline_context->index_segment_reader_->tsd().proto().normalization()
     );
     pipeline_context->bucketize_dynamic_ = bucketize_dynamic;
     check_can_perform_processing(pipeline_context, read_query);
@@ -3137,7 +3171,7 @@ folly::Future<VersionedItem> merge_update_impl(
                         row_count,
                         pipeline_context->descriptor(),
                         std::move(*pipeline_context->norm_meta_),
-                        pipeline_context->user_meta_ ? std::make_optional(std::move(source->user_meta)) : std::nullopt,
+                        std::make_optional(std::move(source->user_meta)),
                         std::nullopt,
                         std::nullopt,
                         write_options.bucketize_dynamic
@@ -3218,97 +3252,215 @@ folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
     });
 }
 
+static folly::Future<std::vector<SliceAndKey>> slice_and_write_frame_remainder(
+        const std::shared_ptr<Store>& store, std::shared_ptr<InputFrame> frame, size_t start_row,
+        uint64_t max_rows_per_segment, const WriteOptions& write_options, IndexPartialKey target_partial_index_key
+) {
+    auto remaining_rows_to_write = (frame->offset + frame->num_rows) - start_row;
+    ReslicingInfo reslicing_info{remaining_rows_to_write, max_rows_per_segment};
+    std::vector<RowRange> row_ranges;
+    for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+        row_ranges.emplace_back(start_row, start_row + reslicing_info.rows_in_slice(idx));
+        start_row += reslicing_info.rows_in_slice(idx);
+    }
+    std::vector<ColRange> col_ranges;
+    if (write_options.dynamic_schema) {
+        col_ranges.emplace_back(frame->desc().index().field_count(), frame->desc().field_count());
+    } else {
+        ColRange col_range{
+                frame->desc().index().field_count(),
+                frame->desc().index().field_count() + write_options.column_group_size
+        };
+        col_ranges.emplace_back(col_range);
+        while (col_range.second < frame->desc().field_count()) {
+            col_range.first += write_options.column_group_size;
+            col_range.second += write_options.column_group_size;
+            col_ranges.emplace_back(col_range);
+        }
+    }
+    const SpecificSlicer slicer{std::move(row_ranges), std::move(col_ranges)};
+    auto res = folly::via(
+            &async::io_executor(),
+            [store, frame, slicer = std::move(slicer), key = std::move(target_partial_index_key)]() mutable {
+                // These rows are being appended, so dedup isn't possible
+                auto de_dup_map = std::make_shared<DeDupMap>();
+                return slice_and_write(frame, slicer, std::move(key), store, de_dup_map, false);
+            }
+    );
+    return res.via(&async::io_executor());
+}
+
 folly::Future<std::optional<VersionedItem>> compact_data_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const WriteOptions& write_options,
-        const IndexPartialKey& target_partial_index_key, uint64_t rows_per_segment
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const WriteOptions& write_options,
+        uint64_t rows_per_segment, std::optional<CompactDataFrame> compact_data_frame
 ) {
     auto read_query = std::make_shared<ReadQuery>();
-    read_query->clauses_.push_back(std::make_shared<Clause>(CompactDataClause(rows_per_segment)));
-    VersionIdentifier resolved =
-            std::make_shared<IndexInformation>(read_index_key_without_column_stats(store, versioned_item.key_));
-    std::shared_ptr<PipelineContext> pipeline_context =
-            setup_pipeline_context(store, std::move(resolved), *read_query, {});
-    return read_modify_write_data_keys(store, read_query, ReadOptions{}, target_partial_index_key, pipeline_context)
-            .thenValue(
-                    [pipeline_context = std::move(pipeline_context),
-                     store,
-                     write_options,
-                     target_partial_index_key,
-                     read_query](std::vector<SliceAndKey>&& slices_and_keys
-                    ) -> folly::Future<std::optional<VersionedItem>> {
-                        if (slices_and_keys.empty()) {
-                            return folly::makeFuture(std::optional<VersionedItem>());
-                        }
-                        // Use an ordered set so we can binary search afterwards
-                        std::set<RowRange> new_row_ranges_set;
-                        for (const auto& slice_and_key : slices_and_keys) {
-                            new_row_ranges_set.insert(slice_and_key.slice().row_range);
-                        }
-                        std::vector<RowRange> new_row_ranges(
-                                std::make_move_iterator(new_row_ranges_set.begin()),
-                                std::make_move_iterator(new_row_ranges_set.end())
-                        );
-                        // When there is column slicing, this means we only binary search for the first_row once per
-                        // row slice in the original data
-                        std::unordered_set<size_t> first_rows_to_keep;
-                        std::unordered_set<size_t> first_rows_to_discard;
-                        for (SliceAndKey& slice_and_key : pipeline_context->slice_and_keys_) {
-                            auto first_row = slice_and_key.slice().row_range.first;
-                            if (first_rows_to_keep.contains(first_row)) {
-                                slices_and_keys.emplace_back(std::move(slice_and_key));
-                            } else if (!first_rows_to_discard.contains(first_row)) {
-                                auto begin = new_row_ranges.cbegin();
-                                auto end = new_row_ranges.cend();
-                                auto mid = begin + std::distance(begin, end) / 2;
-                                while (begin != end) {
-                                    if (mid->contains(first_row)) {
-                                        break;
-                                    } else if (first_row < mid->first) {
-                                        end = mid;
-                                        mid = begin + std::distance(begin, end) / 2;
-                                    } else { // first_row >= mid->second
-                                        begin = std::next(mid);
-                                        mid = begin + std::distance(begin, end) / 2;
+    if (compact_data_frame.has_value()) {
+        read_query->clauses_.push_back(
+                std::make_shared<Clause>(CompactDataClause(rows_per_segment, compact_data_frame->frame_))
+        );
+    } else {
+        read_query->clauses_.push_back(std::make_shared<Clause>(CompactDataClause(rows_per_segment)));
+    }
+
+    VersionIdentifier resolved = std::make_shared<IndexInformation>(
+            read_index_key_without_column_stats(store, *update_info.previous_index_key_)
+    );
+    return async::submit_io_task(SetupPipelineContextTask{store, std::move(resolved), read_query, {}})
+            .via(&async::cpu_executor())
+            .thenValue([store,
+                        update_info = std::move(update_info),
+                        write_options = std::move(write_options),
+                        compact_data_frame = std::move(compact_data_frame),
+                        read_query](std::shared_ptr<PipelineContext>&& pipeline_context) {
+                const auto& stream_id = update_info.previous_index_key_->id();
+                const auto dynamic_schema = write_options.dynamic_schema;
+                std::shared_ptr<TimeseriesDescriptor> merged_tsd;
+                auto frame =
+                        compact_data_frame.has_value() ? compact_data_frame->frame_ : std::shared_ptr<InputFrame>();
+                if (frame) {
+                    check_can_append(
+                            *frame,
+                            *pipeline_context->index_segment_reader_,
+                            update_info,
+                            write_options,
+                            compact_data_frame->validate_index_,
+                            compact_data_frame->empty_types_
+                    );
+                    frame->set_offset(pipeline_context->index_segment_reader_->tsd().total_rows());
+                    merged_tsd = std::make_shared<TimeseriesDescriptor>(index::get_merged_tsd(
+                            frame->offset + frame->num_rows,
+                            dynamic_schema,
+                            pipeline_context->index_segment_reader_->tsd(),
+                            frame
+                    ));
+                }
+                IndexPartialKey target_partial_index_key{stream_id, update_info.next_version_id_};
+                ReadOptions read_options;
+                read_options.set_dynamic_schema(dynamic_schema);
+                return read_modify_write_data_keys(
+                               store, read_query, read_options, target_partial_index_key, pipeline_context
+                )
+                        .thenValue(
+                                [pipeline_context = std::move(pipeline_context),
+                                 store,
+                                 write_options,
+                                 target_partial_index_key,
+                                 read_query,
+                                 merged_tsd,
+                                 frame](std::vector<SliceAndKey>&& slices_and_keys
+                                ) -> folly::Future<std::optional<VersionedItem>> {
+                                    if (slices_and_keys.empty() && !frame) {
+                                        return folly::makeFuture(std::optional<VersionedItem>());
                                     }
+                                    // Use an ordered set so we can binary search afterwards
+                                    std::set<RowRange> new_row_ranges_set;
+                                    for (const auto& slice_and_key : slices_and_keys) {
+                                        new_row_ranges_set.insert(slice_and_key.slice().row_range);
+                                    }
+                                    std::vector<RowRange> new_row_ranges(
+                                            std::make_move_iterator(new_row_ranges_set.begin()),
+                                            std::make_move_iterator(new_row_ranges_set.end())
+                                    );
+                                    size_t last_row_on_disk = new_row_ranges.empty() ? 0 : new_row_ranges.back().second;
+                                    // When there is column slicing, this means we only binary search for the
+                                    // first_row once per row slice in the original data
+                                    std::unordered_set<size_t> first_rows_to_keep;
+                                    std::unordered_set<size_t> first_rows_to_discard;
+                                    for (SliceAndKey& slice_and_key : pipeline_context->slice_and_keys_) {
+                                        auto first_row = slice_and_key.slice().row_range.first;
+                                        if (first_rows_to_keep.contains(first_row)) {
+                                            last_row_on_disk =
+                                                    std::max(last_row_on_disk, slice_and_key.slice().rows().second);
+                                            slices_and_keys.emplace_back(std::move(slice_and_key));
+                                        } else if (!first_rows_to_discard.contains(first_row)) {
+                                            auto begin = new_row_ranges.cbegin();
+                                            auto end = new_row_ranges.cend();
+                                            auto mid = begin + std::distance(begin, end) / 2;
+                                            while (begin != end) {
+                                                if (mid->contains(first_row)) {
+                                                    break;
+                                                } else if (first_row < mid->first) {
+                                                    end = mid;
+                                                    mid = begin + std::distance(begin, end) / 2;
+                                                } else { // first_row >= mid->second
+                                                    begin = std::next(mid);
+                                                    mid = begin + std::distance(begin, end) / 2;
+                                                }
+                                            }
+                                            if (begin == end) {
+                                                last_row_on_disk =
+                                                        std::max(last_row_on_disk, slice_and_key.slice().rows().second);
+                                                slices_and_keys.emplace_back(std::move(slice_and_key));
+                                                first_rows_to_keep.emplace(first_row);
+                                            } else {
+                                                first_rows_to_discard.emplace(first_row);
+                                            }
+                                        }
+                                    }
+                                    // This implies there are more rows in frame that have not yet been written to disk
+                                    auto remaining_slice_and_keys_fut =
+                                            frame && last_row_on_disk < frame->offset + frame->num_rows
+                                                    ? slice_and_write_frame_remainder(
+                                                              store,
+                                                              frame,
+                                                              last_row_on_disk,
+                                                              folly::poly_cast<CompactDataClause>(
+                                                                      *read_query->clauses_.front()
+                                                              )
+                                                                      .max_rows_per_segment_,
+                                                              write_options,
+                                                              target_partial_index_key
+                                                      )
+                                                    : folly::makeFuture(std::vector<SliceAndKey>{});
+                                    return (std::move(remaining_slice_and_keys_fut))
+                                            .thenValue([store,
+                                                        slices_and_keys = std::move(slices_and_keys),
+                                                        pipeline_context,
+                                                        merged_tsd,
+                                                        write_options,
+                                                        target_partial_index_key](
+                                                               std::vector<SliceAndKey>&& remaining_slice_and_keys
+                                                       ) mutable {
+                                                slices_and_keys.insert(
+                                                        slices_and_keys.end(),
+                                                        std::make_move_iterator(remaining_slice_and_keys.begin()),
+                                                        std::make_move_iterator(remaining_slice_and_keys.end())
+                                                );
+                                                ranges::sort(slices_and_keys);
+                                                pipeline_context->slice_and_keys_.clear();
+                                                const size_t row_count =
+                                                        slices_and_keys.back().slice().row_range.second -
+                                                        slices_and_keys.front().slice().row_range.first;
+                                                TimeseriesDescriptor tsd =
+                                                        merged_tsd ? std::move(*merged_tsd)
+                                                                   : make_timeseries_descriptor(
+                                                                             row_count,
+                                                                             std::move(*pipeline_context->desc_),
+                                                                             std::move(*pipeline_context->norm_meta_),
+                                                                             pipeline_context
+                                                                                     ->release_user_defined_metadata(),
+                                                                             std::nullopt,
+                                                                             std::nullopt,
+                                                                             write_options.bucketize_dynamic
+                                                                     );
+                                                // String columns always compacted to dynamic UTF-8
+                                                for (auto& field : tsd.mutable_fields()) {
+                                                    if (is_sequence_type(field.type().data_type())) {
+                                                        field.type_.data_type_ = DataType::UTF_DYNAMIC64;
+                                                    }
+                                                }
+                                                return index::write_index(
+                                                        index_type_from_descriptor(pipeline_context->descriptor()),
+                                                        tsd,
+                                                        std::move(slices_and_keys),
+                                                        target_partial_index_key,
+                                                        store
+                                                );
+                                            });
                                 }
-                                if (begin == end) {
-                                    slices_and_keys.emplace_back(std::move(slice_and_key));
-                                    first_rows_to_keep.emplace(first_row);
-                                } else {
-                                    first_rows_to_discard.emplace(first_row);
-                                }
-                            }
-                        }
-                        ranges::sort(slices_and_keys);
-                        pipeline_context->slice_and_keys_.clear();
-                        const size_t row_count = slices_and_keys.back().slice().row_range.second -
-                                                 slices_and_keys.front().slice().row_range.first;
-                        TimeseriesDescriptor tsd = make_timeseries_descriptor(
-                                row_count,
-                                std::move(*pipeline_context->desc_),
-                                std::move(*pipeline_context->norm_meta_),
-                                pipeline_context->user_meta_
-                                        ? std::make_optional(std::move(*pipeline_context->user_meta_))
-                                        : std::nullopt,
-                                std::nullopt,
-                                std::nullopt,
-                                write_options.bucketize_dynamic
                         );
-                        // String columns always compacted to dynamic UTF-8
-                        for (auto& field : tsd.mutable_fields()) {
-                            if (is_sequence_type(field.type().data_type())) {
-                                field.type_.data_type_ = DataType::UTF_DYNAMIC64;
-                            }
-                        }
-                        return index::write_index(
-                                index_type_from_descriptor(pipeline_context->descriptor()),
-                                tsd,
-                                std::move(slices_and_keys),
-                                target_partial_index_key,
-                                store
-                        );
-                    }
-            );
+            });
 }
 
 folly::Future<SymbolProcessingResult> read_and_process(
@@ -3344,10 +3496,10 @@ folly::Future<SymbolProcessingResult> read_and_process(
                               output_schema = std::move(output_schema)](auto&& entity_ids) mutable {
                 // Pipeline context user metadata is not populated in the case that only incomplete segments exist
                 // for a symbol, no indexed versions
+                auto opt_user_metadata = pipeline_context->release_user_defined_metadata();
                 return SymbolProcessingResult{
                         std::move(res_versioned_item),
-                        pipeline_context->user_meta_ ? std::move(*pipeline_context->user_meta_)
-                                                     : proto::descriptors::UserDefinedMetadata{},
+                        opt_user_metadata.value_or(proto::descriptors::UserDefinedMetadata{}),
                         std::move(output_schema),
                         std::move(entity_ids)
                 };

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -207,9 +207,15 @@ folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, uint64_t rows_per_segment
 );
 
+struct CompactDataFrame {
+    std::shared_ptr<InputFrame> frame_;
+    bool validate_index_;
+    bool empty_types_;
+};
+
 folly::Future<std::optional<VersionedItem>> compact_data_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const WriteOptions& write_options,
-        const IndexPartialKey& target_partial_index_key, uint64_t rows_per_segment
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const WriteOptions& write_options,
+        uint64_t rows_per_segment, std::optional<CompactDataFrame> compact_data_frame = std::nullopt
 );
 
 std::shared_ptr<PipelineContext> setup_pipeline_context(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -772,14 +772,15 @@ VersionedItem PythonVersionStore::test_write_versioned_segment(
 
 VersionedItem PythonVersionStore::append(
         const StreamId& stream_id, const convert::InputItem& item, const py::object& norm, const py::object& user_meta,
-        bool upsert, bool prune_previous_versions, bool validate_index
+        bool upsert, bool prune_previous_versions, bool validate_index, bool compact_data_inline
 ) {
     return append_internal(
             stream_id,
             convert::py_ndf_to_frame(stream_id, item, norm, user_meta, cfg().write_options().empty_types()),
             upsert,
             prune_previous_versions,
-            validate_index
+            validate_index,
+            compact_data_inline
     );
 }
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -72,7 +72,8 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     VersionedItem append(
             const StreamId& stream_id, const convert::InputItem& item, const py::object& norm,
-            const py::object& user_meta, bool upsert, bool prune_previous_versions, bool validate_index
+            const py::object& user_meta, bool upsert, bool prune_previous_versions, bool validate_index,
+            bool compact_data_inline
     );
 
     VersionedItem update(

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -52,7 +52,7 @@ class VersionedEngine {
 
     virtual VersionedItem append_internal(
             const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool upsert,
-            bool prune_previous_versions, bool validate_index
+            bool prune_previous_versions, bool validate_index, bool compact_data_inline
     ) = 0;
 
     virtual VersionedItem delete_range_internal(
@@ -137,6 +137,11 @@ class VersionedEngine {
 
     virtual CompactDataInfo compact_data_explain_plan_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
+    ) = 0;
+
+    virtual VersionedItem maybe_compact_data_and_write_version(
+            const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
+            std::optional<CompactDataFrame> compact_data_frame
     ) = 0;
 
     virtual VersionedItem compact_data_internal(

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -942,6 +942,7 @@ class NativeVersionStore:
         prune_previous_version: Optional[bool] = None,
         validate_index: bool = False,
         index_column: bool = False,
+        compact_data_inline: bool = False,
         **kwargs,
     ) -> Optional[VersionedItem]:
         # FUTURE: use @overload and Literal for the existence of the return value once we ditch Python 3.6
@@ -971,6 +972,12 @@ class NativeVersionStore:
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
+        compact_data_inline: bool, default=False
+            If False, the data being appended will be sliced and written to disk without consideration for how
+            fragmented this may make the data.
+            If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
+            Note that this will usually involve reading some data segments from disk and doing some in-memory
+            processing, and so will generally be slower than when this argument is False.
         kwargs :
             passed through to the write handler
 
@@ -1060,7 +1067,14 @@ class NativeVersionStore:
                 else:
                     call_time = time.time_ns()
                     vit = self.version_store.append(
-                        symbol, item, norm_meta, udm, write_if_missing, prune_previous_version, validate_index
+                        symbol,
+                        item,
+                        norm_meta,
+                        udm,
+                        write_if_missing,
+                        prune_previous_version,
+                        validate_index,
+                        compact_data_inline,
                     )
                     # This is a heuristic to check for the case of using append call to write an empty dataframe in that
                     # case we want to warn users that the processing pipeline might not work as expected. There are two

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1366,6 +1366,7 @@ class Library:
         prune_previous_versions: bool = False,
         validate_index: bool = True,
         index_column: bool = False,
+        compact_data_inline: bool = False,
     ) -> VersionedItem:
         """
         Appends the given data to the existing, stored data. Append always appends along the index. A new version will
@@ -1399,6 +1400,12 @@ class Library:
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
+        compact_data_inline: bool, default=False
+            If False, the data being appended will be sliced and written to disk without consideration for how
+            fragmented this may make the data.
+            If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
+            Note that this will usually involve reading some data segments from disk and doing some in-memory
+            processing, and so will generally be slower than when this argument is False.
 
         Returns
         -------
@@ -1455,6 +1462,7 @@ class Library:
             prune_previous_version=prune_previous_versions,
             validate_index=validate_index,
             index_column=index_column,
+            compact_data_inline=compact_data_inline,
         )
 
     def append_batch(

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -63,29 +63,6 @@ def gen_params_append_single():
 
 
 @pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
-def test_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
-    tz = "America/New_York"
-    version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
-    dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
-    a = np.arange(dtidx.shape[0])
-    tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
-    c1 = dtidx[append_point]
-    c2 = dtidx[append_point + 1]
-    tf1 = tf.tsloc[:c1]
-    sid = "XXX"
-    version_store.write(sid, tf1)
-    tf2 = tf.tsloc[c2:]
-    version_store.append(sid, tf2)
-
-    dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
-    vit = version_store.read(sid, date_range=dtr, columns=list(cols))
-    rtf = tf.tsloc[dtr[0] : dtr[1]]
-    col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
-    rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
-    assert rtf == vit.data
-
-
-@pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
 def test_incomplete_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
     tz = "America/New_York"
     version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
@@ -107,42 +84,6 @@ def test_incomplete_append_partial_read(version_store_factory, colnum, periods, 
     col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
     rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
     assert rtf == vit.data
-
-
-# test_hypothesis_version_store.py covers the appends that are allowed.
-# Only need to check the forbidden ones have useful error messages:
-@pytest.mark.parametrize(
-    "initial, append, match",
-    [
-        # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
-        (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "DataFrame"),
-        (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "E_INCOMPATIBLE_INDEX"),
-        (
-            InputFactories.DF_RC,
-            InputFactories.DF_RC_NON_RANGE,
-            "range",
-        ),
-        (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "step"),
-    ],
-)
-@pytest.mark.parametrize("swap", ["swap", ""])
-def test_(
-    initial: InputFactories,
-    append: InputFactories,
-    match,
-    swap,
-    lmdb_version_store: NativeVersionStore,
-):
-    lib = lmdb_version_store
-    if swap:
-        initial, append = append, initial
-    init_data, next_start = initial.make(1, 3)
-    lib.write("s", init_data)
-
-    to_append, _ = append.make(abs(next_start), 1)
-    with pytest.raises(NormalizationException) as e:
-        lib.append("s", to_append)
-    assert match in str(e.value)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -280,34 +221,96 @@ def test_append_with_defragmentation(
         )
 
 
-def test_regular_append_dynamic_schema_named_index(
-    lmdb_version_store_tiny_segment_dynamic,
-):
-    lib = lmdb_version_store_tiny_segment_dynamic
-    sym = "test_parallel_append_dynamic_schema_named_index"
-    df_0 = pd.DataFrame({"col_0": [0], "col_1": [0.5]}, index=pd.date_range("2024-01-01", periods=1))
-    df_0.index.name = "date"
-    df_1 = pd.DataFrame({"col_0": [1]}, index=pd.date_range("2024-01-02", periods=1))
-    lib.write(sym, df_0)
-    with pytest.raises(StreamDescriptorMismatch) as exception_info:
-        lib.append(sym, df_1)
+@pytest.mark.parametrize("compact_data_inline", [True, False])
+class TestAppendHypothesis:
+    @pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
+    def test_append_partial_read(
+        self, version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point, compact_data_inline
+    ):
+        tz = "America/New_York"
+        version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
+        dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
+        a = np.arange(dtidx.shape[0])
+        tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
+        c1 = dtidx[append_point]
+        c2 = dtidx[append_point + 1]
+        tf1 = tf.tsloc[:c1]
+        sid = "XXX"
+        version_store.write(sid, tf1)
+        tf2 = tf.tsloc[c2:]
+        version_store.append(sid, tf2, compact_data_inline=compact_data_inline)
 
-    assert "date" in str(exception_info.value)
+        dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
+        vit = version_store.read(sid, date_range=dtr, columns=list(cols))
+        rtf = tf.tsloc[dtr[0] : dtr[1]]
+        col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
+        rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
+        assert rtf == vit.data
 
+    # test_hypothesis_version_store.py covers the appends that are allowed.
+    # Only need to check the forbidden ones have useful error messages:
+    @pytest.mark.parametrize(
+        "initial, append, match",
+        [
+            # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
+            (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "DataFrame"),
+            (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "E_INCOMPATIBLE_INDEX"),
+            (
+                InputFactories.DF_RC,
+                InputFactories.DF_RC_NON_RANGE,
+                "range",
+            ),
+            (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "step"),
+        ],
+    )
+    @pytest.mark.parametrize("swap", ["swap", ""])
+    def test_(
+        self,
+        initial: InputFactories,
+        append: InputFactories,
+        match,
+        swap,
+        lmdb_version_store: NativeVersionStore,
+        compact_data_inline,
+    ):
+        lib = lmdb_version_store
+        if swap:
+            initial, append = append, initial
+        init_data, next_start = initial.make(1, 3)
+        lib.write("s", init_data)
 
-@pytest.mark.parametrize(
-    "idx", [pd.date_range(pd.Timestamp("2020-01-01"), periods=3), pd.RangeIndex(start=0, stop=3, step=1)]
-)
-def test_append_bool_named_col(lmdb_version_store_dynamic_schema, idx):
-    symbol = "bad_append"
+        to_append, _ = append.make(abs(next_start), 1)
+        with pytest.raises(NormalizationException) as e:
+            lib.append("s", to_append, compact_data_inline=compact_data_inline)
+        assert match in str(e.value)
 
-    initial = pd.DataFrame({"col": [1, 2, 3]}, index=idx)
-    lmdb_version_store_dynamic_schema.write(symbol, initial)
+    def test_regular_append_dynamic_schema_named_index(
+        self, lmdb_version_store_tiny_segment_dynamic, compact_data_inline
+    ):
+        lib = lmdb_version_store_tiny_segment_dynamic
+        sym = "test_parallel_append_dynamic_schema_named_index"
+        df_0 = pd.DataFrame({"col_0": [0], "col_1": [0.5]}, index=pd.date_range("2024-01-01", periods=1))
+        df_0.index.name = "date"
+        df_1 = pd.DataFrame({"col_0": [1]}, index=pd.date_range("2024-01-02", periods=1))
+        lib.write(sym, df_0)
+        with pytest.raises(StreamDescriptorMismatch) as exception_info:
+            lib.append(sym, df_1, compact_data_inline=compact_data_inline)
 
-    bad_df = pd.DataFrame({True: [4, 5, 6]}, index=idx)
+        assert "date" in str(exception_info.value)
 
-    # The normalization exception is getting reraised as an ArcticNativeException so we check for that
-    with pytest.raises(ArcticNativeException):
-        lmdb_version_store_dynamic_schema.append(symbol, bad_df)
+    @pytest.mark.parametrize(
+        "idx", [pd.date_range(pd.Timestamp("2020-01-01"), periods=3), pd.RangeIndex(start=0, stop=3, step=1)]
+    )
+    def test_append_bool_named_col(self, lmdb_version_store_dynamic_schema, idx, compact_data_inline):
+        symbol = "bad_append"
 
-    assert_frame_equal(lmdb_version_store_dynamic_schema.read(symbol).data, initial)
+        initial = pd.DataFrame({"col": [1, 2, 3]}, index=idx)
+        lmdb_version_store_dynamic_schema.write(symbol, initial)
+
+        bad_df = pd.DataFrame({True: [4, 5, 6]}, index=idx)
+
+        # The normalization exception is getting reraised as an ArcticNativeException so we check for that
+        with pytest.raises(ArcticNativeException):
+            lmdb_version_store_dynamic_schema.append(symbol, bad_df, compact_data_inline=compact_data_inline)
+
+        assert_frame_equal(lmdb_version_store_dynamic_schema.read(symbol).data, initial)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -20,6 +20,7 @@ from arcticdb.version_store.library import Library
 from arcticdb_ext import set_config_int
 import arcticdb_ext.cpp_async as adb_async
 from arcticdb_ext.storage import KeyType
+from arcticdb_ext.exceptions import SchemaException
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.conftest import Marks
 from tests.util.date import DateRange
@@ -543,3 +544,15 @@ def test_all_snapshots_not_loaded_for_tombstoned_as_of(in_memory_store_factory, 
     assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT_REF") == 1
     assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT") == 1
     assert query_stats_operation_count(stats, "Memory_GetObject", "SNAPSHOT_REF") == 1
+
+
+@pytest.mark.parametrize("method", ["append", "update"])
+def test_dynamic_schema_incompatible_types_do_not_orphan_data_keys(in_memory_store_factory, clear_query_stats, method):
+    lib = in_memory_store_factory(dynamic_schema=True)
+    sym = "test_dynamic_schema_incompatible_types_do_not_orphan_data_keys"
+    lib.write(sym, pd.DataFrame({"col": [0]}, index=[pd.Timestamp("2026-01-01")]))
+    lt = lib.library_tool()
+    assert len(lt.find_keys(KeyType.TABLE_DATA)) == 1
+    with pytest.raises(SchemaException):
+        getattr(lib, method)(sym, pd.DataFrame({"col": ["hello"]}, index=[pd.Timestamp("2026-01-02")]))
+    assert len(lt.find_keys(KeyType.TABLE_DATA)) == 1

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -21,147 +21,69 @@ from arcticdb.util.logger import get_logger
 from tests.util.mark import WINDOWS
 
 
-def test_append_simple(lmdb_version_store):
-    symbol = "test_append_simple"
-    df1 = pd.DataFrame({"x": np.arange(1, 10, dtype=np.int64)})
-    lmdb_version_store.write(symbol, df1)
-    vit = lmdb_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
+def get_next_business_date(d: datetime) -> datetime:
+    """Returns next business date from datetime 'd' (uses pandas BDay)."""
 
-    df2 = pd.DataFrame({"x": np.arange(11, 20, dtype=np.int64)})
-    lmdb_version_store.append(symbol, df2)
-    vit = lmdb_version_store.read(symbol)
-    expected = pd.concat([df1, df2], ignore_index=True)
-    assert_frame_equal(vit.data, expected)
+    return (d + BDay(1)).to_pydatetime()
 
 
-@pytest.mark.parametrize("empty_types", (True, False))
-@pytest.mark.parametrize("dynamic_schema", (True, False))
-def test_append_range_index(version_store_factory, empty_types, dynamic_schema):
-    lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
-    sym = "test_append_range_index"
-    df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(0, 4, 2))
-    lib.write(sym, df_0)
-
-    # Appending another range index following on from what is there should work
-    df_1 = pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(4, 8, 2))
-    lib.append(sym, df_1)
-    expected = pd.concat([df_0, df_1])
-    received = lib.read(sym).data
-    assert_frame_equal(expected, received)
-
-    # Appending a range starting earlier or later, or with a different step size, should fail
-    for idx in [
-        pd.RangeIndex(6, 10, 2),
-        pd.RangeIndex(10, 14, 2),
-        pd.RangeIndex(8, 14, 3),
-    ]:
-        with pytest.raises(NormalizationException):
-            lib.append(sym, pd.DataFrame({"col": [4, 5]}, index=idx))
-
-
-@pytest.mark.parametrize("empty_types", (True, False))
-@pytest.mark.parametrize("dynamic_schema", (True, False))
-def test_append_range_index_from_zero(version_store_factory, empty_types, dynamic_schema):
-    lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
-    sym = "test_append_range_index_from_zero"
-    df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(-6, -2, 2))
-    lib.write(sym, df_0)
-
-    with pytest.raises(NormalizationException):
-        lib.append(sym, pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(0, 4, 2)))
-
-
-def test_append_indexed(s3_version_store):
-    symbol = "test_append_simple"
-    idx1 = np.arange(0, 10)
-    d1 = {"x": np.arange(10, 20, dtype=np.int64)}
-    df1 = pd.DataFrame(data=d1, index=idx1)
-    s3_version_store.write(symbol, df1)
-    vit = s3_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
-
-    idx2 = np.arange(10, 20)
-    d2 = {"x": np.arange(20, 30, dtype=np.int64)}
-    df2 = pd.DataFrame(data=d2, index=idx2)
-    s3_version_store.append(symbol, df2)
-    vit = s3_version_store.read(symbol)
-    expected = pd.concat([df1, df2])
-    assert_frame_equal(vit.data, expected)
-
-
-def test_append_string_of_different_sizes(lmdb_version_store):
-    symbol = "test_append_simple"
-    df1 = pd.DataFrame(data={"x": ["cat", "dog"]}, index=np.arange(0, 2))
-    lmdb_version_store.write(symbol, df1)
-    vit = lmdb_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
-
-    df2 = pd.DataFrame(
-        data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]},
-        index=np.arange(2, 4),
+def create_random_data(at_date: datetime, num_cols: int = 5) -> pd.DataFrame:
+    date_range = pd.date_range(
+        start=at_date.replace(hour=0, minute=0, second=0, microsecond=0),
+        end=at_date.replace(hour=18, minute=0, second=0, microsecond=0),
+        freq="s",
     )
-    lmdb_version_store.append(symbol, df2)
-    vit = lmdb_version_store.read(symbol)
-    expected = pd.concat([df1, df2])
-    assert_frame_equal(vit.data, expected)
+    data = np.round(np.random.random(size=(len(date_range), num_cols)) * 100, 2)
+
+    return pd.DataFrame(data=data, index=date_range, columns=[f"c{i + 1}" for i in range(num_cols)])
 
 
-def test_append_dynamic_schema_add_column(lmdb_version_store_dynamic_schema):
-    symbol = "symbol"
-    lib = lmdb_version_store_dynamic_schema
-    df_1 = pd.DataFrame(data={"a": [1.0, 2.0]}, index=pd.date_range("2018-01-01", periods=2))
-    df_2 = pd.DataFrame(data={"b": [3.0, 4.0]}, index=pd.date_range("2018-01-03", periods=2))
+@pytest.mark.xfail(reason="Needs to be fixed with issue #496")
+def test_append_with_cont_mem_problem(sym, lmdb_version_store_tiny_segment_dynamic):
+    set_config_int("SymbolDataCompact.SegmentCount", 1)
+    df0 = pd.DataFrame({"0": ["01234567890123456"]}, index=[pd.Timestamp(0)])
+    df1 = pd.DataFrame({"0": ["012345678901234567"]}, index=[pd.Timestamp(1)])
+    df2 = pd.DataFrame({"0": ["0123456789012345678"]}, index=[pd.Timestamp(2)])
+    df3 = pd.DataFrame({"0": ["01234567890123456789"]}, index=[pd.Timestamp(3)])
+    df = pd.concat([df0, df1, df2, df3])
 
-    lib.write(symbol, df_1)
-    lib.append(symbol, df_2)
-
-    expected_df = pd.concat([df_1, df_2])
-    result_df = lib.read(symbol).data
-    assert_frame_equal(result_df, expected_df)
-
-
-def test_append_snapshot_delete(lmdb_version_store):
-    symbol = "test_append_snapshot_delete"
-    if sys.platform == "win32":
-        # Keep it smaller on Windows due to restricted LMDB size
-        row_count = 1000
-    else:
-        row_count = 1000000
-    idx1 = np.arange(0, row_count)
-    d1 = {"x": np.arange(row_count, 2 * row_count, dtype=np.int64)}
-    df1 = pd.DataFrame(data=d1, index=idx1)
-    lmdb_version_store.write(symbol, df1)
-    vit = lmdb_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
-
-    lmdb_version_store.snapshot("my_snap")
-
-    idx2 = np.arange(row_count, 2 * row_count)
-    d2 = {"x": np.arange(2 * row_count, 3 * row_count, dtype=np.int64)}
-    df2 = pd.DataFrame(data=d2, index=idx2)
-    lmdb_version_store.append(symbol, df2)
-    vit = lmdb_version_store.read(symbol)
-    expected = pd.concat([df1, df2])
-    assert_frame_equal(vit.data, expected)
-
-    lmdb_version_store.delete(symbol)
-    versions = lmdb_version_store.list_versions()
-    assert len(versions) == 1
-    version = versions[0]
-    version.pop("date")
-    assert version == {"deleted": True, "snapshots": ["my_snap"], "symbol": symbol, "version": 0}
-
-    assert_frame_equal(lmdb_version_store.read(symbol, as_of="my_snap").data, df1)
+    for _ in range(100):
+        lib = lmdb_version_store_tiny_segment_dynamic
+        lib.write(sym, df0).version
+        lib.append(sym, df1).version
+        lib.append(sym, df2).version
+        lib.append(sym, df3).version
+        assert lib.get_info(sym)["sorted"] == "ASCENDING"
+        lib.version_store.defragment_symbol_data(sym, None)
+        assert lib.get_info(sym)["sorted"] == "ASCENDING"
+        res = lib.read(sym).data
+        assert_frame_equal(df, res)
 
 
-def test_append_out_of_order_throws(lmdb_version_store):
-    lib: NativeVersionStore = lmdb_version_store
-    lib.write("a", pd.DataFrame({"c": [1, 2, 3]}, index=pd.date_range(0, periods=3)))
-    with pytest.raises(Exception, match="1970-01-03"):
-        lib.append("a", pd.DataFrame({"c": [4]}, index=pd.date_range(1, periods=1)))
+def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
+    pytest.skip("This test is flaky due to trying to retrieve the log messages")
+    lib = s3_store_factory(dynamic_strings=True, incomplete=True)
+    lib_tool = lib.library_tool()
+    symbol = sym
+
+    write_df = pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([1, 2, 3]))
+    lib_tool.append_incomplete(symbol, write_df)
+    # Need to compact so that the APPEND_REF points to a non-existent APPEND_DATA (intentionally)
+    lib.compact_incomplete(symbol, True, False, False, True)
+    set_log_level("DEBUG")
+
+    try:
+        read_df = lib.read(symbol, date_range=(pd.to_datetime(0), pd.to_datetime(10))).data
+        assert_frame_equal(read_df, write_df.tz_localize("UTC"))
+
+        err = get_stderr()
+        assert err.count("W arcticdb.storage | Failed to find segment for key") == 0
+        assert err.count("D arcticdb.storage | Failed to find segment for key") == 1
+    finally:
+        set_log_level()
 
 
+# sort_index assumes segments are internally sorted, which is not the case when appending with compact_data_inline=True
 @pytest.mark.parametrize("prune_previous_versions", [True, False])
 def test_append_out_of_order_and_sort(lmdb_version_store_ignore_order, prune_previous_versions):
     symbol = "out_of_order"
@@ -232,406 +154,6 @@ def test_sort_index(version_store_factory, dynamic_schema, prune_previous_versio
     assert_frame_equal(lib.read(symbol).data, sorted_df)
 
 
-def test_upsert_with_delete(lmdb_version_store_big_map):
-    lib = lmdb_version_store_big_map
-    symbol = "upsert_with_delete"
-    lib.version_store.remove_incomplete(symbol)
-    lib.version_store._set_validate_version_map()
-
-    num_rows = 1111
-    dtidx = pd.date_range("1970-01-01", periods=num_rows)
-    test = pd.DataFrame(
-        {
-            "uint8": random_integers(num_rows, np.uint8),
-            "uint32": random_integers(num_rows, np.uint32),
-        },
-        index=dtidx,
-    )
-    chunk_size = 100
-    list_df = [test[i : i + chunk_size] for i in range(0, test.shape[0], chunk_size)]
-
-    for idx, df in enumerate(list_df):
-        if idx % 3 == 0:
-            lib.delete(symbol)
-
-        lib.append(symbol, df, write_if_missing=True)
-
-    first = list_df[len(list_df) - 3]
-    second = list_df[len(list_df) - 2]
-    third = list_df[len(list_df) - 1]
-
-    expected = pd.concat([first, second, third])
-    vit = lib.read(symbol)
-    assert_frame_equal(vit.data, expected)
-
-
-@pytest.mark.xfail(
-    condition=WINDOWS, raises=arcticdb.exceptions.ArcticDbNotYetImplemented, reason="Not implemented on Windows"
-)
-@pytest.mark.parametrize("dtype", supported_types_list)
-def test_append_numpy_array(lmdb_version_store, dtype):
-    """Tests append with all supported by arctic data types"""
-    sym = f"test_append_numpy_array"
-    np1 = generate_random_numpy_array(10, dtype)
-    lmdb_version_store.write(sym, np1)
-    np2 = generate_random_numpy_array(10, dtype)
-    lmdb_version_store.append(sym, np2)
-    expected = np.concatenate((np1, np2))
-    assert_array_equal(lmdb_version_store.read(sym).data, expected)
-
-
-def test_append_pickled_symbol(lmdb_version_store):
-    symbol = "test_append_pickled_symbol"
-    lmdb_version_store.write(symbol, np.arange(100).tolist())
-    assert lmdb_version_store.is_symbol_pickled(symbol)
-    with pytest.raises(InternalException):
-        _ = lmdb_version_store.append(symbol, np.arange(100).tolist())
-
-
-def test_append_not_sorted_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-
-    with pytest.raises(UnsortedDataException):
-        lmdb_version_store.append(symbol, df2, validate_index=True)
-
-
-@pytest.mark.parametrize("validate_index", (True, False))
-def test_append_same_index_value(lmdb_version_store_v1, validate_index):
-    lib = lmdb_version_store_v1
-    sym = "test_append_same_index_value"
-    df_0 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
-    lib.write(sym, df_0)
-
-    df_1 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range(df_0.index[-1], periods=2))
-    lib.append(sym, df_1, validate_index=validate_index)
-    expected = pd.concat([df_0, df_1])
-    received = lib.read(sym).data
-    assert_frame_equal(expected, received)
-    assert lib.get_info(sym)["sorted"] == "ASCENDING"
-
-
-def test_append_existing_not_sorted_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_initial_rows), 3)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == False
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-
-    with pytest.raises(UnsortedDataException):
-        lmdb_version_store.append(symbol, df2, validate_index=True)
-
-
-def test_append_not_sorted_non_validate_index(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-    lmdb_version_store.append(symbol, df2)
-
-
-def test_append_not_sorted_multi_index_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx1 = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    dtidx2 = np.roll(np.arange(0, num_initial_rows), 3)
-    df = pd.DataFrame(
-        {"c": np.arange(0, num_initial_rows, dtype=np.int64)},
-        index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
-    )
-    assert isinstance(df.index, MultiIndex) == True
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx1 = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    dtidx2 = np.arange(0, num_rows)
-    df2 = pd.DataFrame(
-        {"c": np.arange(0, num_rows, dtype=np.int64)},
-        index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
-    )
-    assert df2.index.is_monotonic_increasing == False
-    assert isinstance(df.index, MultiIndex) == True
-
-    with pytest.raises(UnsortedDataException):
-        lmdb_version_store.append(symbol, df2, validate_index=True)
-
-
-def test_append_not_sorted_range_index_non_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    dtidx = pd.RangeIndex(0, num_initial_rows, 1)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNKNOWN"
-
-    num_rows = 20
-    dtidx = pd.RangeIndex(num_initial_rows, num_initial_rows + num_rows, 1)
-    dtidx = np.roll(dtidx, 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-    with pytest.raises(NormalizationException):
-        lmdb_version_store.append(symbol, df2)
-
-
-def test_append_mix_ascending_not_sorted(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df, validate_index=True)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-    lmdb_version_store.append(symbol, df2, validate_index=True)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2021-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2022-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-
-def test_append_mix_descending_not_sorted(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df.index.is_monotonic_decreasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "DESCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df2.index.is_monotonic_decreasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "DESCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2021-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_decreasing == False
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2022-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df2.index.is_monotonic_decreasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-
-def test_append_mix_ascending_descending(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df.index.is_monotonic_decreasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "DESCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2022-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df2.index.is_monotonic_decreasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-
-@pytest.mark.xfail(reason="Needs to be fixed with issue #496")
-def test_append_with_cont_mem_problem(sym, lmdb_version_store_tiny_segment_dynamic):
-    set_config_int("SymbolDataCompact.SegmentCount", 1)
-    df0 = pd.DataFrame({"0": ["01234567890123456"]}, index=[pd.Timestamp(0)])
-    df1 = pd.DataFrame({"0": ["012345678901234567"]}, index=[pd.Timestamp(1)])
-    df2 = pd.DataFrame({"0": ["0123456789012345678"]}, index=[pd.Timestamp(2)])
-    df3 = pd.DataFrame({"0": ["01234567890123456789"]}, index=[pd.Timestamp(3)])
-    df = pd.concat([df0, df1, df2, df3])
-
-    for _ in range(100):
-        lib = lmdb_version_store_tiny_segment_dynamic
-        lib.write(sym, df0).version
-        lib.append(sym, df1).version
-        lib.append(sym, df2).version
-        lib.append(sym, df3).version
-        assert lib.get_info(sym)["sorted"] == "ASCENDING"
-        lib.version_store.defragment_symbol_data(sym, None)
-        assert lib.get_info(sym)["sorted"] == "ASCENDING"
-        res = lib.read(sym).data
-        assert_frame_equal(df, res)
-
-
-def test_append_docs_example(lmdb_version_store):
-    # This test is really just the append example from the docs.
-    # Other examples are included so that outputs can be easily re-generated.
-    lib = lmdb_version_store
-
-    # Write example
-    cols = ["COL_%d" % i for i in range(50)]
-    df = pd.DataFrame(np.random.randint(0, 50, size=(25, 50)), columns=cols)
-    df.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
-    print(df.head(2))
-    lib.write("test_frame", df)
-
-    # Read it back
-    from_storage_df = lib.read("test_frame").data
-    print(from_storage_df.head(2))
-
-    # Slicing and filtering examples
-    print(lib.read("test_frame", date_range=(df.index[5], df.index[8])).data)
-    _range = (df.index[5], df.index[8])
-    _cols = ["COL_30", "COL_31"]
-    print(lib.read("test_frame", date_range=_range, columns=_cols).data)
-    from arcticdb import QueryBuilder
-
-    q = QueryBuilder()
-    q = q[(q["COL_30"] > 30) & (q["COL_31"] < 50)]
-    print(lib.read("test_frame", date_range=_range, columns=_cols, query_builder=q).data)
-
-    # Update example
-    random_data = np.random.randint(0, 50, size=(25, 50))
-    df2 = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
-    df2.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
-    df2 = df2.iloc[[0, 2]]
-    print(df2)
-    lib.update("test_frame", df2)
-    print(lib.head("test_frame", 2))
-
-    # Append example
-    random_data = np.random.randint(0, 50, size=(5, 50))
-    df_append = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
-    print(df_append)
-    df_append.index = pd.date_range(datetime(2000, 1, 2, 7), periods=5, freq="H")
-
-    lib.append("test_frame", df_append)
-    print(lib.tail("test_frame", 7).data)
-    expected = pd.concat([df2, df.drop(df.index[:3]), df_append])
-    assert_frame_equal(lib.read("test_frame").data, expected)
-
-    print(lib.tail("test_frame", 7, as_of=0).data)
-
-
-def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
-    pytest.skip("This test is flaky due to trying to retrieve the log messages")
-    lib = s3_store_factory(dynamic_strings=True, incomplete=True)
-    lib_tool = lib.library_tool()
-    symbol = sym
-
-    write_df = pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([1, 2, 3]))
-    lib_tool.append_incomplete(symbol, write_df)
-    # Need to compact so that the APPEND_REF points to a non-existent APPEND_DATA (intentionally)
-    lib.compact_incomplete(symbol, True, False, False, True)
-    set_log_level("DEBUG")
-
-    try:
-        read_df = lib.read(symbol, date_range=(pd.to_datetime(0), pd.to_datetime(10))).data
-        assert_frame_equal(read_df, write_df.tz_localize("UTC"))
-
-        err = get_stderr()
-        assert err.count("W arcticdb.storage | Failed to find segment for key") == 0
-        assert err.count("D arcticdb.storage | Failed to find segment for key") == 1
-    finally:
-        set_log_level()
-
-
 @pytest.mark.parametrize("prune_previous_versions", [True, False])
 def test_defragment_read_prev_versions(sym, lmdb_version_store, prune_previous_versions):
     start_time, end_time = pd.to_datetime(("1990-1-1", "1995-1-1"))
@@ -687,114 +209,591 @@ def test_defragment_no_work_to_do(sym, lmdb_version_store):
         lmdb_version_store.defragment_symbol_data(sym)
 
 
-@pytest.mark.parametrize(
-    "to_write, to_append",
-    [
-        (pd.DataFrame({"a": [1]}), pd.Series([2])),
-        (pd.DataFrame({"a": [1]}), np.array([2])),
-        (pd.Series([1]), pd.DataFrame({"a": [2]})),
-        (pd.Series([1]), np.array([2])),
-        (np.array([1]), pd.DataFrame({"a": [2]})),
-        (np.array([1]), pd.Series([2])),
-        (pd.DataFrame({"a": [1], "b": [2]}), pd.Series([2])),
-        (pd.DataFrame({"a": [1], "b": [2]}), np.array([2])),
-        (pd.Series([1]), pd.DataFrame({"a": [2], "b": [2]})),
-        (np.array([1]), pd.DataFrame({"a": [2], "b": [2]})),
-    ],
-)
-def test_append_mismatched_object_kind(to_write, to_append, lmdb_version_store_dynamic_schema_v1):
-    lib = lmdb_version_store_dynamic_schema_v1
-    lib.write("sym", to_write)
-    with pytest.raises(NormalizationException) as e:
-        lib.append("sym", to_append)
-    assert "Append" in str(e.value)
+@pytest.mark.parametrize("compact_data_inline", [True, False])
+class TestAppend:
+    def test_append_simple(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_simple"
+        df1 = pd.DataFrame({"x": np.arange(1, 10, dtype=np.int64)})
+        lmdb_version_store.write(symbol, df1)
+        vit = lmdb_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
 
+        df2 = pd.DataFrame({"x": np.arange(11, 20, dtype=np.int64)})
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = lmdb_version_store.read(symbol)
+        expected = pd.concat([df1, df2], ignore_index=True)
+        assert_frame_equal(vit.data, expected)
 
-@pytest.mark.parametrize(
-    "to_write, to_append",
-    [
-        (pd.Series([1, 2, 3], name="name_1"), pd.Series([4, 5, 6], name="name_2")),
-        (
-            pd.Series(
-                [1, 2, 3], name="name_1", index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(1), pd.Timestamp(2)])
-            ),
-            pd.Series(
-                [4, 5, 6], name="name_2", index=pd.DatetimeIndex([pd.Timestamp(3), pd.Timestamp(4), pd.Timestamp(5)])
-            ),
-        ),
-    ],
-)
-def test_append_series_with_different_column_name_throws(lmdb_version_store_dynamic_schema_v1, to_write, to_append):
-    # It makes sense to create a new column and turn the whole thing into a dataframe. This would require changes in the
-    # logic for storing normalization metadata which is tricky. Noone has requested this, so we just throw.
-    lib = lmdb_version_store_dynamic_schema_v1
-    lib.write("sym", to_write)
-    with pytest.raises(SchemaException) as e:
-        lib.append("sym", to_append)
-    assert "name_1" in str(e.value) and "name_2" in str(e.value)
+    @pytest.mark.parametrize("empty_types", (True, False))
+    @pytest.mark.parametrize("dynamic_schema", (True, False))
+    def test_append_range_index(self, version_store_factory, empty_types, dynamic_schema, compact_data_inline):
+        lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
+        sym = "test_append_range_index"
+        df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(0, 4, 2))
+        lib.write(sym, df_0)
 
+        # Appending another range index following on from what is there should work
+        df_1 = pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(4, 8, 2))
+        lib.append(sym, df_1, compact_data_inline=compact_data_inline)
+        expected = pd.concat([df_0, df_1])
+        received = lib.read(sym).data
+        assert_frame_equal(expected, received)
 
-def test_append_series_with_different_row_range_index_name(lmdb_version_store_dynamic_schema_v1):
-    lib = lmdb_version_store_dynamic_schema_v1
-    to_write = pd.Series([1, 2, 3])
-    to_write.index.name = "index_name_1"
-    to_append = pd.Series([4, 5, 6])
-    to_append.index.name = "index_name_2"
-    lib.write("sym", to_write)
-    lib.append("sym", to_append)
-    # The current behavior is the last modification operation is setting the index name.
-    # See Monday 9797097831, it would be best to require that index names are always matching. This is the case for
-    # datetime index because it's a physical column. It's a potentially breaking change.
-    assert lib.read("sym").data.index.name == "index_name_2"
+        # Appending a range starting earlier or later, or with a different step size, should fail
+        for idx in [
+            pd.RangeIndex(6, 10, 2),
+            pd.RangeIndex(10, 14, 2),
+            pd.RangeIndex(8, 14, 3),
+        ]:
+            with pytest.raises(NormalizationException):
+                lib.append(sym, pd.DataFrame({"col": [4, 5]}, index=idx), compact_data_inline=compact_data_inline)
 
+    @pytest.mark.parametrize("empty_types", (True, False))
+    @pytest.mark.parametrize("dynamic_schema", (True, False))
+    def test_append_range_index_from_zero(
+        self, version_store_factory, empty_types, dynamic_schema, compact_data_inline
+    ):
+        lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
+        sym = "test_append_range_index_from_zero"
+        df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(-6, -2, 2))
+        lib.write(sym, df_0)
 
-def get_next_business_date(d: datetime) -> datetime:
-    """Returns next business date from datetime 'd' (uses pandas BDay)."""
+        with pytest.raises(NormalizationException):
+            lib.append(
+                sym,
+                pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(0, 4, 2)),
+                compact_data_inline=compact_data_inline,
+            )
 
-    return (d + BDay(1)).to_pydatetime()
+    def test_append_indexed(self, s3_version_store, compact_data_inline):
+        symbol = "test_append_simple"
+        idx1 = np.arange(0, 10)
+        d1 = {"x": np.arange(10, 20, dtype=np.int64)}
+        df1 = pd.DataFrame(data=d1, index=idx1)
+        s3_version_store.write(symbol, df1)
+        vit = s3_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
 
+        idx2 = np.arange(10, 20)
+        d2 = {"x": np.arange(20, 30, dtype=np.int64)}
+        df2 = pd.DataFrame(data=d2, index=idx2)
+        s3_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = s3_version_store.read(symbol)
+        expected = pd.concat([df1, df2])
+        assert_frame_equal(vit.data, expected)
 
-def create_random_data(at_date: datetime, num_cols: int = 5) -> pd.DataFrame:
-    date_range = pd.date_range(
-        start=at_date.replace(hour=0, minute=0, second=0, microsecond=0),
-        end=at_date.replace(hour=18, minute=0, second=0, microsecond=0),
-        freq="s",
+    def test_append_string_of_different_sizes(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_simple"
+        df1 = pd.DataFrame(data={"x": ["cat", "dog"]}, index=np.arange(0, 2))
+        lmdb_version_store.write(symbol, df1)
+        vit = lmdb_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
+
+        df2 = pd.DataFrame(
+            data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]},
+            index=np.arange(2, 4),
+        )
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = lmdb_version_store.read(symbol)
+        expected = pd.concat([df1, df2])
+        assert_frame_equal(vit.data, expected)
+
+    def test_append_dynamic_schema_add_column(self, lmdb_version_store_dynamic_schema, compact_data_inline):
+        symbol = "symbol"
+        lib = lmdb_version_store_dynamic_schema
+        df_1 = pd.DataFrame(data={"a": [1.0, 2.0]}, index=pd.date_range("2018-01-01", periods=2))
+        df_2 = pd.DataFrame(data={"b": [3.0, 4.0]}, index=pd.date_range("2018-01-03", periods=2))
+
+        lib.write(symbol, df_1)
+        lib.append(symbol, df_2, compact_data_inline=compact_data_inline)
+
+        expected_df = pd.concat([df_1, df_2])
+        result_df = lib.read(symbol).data
+        assert_frame_equal(result_df, expected_df)
+
+    def test_append_snapshot_delete(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_snapshot_delete"
+        if sys.platform == "win32":
+            # Keep it smaller on Windows due to restricted LMDB size
+            row_count = 1000
+        else:
+            row_count = 1000000
+        idx1 = np.arange(0, row_count)
+        d1 = {"x": np.arange(row_count, 2 * row_count, dtype=np.int64)}
+        df1 = pd.DataFrame(data=d1, index=idx1)
+        lmdb_version_store.write(symbol, df1)
+        vit = lmdb_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
+
+        lmdb_version_store.snapshot("my_snap")
+
+        idx2 = np.arange(row_count, 2 * row_count)
+        d2 = {"x": np.arange(2 * row_count, 3 * row_count, dtype=np.int64)}
+        df2 = pd.DataFrame(data=d2, index=idx2)
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = lmdb_version_store.read(symbol)
+        expected = pd.concat([df1, df2])
+        assert_frame_equal(vit.data, expected)
+
+        lmdb_version_store.delete(symbol)
+        versions = lmdb_version_store.list_versions()
+        assert len(versions) == 1
+        version = versions[0]
+        version.pop("date")
+        assert version == {"deleted": True, "snapshots": ["my_snap"], "symbol": symbol, "version": 0}
+
+        assert_frame_equal(lmdb_version_store.read(symbol, as_of="my_snap").data, df1)
+
+    def test_append_out_of_order_throws(self, lmdb_version_store, compact_data_inline):
+        lib: NativeVersionStore = lmdb_version_store
+        lib.write("a", pd.DataFrame({"c": [1, 2, 3]}, index=pd.date_range(0, periods=3)))
+        with pytest.raises(Exception, match="1970-01-03"):
+            lib.append(
+                "a",
+                pd.DataFrame({"c": [4]}, index=pd.date_range(1, periods=1)),
+                compact_data_inline=compact_data_inline,
+            )
+
+    def test_upsert_with_delete(self, lmdb_version_store_big_map, compact_data_inline):
+        lib = lmdb_version_store_big_map
+        symbol = "upsert_with_delete"
+        lib.version_store.remove_incomplete(symbol)
+        lib.version_store._set_validate_version_map()
+
+        num_rows = 1111
+        dtidx = pd.date_range("1970-01-01", periods=num_rows)
+        test = pd.DataFrame(
+            {
+                "uint8": random_integers(num_rows, np.uint8),
+                "uint32": random_integers(num_rows, np.uint32),
+            },
+            index=dtidx,
+        )
+        chunk_size = 100
+        list_df = [test[i : i + chunk_size] for i in range(0, test.shape[0], chunk_size)]
+
+        for idx, df in enumerate(list_df):
+            if idx % 3 == 0:
+                lib.delete(symbol)
+
+            lib.append(symbol, df, write_if_missing=True, compact_data_inline=compact_data_inline)
+
+        first = list_df[len(list_df) - 3]
+        second = list_df[len(list_df) - 2]
+        third = list_df[len(list_df) - 1]
+
+        expected = pd.concat([first, second, third])
+        vit = lib.read(symbol)
+        assert_frame_equal(vit.data, expected)
+
+    @pytest.mark.xfail(
+        condition=WINDOWS, raises=arcticdb.exceptions.ArcticDbNotYetImplemented, reason="Not implemented on Windows"
     )
-    data = np.round(np.random.random(size=(len(date_range), num_cols)) * 100, 2)
+    @pytest.mark.parametrize("dtype", supported_types_list)
+    def test_append_numpy_array(self, lmdb_version_store, dtype, compact_data_inline):
+        """Tests append with all supported by arctic data types"""
+        sym = f"test_append_numpy_array"
+        np1 = generate_random_numpy_array(10, dtype)
+        lmdb_version_store.write(sym, np1)
+        np2 = generate_random_numpy_array(10, dtype)
+        lmdb_version_store.append(sym, np2, compact_data_inline=compact_data_inline)
+        expected = np.concatenate((np1, np2))
+        assert_array_equal(lmdb_version_store.read(sym).data, expected)
 
-    return pd.DataFrame(data=data, index=date_range, columns=[f"c{i + 1}" for i in range(num_cols)])
+    def test_append_pickled_symbol(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_pickled_symbol"
+        lmdb_version_store.write(symbol, np.arange(100).tolist())
+        assert lmdb_version_store.is_symbol_pickled(symbol)
+        with pytest.raises(InternalException):
+            _ = lmdb_version_store.append(symbol, np.arange(100).tolist(), compact_data_inline=compact_data_inline)
 
+    def test_append_not_sorted_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
 
-def test_append_after_delete_range(sym, lmdb_version_store):
-    lib = lmdb_version_store
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == True
 
-    start_date = datetime(2025, 9, 1)
-    end_date = datetime(2025, 9, 2)
-    cur_date = start_date
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
 
-    # create data
-    while cur_date <= end_date:
-        df = create_random_data(at_date=cur_date)
-        lib.append("sym", df)
-        cur_date = get_next_business_date(cur_date)
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
 
-    # remove date
-    lib.delete("sym", date_range=(datetime(2025, 9, 2), datetime(2025, 9, 3)))
+        with pytest.raises(UnsortedDataException):
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
 
-    # re-insert data
-    start_date = datetime(2025, 9, 2)
-    end_date = datetime(2025, 9, 3)
-    cur_date = start_date
+    @pytest.mark.parametrize("validate_index", (True, False))
+    def test_append_same_index_value(self, lmdb_version_store_v1, validate_index, compact_data_inline):
+        lib = lmdb_version_store_v1
+        sym = "test_append_same_index_value"
+        df_0 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
+        lib.write(sym, df_0)
 
-    expected_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 2))).data
+        df_1 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range(df_0.index[-1], periods=2))
+        lib.append(sym, df_1, validate_index=validate_index, compact_data_inline=compact_data_inline)
+        expected = pd.concat([df_0, df_1])
+        received = lib.read(sym).data
+        assert_frame_equal(expected, received)
+        assert lib.get_info(sym)["sorted"] == "ASCENDING"
 
-    while cur_date <= end_date:
-        df = create_random_data(at_date=cur_date)
-        expected_data = pd.concat([expected_data, df])
-        lib.append("sym", df)
-        cur_date = get_next_business_date(cur_date)
+    def test_append_existing_not_sorted_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
 
-    assert_frame_equal(lib.read("sym").data, expected_data)
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_initial_rows), 3)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == False
 
-    sliced_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 4))).data
-    assert_frame_equal(sliced_data, expected_data)
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+
+        with pytest.raises(UnsortedDataException):
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_non_validate_index(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_multi_index_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx1 = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        dtidx2 = np.roll(np.arange(0, num_initial_rows), 3)
+        df = pd.DataFrame(
+            {"c": np.arange(0, num_initial_rows, dtype=np.int64)},
+            index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
+        )
+        assert isinstance(df.index, MultiIndex) == True
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx1 = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        dtidx2 = np.arange(0, num_rows)
+        df2 = pd.DataFrame(
+            {"c": np.arange(0, num_rows, dtype=np.int64)},
+            index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
+        )
+        assert df2.index.is_monotonic_increasing == False
+        assert isinstance(df.index, MultiIndex) == True
+
+        with pytest.raises(UnsortedDataException):
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_range_index_non_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        dtidx = pd.RangeIndex(0, num_initial_rows, 1)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNKNOWN"
+
+        num_rows = 20
+        dtidx = pd.RangeIndex(num_initial_rows, num_initial_rows + num_rows, 1)
+        dtidx = np.roll(dtidx, 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+        with pytest.raises(NormalizationException):
+            lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+
+    def test_append_mix_ascending_not_sorted(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df, validate_index=True)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+        lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2021-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2022-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+    def test_append_mix_descending_not_sorted(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df.index.is_monotonic_decreasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "DESCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df2.index.is_monotonic_decreasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "DESCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2021-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_decreasing == False
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2022-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df2.index.is_monotonic_decreasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+    def test_append_mix_ascending_descending(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df.index.is_monotonic_decreasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "DESCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2022-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df2.index.is_monotonic_decreasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+    def test_append_docs_example(self, lmdb_version_store, compact_data_inline):
+        # This test is really just the append example from the docs.
+        # Other examples are included so that outputs can be easily re-generated.
+        lib = lmdb_version_store
+
+        # Write example
+        cols = ["COL_%d" % i for i in range(50)]
+        df = pd.DataFrame(np.random.randint(0, 50, size=(25, 50)), columns=cols)
+        df.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
+        print(df.head(2))
+        lib.write("test_frame", df)
+
+        # Read it back
+        from_storage_df = lib.read("test_frame").data
+        print(from_storage_df.head(2))
+
+        # Slicing and filtering examples
+        print(lib.read("test_frame", date_range=(df.index[5], df.index[8])).data)
+        _range = (df.index[5], df.index[8])
+        _cols = ["COL_30", "COL_31"]
+        print(lib.read("test_frame", date_range=_range, columns=_cols).data)
+        from arcticdb import QueryBuilder
+
+        q = QueryBuilder()
+        q = q[(q["COL_30"] > 30) & (q["COL_31"] < 50)]
+        print(lib.read("test_frame", date_range=_range, columns=_cols, query_builder=q).data)
+
+        # Update example
+        random_data = np.random.randint(0, 50, size=(25, 50))
+        df2 = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
+        df2.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
+        df2 = df2.iloc[[0, 2]]
+        print(df2)
+        lib.update("test_frame", df2)
+        print(lib.head("test_frame", 2))
+
+        # Append example
+        random_data = np.random.randint(0, 50, size=(5, 50))
+        df_append = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
+        print(df_append)
+        df_append.index = pd.date_range(datetime(2000, 1, 2, 7), periods=5, freq="H")
+
+        lib.append("test_frame", df_append, compact_data_inline=compact_data_inline)
+        print(lib.tail("test_frame", 7).data)
+        expected = pd.concat([df2, df.drop(df.index[:3]), df_append])
+        assert_frame_equal(lib.read("test_frame").data, expected)
+
+        print(lib.tail("test_frame", 7, as_of=0).data)
+
+    @pytest.mark.parametrize(
+        "to_write, to_append",
+        [
+            (pd.DataFrame({"a": [1]}), pd.Series([2])),
+            (pd.DataFrame({"a": [1]}), np.array([2])),
+            (pd.Series([1]), pd.DataFrame({"a": [2]})),
+            (pd.Series([1]), np.array([2])),
+            (np.array([1]), pd.DataFrame({"a": [2]})),
+            (np.array([1]), pd.Series([2])),
+            (pd.DataFrame({"a": [1], "b": [2]}), pd.Series([2])),
+            (pd.DataFrame({"a": [1], "b": [2]}), np.array([2])),
+            (pd.Series([1]), pd.DataFrame({"a": [2], "b": [2]})),
+            (np.array([1]), pd.DataFrame({"a": [2], "b": [2]})),
+        ],
+    )
+    def test_append_mismatched_object_kind(
+        self, to_write, to_append, lmdb_version_store_dynamic_schema_v1, compact_data_inline
+    ):
+        lib = lmdb_version_store_dynamic_schema_v1
+        lib.write("sym", to_write)
+        with pytest.raises(NormalizationException) as e:
+            lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        assert "Append" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "to_write, to_append",
+        [
+            (pd.Series([1, 2, 3], name="name_1"), pd.Series([4, 5, 6], name="name_2")),
+            (
+                pd.Series(
+                    [1, 2, 3],
+                    name="name_1",
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(1), pd.Timestamp(2)]),
+                ),
+                pd.Series(
+                    [4, 5, 6],
+                    name="name_2",
+                    index=pd.DatetimeIndex([pd.Timestamp(3), pd.Timestamp(4), pd.Timestamp(5)]),
+                ),
+            ),
+        ],
+    )
+    def test_append_series_with_different_column_name_throws(
+        self, lmdb_version_store_dynamic_schema_v1, to_write, to_append, compact_data_inline
+    ):
+        # It makes sense to create a new column and turn the whole thing into a dataframe. This would require changes in the
+        # logic for storing normalization metadata which is tricky. Noone has requested this, so we just throw.
+        lib = lmdb_version_store_dynamic_schema_v1
+        lib.write("sym", to_write)
+        with pytest.raises(SchemaException) as e:
+            lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        assert "name_1" in str(e.value) and "name_2" in str(e.value)
+
+    def test_append_series_with_different_row_range_index_name(
+        self, lmdb_version_store_dynamic_schema_v1, compact_data_inline
+    ):
+        lib = lmdb_version_store_dynamic_schema_v1
+        to_write = pd.Series([1, 2, 3])
+        to_write.index.name = "index_name_1"
+        to_append = pd.Series([4, 5, 6])
+        to_append.index.name = "index_name_2"
+        lib.write("sym", to_write)
+        lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        # The current behavior is the last modification operation is setting the index name.
+        # See Monday 9797097831, it would be best to require that index names are always matching. This is the case for
+        # datetime index because it's a physical column. It's a potentially breaking change.
+        assert lib.read("sym").data.index.name == "index_name_2"
+
+    def test_append_after_delete_range(self, sym, lmdb_version_store, compact_data_inline):
+        lib = lmdb_version_store
+
+        start_date = datetime(2025, 9, 1)
+        end_date = datetime(2025, 9, 2)
+        cur_date = start_date
+
+        # create data
+        while cur_date <= end_date:
+            df = create_random_data(at_date=cur_date)
+            lib.append("sym", df, compact_data_inline=compact_data_inline)
+            cur_date = get_next_business_date(cur_date)
+
+        # remove date
+        lib.delete("sym", date_range=(datetime(2025, 9, 2), datetime(2025, 9, 3)))
+
+        # re-insert data
+        start_date = datetime(2025, 9, 2)
+        end_date = datetime(2025, 9, 3)
+        cur_date = start_date
+
+        expected_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 2))).data
+
+        while cur_date <= end_date:
+            df = create_random_data(at_date=cur_date)
+            expected_data = pd.concat([expected_data, df])
+            lib.append("sym", df, compact_data_inline=compact_data_inline)
+            cur_date = get_next_business_date(cur_date)
+
+        assert_frame_equal(lib.read("sym").data, expected_data)
+
+        sliced_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 4))).data
+        assert_frame_equal(sliced_data, expected_data)

--- a/python/tests/unit/arcticdb/version_store/test_append_compact_data_inline.py
+++ b/python/tests/unit/arcticdb/version_store/test_append_compact_data_inline.py
@@ -1,0 +1,538 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+from hypothesis import given, settings
+import hypothesis.strategies as st
+import numpy as np
+import pandas as pd
+from polars.testing import assert_frame_equal as assert_frame_equal_pl
+import pyarrow as pa
+import pytest
+
+from arcticdb_ext.exceptions import InternalException
+import arcticdb.toolbox.query_stats as qs
+from arcticdb.util.hypothesis import (
+    use_of_function_scoped_fixtures_in_hypothesis_checked,
+)
+from arcticdb.util.test import assert_frame_equal, query_stats_operation_count, random_strings_of_length
+from tests.util.mark import MACOS, WINDOWS
+from tests.util.naughty_strings import read_big_list_of_naughty_strings
+
+pytestmark = pytest.mark.pipeline
+
+
+def generic_compact_data_inline_test(lib, sym, df, **append_kwargs):
+    qs.reset_stats()  # Clear any leftover stats from a previous failed run
+    vit_before_compaction = lib.read(sym, output_format="PANDAS" if isinstance(df, pd.DataFrame) else "POLARS")
+    oracle_sym = sym + "_oracle"
+    lib.write(oracle_sym, vit_before_compaction.data)
+    lib.append(oracle_sym, df, compact_data_inline=False, **append_kwargs)
+    # Use Polars so that sparse data checking is proper
+    expected = lib.read(oracle_sym, output_format="POLARS").data
+    pre_compaction_index = lib.read_index(sym)
+    pre_compaction_data_keys = len(pre_compaction_index)
+
+    with qs.query_stats():
+        lib.append(sym, df, compact_data_inline=True, **append_kwargs)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    rows_per_segment = lib.lib_cfg().lib_desc.version.write_options.segment_row_size
+    if rows_per_segment == 0:
+        rows_per_segment = 100_000
+    vit_after_compaction = lib.read(sym, output_format="POLARS")
+    received = vit_after_compaction.data
+    assert_frame_equal_pl(expected, received)
+    post_compaction_index = lib.read_index(sym)
+    row_counts = post_compaction_index["end_row"] - post_compaction_index["start_row"]
+    # Definitions taken from CompactDataClause constructor
+    min_rows_per_segment = max((2 * rows_per_segment) // 3, 1)
+    max_rows_per_segment = max((4 * rows_per_segment) // 3, rows_per_segment + 1)
+    # There might be fewer rows in total than min_rows_per_segment
+    min_rows_per_segment = min(min_rows_per_segment, len(expected))
+    assert row_counts.min() >= min_rows_per_segment
+    assert row_counts.max() <= max_rows_per_segment
+
+    post_compaction_data_keys = len(post_compaction_index)
+    new_data_keys = len(post_compaction_index[post_compaction_index["version_id"] > vit_before_compaction.version])
+    compacted_data_keys = pre_compaction_data_keys - (post_compaction_data_keys - new_data_keys)
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == compacted_data_keys
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == new_data_keys
+    # Doing a compaction would now have no impact
+    compact_data_info = lib.compact_data_explain_plan(sym)
+    assert not compact_data_info.will_do_work
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_basic(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory()
+    sym = "test_basic"
+    df_0 = pd.DataFrame(
+        {"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20)
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {"col": np.arange(20, 30)}, index=None if index is None else pd.date_range("2026-01-21", periods=10)
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("write_if_missing", [True, False])
+@pytest.mark.parametrize("compact_data_inline", [True, False])
+def test_write_if_missing(in_memory_store_factory, write_if_missing, compact_data_inline):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_write_if_missing"
+    df = pd.DataFrame({"col": np.arange(15)})
+    if write_if_missing:
+        lib.append(sym, df, compact_data_inline=compact_data_inline, write_if_missing=write_if_missing)
+        assert_frame_equal(df, lib.read(sym).data)
+        index = lib.read_index(sym)
+        row_counts = (index["end_row"] - index["start_row"]).to_list()
+        # See comment in LocalVersionedEngine::append_internal as to why this isn't [8, 7] when compact_data_inline is
+        # True
+        assert row_counts == [10, 5]
+    else:
+        with pytest.raises(InternalException):
+            lib.append(sym, df, compact_data_inline=compact_data_inline, write_if_missing=write_if_missing)
+
+
+def test_metadata(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    sym = "test_metadata"
+    lib.write(sym, pd.DataFrame({"col": [0]}), metadata="0")
+    lib.append(sym, pd.DataFrame({"col": [1]}), metadata="1", compact_data_inline=True)
+    vit = lib.read(sym)
+    assert vit.metadata == "1"
+    assert_frame_equal(vit.data, pd.DataFrame({"col": [0, 1]}))
+    assert len(lib.read_index(sym)) == 1
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_compact_whole_symbol(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_compact_whole_symbol"
+    df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
+    lib.write(sym, df[:5])
+    lib.append(sym, df[5:10])
+    lib.append(sym, df[10:15])
+    generic_compact_data_inline_test(lib, sym, df[15:])
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_compact_leftover_slices(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_compact_leftover_slices"
+    df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
+    lib.write(sym, df[:5])
+    generic_compact_data_inline_test(lib, sym, df[5:])
+
+
+def test_existing_data_compacted(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_existing_data_compacted"
+    df = pd.DataFrame({"col": np.arange(20)})
+    lib.write(sym, df[:10])
+    generic_compact_data_inline_test(lib, sym, df[10:])
+
+
+@pytest.mark.parametrize("total_rows", [25, 30, 35])
+def test_tail_of_existing_data_already_compacted(in_memory_store_factory, clear_query_stats, total_rows):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_tail_of_existing_data_already_compacted"
+    df = pd.DataFrame({"col": np.arange(total_rows)})
+    lib.write(sym, df[:5])
+    lib.append(sym, df[5:10])
+    lib.append(sym, df[10:20])
+    assert len(lib.read_index(sym)) == 3
+    generic_compact_data_inline_test(lib, sym, df[20:])
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
+def test_basic_dynamic_schema(in_memory_store_factory, clear_query_stats, index, segment_row_size):
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
+    sym = "test_basic_dynamic_schema"
+    df_0 = pd.DataFrame(
+        {
+            "col_0": np.arange(20, dtype=np.float64),
+            "col_1": np.arange(20, 40, dtype=np.float64),
+            "col_2": np.arange(40, 60, dtype=np.float64),
+        },
+        index=None if index is None else pd.date_range("2026-01-01", periods=20),
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {
+            "col_3": np.arange(100, 110, dtype=np.float64),
+            "col_2": np.arange(60, 70, dtype=np.float64),
+            "col_1": np.arange(40, 50, dtype=np.float64),
+        },
+        index=None if index is None else pd.date_range("2026-01-21", periods=10),
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5])
+def test_column_slicing(in_memory_store_factory, clear_query_stats, index, segment_row_size):
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, column_group_size=2)
+    sym = "test_column_slicing"
+    df_0 = pd.DataFrame(
+        {f"col_{idx}": np.arange(20) for idx in range(5)},
+        index=None if index is None else pd.date_range("2026-01-01", periods=20),
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {f"col_{idx}": np.arange(20, 30) for idx in range(5)},
+        index=None if index is None else pd.date_range("2026-01-21", periods=10),
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("names", [None, ["ts", None], [None, "level 2"], ["ts", "level 2"]])
+def test_multiindex(in_memory_store_factory, clear_query_stats, names):
+    lib = in_memory_store_factory(segment_row_size=10, dynamic_strings=True)
+    sym = "test_multiindex"
+    num_rows = 20
+    df = pd.DataFrame(
+        {"col": np.arange(num_rows)},
+        index=pd.MultiIndex.from_product(
+            [pd.date_range("2026-01-01", periods=num_rows // 2), ["GOOG", "AAPL"]], names=names
+        ),
+    )
+    lib.write(sym, df[:5])
+    generic_compact_data_inline_test(lib, sym, df[5:])
+
+
+def test_string_none_nan_handling(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory(dynamic_strings=True)
+    sym = "test_string_none_nan_handling"
+    df = pd.DataFrame({"col": ["hello", np.nan, np.nan, None, None, None, np.nan, np.nan, None, None]})
+    lib.write(sym, df[:5], coerce_columns={"col": object})
+    generic_compact_data_inline_test(lib, sym, df[5:], coerce_columns={"col": object})
+
+
+@pytest.mark.parametrize("dynamic_strings_first", [True, False])
+def test_fixed_width_and_dynamic_strings(in_memory_store_factory, clear_query_stats, dynamic_strings_first):
+    lib = in_memory_store_factory()
+    sym = "test_fixed_width_and_dynamic_strings"
+    # Include two segments with different widths of strings
+    df = pd.DataFrame({"col": ["a", "bb", "ccc", "dddd", "eeeee", "f", "gg", "hhhhhhhhhhhhhh", "i"]})
+    lib.write(sym, df[:3], dynamic_strings=dynamic_strings_first)
+    lib.append(sym, df[3:5], dynamic_strings=dynamic_strings_first)
+    lib.append(sym, df[5:7], dynamic_strings=not dynamic_strings_first)
+    generic_compact_data_inline_test(lib, sym, df[7:], dynamic_strings=not dynamic_strings_first)
+
+
+@pytest.mark.parametrize("dynamic_strings_first", [True, False])
+def test_blns(in_memory_store_factory, clear_query_stats, dynamic_strings_first):
+    lib = in_memory_store_factory()
+    sym = "test_blns"
+    df = pd.DataFrame({"col": read_big_list_of_naughty_strings()})
+    lib.write(sym, df[: len(df) // 2], dynamic_strings=dynamic_strings_first)
+    generic_compact_data_inline_test(lib, sym, df[len(df) // 2 :], dynamic_strings=not dynamic_strings_first)
+
+
+def test_append_empty_frame_no_work_to_do(in_memory_store_factory):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_append_empty_frame_no_work_to_do"
+    lib.write(sym, pd.DataFrame({"col": np.arange(10)}), metadata="0")
+    # Schema checks happen after empty input frame checks, so we don't need the same column set
+    # This metadata behaviour isn't ideal, but we should be consistent whether compact_data_inline is True or False
+    # See Monday issue 18103677039
+    lib.append(sym, pd.DataFrame(), metadata="1")
+    vit = lib.read(sym)
+    assert vit.version == 0
+    assert vit.metadata == "0"
+    lib.append(sym, pd.DataFrame(), metadata="1", compact_data_inline=True)
+    vit = lib.read(sym)
+    assert vit.version == 0
+    assert vit.metadata == "0"
+
+
+def test_append_empty_frame_compacts_existing_data(in_memory_store_factory):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_append_empty_frame_compacts_existing_data"
+    lib.write(sym, pd.DataFrame({"col": np.arange(5)}))
+    lib.append(sym, pd.DataFrame({"col": np.arange(5, 10)}))
+    # Schema checks happen after empty input frame checks, so we don't need the same column set
+    lib.append(sym, pd.DataFrame())
+    assert lib.read(sym).version == 1
+    lib.append(sym, pd.DataFrame(), compact_data_inline=True)
+    assert lib.read(sym).version == 2
+    assert len(lib.read_index(sym)) == 1
+
+
+@pytest.mark.parametrize("rows_to_append", [5, 10, 15, 20])
+def test_fortran_ordered_data(in_memory_store_factory, clear_query_stats, rows_to_append):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_fortran_ordered_data"
+    cols = ["col_0", "col_1"]
+    df_0 = pd.DataFrame(np.random.randint(0, 100, size=(5, 2)), columns=cols)
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(np.random.randint(0, 100, size=(rows_to_append, 2)), columns=cols)
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_column_filtered_read(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory(column_group_size=2, segment_row_size=10)
+    sym = "test_column_filtered_read"
+    num_rows = 20
+    df = pd.DataFrame(
+        {
+            "col_a": np.arange(num_rows),
+            "col_b": np.arange(num_rows, 2 * num_rows),
+            "col_c": np.arange(2 * num_rows, 3 * num_rows),
+        },
+        index=None if index is None else pd.date_range("2026-01-01", periods=num_rows),
+    )
+    lib.write(sym, df[:5])
+    for i in range(1, 4):
+        generic_compact_data_inline_test(lib, sym, df[i * 5 : (i + 1) * 5])
+    expected_col_a = df[["col_a"]]
+    expected_col_bc = df[["col_b", "col_c"]]
+    assert_frame_equal(expected_col_a, lib.read(sym, columns=["col_a"]).data)
+    assert_frame_equal(expected_col_bc, lib.read(sym, columns=["col_b", "col_c"]).data)
+
+
+@pytest.mark.parametrize("rows_per_segment", [3, 7, 10])
+def test_date_range_read(in_memory_store_factory, clear_query_stats, rows_per_segment):
+    lib = in_memory_store_factory(segment_row_size=rows_per_segment, dynamic_strings=True)
+    sym = "test_date_range_read"
+    num_rows = 100
+    index = pd.date_range("2026-01-01", periods=num_rows)
+    df = pd.DataFrame(
+        {"ints": np.arange(num_rows), "strings": 20 * ["hello", None, "gutentag", np.nan, "konichiwa"]}, index=index
+    )
+    lib.write(sym, df[:5])
+    for i in range(1, 20):
+        generic_compact_data_inline_test(lib, sym, df[i * 5 : (i + 1) * 5])
+    mid = index[num_rows // 2]
+    expected_first_half = df[:mid]
+    expected_second_half = df[mid:]
+    assert_frame_equal(expected_first_half, lib.read(sym, date_range=(index[0], mid)).data)
+    assert_frame_equal(expected_second_half, lib.read(sym, date_range=(mid, index[-1])).data)
+
+
+def test_read_previous_version(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_previous_version"
+    df = pd.DataFrame({"col": np.arange(10)})
+    lib.write(sym, df[:5])
+    generic_compact_data_inline_test(lib, sym, df[5:])
+    assert_frame_equal(df[:5], lib.read(sym, as_of=0).data)
+    assert_frame_equal(df, lib.read(sym, as_of=1).data)
+    assert_frame_equal(df, lib.read(sym).data)
+
+
+def test_schema_mismatch_static(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    sym = "test_schema_mismatch_static"
+    df_0 = pd.DataFrame({"col_0": [0]})
+    lib.write(sym, df_0)
+    # Different column sets
+    df_1 = pd.DataFrame({"col_1": [0]})
+    with pytest.raises(Exception) as e_without_arg:
+        lib.append(sym, df_1)
+    with pytest.raises(Exception) as e_with_arg:
+        lib.append(sym, df_1, compact_data_inline=True)
+    assert e_with_arg.type == e_without_arg.type
+    assert e_with_arg.typename == e_without_arg.typename
+    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+    # Different column type
+    df_1 = pd.DataFrame({"col_0": ["hello"]})
+    with pytest.raises(Exception) as e_without_arg:
+        lib.append(sym, df_1)
+    with pytest.raises(Exception) as e_with_arg:
+        lib.append(sym, df_1, compact_data_inline=True)
+    assert e_with_arg.type == e_without_arg.type
+    assert e_with_arg.typename == e_without_arg.typename
+    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+
+
+def test_schema_mismatch_dynamic(in_memory_store_factory):
+    lib = in_memory_store_factory(dynamic_schema=True)
+    sym = "test_schema_mismatch_dynamic"
+    df_0 = pd.DataFrame({"col_0": [0]})
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame({"col_0": ["hello"]})
+    with pytest.raises(Exception) as e_without_arg:
+        lib.append(sym, df_1)
+    with pytest.raises(Exception) as e_with_arg:
+        lib.append(sym, df_1, compact_data_inline=True)
+    assert e_with_arg.type == e_without_arg.type
+    assert e_with_arg.typename == e_without_arg.typename
+    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+
+
+# We are more interested in the slicing than the data, so the parameters are for:
+# - number of rows and columns
+# - library slicing settings
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(
+    # Making these parameters too large results in all the time being spent in numpy generating random numbers
+    num_rows=st.integers(1, 1_000),
+    num_cols=st.integers(1, 20),
+    # The more interesting cases are when num_rows > rows_per_segment
+    rows_per_segment=st.integers(10, 100),
+    cols_per_segment=st.integers(1, 20),
+    # Shrinks towards False, which is the simpler case
+    sparse=st.booleans(),
+)
+@pytest.mark.skipif(
+    WINDOWS or MACOS,
+    reason="""
+        On macOS/Windows the low timestamp resolution can cause duplicate keys when
+        successive operations land within the same clock tick.
+        TODO: Fix the underlying issue and remove this workaround (monday ticket ref 11777175142)
+""",
+)
+def test_hypothesis_static_schema(
+    in_memory_store_factory, clear_query_stats, num_rows, num_cols, rows_per_segment, cols_per_segment, sparse
+):
+    rng = np.random.default_rng(42)
+    lib = in_memory_store_factory(
+        column_group_size=cols_per_segment, segment_row_size=rows_per_segment, dynamic_strings=True, name="_unique_"
+    )
+    lib._set_allow_arrow_input()
+    sym = "test_hypothesis_static_schema"
+    supported_types = [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.float32,
+        np.float64,
+        bool,
+        str,
+        np.datetime64,
+    ]
+    col_types = rng.choice(supported_types, num_cols)
+    data = {}
+    string_values = random_strings_of_length(10, 5, True)
+    for idx in range(num_cols):
+        col_name = f"col_{idx}"
+        col_type = col_types[idx]
+        if np.issubdtype(col_type, np.integer):
+            arr = rng.integers(np.iinfo(col_type).min, np.iinfo(col_type).max, num_rows, col_type, True)
+        elif np.issubdtype(col_type, np.floating):
+            arr = rng.random(num_rows, col_type)
+        elif col_type == bool:
+            arr = rng.random(num_rows) > 0.5
+        elif col_type == str:
+            arr = rng.choice(string_values, num_rows)
+        else:
+            # datetime
+            arr = pd.date_range("2026-01-01", freq="s", periods=num_rows).values
+            rng.shuffle(arr)
+        if sparse:
+            null_mask = rng.random(num_rows) < 0.5
+            arr = pa.array(arr, mask=null_mask)
+        else:
+            arr = pa.array(arr)
+        data[col_name] = arr
+    table = pa.table(data)
+    # Append random numbers of rows between 1 and 2 * rows_per_segment
+    remaining_rows = num_rows
+    first_iteration = True
+    while remaining_rows > 0:
+        rows_to_take = rng.integers(1, 2 * rows_per_segment)
+        if first_iteration:
+            lib.write(sym, table.slice(length=rows_to_take))
+            first_iteration = False
+        else:
+            generic_compact_data_inline_test(lib, sym, table.slice(length=rows_to_take))
+        # lib.append(sym, table.slice(length=rows_to_take), compact_data_inline=True)
+        table = table.slice(offset=rows_to_take)
+        remaining_rows -= rows_to_take
+
+
+# We are more interested in the slicing than the data, so the parameters are for:
+# - number of rows
+# - library slicing settings
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(
+    # Making these parameters too large results in all the time being spent in numpy generating random numbers
+    num_rows=st.integers(1, 1_000),
+    # The more interesting cases are when num_rows > rows_per_segment
+    rows_per_segment=st.integers(10, 100),
+    # Shrinks towards False, which is the simpler case
+    sparse=st.booleans(),
+)
+@pytest.mark.skipif(
+    WINDOWS or MACOS,
+    reason="""
+        On macOS/Windows the low timestamp resolution can cause duplicate keys when
+        successive operations land within the same clock tick.
+        TODO: Fix the underlying issue and remove this workaround (monday ticket ref 11777175142)
+""",
+)
+def test_hypothesis_dynamic_schema(in_memory_store_factory, clear_query_stats, num_rows, rows_per_segment, sparse):
+    rng = np.random.default_rng(42)
+    lib = in_memory_store_factory(dynamic_schema=True, dynamic_strings=True, name="_unique_")
+    lib._set_allow_arrow_input()
+    sym = "test_hypothesis_dynamic_schema"
+    unsigned_int_types = [np.uint8, np.uint16, np.uint32, np.uint64]
+    signed_int_types = [np.int8, np.int16, np.int32, np.int64]
+    float_types = [np.float32, np.float64]
+    # Two string columns as stringpool dedup make them more complicated
+    cols = {
+        "unsigned_ints": unsigned_int_types,
+        "signed_ints": signed_int_types,
+        "floats": float_types,
+        # Exclude uint64 as it cannot be combined with signed int types at write time
+        "numeric": unsigned_int_types[:3] + signed_int_types + float_types,
+        "bools": [bool],
+        "timestamps": [np.datetime64],
+        "strings_1": [str],
+        "strings_2": [str],
+    }
+    all_col_names = list(cols.keys())
+    string_values = random_strings_of_length(10, 5, True)
+    # Append random numbers of rows between 1 and 2 * rows_per_segment
+    remaining_rows = num_rows
+    first_iteration = True
+    while remaining_rows > 0:
+        rows_to_take = rng.integers(1, 2 * rows_per_segment)
+        # Pick a subset of columns
+        num_columns = rng.integers(1, len(cols) + 1)
+        col_names = rng.choice(all_col_names, num_columns, False)
+        data = {}
+        for col_name in col_names:
+            col_type = rng.choice(cols[col_name])
+            if np.issubdtype(col_type, np.integer):
+                arr = rng.integers(np.iinfo(col_type).min, np.iinfo(col_type).max, rows_to_take, col_type, True)
+            elif np.issubdtype(col_type, np.floating):
+                arr = rng.random(rows_to_take, col_type)
+            elif col_type == bool:
+                arr = rng.random(rows_to_take) > 0.5
+            elif col_type == str:
+                arr = rng.choice(string_values, rows_to_take)
+            else:
+                # datetime
+                arr = pd.date_range("2026-01-01", freq="s", periods=rows_to_take).values
+                rng.shuffle(arr)
+            if sparse:
+                null_mask = rng.random(rows_to_take) < 0.5
+                arr = pa.array(arr, mask=null_mask)
+            else:
+                arr = pa.array(arr)
+            data[col_name] = arr
+        table = pa.table(data)
+        if first_iteration:
+            lib.write(sym, table)
+            first_iteration = False
+        else:
+            generic_compact_data_inline_test(lib, sym, table)
+        remaining_rows -= rows_to_take


### PR DESCRIPTION
#### Reference Issues/PRs
[12036593840](https://man312219.monday.com/boards/7852509418/pulses/12036593840)

#### What does this implement or fix?
Adds a `compact_data_inline` argument to `append` (on both the V1 and V2 APIs). This is roughly (although not exactly) equivalent to calling `append` followed by `compact_data`, but only creates a single new version. The invariant that every row slice will have `segment_row_size` ±33% rows after calling `append` with `compact_data_inline=True` still holds, but the exact on disk structure may differ when calling the two methods separately due to the slicing that can happen in `append` when `compact_data_inline=False`. The exception to this invariant is when the symbol does not exist (i.e. `upsert`). In this case the usual slice+write path is taken, which can result in very small segments due to the `FixedSlicer` greedily consuming rows. A better approach would be to have the `FixedSlicer` logic be more like `ReslicingInfo`, so that rows are more evenly distributed between segments, which would then benefit all modification methods.