### PR TITLE
Adapt to msgpack 1.2.0

### DIFF
--- a/python/arcticdb/flattener.py
+++ b/python/arcticdb/flattener.py
@@ -27,13 +27,16 @@ from arcticdb.version_store._normalization import MsgPackNormalizer, CompositeNo
 from arcticdb.preconditions import check
 from arcticdb_ext import get_config_int
 
-# The binding constraint is the read path: reconstructing the data recurses ~3 Python stack frames
-# per nesting level (see create_original_obj_from_metastruct), so with the default recursion limit of
-# 1000 reads fail above ~330 levels. We pin the cap at 255 - the value it was effectively fixed at for
-# years, when msgpack's DEFAULT_RECURSE_LIMIT was 511 (511 // 2 == 255) - which both packs on write and
-# round-trips on read. The min() keeps msgpack's packer as a ceiling too. Tying the cap directly to
-# DEFAULT_RECURSE_LIMIT broke when msgpack 1.2.0 raised it to 1024, letting writes through at depths the
-# reader could not reconstruct.
+# Two separate limits govern maximum nesting depth:
+#   Write (msgpack packer): uses ~2 Python stack frames per level; capped at DEFAULT_RECURSE_LIMIT // 2.
+#   Read (create_original_obj_from_metastruct): uses ~3 Python stack frames per level, so reads
+#   fail above sys.getrecursionlimit() // 3 ≈ 333 with Python's default limit of 1000.
+#
+# The read path is tighter, so we pin msgpack's DEFAULT_RECURSE_LIMIT at 511, giving a write
+# cap of 511 // 2 == 255 — safely below the ~333 read ceiling. msgpack 1.2.0 raised its own
+# constant DEFAULT_RECURSE_LIMIT to 1024, which silently allowed writes that the reader could not
+# reconstruct. We keep 511 regardless of what msgpack exports.
+# TODO: once the metastruct reader is non-recursive, raise to (sys.getrecursionlimit() - 10) // 2.
 # https://man312219.monday.com/boards/7852509418/pulses/12254825163
 DEFAULT_RECURSE_LIMIT = min(511, _DEFAULT_RECURSE_LIMIT)
 

--- a/python/arcticdb/flattener.py
+++ b/python/arcticdb/flattener.py
@@ -34,6 +34,7 @@ from arcticdb_ext import get_config_int
 # round-trips on read. The min() keeps msgpack's packer as a ceiling too. Tying the cap directly to
 # DEFAULT_RECURSE_LIMIT broke when msgpack 1.2.0 raised it to 1024, letting writes through at depths the
 # reader could not reconstruct.
+# https://man312219.monday.com/boards/7852509418/pulses/12254825163
 DEFAULT_RECURSE_LIMIT = min(511, _DEFAULT_RECURSE_LIMIT)
 
 

--- a/python/arcticdb/flattener.py
+++ b/python/arcticdb/flattener.py
@@ -14,11 +14,11 @@ import sys
 from arcticdb.exceptions import DataTooNestedException, UnsupportedKeyInDictionary
 
 try:
-    from msgpack.fallback import DEFAULT_RECURSE_LIMIT
+    from msgpack.fallback import DEFAULT_RECURSE_LIMIT as _DEFAULT_RECURSE_LIMIT
 except ImportError:
     # The default as of msgpack 1.1.0 - handle the import error in case the msgpack wheel stops exporting this constant.
     # Want to keep compatibility with a wide range of msgpack versions.
-    DEFAULT_RECURSE_LIMIT = 511
+    _DEFAULT_RECURSE_LIMIT = 511
 
 from arcticdb import _msgpack_compat
 from arcticdb.log import version as log
@@ -26,6 +26,15 @@ from arcticdb.version_store._custom_normalizers import get_custom_normalizer
 from arcticdb.version_store._normalization import MsgPackNormalizer, CompositeNormalizer
 from arcticdb.preconditions import check
 from arcticdb_ext import get_config_int
