### PR TITLE
Banning backslash in azure storage

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1094,6 +1094,7 @@ if(${TEST})
             storage/test/common.hpp
             storage/test/test_storage_exceptions.cpp
             storage/test/test_azure_storage.cpp
+            storage/test/test_path_validation.cpp
             storage/test/common.hpp
             storage/test/test_storage_operations.cpp
             stream/test/stream_test_common.cpp

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -184,7 +184,11 @@ class AsyncStore : public Store {
         return WriteIfNoneTask{library_}(std::move(encoded));
     }
 
-    bool is_path_valid(const std::string_view path) const override { return library_->is_path_valid(path); }
+    std::optional<char> is_path_valid(std::string_view path) const override { return library_->is_path_valid(path); }
+
+    std::optional<char> is_library_path_valid(std::string_view path) const override {
+        return library_->is_library_path_valid(path);
+    }
 
     folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair ks) override {
         return async::submit_io_task(WriteCompressedTask{std::move(ks), library_});

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -21,6 +21,8 @@
 #include <arcticdb/storage/mock/azure_mock_client.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
 
+#include <optional>
+
 #undef GetMessage
 
 namespace arcticdb::storage {
@@ -361,6 +363,13 @@ std::string AzureStorage::do_key_path(const VariantKey& key) const {
     auto b = FlatBucketizer{};
     auto key_type_dir = key_type_folder(root_folder_, variant_key_type(key));
     return object_path(b.bucketize(key_type_dir, key), key);
+}
+
+std::optional<char> AzureStorage::do_is_path_valid(std::string_view path) const {
+    // '\' is silently converted to '/' by the Azure Blob service (it is built on .NET's Uri class), so a name
+    // containing it would be stored under a path that no longer matches the recorded name. Disallow it.
+    const auto pos = path.find('\\');
+    return pos == std::string_view::npos ? std::nullopt : std::optional<char>{path[pos]};
 }
 
 } // namespace azure

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -58,6 +58,8 @@ class AzureStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final;
 
+    std::optional<char> do_is_path_valid(std::string_view path) const final;
+
   private:
     std::unique_ptr<AzureClientWrapper> azure_client_;
 

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -158,7 +158,13 @@ class Library {
 
     bool key_exists(const VariantKey& key) { return storages_->key_exists(key); }
 
-    [[nodiscard]] bool is_path_valid(const std::string_view path) const { return storages_->is_path_valid(path); }
+    [[nodiscard]] std::optional<char> is_path_valid(std::string_view path) const {
+        return storages_->is_path_valid(path);
+    }
+
+    [[nodiscard]] std::optional<char> is_library_path_valid(std::string_view path) const {
+        return storages_->is_library_path_valid(path);
+    }
 
     /** Calls VariantStorage::do_key_path on the primary storage */
     [[nodiscard]] std::string key_path(const VariantKey& key) const { return storages_->key_path(key); }

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -333,7 +333,10 @@ bool LmdbStorage::do_iterate_type_until_match(
     return false;
 }
 
-bool LmdbStorage::do_is_path_valid(std::string_view path ARCTICDB_UNUSED) const {
+std::optional<char> LmdbStorage::do_is_library_path_valid(std::string_view path) const {
+    if (auto unsupported = is_path_valid(path)) {
+        return unsupported;
+    }
 #ifdef _WIN32
     // Note that \ and / are valid characters as they will create subdirectories which are expected to work.
     // The filenames such as COM1, LPT1, AUX, CON etc. are reserved but not strictly disallowed by Windows as directory
@@ -341,14 +344,14 @@ bool LmdbStorage::do_is_path_valid(std::string_view path ARCTICDB_UNUSED) const 
     std::string_view invalid_win32_chars = "<>:\"|?*";
     auto found = path.find_first_of(invalid_win32_chars);
     if (found != std::string::npos) {
-        return false;
+        return path[found];
     }
 
     if (!path.empty() && (path.back() == '.' || std::isspace(path.back()))) {
-        return false;
+        return path.back();
     }
 #endif
-    return true;
+    return std::nullopt;
 }
 
 void remove_db_files(const fs::path& lib_path) {

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -65,7 +65,7 @@ class LmdbStorage final : public Storage {
 
     bool do_key_exists(const VariantKey& key) final;
 
-    bool do_is_path_valid(std::string_view path) const final;
+    std::optional<char> do_is_library_path_valid(std::string_view path) const final;
 
     ::lmdb::env& env();
 

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -19,8 +19,6 @@
 
 namespace arcticdb::storage::mongo {
 
-const auto UNSUPPORTED_MONGO_CHARS = std::unordered_set<char>{'/'};
-
 std::string MongoStorage::collection_name(KeyType k) { return (fmt::format("{}{}", prefix_, k)); }
 
 /*
@@ -201,8 +199,12 @@ bool MongoStorage::do_iterate_type_until_match(
     return false;
 }
 
-bool MongoStorage::do_is_path_valid(std::string_view path) const {
-    return std::none_of(path.cbegin(), path.cend(), [](auto c) { return UNSUPPORTED_MONGO_CHARS.contains(c); });
+std::optional<char> MongoStorage::do_is_library_path_valid(std::string_view path) const {
+    if (auto unsupported = is_path_valid(path)) {
+        return unsupported;
+    }
+    const auto pos = path.find('/');
+    return pos == std::string_view::npos ? std::nullopt : std::optional<char>{path[pos]};
 }
 
 bool MongoStorage::do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -203,6 +203,8 @@ std::optional<char> MongoStorage::do_is_library_path_valid(std::string_view path
     if (auto unsupported = is_path_valid(path)) {
         return unsupported;
     }
+    // (Part of) Library name forms the name of mongo database. Some characters are not allowed there
+    // https://www.mongodb.com/docs/manual/reference/limits/?atlas-provider=aws&atlas-class=general#mongodb-limit-Restrictions-on-Database-Names-for-Unix-and-Linux-Systems
     const auto pos = path.find('/');
     return pos == std::string_view::npos ? std::nullopt : std::optional<char>{path[pos]};
 }

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -54,7 +54,7 @@ class MongoStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
-    bool do_is_path_valid(std::string_view path) const final;
+    std::optional<char> do_is_library_path_valid(std::string_view path) const final;
 
     std::string collection_name(KeyType k);
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -164,7 +164,12 @@ class Storage {
 
     [[nodiscard]] std::string key_path(const VariantKey& key) const { return do_key_path(key); }
 
-    [[nodiscard]] bool is_path_valid(std::string_view path) const { return do_is_path_valid(path); }
+    // Returns the first character of `path` that this backend cannot store faithfully in a key, or std::nullopt if the
+    // path is acceptable.
+    [[nodiscard]] std::optional<char> is_path_valid(std::string_view path) const { return do_is_path_valid(path); }
+    [[nodiscard]] std::optional<char> is_library_path_valid(std::string_view path) const {
+        return do_is_library_path_valid(path);
+    }
 
     [[nodiscard]] const LibraryPath& library_path() const { return lib_path_; }
     [[nodiscard]] OpenMode open_mode() const { return mode_; }
@@ -255,7 +260,10 @@ class Storage {
 
     [[nodiscard]] virtual std::string do_key_path(const VariantKey& key) const = 0;
 
-    [[nodiscard]] virtual bool do_is_path_valid(std::string_view) const { return true; }
+    [[nodiscard]] virtual std::optional<char> do_is_path_valid(std::string_view) const { return std::nullopt; }
+    [[nodiscard]] virtual std::optional<char> do_is_library_path_valid(std::string_view path) const {
+        return do_is_path_valid(path);
+    }
 
     LibraryPath lib_path_;
     OpenMode mode_;

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -69,7 +69,13 @@ class Storages {
 
     bool key_exists(const VariantKey& key) { return primary().key_exists(key); }
 
-    [[nodiscard]] bool is_path_valid(const std::string_view path) const { return primary().is_path_valid(path); }
+    [[nodiscard]] std::optional<char> is_path_valid(std::string_view path) const {
+        return primary().is_path_valid(path);
+    }
+
+    [[nodiscard]] std::optional<char> is_library_path_valid(std::string_view path) const {
+        return primary().is_library_path_valid(path);
+    }
 
     void read_sync_fallthrough(const VariantKey& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
         for (const auto& storage : storages_) {

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -137,7 +137,9 @@ class InMemoryStore : public Store {
         return key;
     }
 
-    bool is_path_valid(const std::string_view) const override { return true; }
+    std::optional<char> is_path_valid(std::string_view) const override { return std::nullopt; }
+
+    std::optional<char> is_library_path_valid(std::string_view) const override { return std::nullopt; }
 
     folly::Future<entity::VariantKey> write(
             stream::KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment

--- a/cpp/arcticdb/storage/test/test_path_validation.cpp
+++ b/cpp/arcticdb/storage/test/test_path_validation.cpp
@@ -1,0 +1,58 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/storage/storage.hpp>
+#include <arcticdb/storage/azure/azure_storage.hpp>
+#include <arcticdb/storage/mongo/mongo_storage.hpp>
+#include <arcticdb/storage/memory/memory_storage.hpp>
+
+using namespace arcticdb;
+using namespace arcticdb::storage;
+
+namespace {
+std::unique_ptr<Storage> make_azure() {
+    arcticdb::proto::azure_storage::Config cfg;
+    cfg.set_use_mock_storage_for_testing(true);
+    return std::make_unique<azure::AzureStorage>(LibraryPath("lib", '/'), OpenMode::DELETE, cfg);
+}
+
+std::unique_ptr<Storage> make_mongo() {
+    arcticdb::proto::mongo_storage::Config cfg;
+    cfg.set_use_mock_storage_for_testing(true);
+    return std::make_unique<mongo::MongoStorage>(LibraryPath("lib", '/'), OpenMode::DELETE, cfg);
+}
+
+std::unique_ptr<Storage> make_memory() {
+    arcticdb::proto::memory_storage::Config cfg;
+    return std::make_unique<memory::MemoryStorage>(LibraryPath("lib", '.'), OpenMode::DELETE, cfg);
+}
+} // namespace
+
+TEST(PathValidation, AzureRejectsBackslashEverywhere) {
+    auto store = make_azure();
+    EXPECT_EQ(store->is_path_valid("a\\b"), '\\');
+    EXPECT_EQ(store->is_library_path_valid("a\\b"), '\\');
+    EXPECT_FALSE(store->is_path_valid("a/b").has_value());
+    EXPECT_FALSE(store->is_library_path_valid("a/b").has_value());
+}
+
+TEST(PathValidation, MongoForwardSlashIsLibraryOnly) {
+    auto store = make_mongo();
+    EXPECT_FALSE(store->is_path_valid("a/b").has_value());
+    EXPECT_EQ(store->is_library_path_valid("a/b"), '/');
+}
+
+TEST(PathValidation, BackendsWithoutRestrictionsAcceptEverything) {
+    auto store = make_memory();
+    EXPECT_FALSE(store->is_path_valid("a/b").has_value());
+    EXPECT_FALSE(store->is_path_valid("a\\b").has_value());
+    EXPECT_FALSE(store->is_library_path_valid("a/b").has_value());
+    EXPECT_FALSE(store->is_library_path_valid("a\\b").has_value());
+}

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -481,7 +481,7 @@ std::vector<AtomKey> write_parallel_impl(
 ) {
     // Apply validation for new symbols, but don't interfere with pre-existing symbols that would fail our modern
     // validation.
-    CheckOutcome check_outcome = verify_symbol_key(stream_id);
+    CheckOutcome check_outcome = verify_symbol_key(stream_id, store);
     if (std::holds_alternative<Error>(check_outcome) &&
         !store->key_exists_sync(RefKey{stream_id, KeyType::VERSION_REF})) {
         std::get<Error>(check_outcome).throw_error();

--- a/cpp/arcticdb/stream/python_bindings.cpp
+++ b/cpp/arcticdb/stream/python_bindings.cpp
@@ -395,10 +395,6 @@ void register_stream_bindings(py::module& m) {
             .def("add_segment", &TickReader::add_segment)
             .def("at", &TickReader::at);
 
-    m.def("is_symbol_key_valid", [](const StreamId& symbol_key) {
-        return std::holds_alternative<std::monostate>(verify_symbol_key(symbol_key));
-    });
-
     m.attr("MAX_SYMBOL_LENGTH") = MAX_SYMBOL_LENGTH;
 }
 

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -109,7 +109,9 @@ struct StreamSink {
             const std::shared_ptr<DeDupMap>& de_dup_map
     ) = 0;
 
-    virtual bool is_path_valid(const std::string_view path) const = 0;
+    virtual std::optional<char> is_path_valid(std::string_view path) const = 0;
+
+    virtual std::optional<char> is_library_path_valid(std::string_view path) const = 0;
 
     [[nodiscard]] virtual folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs
     ) = 0;

--- a/cpp/arcticdb/util/name_validation.cpp
+++ b/cpp/arcticdb/util/name_validation.cpp
@@ -101,42 +101,51 @@ const auto UNSUPPORTED_S3_CHARS = std::set<char>{'*', '<', '>'};
     return std::monostate{};
 }
 
-CheckOutcome verify_symbol_key(const StreamId& symbol_key) {
+[[nodiscard]] CheckOutcome verify_name_for_backend(
+        const std::string& name_type_for_error, const VariantId& id, const std::shared_ptr<Store>& store
+) {
     if (ConfigsMap::instance()->get_int("VersionStore.NoStrictSymbolCheck")) {
         ARCTICDB_DEBUG(
                 log::version(),
                 "Key with stream id {} will not be strictly checked because VersionStore.NoStrictSymbolCheck variable "
                 "is set to 1.",
-                symbol_key
+                id
         );
         return std::monostate{};
     }
 
     return util::variant_match(
-            symbol_key,
-            [](const NumericId&) -> CheckOutcome { return std::monostate{}; },
-            [](const StringId& str_symbol_key) -> CheckOutcome { return verify_name("symbol key", str_symbol_key); }
-    );
-}
-
-CheckOutcome verify_snapshot_id(const SnapshotId& snapshot_id) {
-    if (ConfigsMap::instance()->get_int("VersionStore.NoStrictSymbolCheck")) {
-        ARCTICDB_DEBUG(
-                log::version(),
-                "Key with stream id {} will not be strictly checked because VersionStore.NoStrictSymbolCheck variable "
-                "is set to 1.",
-                snapshot_id
-        );
-        return std::monostate{};
-    }
-
-    return util::variant_match(
-            snapshot_id,
-            [](const StringId& str_snapshot_id) -> CheckOutcome {
-                return verify_name("snapshot name", str_snapshot_id);
+            id,
+            [&](const StringId& name) -> CheckOutcome {
+                CheckOutcome res = verify_name(name_type_for_error, name);
+                if (std::holds_alternative<Error>(res)) {
+                    return res;
+                }
+                if (auto unsupported = store->is_path_valid(name)) {
+                    return Error{
+                            throw_error<ErrorCode::E_INVALID_CHAR_IN_NAME>,
+                            fmt::format(
+                                    "The {} contains character unsupported by storage backend {}. {}: {} BadChar: {}",
+                                    name_type_for_error,
+                                    store->name(),
+                                    name_type_for_error,
+                                    name,
+                                    *unsupported
+                            )
+                    };
+                }
+                return std::monostate{};
             },
             [](const auto&) -> CheckOutcome { return std::monostate{}; }
     );
+}
+
+CheckOutcome verify_symbol_key(const StreamId& symbol_key, const std::shared_ptr<Store>& store) {
+    return verify_name_for_backend("symbol key", symbol_key, store);
+}
+
+CheckOutcome verify_snapshot_id(const SnapshotId& snapshot_id, const std::shared_ptr<Store>& store) {
+    return verify_name_for_backend("snapshot name", snapshot_id, store);
 }
 
 // Library names starting with "/" fail if storage is LMDB and library parts starting with "/" will fail in Mongo
@@ -172,11 +181,14 @@ void verify_library_path_on_write(const Store* store, const StringId& library_pa
     if (std::holds_alternative<Error>(res)) {
         std::get<Error>(res).throw_error();
     }
-    user_input::check<ErrorCode::E_INVALID_CHAR_IN_NAME>(
-            store->is_path_valid(library_path),
-            "The library name contains unsupported chars. Library Name: {}",
-            library_path
-    );
+    if (auto unsupported = store->is_library_path_valid(library_path)) {
+        user_input::raise<ErrorCode::E_INVALID_CHAR_IN_NAME>(
+                "The library name contains character unsupported by storage backend {}. Library Name: {} BadChar: {}",
+                store->name(),
+                library_path,
+                *unsupported
+        );
+    }
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/util/name_validation.hpp
+++ b/cpp/arcticdb/util/name_validation.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/entity/types.hpp>
+#include <memory>
 #include <string>
 
 namespace arcticdb {
@@ -20,10 +21,13 @@ constexpr size_t MAX_SYMBOL_LENGTH = std::numeric_limits<uint8_t>::max() - 1;
 
 // Verifies whether a symbol_key is valid and raises UserInputException exceptions on invalid symbol names.
 // Should be used only when writing new symbols to allow for backwards compatibility with old symbols.
-[[nodiscard]] CheckOutcome verify_symbol_key(const StreamId& symbol_key);
+// The name is also checked against the storage backend (e.g. Azure rejects '\').
+[[nodiscard]] CheckOutcome verify_symbol_key(const StreamId& symbol_key, const std::shared_ptr<Store>& store);
 
 // Similar to verify_symbol_key above.
-[[nodiscard]] CheckOutcome verify_snapshot_id(const entity::SnapshotId& snapshot_id);
+[[nodiscard]] CheckOutcome verify_snapshot_id(
+        const entity::SnapshotId& snapshot_id, const std::shared_ptr<Store>& store
+);
 
 // Does strict checks on library names and raises UserInputException if it encounters an error.
 // Should be checked only when writing new libraries to allow for backwards compatibility

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -922,7 +922,7 @@ VersionedItem LocalVersionedEngine::write_segment(
     auto de_dup_map = get_de_dup_map(stream_id, maybe_prev, write_options);
 
     if (version_id == 0) {
-        auto check_outcome = verify_symbol_key(stream_id);
+        auto check_outcome = verify_symbol_key(stream_id, store());
         if (std::holds_alternative<Error>(check_outcome)) {
             std::get<Error>(check_outcome).throw_error();
         }
@@ -1717,7 +1717,7 @@ folly::Future<std::vector<AtomKey>> LocalVersionedEngine::batch_write_internal(
         auto write_options = get_write_options();
         frame->set_bucketize_dynamic(write_options.bucketize_dynamic);
         auto [partial_key, slicing_policy] =
-                get_partial_key_and_slicing_policy(write_options, *frame, version_id, validate_index);
+                get_partial_key_and_slicing_policy(store(), write_options, *frame, version_id, validate_index);
         auto fut_slice_keys =
                 slice_and_write(frame, slicing_policy, std::move(partial_key), store(), de_dup_maps[idx], false);
         batch_futures.emplace_back(std::move(fut_slice_keys));

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -101,10 +101,11 @@ VersionedItem write_dataframe_impl(
 }
 
 std::tuple<IndexPartialKey, SlicingPolicy> get_partial_key_and_slicing_policy(
-        const WriteOptions& options, const InputFrame& frame, VersionId version_id, bool validate_index
+        const std::shared_ptr<Store>& store, const WriteOptions& options, const InputFrame& frame, VersionId version_id,
+        bool validate_index
 ) {
     if (version_id == 0) {
-        auto check_outcome = verify_symbol_key(frame.desc().id());
+        auto check_outcome = verify_symbol_key(frame.desc().id(), store);
         if (std::holds_alternative<Error>(check_outcome)) {
             std::get<Error>(check_outcome).throw_error();
         }
@@ -130,7 +131,7 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     ARCTICDB_SAMPLE(DoWrite, 0)
     frame->set_bucketize_dynamic(options.bucketize_dynamic);
     auto [partial_key, slicing_policy] =
-            get_partial_key_and_slicing_policy(options, *frame, version_id, validate_index);
+            get_partial_key_and_slicing_policy(store, options, *frame, version_id, validate_index);
     return write_frame(std::move(partial_key), frame, slicing_policy, store, de_dup_map, sparsify_floats);
 }
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -40,7 +40,8 @@ VersionedItem write_dataframe_impl(
 );
 
 std::tuple<IndexPartialKey, SlicingPolicy> get_partial_key_and_slicing_policy(
-        const WriteOptions& options, const InputFrame& frame, VersionId version_id, bool validate_index
+        const std::shared_ptr<Store>& store, const WriteOptions& options, const InputFrame& frame, VersionId version_id,
+        bool validate_index
 );
 
 folly::Future<entity::AtomKey> async_write_dataframe_impl(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -542,7 +542,8 @@ void PythonVersionStore::remove_from_snapshot(
 }
 
 void PythonVersionStore::verify_snapshot(const SnapshotId& snap_name) {
-    if (CheckOutcome check_outcome = verify_snapshot_id(snap_name); std::holds_alternative<Error>(check_outcome)) {
+    if (CheckOutcome check_outcome = verify_snapshot_id(snap_name, store());
+        std::holds_alternative<Error>(check_outcome)) {
         std::get<Error>(check_outcome).throw_error();
     }
 }

--- a/docs/mkdocs/docs/faq.md
+++ b/docs/mkdocs/docs/faq.md
@@ -218,8 +218,9 @@ ArcticDB validates names for symbols, snapshots, and libraries. The rules are en
 - Must not be empty (i.e. the name must not contain `..` or end with `.`).
 - Must not start with `/` (this causes failures with LMDB and MongoDB backends).
 
-Some storage backends impose additional restrictions on library names:
+Some storage backends impose additional restrictions:
 
+- **Azure** forbids `\` in symbol, snapshot, and library names. The Azure Blob service silently converts `\` to `/`, so the stored path would no longer match the recorded name.
 - **MongoDB** forbids `/` anywhere in the library name.
 - **LMDB on Windows** forbids the characters `<>:"|?*`, and names ending with `.` or whitespace.
 

--- a/python/tests/integration/arcticdb/test_name_validation.py
+++ b/python/tests/integration/arcticdb/test_name_validation.py
@@ -1,0 +1,84 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+will be governed by the Apache License, version 2.0.
+"""
+
+import pytest
+
+from arcticdb_ext.exceptions import UserInputException
+from arcticdb.storage_fixtures.azure import AzureContainer
+from arcticdb.util.test import assert_frame_equal, config_context, sample_dataframe
+from tests.util.mark import AZURE_TESTS_MARK
+
+# Azure Blob Storage silently converts '\' to '/' (the service is built on .NET's Uri class), so the recorded name no
+# longer matches the on-disk blob path. New symbol/snapshot/library names containing '\' must therefore be rejected on
+# Azure, while names that already exist must keep working.
+BACKSLASH_NAME = "with\\backslash"
+
+
+@AZURE_TESTS_MARK
+def test_write_new_symbol_with_backslash_rejected_on_azure(azure_version_store):
+    with pytest.raises(UserInputException):
+        azure_version_store.write(BACKSLASH_NAME, sample_dataframe())
+    assert BACKSLASH_NAME not in azure_version_store.list_symbols()
+
+
+@pytest.mark.parametrize("symbol", ["with\\backslash", "with/forwardslash"])
+def test_write_new_symbol_with_slashes_allowed_on_non_azure(lmdb_version_store, symbol):
+    # Backslash is only problematic for Azure, and the '/' library-name restriction (Mongo) must not leak onto symbol
+    # names. Other backends must keep accepting both.
+    lmdb_version_store.write(symbol, sample_dataframe())
+    assert symbol in lmdb_version_store.list_symbols()
+
+
+@AZURE_TESTS_MARK
+def test_existing_backslash_symbol_remains_usable_on_azure(azure_version_store):
+    lib = azure_version_store
+    df_v0 = sample_dataframe(10)
+    # Simulate a symbol created before this validation existed by disabling the strict check for the initial write.
+    with config_context("VersionStore.NoStrictSymbolCheck", 1):
+        lib.write(BACKSLASH_NAME, df_v0)
+
+    assert_frame_equal(lib.read(BACKSLASH_NAME).data, df_v0)
+
+    df_v1 = sample_dataframe(20)
+    lib.append(BACKSLASH_NAME, df_v1)  # version_id != 0 -> validation is skipped
+    df_v2 = sample_dataframe(30)
+    lib.write(BACKSLASH_NAME, df_v2)  # overwriting an existing symbol -> validation is skipped
+    assert_frame_equal(lib.read(BACKSLASH_NAME).data, df_v2)
+
+
+@AZURE_TESTS_MARK
+def test_create_snapshot_with_backslash_rejected_on_azure(azurite_storage: AzureContainer):
+    ac = azurite_storage.create_arctic()
+    lib = ac.create_library("test_snapshot_backslash")
+    lib.write("sym", sample_dataframe())
+    with pytest.raises(UserInputException):
+        lib.snapshot(BACKSLASH_NAME)
+    assert BACKSLASH_NAME not in lib.list_snapshots()
+
+
+@AZURE_TESTS_MARK
+def test_create_library_with_backslash_rejected_on_azure(azurite_storage: AzureContainer):
+    ac = azurite_storage.create_arctic()
+    with pytest.raises(UserInputException):
+        ac.create_library(f"lib_{BACKSLASH_NAME}")
+
+
+def test_create_snapshot_with_backslash_allowed_on_non_azure(lmdb_storage):
+    ac = lmdb_storage.create_arctic()
+    lib = ac.create_library("test_snapshot_backslash_allowed")
+    lib.write("sym", sample_dataframe())
+    lib.snapshot(BACKSLASH_NAME)
+    assert BACKSLASH_NAME in lib.list_snapshots()
+
+
+def test_create_library_with_backslash_allowed_on_non_azure(lmdb_storage):
+    ac = lmdb_storage.create_arctic()
+    lib_name = f"lib_{BACKSLASH_NAME}"
+    ac.create_library(lib_name)
+    assert lib_name in ac.list_libraries()

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -95,8 +95,12 @@ def test_simple_flow(basic_store_no_symbol_list, symbol):
 def test_special_chars(object_version_store):
     """Test chars with special URI encoding under RFC 3986"""
     errors = []
+    special_chars = list("$@=;/:+ ,?{^}%`[]\"'~#|!-_.()")
+    # Azure silently maps '\' to '/', so it's rejected on new symbol writes
+    if object_version_store.get_backing_store() != "azure_storage":
+        special_chars += "\\"
     # we are doing manual iteration due to a limitation that should be fixed by issue #1053
-    for special_char in list("$@=;/:+ ,?\\{^}%`[]\"'~#|!-_.()"):
+    for special_char in special_chars:
         try:
             sym = f"prefix{special_char}postfix"
             df = sample_dataframe()


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://man312219.monday.com/boards/7852509418/pulses/12053019058
#### What does this implement or fix?
Highlight:
1. Rename and update `do_is_path_valid` to `do_is_library_path_valid` as its sole purpose is to validate library path
2. Add new `is_path_valid` function for storage specific key's path, global validation. Currently only `azure` storage uses it
* This is the part which backslash validation is added
* Some pumping is done to make the check azure backend specific
3. Remove `is_symbol_key_valid` python bindings. It is added recently but not used in our codebase nor in any internal repo
4. Consolidate `verify_symbol_key` and `verify_snapshot_id` as they are essentially doing the same check
#### Any other comments?
There is an existing check for library path for **all** storage backends against a list of unsupported s3 characters (`UNSUPPORTED_S3_CHARS`). I leave it as it is since the check is in place for 2+ years
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
