### PR TITLE
Reduce symbol list peak heap usage

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1264,6 +1264,7 @@ if(${TEST})
             processing/test/benchmark_ternary.cpp
             util/test/benchmark_bitset.cpp
             version/test/benchmark_write.cpp
+            version/test/benchmark_symbol_list.cpp
     )
     set_pdb_name_per_translation_unit(${benchmark_srcs})
 

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -430,6 +430,8 @@ class AsyncStore : public Store {
         }
     }
 
+    std::optional<size_t> max_delete_batch_size() const override { return library_->max_delete_batch_size(); }
+
     std::vector<folly::Future<VariantKey>> batch_read_compressed(
             std::vector<std::pair<entity::VariantKey, ReadContinuation>>&& keys_and_continuations,
             const BatchReadArgs& args

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -140,6 +140,10 @@ struct StreamSink {
             std::vector<entity::VariantKey>&& keys, storage::RemoveOpts opts = storage::RemoveOpts{}
     ) = 0;
 
+    // Largest number of keys the underlying storage will delete in a single request, or nullopt when
+    // there is no such limit. Callers can use this to size the key batches they submit for deletion.
+    [[nodiscard]] virtual std::optional<size_t> max_delete_batch_size() const { return std::nullopt; }
+
     virtual timestamp current_timestamp() = 0;
 };
 

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -799,7 +799,7 @@ void delete_keys(const std::shared_ptr<Store>& store, std::vector<AtomKey>&& rem
         // Corner case: if the newly written Compaction key (exclude) has the same timestamp as an existing one
         // (e.g. when a previous compaction round failed in the deletion step), we don't want to delete the former
         if (atom_key != exclude)
-            to_remove.emplace_back(std::move(atom_key));
+            variant_keys.emplace_back(std::move(atom_key));
     }
 
     store->remove_keys_sync(variant_keys);

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -91,59 +91,6 @@ std::vector<SymbolListEntry> load_previous_from_version_keys(
     return symbols;
 }
 
-std::vector<AtomKey> get_all_symbol_list_keys(
-        const std::shared_ptr<StreamSource>& store, SymbolListData& data, WillAttemptCompaction will_attempt_compaction
-) {
-    std::vector<AtomKey> output;
-    uint64_t uncompacted_keys_found = 0;
-    store->iterate_type(
-            KeyType::SYMBOL_LIST,
-            [&data, &output, &uncompacted_keys_found, will_attempt_compaction](auto&& key) {
-                auto atom_key = to_atom(std::forward<decltype(key)>(key));
-                if (atom_key.id() != compaction_id) {
-                    uncompacted_keys_found++;
-                }
-                if (uncompacted_keys_found == warning_threshold() && !data.warned_expected_slowdown_) {
-                    log::symbol().warn(
-                            "`list_symbols` may take longer than expected as there have been many modifications "
-                            "since `list_symbols` was last called. \n\n"
-                            "See here for more information: "
-                            "https://docs.arcticdb.io/latest/technical/on_disk_storage/#symbol-list-caching\n\n"
-                            "To resolve, run `list_symbols` through to completion frequently. "
-                            "Note: write access to storage is required for compaction. "
-                            "{}.\n"
-                            "Note: This warning will only appear once.\n",
-                            will_attempt_compaction
-                    );
-
-                    data.warned_expected_slowdown_ = true;
-                }
-
-                output.push_back(atom_key);
-            }
-    );
-
-    std::sort(output.begin(), output.end(), [](const AtomKey& left, const AtomKey& right) {
-        // Some very old symbol list keys have a non-zero version number, but with different semantics to the new style,
-        // so ignore it. See arcticdb-man#116. Most old style symbol list keys have version ID 0 anyway.
-        auto left_version = is_new_style_key(left) ? left.version_id() : 0;
-        auto right_version = is_new_style_key(right) ? right.version_id() : 0;
-        return std::tie(left.start_index(), left_version, left.creation_ts()) <
-               std::tie(right.start_index(), right_version, right.creation_ts());
-    });
-    return output;
-}
-
-MaybeCompaction last_compaction(const std::vector<AtomKey>& keys) {
-    auto pos = std::find_if(keys.rbegin(), keys.rend(), [](const auto& key) { return key.id() == compaction_id; });
-
-    if (pos == keys.rend()) {
-        return std::nullopt;
-    } else {
-        return {(pos + 1).base()}; // reverse_iterator -> forward itr has an offset of 1 per docs
-    }
-}
-
 // The below string_at and scalar_at functions should be used for symbol list cache segments instead of the ones
 // provided in SegmentInMemory, because the symbol list structure is the only place where columns can have more entries
 // than the segment has rows. Hence, we need to bypass the checks inside SegmentInMemory's function and directly call
@@ -269,20 +216,72 @@ std::vector<SymbolListEntry> read_from_storage(const std::shared_ptr<StreamSourc
         return read_new_style_list_from_storage(seg);
 }
 