+
+# The binding constraint is the read path: reconstructing the data recurses ~3 Python stack frames
+# per nesting level (see create_original_obj_from_metastruct), so with the default recursion limit of
+# 1000 reads fail above ~330 levels. We pin the cap at 255 - the value it was effectively fixed at for
+# years, when msgpack's DEFAULT_RECURSE_LIMIT was 511 (511 // 2 == 255) - which both packs on write and
+# round-trips on read. The min() keeps msgpack's packer as a ceiling too. Tying the cap directly to
+# DEFAULT_RECURSE_LIMIT broke when msgpack 1.2.0 raised it to 1024, letting writes through at depths the
+# reader could not reconstruct.
+DEFAULT_RECURSE_LIMIT = min(511, _DEFAULT_RECURSE_LIMIT)
 
 
 class Flattener:

--- a/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
+++ b/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
@@ -8,7 +8,7 @@ import pytest
 import numpy as np
 import arcticdb
 from arcticdb import QueryBuilder, LibraryOptions
-from arcticdb.flattener import Flattener
+from arcticdb.flattener import Flattener, DEFAULT_RECURSE_LIMIT
 from arcticdb.version_store._custom_normalizers import (
     CustomNormalizer,
     register_normalizer,
@@ -392,12 +392,18 @@ def test_deep_nesting_metastruct_size_over_limit(lmdb_version_store_v1, all_recu
     key = "reasonable_length_key"
     data = {key: pd.DataFrame({"col": [0]})}
 
-    nesting_levels = 256
+    # Mirror the guard in flattener._create_meta_structure (raises above DEFAULT_RECURSE_LIMIT // 2).
+    # flattener clamps DEFAULT_RECURSE_LIMIT to 511, so this is 255 - see the note there for why.
+    nesting_limit = DEFAULT_RECURSE_LIMIT // 2
+    nesting_levels = nesting_limit + 1
     for i in range(nesting_levels - 1):
         data[key] = {key: data[key]}
 
     # When & Then
-    with pytest.raises(DataTooNestedException, match=r"^Symbol sym cannot be recursively normalized.*255 levels.*"):
+    with pytest.raises(
+        DataTooNestedException,
+        match=rf"^Symbol sym cannot be recursively normalized.*{nesting_limit} levels.*",
+    ):
         lib.write(sym, data, recursive_normalizers=True)
 
 
@@ -408,7 +414,7 @@ def test_deep_nesting_metastruct_size_under_limit(lmdb_version_store_v1, all_rec
     key = "reasonable_length_key"
     data = {key: pd.DataFrame({"col": [0]})}
 
-    nesting_levels = 255
+    nesting_levels = (DEFAULT_RECURSE_LIMIT - 1) // 2
     for i in range(nesting_levels - 1):
         data[key] = {key: data[key]}
 


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Fix `test_deep_nesting_metastruct_size_over_limit` and `test_deep_nesting_metastruct_size_under_limit`
Culprit: `msgpack 1.2.0` has just released. It includes [Raise DEFAULT_RECURSE_LIMIT from 511 to 1024 by Copilot · Pull Request #676 · msgpack/msgpack-python](https://github.com/msgpack/msgpack-python/pull/676)
which changes `DEFAULT_RECURSE_LIMIT` from 511 to 1024
`python 3.9` is unaffected as the new msgpack version has dropped the support

#### What does this implement or fix?
Hard-pin the arcticdb limit to `511` as msgpack <1.2.0
#### Any other comments?
msgpack <1.2.0 has the recurse limit set at 511. arcticdb imports the limit from msgpack to calculate the metastruct layer limit
msgpack 1.2.0 has raised limit from 511 to 1024. Since reconstructing the metastruct from is done by recursion, increasing the no. of layers in the metastruct will make arcticdb hit the python recursion limit.
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