-MapType load_journal_keys(const std::vector<AtomKey>& keys) {
-    MapType map;
-    for (const auto& key : keys) {
-        const auto& action_id = key.id();
-        if (action_id == compaction_id)
-            continue;
+void add_update_map_entry(MapType& update_map, const AtomKey& key) {
+    const auto& symbol = key.start_index();
+    const auto version_id = is_new_style_key(key) ? key.version_id() : unknown_version_id;
+    const auto ts = key.creation_ts();
+    ActionType action = std::get<StringId>(key.id()) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD;
+    update_map[symbol].emplace_back(version_id, ts, action);
+}
 
-        const auto& symbol = key.start_index();
-        const auto version_id = is_new_style_key(key) ? key.version_id() : unknown_version_id;
-        const auto timestamp = key.creation_ts();
-        ActionType action = std::get<StringId>(action_id) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD;
-        map[symbol].emplace_back(version_id, timestamp, action);
+void sort_update_map_entries(MapType& update_map) {
+    for (auto& [symbol, entries] : update_map) {
+        std::sort(entries.begin(), entries.end(), [](const SymbolEntryData& a, const SymbolEntryData& b) {
+            auto a_ver = a.reference_id_ == unknown_version_id ? VersionId{0} : a.reference_id_;
+            auto b_ver = b.reference_id_ == unknown_version_id ? VersionId{0} : b.reference_id_;
+            return std::tie(a_ver, a.timestamp_) < std::tie(b_ver, b.timestamp_);
+        });
     }
-    return map;
+}
+
+auto key_sort_comparator = [](const AtomKey& l, const AtomKey& r) {
+    auto l_ver = is_new_style_key(l) ? l.version_id() : VersionId{0};
+    auto r_ver = is_new_style_key(r) ? r.version_id() : VersionId{0};
+    return std::tie(l.start_index(), l_ver, l.creation_ts()) < std::tie(r.start_index(), r_ver, r.creation_ts());
+};
+
+/// Single-pass iteration over SYMBOL_LIST keys: builds the update map directly and locates the
+/// latest compaction key, optionally collecting all keys for later deletion.
+JournalResult load_journal_streaming(
+        const std::shared_ptr<Store>& store, SymbolListData& data, WillAttemptCompaction will_attempt_compaction,
+        bool collect_keys
+) {
+    JournalResult result;
+    size_t uncompacted_keys_found = 0;
+
+    store->iterate_type(KeyType::SYMBOL_LIST, [&](auto&& key) {
+        auto atom_key = to_atom(std::forward<decltype(key)>(key));
+        result.total_key_count++;
+
+        if (atom_key.id() == compaction_id) {
+            if (!result.compaction_key || atom_key.creation_ts() > result.compaction_key->creation_ts())
+                result.compaction_key = atom_key;
+        } else {
+            ++uncompacted_keys_found;
+            if (uncompacted_keys_found == warning_threshold() && !data.warned_expected_slowdown_) {
+                log::symbol().warn(
+                        "`list_symbols` may take longer than expected as there have been many modifications "
+                        "since `list_symbols` was last called. \n\n"
+                        "See here for more information: "
+                        "https://docs.arcticdb.io/latest/technical/on_disk_storage/#symbol-list-caching\n\n"
+                        "To resolve, run `list_symbols` through to completion frequently. "
+                        "Note: write access to storage is required for compaction. "
+                        "{}.\n"
+                        "Note: This warning will only appear once.\n",
+                        will_attempt_compaction
+                );
+                data.warned_expected_slowdown_ = true;
+            }
+            add_update_map_entry(result.update_map, atom_key);
+        }
+
+        if (collect_keys)
+            result.all_keys.emplace_back(std::move(atom_key));
+    });
+
+    sort_update_map_entries(result.update_map);
+
+    return result;
 }
 
 auto tail_range(const std::vector<SymbolEntryData>& updated) {
@@ -393,12 +392,11 @@ ProblematicResult is_problematic(
     return ProblematicResult{latest};
 }
 
-CollectionType merge_existing_with_journal_keys(
-        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
-        const std::vector<AtomKey>& keys, std::vector<SymbolListEntry>&& existing
+CollectionType merge_existing_with_journal_map(
+        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store, MapType& update_map,
+        std::vector<SymbolListEntry>&& existing
 ) {
     auto existing_keys = std::move(existing);
-    auto update_map = load_journal_keys(keys);
 
     CollectionType symbols;
     std::map<StreamId, std::pair<VersionId, timestamp>> problematic_symbols;
@@ -489,55 +487,46 @@ CollectionType merge_existing_with_journal_keys(
     return symbols;
 }
 
-CollectionType load_from_symbol_list_keys(
-        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
-        const std::vector<AtomKey>& keys, const Compaction& compaction
-) {
-    ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from symbol list keys");
-
-    auto previous_compaction = read_from_storage(store, *compaction);
-    return merge_existing_with_journal_keys(version_map, store, keys, std::move(previous_compaction));
-}
-
-CollectionType load_from_version_keys(
-        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
-        const std::vector<AtomKey>& keys, SymbolListData& data, WillAttemptCompaction will_attempt_compaction
-) {
-    ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from version keys");
-    auto previous_entries = load_previous_from_version_keys(store, data, will_attempt_compaction);
-    return merge_existing_with_journal_keys(version_map, store, keys, std::move(previous_entries));
-}
-
 LoadResult attempt_load(
         const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store, SymbolListData& data,
         WillAttemptCompaction will_attempt_compaction
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Symbol list load attempt");
+    const bool collect_keys = will_attempt_compaction == WillAttemptCompaction::YES;
+    auto journal = load_journal_streaming(store, data, will_attempt_compaction, collect_keys);
+
     LoadResult load_result;
-    load_result.symbol_list_keys_ = get_all_symbol_list_keys(store, data, will_attempt_compaction);
-    load_result.maybe_previous_compaction = last_compaction(load_result.symbol_list_keys_);
+    load_result.compaction_key_ = journal.compaction_key;
+    load_result.total_key_count_ = journal.total_key_count;
+    load_result.symbol_list_keys_ = std::move(journal.all_keys);
 
-    if (load_result.maybe_previous_compaction)
-        load_result.symbols_ = load_from_symbol_list_keys(
-                version_map, store, load_result.symbol_list_keys_, *load_result.maybe_previous_compaction
-        );
-    else {
-        load_result.symbols_ = load_from_version_keys(
-                version_map, store, load_result.symbol_list_keys_, data, will_attempt_compaction
-        );
-        std::unordered_set<StreamId> keys_in_versions;
-        for (const auto& entry : load_result.symbols_)
-            keys_in_versions.emplace(entry.stream_id_);
+    if (journal.compaction_key) {
+        ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from symbol list keys");
+        auto existing = read_from_storage(store, *journal.compaction_key);
+        load_result.symbols_ =
+                merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(existing));
+    } else {
+        ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from version keys");
+        auto previous_entries = load_previous_from_version_keys(store, data, will_attempt_compaction);
+        load_result.symbols_ =
+                merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(previous_entries));
 
-        for (const auto& key : load_result.symbol_list_keys_)
-            util::check(
-                    keys_in_versions.find(StreamId{std::get<StringIndex>(key.start_index())}) != keys_in_versions.end(),
-                    "Would delete unseen key {}",
-                    key
-            );
+        // Verify every journal key we'd delete during compaction corresponds to a symbol in the
+        // merged output. Guards against silent data loss from merge bugs.
+        if (collect_keys) {
+            std::unordered_set<StreamId> symbols_in_merge;
+            for (const auto& entry : load_result.symbols_)
+                symbols_in_merge.emplace(entry.stream_id_);
+
+            for (const auto& key : load_result.symbol_list_keys_)
+                util::check(
+                        symbols_in_merge.count(StreamId{std::get<StringIndex>(to_atom(key).start_index())}) > 0,
+                        "Would delete unseen key {}",
+                        key
+                );
+        }
     }
 
-    load_result.timestamp_ = store->current_timestamp();
     return load_result;
 }
 
@@ -624,12 +613,12 @@ StreamDescriptor delete_symbol_stream_descriptor(const StreamId& stream_id, cons
 }
 
 bool SymbolList::needs_compaction(const LoadResult& load_result) const {
-    if (!load_result.maybe_previous_compaction) {
+    if (!load_result.compaction_key_) {
         log::version().debug("Symbol list: needs_compaction=[true] as no previous compaction");
         return true;
     }
 
-    auto n_keys = static_cast<int64_t>(load_result.symbol_list_keys_.size());
+    auto n_keys = static_cast<int64_t>(load_result.total_key_count_);
     if (auto fixed = ConfigsMap::instance()->get_int("SymbolList.MaxDelta")) {
         auto result = n_keys > *fixed;
         log::version().debug(
@@ -744,7 +733,7 @@ SegmentInMemory create_empty_segment(const StreamId& stream_id) {
 }
 
 VariantKey write_symbols(
-        const std::shared_ptr<Store>& store, const CollectionType& symbols, const StreamId& stream_id,
+        const std::shared_ptr<Store>& store, CollectionType symbols, const StreamId& stream_id,
         const StreamId& type_holder
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Writing {} symbols to symbol list cache", symbols.size());
@@ -772,26 +761,23 @@ void delete_keys(const std::shared_ptr<Store>& store, std::vector<AtomKey>&& rem
         // Corner case: if the newly written Compaction key (exclude) has the same timestamp as an existing one
         // (e.g. when a previous compaction round failed in the deletion step), we don't want to delete the former
         if (atom_key != exclude)
-            variant_keys.emplace_back(atom_key);
+            to_remove.emplace_back(std::move(atom_key));
     }
 
     store->remove_keys_sync(variant_keys);
 }
 
-bool has_recent_compaction(
-        const std::shared_ptr<Store>& store,
-        const std::optional<std::vector<AtomKey>::const_iterator>& maybe_previous_compaction
-) {
+bool has_recent_compaction(const std::shared_ptr<Store>& store, const std::optional<AtomKey>& compaction_key) {
     bool found_last = false;
     bool has_newer = false;
 
-    if (maybe_previous_compaction.has_value()) {
-        // Symbol list keys source
+    if (compaction_key) {
+        // We found a compaction key during load. Re-scan to check two things:
+        // 1. The key we saw still exists (another process may have already replaced it).
+        // 2. A newer compaction key has appeared since we loaded (another process compacted concurrently).
         store->iterate_type(
                 KeyType::SYMBOL_LIST,
-                [&found_last,
-                 &has_newer,
-                 &last_compaction_key = *maybe_previous_compaction.value()](const VariantKey& key) {
+                [&found_last, &has_newer, &last_compaction_key = *compaction_key](const VariantKey& key) {
                     const auto& atom = to_atom(key);
                     if (atom == last_compaction_key)
                         found_last = true;
@@ -801,7 +787,8 @@ bool has_recent_compaction(
                 std::get<std::string>(compaction_id)
         );
     } else {
-        // Version keys source
+        // No compaction key was present during load. Check whether one has appeared since
+        // (another process may have compacted while we were loading).
         store->iterate_type(
                 KeyType::SYMBOL_LIST,
                 [&has_newer](const VariantKey&) { has_newer = true; },
@@ -809,7 +796,8 @@ bool has_recent_compaction(
         );
     }
 
-    return (maybe_previous_compaction && !found_last) || has_newer;
+    // Abort our compaction if our key was replaced (!found_last) or a newer one exists (has_newer).
+    return (compaction_key && !found_last) || has_newer;
 }
 
 size_t SymbolList::compact(const std::shared_ptr<Store>& store) {
@@ -817,7 +805,7 @@ size_t SymbolList::compact(const std::shared_ptr<Store>& store) {
     LoadResult load_result = ExponentialBackoff<StorageException>(100, 2000).go([this, &version_map, &store]() {
         return attempt_load(version_map, store, data_, WillAttemptCompaction::YES);
     });
-    auto num_symbol_list_keys = load_result.symbol_list_keys_.size();
+    auto num_symbol_list_keys = load_result.total_key_count_;
 
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Forcing compaction. Obtaining lock...");
     StorageLock lock{StringId{CompactionLockName}};
@@ -830,7 +818,7 @@ size_t SymbolList::compact(const std::shared_ptr<Store>& store) {
 }
 
 void SymbolList::compact_internal(const std::shared_ptr<Store>& store, LoadResult& load_result) const {
-    if (has_recent_compaction(store, load_result.maybe_previous_compaction)) {
+    if (has_recent_compaction(store, load_result.compaction_key_)) {
         // legacy arcticc symbol list entries don't get correctly listed when doing `iterate_type`, so can mess
         // up racing symbol list compaction detection.
         ARCTICDB_RUNTIME_DEBUG(
@@ -838,10 +826,27 @@ void SymbolList::compact_internal(const std::shared_ptr<Store>& store, LoadResul
                 "Symbol list compaction will be skipped: either a concurrent compaction was detected "
                 "or there are legacy arcticc symbol list entries that cannot be verified."
         );
-    } else {
-        auto written = write_symbols(store, load_result.symbols_, compaction_id, data_.type_holder_);
-        delete_keys(store, load_result.detach_symbol_list_keys(), std::get<AtomKey>(written));
+        return;
     }
+
+    auto written = write_symbols(store, std::move(load_result.symbols_), compaction_id, data_.type_holder_);
+    auto written_key = std::get<AtomKey>(written);
+
+    // Sort pre-collected keys for storage backend performance, then delete excluding the newly written key
+    auto& keys = load_result.symbol_list_keys_;
+    std::sort(keys.begin(), keys.end(), [](const VariantKey& l, const VariantKey& r) {
+        return key_sort_comparator(to_atom(l), to_atom(r));
+    });
+    keys.erase(
+            std::remove_if(
+                    keys.begin(),
+                    keys.end(),
+                    [&written_key](const VariantKey& vk) { return to_atom(vk) == written_key; }
+            ),
+            keys.end()
+    );
+    if (!keys.empty())
+        store->remove_keys_sync(std::move(keys));
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -18,6 +18,9 @@
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/store.hpp>
 #include <arcticdb/stream/merge_utils.hpp>
+#include <arcticdb/async/task_scheduler.hpp>
+
+#include <ankerl/unordered_dense.h>
 
 namespace arcticdb {
 
@@ -216,13 +219,12 @@ std::vector<SymbolListEntry> read_from_storage(const std::shared_ptr<StreamSourc
         return read_new_style_list_from_storage(seg);
 }
 
-JournalEntryData journal_entry_from_atom(const AtomKey& key) {
-    return {key.version_id(),
-            key.creation_ts(),
-            key.content_hash(),
-            std::get<StringId>(key.id()) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD,
-            is_new_style_key(key)};
-}
+JournalEntryData::JournalEntryData(const AtomKey& key) :
+    key_version_id(key.version_id()),
+    creation_ts(key.creation_ts()),
+    content_hash(key.content_hash()),
+    action(std::get<StringId>(key.id()) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD),
+    is_new_style(is_new_style_key(key)) {}
 
 // Reconstructs the original AtomKey from a JournalEntryData + the owning symbol (map key).
 // For new-style keys the end_index encodes the version marker; for old-style it equals the symbol.
@@ -243,13 +245,8 @@ AtomKey atom_key_from_journal_entry(const StreamId& symbol, const JournalEntryDa
             .build(action_id(ck.action), KeyType::SYMBOL_LIST);
 }
 
-SymbolEntryData to_symbol_entry_data(const JournalEntryData& ck) {
-    const auto reference_id = ck.is_new_style ? ck.key_version_id : unknown_version_id;
-    return {reference_id, ck.creation_ts, ck.action};
-}
-
 void add_journal_entry(JournalMapType& update_map, const AtomKey& key) {
-    update_map[key.start_index()].emplace_back(journal_entry_from_atom(key));
+    update_map[key.start_index()].emplace_back(key);
 }
 
 void sort_journal_map(JournalMapType& update_map) {
@@ -263,7 +260,7 @@ void sort_journal_map(JournalMapType& update_map) {
 }
 
 /// Single-pass iteration over SYMBOL_LIST keys: builds the update map and locates the latest
-/// compaction key. Always uses JournalEntryData (32B/entry) for the update map.
+/// compaction key. Always uses JournalEntryData (26B/entry) for the update map.
 JournalResult load_journal_streaming(
         const std::shared_ptr<Store>& store, SymbolListData& data, WillAttemptCompaction will_attempt_compaction
 ) {
@@ -302,15 +299,15 @@ JournalResult load_journal_streaming(
     return result;
 }
 
-auto tail_range(const std::vector<SymbolEntryData>& updated) {
+auto tail_range(const std::vector<JournalEntryData>& updated) {
     auto it = std::crbegin(updated);
-    const auto reference_id = it->reference_id_;
-    auto action = it->action_;
+    const auto reference_id = it->reference_id();
+    auto action = it->action;
     bool all_same_action = true;
     ++it;
 
-    while (it != std::crend(updated) && it->reference_id_ == reference_id) {
-        if (it->action_ != action)
+    while (it != std::crend(updated) && it->reference_id() == reference_id) {
+        if (it->action != action)
             all_same_action = false;
 
         ++it;
@@ -320,27 +317,27 @@ auto tail_range(const std::vector<SymbolEntryData>& updated) {
 }
 
 std::optional<SymbolEntryData> timestamps_too_close(
-        const std::vector<SymbolEntryData>::const_reverse_iterator& first, const std::vector<SymbolEntryData>& updated,
-        timestamp min_allowed_interval, bool all_same_action
+        const std::vector<JournalEntryData>::const_reverse_iterator& first,
+        const std::vector<JournalEntryData>& updated, timestamp min_allowed_interval, bool all_same_action
 ) {
     if (first == std::crend(updated))
         return std::nullopt;
 
     const auto& latest = *updated.rbegin();
-    const bool same_as_updates = all_same_action && latest.action_ == first->action_;
-    const auto diff = latest.timestamp_ - first->timestamp_;
+    const bool same_as_updates = all_same_action && latest.action == first->action;
+    const auto diff = latest.creation_ts - first->creation_ts;
 
     if (same_as_updates || diff >= min_allowed_interval)
         return std::nullopt;
 
-    return latest;
+    return SymbolEntryData{latest};
 }
 
 bool has_unknown_reference_id(const SymbolEntryData& data) { return data.reference_id_ == unknown_version_id; }
 
-bool contains_unknown_reference_ids(const std::vector<SymbolEntryData>& updated) {
+bool contains_unknown_reference_ids(const std::vector<JournalEntryData>& updated) {
     return std::any_of(std::begin(updated), std::end(updated), [](const auto& data) {
-        return has_unknown_reference_id(data);
+        return data.reference_id() == unknown_version_id;
     });
 }
 
@@ -352,7 +349,7 @@ SymbolVectorResult vector_okay(bool all_same_version, bool all_same_action, size
     return {ProblematicResult{false}, all_same_version, all_same_action, latest_id_count};
 }
 
-SymbolVectorResult is_problematic_vector(const std::vector<SymbolEntryData>& updated, timestamp min_allowed_interval) {
+SymbolVectorResult is_problematic_vector(const std::vector<JournalEntryData>& updated, timestamp min_allowed_interval) {
     if (contains_unknown_reference_ids(updated))
         return cannot_validate_symbol_vector();
 
@@ -367,22 +364,20 @@ SymbolVectorResult is_problematic_vector(const std::vector<SymbolEntryData>& upd
     if (latest_id_count <= 2 || all_same_action)
         return vector_okay(all_same_version, all_same_action, latest_id_count);
 
-    return vector_has_problem(*std::crbegin(updated));
+    return vector_has_problem(SymbolEntryData{*std::crbegin(updated)});
 }
 
-ProblematicResult is_problematic(const std::vector<SymbolEntryData>& updated, timestamp min_allowed_interval) {
+ProblematicResult is_problematic(const std::vector<JournalEntryData>& updated, timestamp min_allowed_interval) {
     return is_problematic_vector(updated, min_allowed_interval).problematic_result_;
 }
 
 ProblematicResult is_problematic(
-        const SymbolListEntry& existing, const std::vector<SymbolEntryData>& updated, timestamp min_allowed_interval
+        const SymbolListEntry& existing, const std::vector<JournalEntryData>& updated, timestamp min_allowed_interval
 ) {
-    ARCTICDB_DEBUG(
-            log::symbol(), "{} {} {}", existing.stream_id_, static_cast<const SymbolEntryData&>(existing), updated
-    );
+    ARCTICDB_DEBUG(log::symbol(), "{} {}", existing.stream_id_, static_cast<const SymbolEntryData&>(existing));
 
     const auto& latest = *std::crbegin(updated);
-    if (existing.reference_id_ > latest.reference_id_)
+    if (existing.reference_id_ > latest.reference_id())
         return ProblematicResult{existing};
 
     auto [problematic_result, vector_all_same_version, vector_all_same_action, last_id_count] =
@@ -393,12 +388,15 @@ ProblematicResult is_problematic(
     if (problematic_result.contains_unknown_reference_ids_ || has_unknown_reference_id(existing))
         return cannot_determine_validity();
 
-    const bool all_same_action = vector_all_same_action && existing.action_ == latest.action_;
+    const bool all_same_action = vector_all_same_action && existing.action_ == latest.action;
 
-    if (latest.timestamp_ - existing.timestamp_ < min_allowed_interval && !all_same_action)
-        return ProblematicResult{latest.reference_id_ > existing.reference_id_ ? latest : existing};
+    if (latest.creation_ts - existing.timestamp_ < min_allowed_interval && !all_same_action)
+        return ProblematicResult{
+                latest.reference_id() > existing.reference_id_ ? SymbolEntryData{latest}
+                                                               : static_cast<SymbolEntryData>(existing)
+        };
 
-    if (existing.reference_id_ < latest.reference_id_)
+    if (existing.reference_id_ < latest.reference_id())
         return not_a_problem();
 
     if (all_same_action)
@@ -407,12 +405,13 @@ ProblematicResult is_problematic(
     if (last_id_count == 1)
         return not_a_problem();
 
-    return ProblematicResult{latest};
+    return ProblematicResult{SymbolEntryData{latest}};
 }
 
 void resolve_problematic_symbols(
         const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
-        std::map<StreamId, std::pair<VersionId, timestamp>>& problematic_symbols, CollectionType& symbols
+        ankerl::unordered_dense::map<StreamId, std::pair<VersionId, timestamp>>& problematic_symbols,
+        CollectionType& symbols
 ) {
     if (problematic_symbols.empty())
         return;
@@ -468,7 +467,7 @@ CollectionType merge_existing_with_journal_map(
     auto existing_keys = std::move(existing);
 
     CollectionType symbols;
-    std::map<StreamId, std::pair<VersionId, timestamp>> problematic_symbols;
+    ankerl::unordered_dense::map<StreamId, std::pair<VersionId, timestamp>> problematic_symbols;
     std::unordered_set<StreamId> seen_in_existing;
     const auto min_allowed_interval = ConfigsMap::instance()->get_int("SymbolList.MinIntervalNs", 100'000'000LL);
 
@@ -487,38 +486,67 @@ CollectionType merge_existing_with_journal_map(
         } else {
             util::check(!updated->second.empty(), "Unexpected empty entry for symbol {}", updated->first);
             seen_in_existing.insert(stream_id);
-            std::vector<SymbolEntryData> entries;
-            entries.reserve(updated->second.size());
-            for (const auto& ck : updated->second)
-                entries.push_back(to_symbol_entry_data(ck));
-            if (auto problematic_entry = is_problematic(previous_entry, entries, min_allowed_interval);
+            if (auto problematic_entry = is_problematic(previous_entry, updated->second, min_allowed_interval);
                 problematic_entry) {
                 problematic_symbols.try_emplace(
                         stream_id, std::make_pair(problematic_entry.reference_id(), problematic_entry.time())
                 );
             } else {
-                const auto last = to_symbol_entry_data(updated->second.back());
+                const auto last = SymbolEntryData{updated->second.back()};
                 symbols.emplace_back(updated->first, last.reference_id_, last.timestamp_, last.action_);
             }
         }
     }
 
     for (const auto& [symbol, ck_entries] : update_map) {
-        if (seen_in_existing.count(symbol) > 0)
+        if (seen_in_existing.contains(symbol))
             continue;
-        std::vector<SymbolEntryData> entries;
-        entries.reserve(ck_entries.size());
-        for (const auto& ck : ck_entries)
-            entries.push_back(to_symbol_entry_data(ck));
-        if (auto problematic_entry = is_problematic(entries, min_allowed_interval); problematic_entry) {
-            problematic_symbols.try_emplace(symbol, problematic_entry.reference_id(), problematic_entry.time());
+        if (auto problematic_entry = is_problematic(ck_entries, min_allowed_interval); problematic_entry) {
+            problematic_symbols.try_emplace(
+                    symbol, std::make_pair(problematic_entry.reference_id(), problematic_entry.time())
+            );
         } else {
-            const auto last = to_symbol_entry_data(ck_entries.back());
+            const auto last = SymbolEntryData{ck_entries.back()};
             symbols.emplace_back(symbol, last.reference_id_, last.timestamp_, last.action_);
         }
     }
 
     resolve_problematic_symbols(version_map, store, problematic_symbols, symbols);
+    return symbols;
+}
+
+CollectionType load_from_symbol_list_keys(
+        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
+        const JournalMapType& update_map, const AtomKey& compaction_key
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from symbol list keys");
+    auto existing = read_from_storage(store, compaction_key);
+    // If there are no journal entries, there is nothing to merge
+    // and we can return the existing entries directly
+    if (update_map.empty()) {
+        return CollectionType(std::make_move_iterator(existing.begin()), std::make_move_iterator(existing.end()));
+    }
+    return merge_existing_with_journal_map(version_map, store, update_map, std::move(existing));
+}
+
+CollectionType load_from_version_keys(
+        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
+        const JournalMapType& update_map, SymbolListData& data, WillAttemptCompaction will_attempt_compaction
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from version keys");
+    auto previous_entries = load_previous_from_version_keys(store, data, will_attempt_compaction);
+    auto symbols = merge_existing_with_journal_map(version_map, store, update_map, std::move(previous_entries));
+    if (will_attempt_compaction == WillAttemptCompaction::YES) {
+        // Verify every journal symbol we'd delete corresponds to a symbol in the merged output.
+        // Guards against silent data loss from merge bugs. The merged output holds one entry per
+        // symbol, so the set size is known exactly up front.
+        ankerl::unordered_dense::set<StreamId> symbols_in_merge;
+        symbols_in_merge.reserve(symbols.size());
+        for (const auto& entry : symbols)
+            symbols_in_merge.emplace(entry.stream_id_);
+        for (const auto& [symbol, _] : update_map)
+            util::check(symbols_in_merge.contains(symbol), "Would delete unseen symbol {}", symbol);
+    }
     return symbols;
 }
 
@@ -528,41 +556,24 @@ LoadResult attempt_load(
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Symbol list load attempt");
     const bool will_compact = will_attempt_compaction == WillAttemptCompaction::YES;
-    auto journal = load_journal_streaming(store, data, will_attempt_compaction);
 
     LoadResult load_result;
-    load_result.compaction_key_ = journal.compaction_key;
-    load_result.total_key_count_ = journal.total_key_count;
+    auto& journal = load_result.journal_;
+    journal = load_journal_streaming(store, data, will_attempt_compaction);
 
     if (journal.compaction_key) {
-        ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from symbol list keys");
-        auto existing = read_from_storage(store, *journal.compaction_key);
-        if (journal.update_map.empty()) {
-            load_result.symbols_ =
-                    CollectionType(std::make_move_iterator(existing.begin()), std::make_move_iterator(existing.end()));
-        } else {
-            load_result.symbols_ =
-                    merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(existing));
-        }
-    } else {
-        ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from version keys");
-        auto previous_entries = load_previous_from_version_keys(store, data, will_attempt_compaction);
         load_result.symbols_ =
-                merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(previous_entries));
-        if (will_compact) {
-            // Verify every journal symbol we'd delete corresponds to a symbol in the merged output.
-            // Guards against silent data loss from merge bugs.
-            std::unordered_set<StreamId> symbols_in_merge;
-            for (const auto& entry : load_result.symbols_)
-                symbols_in_merge.emplace(entry.stream_id_);
-            for (const auto& [symbol, _] : journal.update_map)
-                util::check(symbols_in_merge.count(symbol) > 0, "Would delete unseen symbol {}", symbol);
-        }
+                load_from_symbol_list_keys(version_map, store, journal.update_map, *journal.compaction_key);
+    } else {
+        load_result.symbols_ =
+                load_from_version_keys(version_map, store, journal.update_map, data, will_attempt_compaction);
     }
 
-    if (will_compact) {
-        load_result.old_compaction_keys_ = std::move(journal.compaction_keys);
-        load_result.update_map_ = std::move(journal.update_map);
+    if (!will_compact) {
+        // Not compacting: release the journal entries and compaction keys now rather than
+        // carrying them in the returned LoadResult.
+        journal.update_map.clear();
+        journal.compaction_keys.clear();
     }
 
     return load_result;
@@ -651,12 +662,12 @@ StreamDescriptor delete_symbol_stream_descriptor(const StreamId& stream_id, cons
 }
 
 bool SymbolList::needs_compaction(const LoadResult& load_result) const {
-    if (!load_result.compaction_key_) {
+    if (!load_result.journal_.compaction_key) {
         log::version().debug("Symbol list: needs_compaction=[true] as no previous compaction");
         return true;
     }
 
-    auto n_keys = static_cast<int64_t>(load_result.total_key_count_);
+    auto n_keys = static_cast<int64_t>(load_result.journal_.total_key_count);
     if (auto fixed = ConfigsMap::instance()->get_int("SymbolList.MaxDelta")) {
         auto result = n_keys > *fixed;
         log::version().debug(
@@ -771,7 +782,7 @@ SegmentInMemory create_empty_segment(const StreamId& stream_id) {
 }
 
 VariantKey write_symbols(
-        const std::shared_ptr<Store>& store, CollectionType symbols, const StreamId& stream_id,
+        const std::shared_ptr<Store>& store, CollectionType&& symbols, const StreamId& stream_id,
         const StreamId& type_holder
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Writing {} symbols to symbol list cache", symbols.size());
@@ -843,7 +854,7 @@ size_t SymbolList::compact(const std::shared_ptr<Store>& store) {
     LoadResult load_result = ExponentialBackoff<StorageException>(100, 2000).go([this, &version_map, &store]() {
         return attempt_load(version_map, store, data_, WillAttemptCompaction::YES);
     });
-    auto num_symbol_list_keys = load_result.total_key_count_;
+    auto num_symbol_list_keys = load_result.journal_.total_key_count;
 
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Forcing compaction. Obtaining lock...");
     StorageLock lock{StringId{CompactionLockName}};
@@ -855,8 +866,71 @@ size_t SymbolList::compact(const std::shared_ptr<Store>& store) {
     return num_symbol_list_keys;
 }
 
+// Number of keys to accumulate before issuing a delete. Each batch is handed to the async
+// remove_keys, which internally chunks it to the storage's delete limit and runs the chunks across
+// the IO threads — so io_thread_count * delete_batch_size keys per batch saturates the IO pool while
+// keeping the reconstructed-key memory bounded. Overridable via config for tuning.
+size_t compaction_delete_batch_size(const std::shared_ptr<Store>& store) {
+    constexpr size_t default_storage_batch = 1000; // assumed limit when the storage reports none
+    const auto io_threads = static_cast<size_t>(async::TaskScheduler::instance()->io_thread_count());
+    const auto storage_batch = store->max_delete_batch_size().value_or(default_storage_batch);
+    return static_cast<size_t>(ConfigsMap::instance()->get_int(
+            "SymbolList.CompactionDeleteBatchSize", static_cast<int64_t>(io_threads * storage_batch)
+    ));
+}
+
+// Deletes the symbol-list keys superseded by the newly written compaction key: the old compaction
+// keys (typically 0–1) and every journal key, all deleted through one batched flow. The freshly
+// written compaction key is excluded from the deletion (see the corner case below). Consumes
+// journal.compaction_keys and journal.update_map.
+void delete_superseded_keys(const std::shared_ptr<Store>& store, JournalResult& journal, const AtomKey& written_key) {
+    const size_t batch_size = compaction_delete_batch_size(store);
+    std::vector<VariantKey> batch;
+    batch.reserve(batch_size);
+
+    auto flush = [&] {
+        if (!batch.empty()) {
+            store->remove_keys(std::move(batch)).get();
+            batch.clear();
+        }
+    };
+    auto add = [&](AtomKey key) {
+        // Corner case: if the newly written Compaction key (written_key) has the same timestamp as an existing
+        // one (e.g. when a previous compaction round failed in the deletion step), we don't want to delete the former
+        // this can happen in the following scenario:
+        // 1. Process A writes a compaction key at timestamp T.
+        // 2. Process A fails to delete the old SL entries (e.g. due to a crash) and exits.
+        // 3. Process B attemps to compact the SL, incl. the compacted key from process A.
+        // 4. Due to clock skew, process B writes a new compaction key at timestamp T (same as process A's key)
+        // ---> this results in the exact same compaction key which will overwrite the previous one,
+        // 5. we DON'T want to delete the compaction key from process A, as it is the same as the one from process B, so
+        // we skip it here.
+        // ---> this would result in wiping out the whole SL cache
+        if (key == written_key)
+            return;
+        batch.emplace_back(std::move(key));
+        if (batch.size() >= batch_size)
+            flush();
+    };
+
+    for (const auto& ck : journal.compaction_keys) {
+        add(to_atom(ck));
+    }
+    journal.compaction_keys.clear();
+
+    // Reconstruct journal keys from the JournalMapType, freeing each symbol's entries as they are processed.
+    for (auto it = journal.update_map.begin(); it != journal.update_map.end();) {
+        const auto& [symbol, ck_entries] = *it;
+        for (const auto& ck : ck_entries) {
+            add(atom_key_from_journal_entry(symbol, ck));
+        }
+        it = journal.update_map.erase(it);
+    }
+    flush();
+}
+
 void SymbolList::compact_internal(const std::shared_ptr<Store>& store, LoadResult& load_result) const {
-    if (has_recent_compaction(store, load_result.compaction_key_)) {
+    if (has_recent_compaction(store, load_result.journal_.compaction_key)) {
         // legacy arcticc symbol list entries don't get correctly listed when doing `iterate_type`, so can mess
         // up racing symbol list compaction detection.
         ARCTICDB_RUNTIME_DEBUG(
@@ -868,40 +942,7 @@ void SymbolList::compact_internal(const std::shared_ptr<Store>& store, LoadResul
     }
 
     auto written = write_symbols(store, std::move(load_result.symbols_), compaction_id, data_.type_holder_);
-    const auto& written_key = std::get<AtomKey>(written);
-
-    // Delete old compaction keys (typically 0–1 entries; exclude the newly written one).
-    auto& old_ck = load_result.old_compaction_keys_;
-    old_ck.erase(
-            std::remove_if(
-                    old_ck.begin(),
-                    old_ck.end(),
-                    [&written_key](const VariantKey& vk) { return to_atom(vk) == written_key; }
-            ),
-            old_ck.end()
-    );
-    if (!old_ck.empty())
-        store->remove_keys_sync(std::move(old_ck));
-
-    // Reconstruct and delete journal keys in batches from the JournalMapType, freeing each symbol's
-    // entries as they are processed. Journal keys can never equal written_key (different id field).
-    static constexpr size_t kBatchSize = 10'000;
-    std::vector<VariantKey> batch;
-    batch.reserve(kBatchSize);
-    for (auto it = load_result.update_map_.begin(); it != load_result.update_map_.end();) {
-        const auto& [symbol, ck_entries] = *it;
-        for (const auto& ck : ck_entries) {
-            batch.emplace_back(atom_key_from_journal_entry(symbol, ck));
-            if (batch.size() == kBatchSize) {
-                store->remove_keys_sync(std::move(batch));
-                batch.clear();
-                batch.reserve(kBatchSize);
-            }
-        }
-        it = load_result.update_map_.erase(it);
-    }
-    if (!batch.empty())
-        store->remove_keys_sync(std::move(batch));
+    delete_superseded_keys(store, load_result.journal_, std::get<AtomKey>(written));
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/symbol_list.cpp
+++ b/cpp/arcticdb/version/symbol_list.cpp
@@ -216,35 +216,56 @@ std::vector<SymbolListEntry> read_from_storage(const std::shared_ptr<StreamSourc
         return read_new_style_list_from_storage(seg);
 }
 
-void add_update_map_entry(MapType& update_map, const AtomKey& key) {
-    const auto& symbol = key.start_index();
-    const auto version_id = is_new_style_key(key) ? key.version_id() : unknown_version_id;
-    const auto ts = key.creation_ts();
-    ActionType action = std::get<StringId>(key.id()) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD;
-    update_map[symbol].emplace_back(version_id, ts, action);
+JournalEntryData journal_entry_from_atom(const AtomKey& key) {
+    return {key.version_id(),
+            key.creation_ts(),
+            key.content_hash(),
+            std::get<StringId>(key.id()) == DeleteSymbol ? ActionType::DELETE : ActionType::ADD,
+            is_new_style_key(key)};
 }
 
-void sort_update_map_entries(MapType& update_map) {
-    for (auto& [symbol, entries] : update_map) {
-        std::sort(entries.begin(), entries.end(), [](const SymbolEntryData& a, const SymbolEntryData& b) {
-            auto a_ver = a.reference_id_ == unknown_version_id ? VersionId{0} : a.reference_id_;
-            auto b_ver = b.reference_id_ == unknown_version_id ? VersionId{0} : b.reference_id_;
-            return std::tie(a_ver, a.timestamp_) < std::tie(b_ver, b.timestamp_);
+// Reconstructs the original AtomKey from a JournalEntryData + the owning symbol (map key).
+// For new-style keys the end_index encodes the version marker; for old-style it equals the symbol.
+AtomKey atom_key_from_journal_entry(const StreamId& symbol, const JournalEntryData& ck) {
+    IndexValue end_index;
+    if (ck.is_new_style) {
+        end_index = std::holds_alternative<StringId>(symbol) ? IndexValue{StringIndex{std::string{version_string}}}
+                                                             : IndexValue{NumericIndex{version_identifier}};
+    } else {
+        end_index = IndexValue{symbol};
+    }
+    return atom_key_builder()
+            .version_id(ck.key_version_id)
+            .creation_ts(ck.creation_ts)
+            .content_hash(ck.content_hash)
+            .start_index(IndexValue{symbol})
+            .end_index(end_index)
+            .build(action_id(ck.action), KeyType::SYMBOL_LIST);
+}
+
+SymbolEntryData to_symbol_entry_data(const JournalEntryData& ck) {
+    const auto reference_id = ck.is_new_style ? ck.key_version_id : unknown_version_id;
+    return {reference_id, ck.creation_ts, ck.action};
+}
+
+void add_journal_entry(JournalMapType& update_map, const AtomKey& key) {
+    update_map[key.start_index()].emplace_back(journal_entry_from_atom(key));
+}
+
+void sort_journal_map(JournalMapType& update_map) {
+    for (auto& [symbol, keys] : update_map) {
+        std::sort(keys.begin(), keys.end(), [](const JournalEntryData& a, const JournalEntryData& b) {
+            auto a_ver = a.is_new_style ? a.key_version_id : VersionId{0};
+            auto b_ver = b.is_new_style ? b.key_version_id : VersionId{0};
+            return std::tie(a_ver, a.creation_ts) < std::tie(b_ver, b.creation_ts);
         });
     }
 }
 
-auto key_sort_comparator = [](const AtomKey& l, const AtomKey& r) {
-    auto l_ver = is_new_style_key(l) ? l.version_id() : VersionId{0};
-    auto r_ver = is_new_style_key(r) ? r.version_id() : VersionId{0};
-    return std::tie(l.start_index(), l_ver, l.creation_ts()) < std::tie(r.start_index(), r_ver, r.creation_ts());
-};
-
-/// Single-pass iteration over SYMBOL_LIST keys: builds the update map directly and locates the
-/// latest compaction key, optionally collecting all keys for later deletion.
+/// Single-pass iteration over SYMBOL_LIST keys: builds the update map and locates the latest
+/// compaction key. Always uses JournalEntryData (32B/entry) for the update map.
 JournalResult load_journal_streaming(
-        const std::shared_ptr<Store>& store, SymbolListData& data, WillAttemptCompaction will_attempt_compaction,
-        bool collect_keys
+        const std::shared_ptr<Store>& store, SymbolListData& data, WillAttemptCompaction will_attempt_compaction
 ) {
     JournalResult result;
     size_t uncompacted_keys_found = 0;
@@ -256,6 +277,7 @@ JournalResult load_journal_streaming(
         if (atom_key.id() == compaction_id) {
             if (!result.compaction_key || atom_key.creation_ts() > result.compaction_key->creation_ts())
                 result.compaction_key = atom_key;
+            result.compaction_keys.emplace_back(std::move(atom_key));
         } else {
             ++uncompacted_keys_found;
             if (uncompacted_keys_found == warning_threshold() && !data.warned_expected_slowdown_) {
@@ -272,15 +294,11 @@ JournalResult load_journal_streaming(
                 );
                 data.warned_expected_slowdown_ = true;
             }
-            add_update_map_entry(result.update_map, atom_key);
+            add_journal_entry(result.update_map, atom_key);
         }
-
-        if (collect_keys)
-            result.all_keys.emplace_back(std::move(atom_key));
     });
 
-    sort_update_map_entries(result.update_map);
-
+    sort_journal_map(result.update_map);
     return result;
 }
 
@@ -392,14 +410,66 @@ ProblematicResult is_problematic(
     return ProblematicResult{latest};
 }
 
+void resolve_problematic_symbols(
+        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
+        std::map<StreamId, std::pair<VersionId, timestamp>>& problematic_symbols, CollectionType& symbols
+) {
+    if (problematic_symbols.empty())
+        return;
+
+    auto symbol_versions = std::make_shared<std::vector<StreamId>>();
+    for (const auto& [symbol, reference_pair] : problematic_symbols)
+        symbol_versions->emplace_back(symbol);
+
+    auto versions = batch_check_latest_id_and_status(store, version_map, symbol_versions);
+
+    for (const auto& [symbol, reference_pair] : problematic_symbols) {
+        auto reference_id = reference_pair.first;
+
+        if (auto version = versions->find(symbol); version != versions->end()) {
+            const auto& symbol_state = version->second;
+            if (symbol_state.exists_) {
+                ARCTICDB_DEBUG(
+                        log::symbol(),
+                        "Problematic symbol/version pair: {}@{}: exists at id {}",
+                        symbol,
+                        reference_id,
+                        symbol_state.version_id_
+                );
+                symbols.emplace_back(symbol, symbol_state.version_id_, symbol_state.timestamp_, ActionType::ADD);
+            } else {
+                symbols.emplace_back(symbol, symbol_state.version_id_, symbol_state.timestamp_, ActionType::DELETE);
+                ARCTICDB_DEBUG(
+                        log::symbol(),
+                        "Problematic symbol/version pair: {}@{}: deleted at id {}",
+                        symbol,
+                        reference_id,
+                        symbol_state.version_id_
+                );
+            }
+        } else {
+            ARCTICDB_DEBUG(
+                    log::symbol(), "Problematic symbol/version pair: {}@{}: cannot be found", symbol, reference_id
+            );
+            symbols.emplace_back(symbol, reference_id, reference_pair.second, ActionType::DELETE);
+        }
+    }
+    std::sort(std::begin(symbols), std::end(symbols), [](const auto& l, const auto& r) {
+        return l.stream_id_ < r.stream_id_;
+    });
+}
+
+/// Merges journal entries (JournalEntryData map) with existing compacted or version-key symbols.
+/// The map is read-only so it can be moved into LoadResult for later batch deletion.
 CollectionType merge_existing_with_journal_map(
-        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store, MapType& update_map,
-        std::vector<SymbolListEntry>&& existing
+        const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store,
+        const JournalMapType& update_map, std::vector<SymbolListEntry>&& existing
 ) {
     auto existing_keys = std::move(existing);
 
     CollectionType symbols;
     std::map<StreamId, std::pair<VersionId, timestamp>> problematic_symbols;
+    std::unordered_set<StreamId> seen_in_existing;
     const auto min_allowed_interval = ConfigsMap::instance()->get_int("SymbolList.MinIntervalNs", 100'000'000LL);
 
     for (auto& previous_entry : existing_keys) {
@@ -416,74 +486,39 @@ CollectionType merge_existing_with_journal_map(
                 );
         } else {
             util::check(!updated->second.empty(), "Unexpected empty entry for symbol {}", updated->first);
-            if (auto problematic_entry = is_problematic(previous_entry, updated->second, min_allowed_interval);
+            seen_in_existing.insert(stream_id);
+            std::vector<SymbolEntryData> entries;
+            entries.reserve(updated->second.size());
+            for (const auto& ck : updated->second)
+                entries.push_back(to_symbol_entry_data(ck));
+            if (auto problematic_entry = is_problematic(previous_entry, entries, min_allowed_interval);
                 problematic_entry) {
                 problematic_symbols.try_emplace(
                         stream_id, std::make_pair(problematic_entry.reference_id(), problematic_entry.time())
                 );
             } else {
-                const auto& last_entry = updated->second.rbegin();
-                symbols.emplace_back(
-                        updated->first, last_entry->reference_id_, last_entry->timestamp_, last_entry->action_
-                );
+                const auto last = to_symbol_entry_data(updated->second.back());
+                symbols.emplace_back(updated->first, last.reference_id_, last.timestamp_, last.action_);
             }
-            update_map.erase(updated);
         }
     }
 
-    for (const auto& [symbol, entries] : update_map) {
-        ARCTICDB_DEBUG(log::symbol(), "{} {}", symbol, entries);
+    for (const auto& [symbol, ck_entries] : update_map) {
+        if (seen_in_existing.count(symbol) > 0)
+            continue;
+        std::vector<SymbolEntryData> entries;
+        entries.reserve(ck_entries.size());
+        for (const auto& ck : ck_entries)
+            entries.push_back(to_symbol_entry_data(ck));
         if (auto problematic_entry = is_problematic(entries, min_allowed_interval); problematic_entry) {
             problematic_symbols.try_emplace(symbol, problematic_entry.reference_id(), problematic_entry.time());
         } else {
-            const auto& last_entry = entries.rbegin();
-            symbols.emplace_back(symbol, last_entry->reference_id_, last_entry->timestamp_, last_entry->action_);
+            const auto last = to_symbol_entry_data(ck_entries.back());
+            symbols.emplace_back(symbol, last.reference_id_, last.timestamp_, last.action_);
         }
     }
 
-    if (!problematic_symbols.empty()) {
-        auto symbol_versions = std::make_shared<std::vector<StreamId>>();
-        for (const auto& [symbol, reference_pair] : problematic_symbols)
-            symbol_versions->emplace_back(symbol);
-
-        auto versions = batch_check_latest_id_and_status(store, version_map, symbol_versions);
-
-        for (const auto& [symbol, reference_pair] : problematic_symbols) {
-            auto reference_id = reference_pair.first;
-
-            if (auto version = versions->find(symbol); version != versions->end()) {
-                const auto& symbol_state = version->second;
-                if (symbol_state.exists_) {
-                    ARCTICDB_DEBUG(
-                            log::symbol(),
-                            "Problematic symbol/version pair: {}@{}: exists at id {}",
-                            symbol,
-                            reference_id,
-                            symbol_state.version_id_
-                    );
-                    symbols.emplace_back(symbol, symbol_state.version_id_, symbol_state.timestamp_, ActionType::ADD);
-                } else {
-                    symbols.emplace_back(symbol, symbol_state.version_id_, symbol_state.timestamp_, ActionType::DELETE);
-                    ARCTICDB_DEBUG(
-                            log::symbol(),
-                            "Problematic symbol/version pair: {}@{}: deleted at id {}",
-                            symbol,
-                            reference_id,
-                            symbol_state.version_id_
-                    );
-                }
-            } else {
-                ARCTICDB_DEBUG(
-                        log::symbol(), "Problematic symbol/version pair: {}@{}: cannot be found", symbol, reference_id
-                );
-                symbols.emplace_back(symbol, reference_id, reference_pair.second, ActionType::DELETE);
-            }
-        }
-        std::sort(std::begin(symbols), std::end(symbols), [](const auto& l, const auto& r) {
-            return l.stream_id_ < r.stream_id_;
-        });
-    }
-
+    resolve_problematic_symbols(version_map, store, problematic_symbols, symbols);
     return symbols;
 }
 
@@ -492,39 +527,42 @@ LoadResult attempt_load(
         WillAttemptCompaction will_attempt_compaction
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Symbol list load attempt");
-    const bool collect_keys = will_attempt_compaction == WillAttemptCompaction::YES;
-    auto journal = load_journal_streaming(store, data, will_attempt_compaction, collect_keys);
+    const bool will_compact = will_attempt_compaction == WillAttemptCompaction::YES;
+    auto journal = load_journal_streaming(store, data, will_attempt_compaction);
 
     LoadResult load_result;
     load_result.compaction_key_ = journal.compaction_key;
     load_result.total_key_count_ = journal.total_key_count;
-    load_result.symbol_list_keys_ = std::move(journal.all_keys);
 
     if (journal.compaction_key) {
         ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from symbol list keys");
         auto existing = read_from_storage(store, *journal.compaction_key);
-        load_result.symbols_ =
-                merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(existing));
+        if (journal.update_map.empty()) {
+            load_result.symbols_ =
+                    CollectionType(std::make_move_iterator(existing.begin()), std::make_move_iterator(existing.end()));
+        } else {
+            load_result.symbols_ =
+                    merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(existing));
+        }
     } else {
         ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Loading symbols from version keys");
         auto previous_entries = load_previous_from_version_keys(store, data, will_attempt_compaction);
         load_result.symbols_ =
                 merge_existing_with_journal_map(version_map, store, journal.update_map, std::move(previous_entries));
-
-        // Verify every journal key we'd delete during compaction corresponds to a symbol in the
-        // merged output. Guards against silent data loss from merge bugs.
-        if (collect_keys) {
+        if (will_compact) {
+            // Verify every journal symbol we'd delete corresponds to a symbol in the merged output.
+            // Guards against silent data loss from merge bugs.
             std::unordered_set<StreamId> symbols_in_merge;
             for (const auto& entry : load_result.symbols_)
                 symbols_in_merge.emplace(entry.stream_id_);
-
-            for (const auto& key : load_result.symbol_list_keys_)
-                util::check(
-                        symbols_in_merge.count(StreamId{std::get<StringIndex>(to_atom(key).start_index())}) > 0,
-                        "Would delete unseen key {}",
-                        key
-                );
+            for (const auto& [symbol, _] : journal.update_map)
+                util::check(symbols_in_merge.count(symbol) > 0, "Would delete unseen symbol {}", symbol);
         }
+    }
+
+    if (will_compact) {
+        load_result.old_compaction_keys_ = std::move(journal.compaction_keys);
+        load_result.update_map_ = std::move(journal.update_map);
     }
 
     return load_result;
@@ -830,23 +868,40 @@ void SymbolList::compact_internal(const std::shared_ptr<Store>& store, LoadResul
     }
 
     auto written = write_symbols(store, std::move(load_result.symbols_), compaction_id, data_.type_holder_);
-    auto written_key = std::get<AtomKey>(written);
+    const auto& written_key = std::get<AtomKey>(written);
 
-    // Sort pre-collected keys for storage backend performance, then delete excluding the newly written key
-    auto& keys = load_result.symbol_list_keys_;
-    std::sort(keys.begin(), keys.end(), [](const VariantKey& l, const VariantKey& r) {
-        return key_sort_comparator(to_atom(l), to_atom(r));
-    });
-    keys.erase(
+    // Delete old compaction keys (typically 0–1 entries; exclude the newly written one).
+    auto& old_ck = load_result.old_compaction_keys_;
+    old_ck.erase(
             std::remove_if(
-                    keys.begin(),
-                    keys.end(),
+                    old_ck.begin(),
+                    old_ck.end(),
                     [&written_key](const VariantKey& vk) { return to_atom(vk) == written_key; }
             ),
-            keys.end()
+            old_ck.end()
     );
-    if (!keys.empty())
-        store->remove_keys_sync(std::move(keys));
+    if (!old_ck.empty())
+        store->remove_keys_sync(std::move(old_ck));
+
+    // Reconstruct and delete journal keys in batches from the JournalMapType, freeing each symbol's
+    // entries as they are processed. Journal keys can never equal written_key (different id field).
+    static constexpr size_t kBatchSize = 10'000;
+    std::vector<VariantKey> batch;
+    batch.reserve(kBatchSize);
+    for (auto it = load_result.update_map_.begin(); it != load_result.update_map_.end();) {
+        const auto& [symbol, ck_entries] = *it;
+        for (const auto& ck : ck_entries) {
+            batch.emplace_back(atom_key_from_journal_entry(symbol, ck));
+            if (batch.size() == kBatchSize) {
+                store->remove_keys_sync(std::move(batch));
+                batch.clear();
+                batch.reserve(kBatchSize);
+            }
+        }
+        it = load_result.update_map_.erase(it);
+    }
+    if (!batch.empty())
+        store->remove_keys_sync(std::move(batch));
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -19,17 +19,38 @@
 namespace arcticdb {
 enum class ActionType : uint8_t { ADD, DELETE };
 
-// Compact 32-byte representation of a SYMBOL_LIST journal AtomKey.
+constexpr VersionId unknown_version_id = std::numeric_limits<VersionId>::max();
+
+// Compact representation of a SYMBOL_LIST journal AtomKey, packed to a fixed 26 bytes so the size
+// is consistent across architectures (an unpacked layout would pad to 32+ depending on the target).
 // Stores only the fields needed to reconstruct the full AtomKey for deletion.
 // The symbol (start_index / map key) is held separately by the containing JournalMapType.
+#pragma pack(push)
+#pragma pack(1)
 struct JournalEntryData {
     entity::VersionId key_version_id; // 8 bytes
     timestamp creation_ts;            // 8 bytes
     entity::ContentHash content_hash; // 8 bytes
     ActionType action;                // 1 byte
     bool is_new_style;                // 1 byte
-    // 6 bytes implicit padding
+
+    explicit JournalEntryData(const AtomKey& key);
+
+    // Logical constructor from a (reference id, time, action) triple. content_hash is left zero as it
+    // is not part of the logical identity is_problematic cares about; use the AtomKey constructor when
+    // the entry must round-trip back to a deletable key.
+    JournalEntryData(entity::VersionId reference_id, timestamp creation_time, ActionType action_type) :
+        key_version_id(reference_id),
+        creation_ts(creation_time),
+        content_hash(0),
+        action(action_type),
+        is_new_style(reference_id != unknown_version_id) {}
+
+    // Old-style keys carry no usable version id, so they report unknown_version_id.
+    [[nodiscard]] entity::VersionId reference_id() const { return is_new_style ? key_version_id : unknown_version_id; }
 };
+static_assert(sizeof(JournalEntryData) == 26);
+#pragma pack(pop)
 
 using JournalMapType = std::unordered_map<StreamId, std::vector<JournalEntryData>>;
 
@@ -42,21 +63,21 @@ enum class WillAttemptCompaction : uint8_t {
     NO_DISABLED                  // compaction explicitly disabled by caller
 };
 
+// Result of the single-pass scan over SYMBOL_LIST keys. When compacting, update_map and
+// compaction_keys are consumed by compact_internal; otherwise they are cleared after the merge.
 struct JournalResult {
     std::optional<AtomKey> compaction_key;
-    JournalMapType update_map; // JournalEntryData (32B/entry) for all journal entries
     size_t total_key_count = 0;
-    std::vector<VariantKey> compaction_keys; // VariantKeys of all compaction keys found during scan
+    // Journal keys stored as JournalEntryData (26 B each); reconstructed in batches during compact_internal.
+    JournalMapType update_map;
+    // VariantKeys of all compaction keys found during scan (typically 0–1); the stale ones are
+    // freed immediately after compact_internal deletes them.
+    std::vector<VariantKey> compaction_keys;
 };
 
 struct LoadResult {
-    std::optional<AtomKey> compaction_key_;
+    JournalResult journal_;
     CollectionType symbols_;
-    size_t total_key_count_ = 0;
-    // Old compaction VariantKeys (typically 0–1); freed immediately after compact_internal deletes them.
-    std::vector<VariantKey> old_compaction_keys_;
-    // Journal keys stored as JournalEntryData (32 B each); reconstructed in batches during compact_internal.
-    JournalMapType update_map_;
 };
 
 struct SymbolListData {
@@ -74,8 +95,6 @@ constexpr std::string_view CompactionId = "__symbols__";
 constexpr std::string_view CompactionLockName = "SymbolListCompactionLock";
 constexpr std::string_view AddSymbol = "__add__";
 constexpr std::string_view DeleteSymbol = "__delete__";
-
-constexpr VersionId unknown_version_id = std::numeric_limits<VersionId>::max();
 
 inline StreamId action_id(ActionType action) {
     switch (action) {
@@ -98,6 +117,11 @@ struct SymbolEntryData {
         reference_id_(reference_id),
         timestamp_(time),
         action_(action) {}
+
+    explicit SymbolEntryData(const JournalEntryData& ck) :
+        reference_id_(ck.reference_id()),
+        timestamp_(ck.creation_ts),
+        action_(ck.action) {}
 
     void verify() const { magic_.check(); }
 };
@@ -143,10 +167,10 @@ struct SymbolVectorResult {
 };
 
 ProblematicResult is_problematic(
-        const SymbolListEntry& existing, const std::vector<SymbolEntryData>& updated, timestamp min_allowed_interval
+        const SymbolListEntry& existing, const std::vector<JournalEntryData>& updated, timestamp min_allowed_interval
 );
 
-ProblematicResult is_problematic(const std::vector<SymbolEntryData>& updated, timestamp min_allowed_interval);
+ProblematicResult is_problematic(const std::vector<JournalEntryData>& updated, timestamp min_allowed_interval);
 
 LoadResult attempt_load(
         const std::shared_ptr<VersionMap>& version_map, const std::shared_ptr<Store>& store, SymbolListData& data,

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -21,8 +21,6 @@ struct SymbolListEntry;
 struct SymbolEntryData;
 
 using MapType = std::unordered_map<StreamId, std::vector<SymbolEntryData>>;
-using Compaction = std::vector<AtomKey>::const_iterator;
-using MaybeCompaction = std::optional<Compaction>;
 using CollectionType = std::vector<SymbolListEntry>;
 
 enum class WillAttemptCompaction : uint8_t {
@@ -31,13 +29,18 @@ enum class WillAttemptCompaction : uint8_t {
     NO_DISABLED                  // compaction explicitly disabled by caller
 };
 
-struct LoadResult {
-    std::vector<AtomKey> symbol_list_keys_;
-    MaybeCompaction maybe_previous_compaction;
-    CollectionType symbols_;
-    timestamp timestamp_ = 0L;
+struct JournalResult {
+    std::optional<AtomKey> compaction_key;
+    MapType update_map;
+    size_t total_key_count = 0;
+    std::vector<VariantKey> all_keys; // only populated when collect_keys=true
+};
 
-    std::vector<AtomKey>&& detach_symbol_list_keys() { return std::move(symbol_list_keys_); }
+struct LoadResult {
+    std::optional<AtomKey> compaction_key_;
+    CollectionType symbols_;
+    size_t total_key_count_ = 0;
+    std::vector<VariantKey> symbol_list_keys_;
 };
 
 struct SymbolListData {
@@ -160,6 +163,13 @@ class SymbolList {
                 }
         );
 
+        // Build output before compaction — compact_internal moves symbols_ into write_symbols
+        R output;
+        for (const auto& entry : load_result.symbols_) {
+            if (entry.action_ == ActionType::ADD)
+                output.insert(entry.stream_id_);
+        }
+
         if (will_attempt_compaction == WillAttemptCompaction::YES && needs_compaction(load_result)) {
             ARCTICDB_RUNTIME_DEBUG(log::symbol(), "Compaction necessary. Obtaining lock...");
             try {
@@ -178,12 +188,6 @@ class SymbolList {
             } catch (const std::exception& ex) {
                 log::symbol().warn("Ignoring error while trying to compact the symbol list: {}", ex.what());
             }
-        }
-
-        R output;
-        for (const auto& entry : load_result.symbols_) {
-            if (entry.action_ == ActionType::ADD)
-                output.insert(entry.stream_id_);
         }
 
         return output;

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -17,10 +17,21 @@
 #include <util/storage_lock.hpp>
 
 namespace arcticdb {
-struct SymbolListEntry;
-struct SymbolEntryData;
+// Compact 32-byte representation of a SYMBOL_LIST journal AtomKey.
+// Stores only the fields needed to reconstruct the full AtomKey for deletion.
+// The symbol (start_index / map key) is held separately by the containing JournalMapType.
+struct JournalEntryData {
+    entity::VersionId key_version_id; // 8 bytes
+    timestamp creation_ts;            // 8 bytes
+    entity::ContentHash content_hash; // 8 bytes
+    ActionType action;                // 1 byte
+    bool is_new_style;                // 1 byte
+    // 6 bytes implicit padding
+};
 
-using MapType = std::unordered_map<StreamId, std::vector<SymbolEntryData>>;
+using JournalMapType = std::unordered_map<StreamId, std::vector<JournalEntryData>>;
+
+struct SymbolListEntry;
 using CollectionType = std::vector<SymbolListEntry>;
 
 enum class WillAttemptCompaction : uint8_t {
@@ -31,16 +42,19 @@ enum class WillAttemptCompaction : uint8_t {
 
 struct JournalResult {
     std::optional<AtomKey> compaction_key;
-    MapType update_map;
+    JournalMapType update_map; // JournalEntryData (32B/entry) for all journal entries
     size_t total_key_count = 0;
-    std::vector<VariantKey> all_keys; // only populated when collect_keys=true
+    std::vector<VariantKey> compaction_keys; // VariantKeys of all compaction keys found during scan
 };
 
 struct LoadResult {
     std::optional<AtomKey> compaction_key_;
     CollectionType symbols_;
     size_t total_key_count_ = 0;
-    std::vector<VariantKey> symbol_list_keys_;
+    // Old compaction VariantKeys (typically 0–1); freed immediately after compact_internal deletes them.
+    std::vector<VariantKey> old_compaction_keys_;
+    // Journal keys stored as JournalEntryData (32 B each); reconstructed in batches during compact_internal.
+    JournalMapType update_map_;
 };
 
 struct SymbolListData {

--- a/cpp/arcticdb/version/symbol_list.hpp
+++ b/cpp/arcticdb/version/symbol_list.hpp
@@ -17,6 +17,8 @@
 #include <util/storage_lock.hpp>
 
 namespace arcticdb {
+enum class ActionType : uint8_t { ADD, DELETE };
+
 // Compact 32-byte representation of a SYMBOL_LIST journal AtomKey.
 // Stores only the fields needed to reconstruct the full AtomKey for deletion.
 // The symbol (start_index / map key) is held separately by the containing JournalMapType.
@@ -74,8 +76,6 @@ constexpr std::string_view AddSymbol = "__add__";
 constexpr std::string_view DeleteSymbol = "__delete__";
 
 constexpr VersionId unknown_version_id = std::numeric_limits<VersionId>::max();
-
-enum class ActionType : uint8_t { ADD, DELETE };
 
 inline StreamId action_id(ActionType action) {
     switch (action) {

--- a/cpp/arcticdb/version/test/benchmark_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/benchmark_symbol_list.cpp
@@ -1,0 +1,328 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <benchmark/benchmark.h>
+#include <atomic>
+#include <thread>
+
+#ifdef __linux__
+#include <malloc.h>
+#endif
+
+#include <arcticdb/version/symbol_list.hpp>
+#include <arcticdb/version/version_map.hpp>
+#include <arcticdb/storage/test/in_memory_store.hpp>
+#include <arcticdb/storage/s3/s3_storage.hpp>
+#include <arcticdb/storage/s3/s3_api.hpp>
+#include <arcticdb/storage/storages.hpp>
+#include <arcticdb/storage/library.hpp>
+#include <arcticdb/async/async_store.hpp>
+#include <arcticdb/codec/default_codecs.hpp>
+#include <arcticdb/util/configs_map.hpp>
+
+using namespace arcticdb;
+
+std::shared_ptr<Store> create_s3_mock_store(const std::string& lib_name = "benchmark_sl") {
+    storage::s3::S3ApiInstance::instance();
+    arcticdb::proto::storage::VariantStorage vs;
+    arcticdb::proto::s3_storage::Config cfg;
+    cfg.set_bucket_name("test-bucket");
+    cfg.set_use_mock_storage_for_testing(true);
+    util::pack_to_any(cfg, *vs.mutable_config());
+
+    storage::LibraryPath path{lib_name.c_str(), "store"};
+    auto storages = storage::create_storages(path, storage::OpenMode::DELETE, {vs});
+    auto library = std::make_shared<storage::Library>(path, std::move(storages));
+    return std::make_shared<async::AsyncStore<>>(
+            async::AsyncStore(library, codec::default_lz4_codec(), EncodingVersion::V1)
+    );
+}
+
+// Tracks peak heap usage by polling mallinfo2 from a background thread.
+// Only functional on Linux with glibc; on other platforms it reports zero.
+struct PeakHeapTracker {
+    std::atomic<bool> running_{false};
+    std::atomic<size_t> peak_uordblks_{0};
+    size_t baseline_{0};
+    std::thread sampler_;
+
+    static size_t current_heap_bytes() {
+#ifdef __linux__
+#if __GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33)
+        return mallinfo2().uordblks;
+#else
+        return static_cast<size_t>(mallinfo().uordblks);
+#endif
+#else
+        return 0;
+#endif
+    }
+
+    void start() {
+#ifdef __linux__
+        malloc_trim(0);
+#endif
+        baseline_ = current_heap_bytes();
+        peak_uordblks_ = baseline_;
+        running_ = true;
+        sampler_ = std::thread([this] {
+            while (running_.load(std::memory_order_relaxed)) {
+                auto current = current_heap_bytes();
+                auto prev = peak_uordblks_.load(std::memory_order_relaxed);
+                while (current > prev && !peak_uordblks_.compare_exchange_weak(prev, current, std::memory_order_relaxed)
+                )
+                    ;
+                std::this_thread::sleep_for(std::chrono::microseconds(100));
+            }
+        });
+    }
+
+    size_t stop() {
+        running_ = false;
+        if (sampler_.joinable())
+            sampler_.join();
+        auto current = current_heap_bytes();
+        auto prev = peak_uordblks_.load(std::memory_order_relaxed);
+        if (current > prev)
+            peak_uordblks_.store(current, std::memory_order_relaxed);
+        return peak_uordblks_.load() - baseline_;
+    }
+};
+
+// Benchmarks peak memory usage of symbol list loading via the compaction path.
+//
+// Run with: --benchmark_time_unit=ms --benchmark_filter=BM_symbol_list_load
+
+static void BM_symbol_list_load(benchmark::State& state) {
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    auto num_symbols = state.range(0);
+
+    // Write journal entries for num_symbols symbols
+    for (int64_t i = 0; i < num_symbols; ++i) {
+        SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 0);
+    }
+
+    // Force compaction on first load to create the compacted segment
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    {
+        SymbolList sl{version_map};
+        sl.load<std::set<StreamId>>(version_map, store, false);
+    }
+
+    // Add a few journal entries to exercise the merge path
+    for (int64_t i = 0; i < 100; ++i) {
+        SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 1);
+    }
+
+    // Disable compaction during the benchmark iterations
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+
+    for (auto _ : state) {
+        PeakHeapTracker tracker;
+        tracker.start();
+
+        SymbolList sl{version_map};
+        auto result = sl.load<std::set<StreamId>>(version_map, store, true);
+
+        auto peak_delta = tracker.stop();
+        auto retained = PeakHeapTracker::current_heap_bytes() - tracker.baseline_;
+
+        state.counters["PeakMB"] = benchmark::Counter(static_cast<double>(peak_delta) / (1024.0 * 1024.0));
+        state.counters["RetainedMB"] = benchmark::Counter(static_cast<double>(retained) / (1024.0 * 1024.0));
+        state.counters["NumSymbols"] = benchmark::Counter(static_cast<double>(result.size()));
+
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(BM_symbol_list_load)->Arg(100'000)->Arg(300'000)->Unit(benchmark::kMillisecond)->Iterations(3);
+BENCHMARK(BM_symbol_list_load)->Arg(1'000'000)->Unit(benchmark::kMillisecond)->Iterations(3);
+
+// Benchmarks peak memory with many uncompacted journal entries per symbol.
+// This is the scenario where the AtomKey vector elimination matters most.
+//
+// Setup: N_SYMBOLS symbols, each with ENTRIES_PER_SYMBOL journal entries.
+
+static void BM_symbol_list_load_many_entries(benchmark::State& state) {
+    auto store = std::make_shared<InMemoryStore>();
+    auto version_map = std::make_shared<VersionMap>();
+    auto num_symbols = state.range(0);
+    auto entries_per_symbol = state.range(1);
+
+    // Write journal entries: each symbol gets multiple versions
+    for (int64_t i = 0; i < num_symbols; ++i) {
+        for (int64_t v = 0; v < entries_per_symbol; ++v) {
+            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, v);
+        }
+    }
+
+    // Force compaction to create the compacted segment
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    {
+        SymbolList sl{version_map};
+        sl.load<std::set<StreamId>>(version_map, store, false);
+    }
+
+    // Write more journal entries (uncompacted)
+    for (int64_t i = 0; i < num_symbols; ++i) {
+        for (int64_t v = 0; v < entries_per_symbol; ++v) {
+            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, entries_per_symbol + v);
+        }
+    }
+
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+
+    for (auto _ : state) {
+        PeakHeapTracker tracker;
+        tracker.start();
+
+        SymbolList sl{version_map};
+        auto result = sl.load<std::set<StreamId>>(version_map, store, true);
+
+        auto peak_delta = tracker.stop();
+        auto retained = PeakHeapTracker::current_heap_bytes() - tracker.baseline_;
+
+        state.counters["PeakMB"] = benchmark::Counter(static_cast<double>(peak_delta) / (1024.0 * 1024.0));
+        state.counters["RetainedMB"] = benchmark::Counter(static_cast<double>(retained) / (1024.0 * 1024.0));
+        state.counters["NumSymbols"] = benchmark::Counter(static_cast<double>(result.size()));
+        state.counters["TotalEntries"] = benchmark::Counter(static_cast<double>(num_symbols * entries_per_symbol));
+
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(BM_symbol_list_load_many_entries)->Args({1'000, 1'000})->Unit(benchmark::kMillisecond)->Iterations(1);
+// Disabled in CI: 300K-symbol setup writes 600K journal entries (~25 s on CI hardware).
+// Run locally: make bench-cpp FILTER=BM_symbol_list_load_many_entries/300000
+// BENCHMARK(BM_symbol_list_load_many_entries)->Args({300'000, 1})->Unit(benchmark::kMillisecond)->Iterations(1);
+
+// Benchmarks peak memory during a load that triggers compaction.
+// This measures the compaction path where keys are collected for deletion.
+//
+// Setup: N_SYMBOLS symbols with ENTRIES_PER_SYMBOL uncompacted journal entries each.
+// MaxDelta=0 forces compaction on every load.
+
+static void BM_symbol_list_compaction(benchmark::State& state) {
+    auto version_map = std::make_shared<VersionMap>();
+    auto num_symbols = state.range(0);
+    auto entries_per_symbol = state.range(1);
+
+    // Setup outside the benchmark loop — write journal entries once
+    auto store = std::make_shared<InMemoryStore>();
+    for (int64_t i = 0; i < num_symbols; ++i) {
+        for (int64_t v = 0; v < entries_per_symbol; ++v) {
+            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, v);
+        }
+    }
+
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+
+    for (auto _ : state) {
+        PeakHeapTracker tracker;
+        tracker.start();
+
+        SymbolList sl{version_map};
+        auto result = sl.load<std::set<StreamId>>(version_map, store, false);
+
+        auto peak_delta = tracker.stop();
+
+        state.counters["PeakMB"] = benchmark::Counter(static_cast<double>(peak_delta) / (1024.0 * 1024.0));
+        state.counters["NumSymbols"] = benchmark::Counter(static_cast<double>(result.size()));
+        state.counters["TotalEntries"] = benchmark::Counter(static_cast<double>(num_symbols * entries_per_symbol));
+
+        benchmark::DoNotOptimize(result);
+    }
+
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+}
+
+BENCHMARK(BM_symbol_list_compaction)
+        ->Args({100, 100})
+        // ->Args({10'000, 10})
+        // ->Args({1'000, 100})
+        // ->Args({1'000, 1'000})
+        // ->Args({10'000, 100})
+        ->Unit(benchmark::kMillisecond)
+        ->Iterations(1);
+
+// ---- S3 mock variants: exercise the full S3 storage layer (serialization, key parsing) ----
+
+static void BM_symbol_list_load_s3(benchmark::State& state) {
+    auto store = create_s3_mock_store();
+    auto version_map = std::make_shared<VersionMap>();
+    auto num_symbols = state.range(0);
+
+    for (int64_t i = 0; i < num_symbols; ++i) {
+        SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 0);
+    }
+
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    {
+        SymbolList sl{version_map};
+        sl.load<std::set<StreamId>>(version_map, store, false);
+    }
+
+    for (int64_t i = 0; i < 100; ++i) {
+        SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 1);
+    }
+
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+
+    for (auto _ : state) {
+        PeakHeapTracker tracker;
+        tracker.start();
+
+        SymbolList sl{version_map};
+        auto result = sl.load<std::set<StreamId>>(version_map, store, true);
+
+        auto peak_delta = tracker.stop();
+
+        state.counters["PeakMB"] = benchmark::Counter(static_cast<double>(peak_delta) / (1024.0 * 1024.0));
+        state.counters["NumSymbols"] = benchmark::Counter(static_cast<double>(result.size()));
+
+        benchmark::DoNotOptimize(result);
+    }
+}
+
+BENCHMARK(BM_symbol_list_load_s3)->Arg(10'000)->Unit(benchmark::kMillisecond)->Iterations(1);
+
+[[maybe_unused]] static void BM_symbol_list_compaction_s3(benchmark::State& state) {
+    auto version_map = std::make_shared<VersionMap>();
+    auto num_symbols = state.range(0);
+    auto entries_per_symbol = state.range(1);
+
+    auto store = create_s3_mock_store();
+    for (int64_t i = 0; i < num_symbols; ++i) {
+        for (int64_t v = 0; v < entries_per_symbol; ++v) {
+            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, v);
+        }
+    }
+
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+
+    for (auto _ : state) {
+        PeakHeapTracker tracker;
+        tracker.start();
+
+        SymbolList sl{version_map};
+        auto result = sl.load<std::set<StreamId>>(version_map, store, false);
+
+        auto peak_delta = tracker.stop();
+
+        state.counters["PeakMB"] = benchmark::Counter(static_cast<double>(peak_delta) / (1024.0 * 1024.0));
+        state.counters["NumSymbols"] = benchmark::Counter(static_cast<double>(result.size()));
+        state.counters["TotalEntries"] = benchmark::Counter(static_cast<double>(num_symbols * entries_per_symbol));
+
+        benchmark::DoNotOptimize(result);
+    }
+
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+}
+
+BENCHMARK(BM_symbol_list_compaction_s3)->Args({1'000, 100})->Unit(benchmark::kMillisecond)->Iterations(1);

--- a/cpp/arcticdb/version/test/benchmark_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/benchmark_symbol_list.cpp
@@ -17,16 +17,21 @@
 #include <arcticdb/version/symbol_list.hpp>
 #include <arcticdb/version/version_map.hpp>
 #include <arcticdb/storage/test/in_memory_store.hpp>
-#include <arcticdb/storage/s3/s3_storage.hpp>
-#include <arcticdb/storage/s3/s3_api.hpp>
-#include <arcticdb/storage/storages.hpp>
-#include <arcticdb/storage/library.hpp>
-#include <arcticdb/async/async_store.hpp>
-#include <arcticdb/codec/default_codecs.hpp>
 #include <arcticdb/util/configs_map.hpp>
+
+// The S3-mock benchmarks below are disabled (see the note above BM_symbol_list_load_s3). When
+// re-enabling them, restore these includes:
+// #include <arcticdb/storage/s3/s3_storage.hpp>
+// #include <arcticdb/storage/s3/s3_api.hpp>
+// #include <arcticdb/storage/storages.hpp>
+// #include <arcticdb/storage/library.hpp>
+// #include <arcticdb/async/async_store.hpp>
+// #include <arcticdb/codec/default_codecs.hpp>
 
 using namespace arcticdb;
 
+// Disabled together with the S3-mock benchmarks below; see the note above BM_symbol_list_load_s3.
+#if 0
 std::shared_ptr<Store> create_s3_mock_store(const std::string& lib_name = "benchmark_sl") {
     storage::s3::S3ApiInstance::instance();
     arcticdb::proto::storage::VariantStorage vs;
@@ -42,6 +47,7 @@ std::shared_ptr<Store> create_s3_mock_store(const std::string& lib_name = "bench
             async::AsyncStore(library, codec::default_lz4_codec(), EncodingVersion::V1)
     );
 }
+#endif
 
 // Tracks peak heap usage by polling mallinfo2 from a background thread.
 // Only functional on Linux with glibc; on other platforms it reports zero.
@@ -252,7 +258,14 @@ BENCHMARK(BM_symbol_list_compaction)
         ->Iterations(1);
 
 // ---- S3 mock variants: exercise the full S3 storage layer (serialization, key parsing) ----
-
+//
+// Disabled in CI: these init the AWS C++ SDK (S3ApiInstance -> Aws::InitAPI), which aborts the
+// process during teardown on macOS (Aws::CleanupMonitoring; the SDK is deliberately never given a
+// matching Aws::ShutdownAPI, see s3_api.cpp). The abort happens at process exit, after the
+// benchmark has already run. They pass on Linux, so re-enable and run there:
+//   make bench-cpp FILTER=BM_symbol_list_.*_s3
+// Remember to restore the S3 includes at the top of this file when re-enabling.
+#if 0
 static void BM_symbol_list_load_s3(benchmark::State& state) {
     auto store = create_s3_mock_store();
     auto version_map = std::make_shared<VersionMap>();
@@ -326,3 +339,4 @@ BENCHMARK(BM_symbol_list_load_s3)->Arg(10'000)->Unit(benchmark::kMillisecond)->I
 }
 
 BENCHMARK(BM_symbol_list_compaction_s3)->Args({1'000, 100})->Unit(benchmark::kMillisecond)->Iterations(1);
+#endif // S3-mock benchmarks disabled (macOS AWS SDK teardown abort)

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -757,7 +757,13 @@ TEST_F(SymbolListSuite, BackwardsCompat) {
 
     auto old_keys = backwards_compat_get_all_symbol_list_keys(store);
     auto old_symbols = backwards_compat_get_symbols(store);
+    std::set<AtomKey> old_key_set(old_keys.begin(), old_keys.end());
     backwards_compat_compact(store, std::move(old_keys), old_symbols);
+
+    // delete_keys must remove every old journal/compaction key, leaving only the freshly written compaction key
+    auto keys_after_compact = backwards_compat_get_all_symbol_list_keys(store);
+    ASSERT_EQ(keys_after_compact.size(), 1);
+    ASSERT_EQ(old_key_set.count(keys_after_compact.front()), 0);
 
     ASSERT_EQ(all_symbols_match(store, symbol_list, expected), true);
 

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -423,24 +423,26 @@ TEST(SymbolList, IsProblematic) {
     const timestamp min_interval = 100000;
 
     // No conflict - all adds
-    std::vector<SymbolEntryData> vec1{{0, 0, ActionType::ADD}, {1, 1_s, ActionType::ADD}, {2, 2_s, ActionType::ADD}};
+    std::vector<JournalEntryData> vec1{{0, 0, ActionType::ADD}, {1, 1_s, ActionType::ADD}, {2, 2_s, ActionType::ADD}};
     auto result = is_problematic(vec1, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // No conflict with delete
-    std::vector<SymbolEntryData> vec2{{0, 0, ActionType::ADD}, {1, 1_s, ActionType::ADD}, {1, 2_s, ActionType::DELETE}};
+    std::vector<JournalEntryData> vec2{
+            {0, 0, ActionType::ADD}, {1, 1_s, ActionType::ADD}, {1, 2_s, ActionType::DELETE}
+    };
     result = is_problematic(vec2, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // Version conflict not in the most recent is okay
-    std::vector<SymbolEntryData> vec3{
+    std::vector<JournalEntryData> vec3{
             {0, 0, ActionType::ADD}, {0, 1_s, ActionType::DELETE}, {0, 2_s, ActionType::ADD}, {1, 3_s, ActionType::ADD}
     };
     result = is_problematic(vec3, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // Version conflict with same action also fine
-    std::vector<SymbolEntryData> vec4{
+    std::vector<JournalEntryData> vec4{
             {0, 0, ActionType::ADD},
             {0, 1_s, ActionType::DELETE},
             {1, 2_s, ActionType::ADD},
@@ -451,7 +453,7 @@ TEST(SymbolList, IsProblematic) {
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // Version conflict at end returns latest
-    std::vector<SymbolEntryData> vec5{
+    std::vector<JournalEntryData> vec5{
             {0, 0, ActionType::ADD},
             {1, 1_s, ActionType::DELETE},
             {1, 2_s, ActionType::DELETE},
@@ -462,7 +464,7 @@ TEST(SymbolList, IsProblematic) {
     ASSERT_EQ(result_equals(result, expected1), true);
 
     // As above but with the first version
-    std::vector<SymbolEntryData> vec6{
+    std::vector<JournalEntryData> vec6{
             {0, 1_s, ActionType::DELETE}, {0, 2_s, ActionType::DELETE}, {0, 3_s, ActionType::ADD}
     };
     result = is_problematic(vec6, min_interval);
@@ -470,12 +472,14 @@ TEST(SymbolList, IsProblematic) {
     ASSERT_EQ(result_equals(result, expected2), true);
 
     // Timestamps too close but not more recent is okay
-    std::vector<SymbolEntryData> vec7{{0, 0, ActionType::ADD}, {1, 100, ActionType::DELETE}, {2, 2_s, ActionType::ADD}};
+    std::vector<JournalEntryData> vec7{
+            {0, 0, ActionType::ADD}, {1, 100, ActionType::DELETE}, {2, 2_s, ActionType::ADD}
+    };
     result = is_problematic(vec7, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // Timestamp clash in most recent returns latest entry
-    std::vector<SymbolEntryData> vec8{
+    std::vector<JournalEntryData> vec8{
             {0, 0, ActionType::ADD}, {0, 1_s, ActionType::DELETE}, {0, 1_s + 100, ActionType::ADD}
     };
     result = is_problematic(vec8, min_interval);
@@ -483,7 +487,7 @@ TEST(SymbolList, IsProblematic) {
     ASSERT_EQ(result_equals(result, expected3), true);
 
     // Contains unknown reference ids
-    std::vector<SymbolEntryData> vec9{
+    std::vector<JournalEntryData> vec9{
             {0, 0, ActionType::ADD}, {unknown_version_id, 1_s, ActionType::DELETE}, {2, 2_s, ActionType::ADD}
     };
     result = is_problematic(vec9, min_interval);
@@ -495,13 +499,13 @@ TEST(SymbolList, IsProblematicWithStored) {
 
     // No conflict
     SymbolListEntry entry1{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec1{{1, 1_s, ActionType::ADD}, {2, 2_s, ActionType::ADD}, {3, 3_s, ActionType::ADD}};
+    std::vector<JournalEntryData> vec1{{1, 1_s, ActionType::ADD}, {2, 2_s, ActionType::ADD}, {3, 3_s, ActionType::ADD}};
     auto result = is_problematic(entry1, vec1, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // No conflict with delete
     SymbolListEntry entry2{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec2{
+    std::vector<JournalEntryData> vec2{
             {0, 1_s, ActionType::DELETE},
             {1, 2_s, ActionType::ADD},
             {1, 3_s, ActionType::DELETE},
@@ -513,7 +517,7 @@ TEST(SymbolList, IsProblematicWithStored) {
 
     // Conflict between stored and update, but not most recent is okay
     SymbolListEntry entry3{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec3{
+    std::vector<JournalEntryData> vec3{
             {0, 1_s, ActionType::ADD},
             {0, 2_s, ActionType::DELETE},
             {1, 3_s, ActionType::ADD},
@@ -525,13 +529,13 @@ TEST(SymbolList, IsProblematicWithStored) {
 
     // Version conflict but same action is fine
     SymbolListEntry entry4{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec4{{0, 1_s, ActionType::ADD}, {0, 2_s, ActionType::ADD}};
+    std::vector<JournalEntryData> vec4{{0, 1_s, ActionType::ADD}, {0, 2_s, ActionType::ADD}};
     result = is_problematic(entry4, vec4, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // Conflicting version in update returns most recent update
     SymbolListEntry entry5{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec5{
+    std::vector<JournalEntryData> vec5{
             {0, 1_s, ActionType::DELETE},
             {1, 2_s, ActionType::DELETE},
             {1, 3_s, ActionType::ADD},
@@ -543,7 +547,7 @@ TEST(SymbolList, IsProblematicWithStored) {
 
     // Conflict exists but there is an old-style symbol list key
     SymbolListEntry entry6{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec6{
+    std::vector<JournalEntryData> vec6{
             {unknown_version_id, 1_s, ActionType::ADD}, {0, 2_s, ActionType::ADD}, {0, 3_s, ActionType::DELETE}
     };
     result = is_problematic(entry6, vec6, min_interval);
@@ -552,21 +556,21 @@ TEST(SymbolList, IsProblematicWithStored) {
 
     // Simple conflict between update and existing
     SymbolListEntry entry7{"test", 0, 0, ActionType::ADD};
-    std::vector<SymbolEntryData> vec7{{0, 2_s, ActionType::ADD}, {0, 3_s, ActionType::DELETE}};
+    std::vector<JournalEntryData> vec7{{0, 2_s, ActionType::ADD}, {0, 3_s, ActionType::DELETE}};
     result = is_problematic(entry7, vec7, min_interval);
     expected = SymbolEntryData{0, 3_s, ActionType::DELETE};
     ASSERT_EQ(result_equals(result, expected), true);
 
     // Update conflicts with existing
     SymbolListEntry entry8{"test", 0, 0, ActionType::DELETE};
-    std::vector<SymbolEntryData> vec8{{0, 1_s, ActionType::ADD}, {0, 2_s, ActionType::ADD}};
+    std::vector<JournalEntryData> vec8{{0, 1_s, ActionType::ADD}, {0, 2_s, ActionType::ADD}};
     result = is_problematic(entry8, vec8, min_interval);
     expected = SymbolEntryData{0, 2_s, ActionType::ADD};
     ASSERT_EQ(result_equals(result, expected), true);
 
     // Update and existing timestamps too close
     SymbolListEntry entry9{"test", 0, 0, ActionType::DELETE};
-    std::vector<SymbolEntryData> vec9{{1, 100, ActionType::ADD}};
+    std::vector<JournalEntryData> vec9{{1, 100, ActionType::ADD}};
 
     result = is_problematic(entry9, vec9, min_interval);
     expected = SymbolEntryData{1, 100, ActionType::ADD};
@@ -574,14 +578,14 @@ TEST(SymbolList, IsProblematicWithStored) {
 
     // Update and existing timestamps too close, same action is okay
     SymbolListEntry entry10{"test", 0, 0, ActionType::DELETE};
-    std::vector<SymbolEntryData> vec10{{1, 100, ActionType::DELETE}};
+    std::vector<JournalEntryData> vec10{{1, 100, ActionType::DELETE}};
 
     result = is_problematic(entry10, vec10, min_interval);
     ASSERT_EQ(static_cast<bool>(result), false);
 
     // Timestamps too close, but not most recent
     SymbolListEntry entry11{"test", 0, 0, ActionType::DELETE};
-    std::vector<SymbolEntryData> vec11{
+    std::vector<JournalEntryData> vec11{
             {1, 100, ActionType::ADD},
             {2, 2_s, ActionType::ADD},
     };
@@ -592,7 +596,7 @@ TEST(SymbolList, IsProblematicWithStored) {
 
 TEST(Problematic, RealTimestamps2) {
     // SymbolListEntry entry1{"test", 0, 1694701083539622714, ActionType::ADD};
-    std::vector<SymbolEntryData> vec1{
+    std::vector<JournalEntryData> vec1{
             {0, 1696255639552055287, ActionType::ADD}, {0, 1696255639570862954, ActionType::ADD}
     };
 
@@ -602,7 +606,7 @@ TEST(Problematic, RealTimestamps2) {
 
 TEST(Problematic, RealTimestamps) {
     SymbolListEntry entry1{"test", 0, 1694701083539622714, ActionType::ADD};
-    std::vector<SymbolEntryData> vec1{
+    std::vector<JournalEntryData> vec1{
             {0, 1694701083516771231, ActionType::ADD},
             {0, 1694701083531817347, ActionType::ADD},
             {0, 1694701083541496287, ActionType::ADD},
@@ -616,7 +620,7 @@ TEST(Problematic, RealTimestamps) {
     ASSERT_EQ(result_equals(result, expected), true);
 
     SymbolListEntry entry2{"test", 2, 1694779989680380390, ActionType::ADD};
-    std::vector<SymbolEntryData> vec2{
+    std::vector<JournalEntryData> vec2{
             {0, 1694779976040611297, ActionType::ADD}, {0, 1694779976054908858, ActionType::ADD},
             {0, 1694779976062913894, ActionType::ADD}, {0, 1694779976086496686, ActionType::ADD},
             {0, 1694779976095000098, ActionType::ADD}, {0, 1694779976098613575, ActionType::ADD},
@@ -633,7 +637,7 @@ TEST(Problematic, RealTimestamps) {
     ASSERT_EQ(static_cast<bool>(result), false);
 
     SymbolListEntry entry3{"test", 0, 1696510154249460459, ActionType::ADD};
-    std::vector<SymbolEntryData> vec3{
+    std::vector<JournalEntryData> vec3{
             {0, 1696510154081738353, ActionType::ADD},
             {0, 1696510154273679131, ActionType::ADD},
             {0, 1696510154277544441, ActionType::ADD},
@@ -1064,8 +1068,11 @@ INSTANTIATE_TEST_SUITE_P(SymbolListSource, SymbolListRace, Combine(Values('S'), 
 // For version keys source (initial compaction), there's no old compaction key to remove:
 INSTANTIATE_TEST_SUITE_P(VersionKeysSource, SymbolListRace, Combine(Values('V'), Values(false), Bool(), Bool()));
 
-TEST_F(SymbolListSuite, DirectPathEquivalence) {
-    // Setup: add symbols and force compaction
+// Loading with no_compaction=true (skip the compaction write/delete, just merge and return) must
+// produce the same symbols as the compaction-eligible path. Here the journal mixes new symbols,
+// re-adds of already-present symbols, and removes of symbols still live in the version map.
+TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPath) {
+    // Setup: add symbols and force a compaction so we have a compaction key to load from.
     for (int i = 0; i < 50; ++i) {
         auto symbol = fmt::format("sym_{}", i);
         SymbolList::add_symbol(store_, StreamId{symbol}, 0);
@@ -1074,12 +1081,11 @@ TEST_F(SymbolListSuite, DirectPathEquivalence) {
     }
 
     ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
-    {
-        SymbolList sl{version_map_};
-        sl.load<std::set<StreamId>>(version_map_, store_, false);
-    }
+    SymbolList sl{version_map_};
+    sl.load<std::set<StreamId>>(version_map_, store_, false);
 
-    // Add journal entries: new symbols + deletes of existing ones
+    // Journal entries on top of the compaction key: sym_40..49 re-add already-present symbols,
+    // sym_50..59 are new, and sym_0..9 are removed (but kept in the version map, see below).
     for (int i = 40; i < 60; ++i) {
         auto symbol = fmt::format("sym_{}", i);
         SymbolList::add_symbol(store_, StreamId{symbol}, 1);
@@ -1097,18 +1103,21 @@ TEST_F(SymbolListSuite, DirectPathEquivalence) {
     SymbolList sl1{version_map_};
     auto compaction_result = sl1.load<std::set<StreamId>>(version_map_, store_, false);
 
-    // Load via direct path (no_compaction=true)
+    // Load with compaction disabled (no_compaction=true)
     SymbolList sl2{version_map_};
     auto direct_result = sl2.load<std::set<StreamId>>(version_map_, store_, true);
 
     EXPECT_EQ(compaction_result, direct_result);
-    // 50 original + 10 new = 60. The remove_symbol journal entries are resolved
-    // as ADD because the version map still shows those symbols as existing.
+    // 50 original + 10 new (sym_50..59) = 60. The sym_0..9 removes land close in time to their
+    // original adds, so the merge flags them as problematic and resolves them against the version
+    // map; since we never tombstoned them there, they resolve back to ADD and remain present.
     EXPECT_EQ(direct_result.size(), 60u);
 }
 
-TEST_F(SymbolListSuite, DirectPathEquivalenceWithTrueDeletes) {
-    // Setup: add symbols and force compaction
+// Same equivalence check, but the removed symbols are also tombstoned in the version map, so they
+// resolve to true DELETEs and drop out of both load paths.
+TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPathWithTrueDeletes) {
+    // Setup: add symbols and force a compaction so we have a compaction key to load from.
     for (int i = 0; i < 50; ++i) {
         auto symbol = fmt::format("sym_{}", i);
         SymbolList::add_symbol(store_, StreamId{symbol}, 0);
@@ -1117,10 +1126,8 @@ TEST_F(SymbolListSuite, DirectPathEquivalenceWithTrueDeletes) {
     }
 
     ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
-    {
-        SymbolList sl{version_map_};
-        sl.load<std::set<StreamId>>(version_map_, store_, false);
-    }
+    SymbolList sl{version_map_};
+    sl.load<std::set<StreamId>>(version_map_, store_, false);
 
     // Add new symbols
     for (int i = 50; i < 60; ++i) {

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -1071,6 +1071,9 @@ INSTANTIATE_TEST_SUITE_P(VersionKeysSource, SymbolListRace, Combine(Values('V'),
 // Loading with no_compaction=true (skip the compaction write/delete, just merge and return) must
 // produce the same symbols as the compaction-eligible path. Here the journal mixes new symbols,
 // re-adds of already-present symbols, and removes of symbols still live in the version map.
+// Only the sym_0..9 removes conflict with the compacted ADD entry, so only those go through the
+// problematic path and get resolved against the version map's ground truth, ignoring reference_id.
+// The re-adds/new-adds never hit that path, but reference_ids are still kept realistic throughout.
 TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPath) {
     // Setup: add symbols and force a compaction so we have a compaction key to load from.
     for (int i = 0; i < 50; ++i) {
@@ -1084,17 +1087,29 @@ TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPath) {
     SymbolList sl{version_map_};
     sl.load<std::set<StreamId>>(version_map_, store_, false);
 
-    // Journal entries on top of the compaction key: sym_40..49 re-add already-present symbols,
-    // sym_50..59 are new, and sym_0..9 are removed (but kept in the version map, see below).
-    for (int i = 40; i < 60; ++i) {
+    // Journal entries on top of the compaction key, split by scenario:
+
+    // sym_40..49 already exist at version 0 (from the setup above); write a genuine second
+    // version for them, so the reference_id on the new ADD entry is 1 (the version just written).
+    for (int i = 40; i < 50; ++i) {
         auto symbol = fmt::format("sym_{}", i);
-        SymbolList::add_symbol(store_, StreamId{symbol}, 1);
         auto key = atom_key_builder().version_id(1).build(symbol, KeyType::TABLE_INDEX);
         version_map_->write_version(store_, key, std::nullopt);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 1);
     }
+    // sym_50..59 are brand new symbols; their first version is 0, so the reference_id matches that.
+    for (int i = 50; i < 60; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        auto key = atom_key_builder().version_id(0).build(symbol, KeyType::TABLE_INDEX);
+        version_map_->write_version(store_, key, std::nullopt);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 0);
+    }
+    // sym_0..9 are removed, but their only version (0) is left live in the version map below -
+    // the reference_id on the DELETE entry must match that still-live version, not a version that
+    // was never written.
     for (int i = 0; i < 10; ++i) {
         auto symbol = fmt::format("sym_{}", i);
-        SymbolList::remove_symbol(store_, StreamId{symbol}, 1);
+        SymbolList::remove_symbol(store_, StreamId{symbol}, 0);
     }
 
     ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
@@ -1116,6 +1131,9 @@ TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPath) {
 
 // Same equivalence check, but the removed symbols are also tombstoned in the version map, so they
 // resolve to true DELETEs and drop out of both load paths.
+// As above, only the sym_0..9 removes go through the problematic path (resolved against the
+// version map's ground truth); the sym_50..59 new adds never do, but reference_ids are still kept
+// realistic throughout.
 TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPathWithTrueDeletes) {
     // Setup: add symbols and force a compaction so we have a compaction key to load from.
     for (int i = 0; i < 50; ++i) {
@@ -1129,18 +1147,19 @@ TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPathWithTrueDeletes) {
     SymbolList sl{version_map_};
     sl.load<std::set<StreamId>>(version_map_, store_, false);
 
-    // Add new symbols
+    // Add new symbols; their first version is 0, so the reference_id matches that.
     for (int i = 50; i < 60; ++i) {
         auto symbol = fmt::format("sym_{}", i);
-        SymbolList::add_symbol(store_, StreamId{symbol}, 1);
-        auto key = atom_key_builder().version_id(1).build(symbol, KeyType::TABLE_INDEX);
+        auto key = atom_key_builder().version_id(0).build(symbol, KeyType::TABLE_INDEX);
         version_map_->write_version(store_, key, std::nullopt);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 0);
     }
 
-    // Delete symbols 0-9 via both the symbol list journal AND the version map
+    // Delete symbols 0-9 via both the symbol list journal AND the version map. Their only version
+    // is 0, so that's the version being tombstoned and the reference_id the DELETE entry must carry.
     for (int i = 0; i < 10; ++i) {
         auto symbol = fmt::format("sym_{}", i);
-        SymbolList::remove_symbol(store_, StreamId{symbol}, 1);
+        SymbolList::remove_symbol(store_, StreamId{symbol}, 0);
         version_map_->tombstone_from_key_or_all(store_, StreamId{symbol});
     }
 

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -1057,3 +1057,95 @@ TEST_P(SymbolListRace, Run) {
 INSTANTIATE_TEST_SUITE_P(SymbolListSource, SymbolListRace, Combine(Values('S'), Bool(), Bool(), Bool()));
 // For version keys source (initial compaction), there's no old compaction key to remove:
 INSTANTIATE_TEST_SUITE_P(VersionKeysSource, SymbolListRace, Combine(Values('V'), Values(false), Bool(), Bool()));
+
+TEST_F(SymbolListSuite, DirectPathEquivalence) {
+    // Setup: add symbols and force compaction
+    for (int i = 0; i < 50; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 0);
+        auto key = atom_key_builder().build(symbol, KeyType::TABLE_INDEX);
+        version_map_->write_version(store_, key, std::nullopt);
+    }
+
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    {
+        SymbolList sl{version_map_};
+        sl.load<std::set<StreamId>>(version_map_, store_, false);
+    }
+
+    // Add journal entries: new symbols + deletes of existing ones
+    for (int i = 40; i < 60; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 1);
+        auto key = atom_key_builder().version_id(1).build(symbol, KeyType::TABLE_INDEX);
+        version_map_->write_version(store_, key, std::nullopt);
+    }
+    for (int i = 0; i < 10; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        SymbolList::remove_symbol(store_, StreamId{symbol}, 1);
+    }
+
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+
+    // Load via compaction-eligible path (will not actually compact since threshold is default)
+    SymbolList sl1{version_map_};
+    auto compaction_result = sl1.load<std::set<StreamId>>(version_map_, store_, false);
+
+    // Load via direct path (no_compaction=true)
+    SymbolList sl2{version_map_};
+    auto direct_result = sl2.load<std::set<StreamId>>(version_map_, store_, true);
+
+    EXPECT_EQ(compaction_result, direct_result);
+    // 50 original + 10 new = 60. The remove_symbol journal entries are resolved
+    // as ADD because the version map still shows those symbols as existing.
+    EXPECT_EQ(direct_result.size(), 60u);
+}
+
+TEST_F(SymbolListSuite, DirectPathEquivalenceWithTrueDeletes) {
+    // Setup: add symbols and force compaction
+    for (int i = 0; i < 50; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 0);
+        auto key = atom_key_builder().build(symbol, KeyType::TABLE_INDEX);
+        version_map_->write_version(store_, key, std::nullopt);
+    }
+
+    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    {
+        SymbolList sl{version_map_};
+        sl.load<std::set<StreamId>>(version_map_, store_, false);
+    }
+
+    // Add new symbols
+    for (int i = 50; i < 60; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        SymbolList::add_symbol(store_, StreamId{symbol}, 1);
+        auto key = atom_key_builder().version_id(1).build(symbol, KeyType::TABLE_INDEX);
+        version_map_->write_version(store_, key, std::nullopt);
+    }
+
+    // Delete symbols 0-9 via both the symbol list journal AND the version map
+    for (int i = 0; i < 10; ++i) {
+        auto symbol = fmt::format("sym_{}", i);
+        SymbolList::remove_symbol(store_, StreamId{symbol}, 1);
+        version_map_->tombstone_from_key_or_all(store_, StreamId{symbol});
+    }
+
+    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
+
+    SymbolList sl1{version_map_};
+    auto compaction_result = sl1.load<std::set<StreamId>>(version_map_, store_, false);
+
+    SymbolList sl2{version_map_};
+    auto direct_result = sl2.load<std::set<StreamId>>(version_map_, store_, true);
+
+    EXPECT_EQ(compaction_result, direct_result);
+    // 50 original - 10 deleted + 10 new = 50
+    EXPECT_EQ(direct_result.size(), 50u);
+    // Verify deleted symbols are absent
+    for (int i = 0; i < 10; ++i)
+        EXPECT_EQ(direct_result.count(StreamId{fmt::format("sym_{}", i)}), 0u);
+    // Verify new symbols are present
+    for (int i = 50; i < 60; ++i)
+        EXPECT_EQ(direct_result.count(StreamId{fmt::format("sym_{}", i)}), 1u);
+}


### PR DESCRIPTION

## 1. 63ebc8b3 - Change load approach to stream the entries rather than keeping all of them

**What it does:**

Replaces the two-pass approach (`get_all_symbol_list_keys` + `load_journal_keys`) with a single
streaming pass (`load_journal_streaming`). Instead of materialising all N `AtomKey`s into a
`vector<AtomKey>` and then building the update map from it, the streaming pass builds the
`MapType` (symbol → `vector<SymbolEntryData>`) directly during iteration.

**Result:**

Scan phase no longer requires a temporary `vector<AtomKey>`. The update map is built in one
iteration rather than two. The `all_keys` list (compaction path only) still holds N×AtomKey
(~160 B each), so peak memory during compaction is unchanged at this stage.

---

## 2. 0760d950 - Refactor the SL update map to store a more compacted version of the SL keys

**What it does:**

The main memory reduction commit. Replaces all `SymbolEntryData` / `MapType` / `vector<AtomKey>`
storage for journal entries with a single 32-byte `JournalEntryData` struct and unified
`JournalMapType`.

Key changes:

- **`JournalEntryData`** (32 B): stores `key_version_id`, `creation_ts`, `content_hash`,
  `action`, `is_new_style` — enough to reconstruct the full `AtomKey` for deletion without
  holding the symbol string (the map key provides that)
- **Unified map**: `MapType` (symbol → `vector<SymbolEntryData>`) replaced by `JournalMapType`
  (symbol → `vector<JournalEntryData>`) on all paths; removes the `collect_keys` boolean and
  its branching throughout `load_journal_streaming` and `attempt_load`
- **`LoadResult`**: `symbol_list_keys_: vector<VariantKey>` (N×~160 B) replaced by
  `update_map_: JournalMapType` (N×32 B) + `old_compaction_keys_: vector<VariantKey>` (0–1 entries)
- **Lazy batch deletion** in `compact_internal`: reconstructs `AtomKey`s from `JournalEntryData`
  in batches of 10 000, erasing each symbol's entry after dispatch to free memory incrementally
- **Removed dead code**: `key_sort_comparator`, `add_update_map_entry`, `sort_update_map_entries`,
  and the old `merge_existing_with_journal_map` (MapType version); `merge_existing_with_journal_map`
  is now the single merge function operating on the `JournalMapType`

**Result (measured with `BM_symbol_list_compaction` release benchmarks):**

| Scenario | Before | After | Reduction |
|----------|--------|-------|-----------|
| 1 000 symbols × 1 000 versions (1 M entries) | 68.4 MB | 33.5 MB | −51 % |
| 10 000 symbols × 100 versions (1 M entries)  | 76.5 MB | 43.7 MB | −43 % |

The 1K×1K peak of 33.5 MB is close to the theoretical N×32 B = 32 MB floor (small overhead
from `unordered_map` buckets and the `seen_in_existing` set in the merge path).

---

## 4. bbc5f3db - Add C++ benchmarks

**What it does:**

Adds `cpp/arcticdb/version/test/benchmark_symbol_list.cpp` with the
`BM_symbol_list_compaction` Google Benchmark suite. The benchmark:

- Writes N symbols × V versions of journal entries to an in-memory LMDB store
- Runs `list_symbols` (which triggers compaction) and records wall time and peak RSS memory
- Parameterised over `(N_symbols, N_versions)` pairs: (100×100), (1K×100), (1K×1K), (10K×10),
  (10K×100), plus an S3-mock variant for (1K×100) - most are commented to not interfere with the CI but still be usable for local benchmarking

## 5. 6b9bd224 - Fixes `ActionType` definition order

## 6. ba823cf1 - Updates one of the tests
