### PR TITLE
Support loading only specific symbols when loading snapshots

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -194,6 +194,7 @@ class LocalVersionedEngine : public VersionedEngine {
             const PreDeleteChecks& checks = default_pre_delete_checks
     ) override {
         std::unordered_set<StreamId> stream_ids;
+        stream_ids.reserve(idx_to_be_deleted.size());
         for (const auto& key : idx_to_be_deleted) {
             stream_ids.insert(key.id());
         }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -193,7 +193,11 @@ class LocalVersionedEngine : public VersionedEngine {
             const std::vector<IndexTypeKey>& idx_to_be_deleted,
             const PreDeleteChecks& checks = default_pre_delete_checks
     ) override {
-        auto snapshot_map = get_master_snapshots_map(store());
+        std::unordered_set<StreamId> stream_ids;
+        for (const auto& key : idx_to_be_deleted) {
+            stream_ids.insert(key.id());
+        }
+        auto snapshot_map = get_master_snapshots_map(store(), stream_ids);
         delete_trees_responsibly(store(), version_map(), idx_to_be_deleted, snapshot_map, std::nullopt, checks).get();
     };
 

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -396,36 +396,40 @@ SnapshotMap get_versions_from_snapshots(const std::shared_ptr<Store>& store, con
     return snapshot_map;
 }
 
-MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(
-        std::shared_ptr<Store> store,
-        const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>&
-                get_keys_in_snapshot
-) {
+MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(std::shared_ptr<Store> store) {
     MasterSnapshotMapWithStats out;
-    iterate_snapshots(store, [&get_keys_in_snapshot, &out, &store](const VariantKey& sk) {
+    iterate_snapshots(store, [&out, &store](const VariantKey& sk) {
         ++out.total_snapshots;
         auto snapshot_id = variant_key_id(sk);
         auto snapshot_segment = store->read_sync(sk).second;
         for (size_t idx = 0; idx < snapshot_segment.row_count(); idx++) {
             auto stream_index = read_key_row(snapshot_segment, static_cast<ssize_t>(idx));
             out.map[stream_index.id()][stream_index].insert(snapshot_id);
-            if (get_keys_in_snapshot) {
-                auto [wanted_snap_key, sink] = *get_keys_in_snapshot;
-                if (wanted_snap_key == sk) {
-                    sink.push_back(stream_index);
-                }
-            }
         }
     });
     return out;
 }
 
-MasterSnapshotMap get_master_snapshots_map(
-        std::shared_ptr<Store> store,
-        const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>&
-                get_keys_in_snapshot
+MasterSnapshotMap get_master_snapshots_map(std::shared_ptr<Store> store) {
+    return get_master_snapshots_map_with_stats(std::move(store)).map;
+}
+
+MasterSnapshotMapAndKeys get_master_snapshots_map_and_keys_in_given_snapshot(
+        std::shared_ptr<Store> store, const SnapshotVariantKey& given_snapshot
 ) {
-    return get_master_snapshots_map_with_stats(std::move(store), get_keys_in_snapshot).map;
+    MasterSnapshotMapAndKeys out;
+    iterate_snapshots(store, [&given_snapshot, &out, &store](const VariantKey& sk) {
+        auto snapshot_id = variant_key_id(sk);
+        auto snapshot_segment = store->read_sync(sk).second;
+        for (size_t idx = 0; idx < snapshot_segment.row_count(); idx++) {
+            auto stream_index = read_key_row(snapshot_segment, static_cast<ssize_t>(idx));
+            out.map[stream_index.id()][stream_index].insert(snapshot_id);
+            if (given_snapshot == sk) {
+                out.index_keys_in_given_snapshot.push_back(stream_index);
+            }
+        }
+    });
+    return out;
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/snapshot.cpp
+++ b/cpp/arcticdb/version/snapshot.cpp
@@ -396,22 +396,28 @@ SnapshotMap get_versions_from_snapshots(const std::shared_ptr<Store>& store, con
     return snapshot_map;
 }
 
-MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(std::shared_ptr<Store> store) {
+MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(
+        std::shared_ptr<Store> store, const std::optional<std::unordered_set<StreamId>>& stream_ids
+) {
     MasterSnapshotMapWithStats out;
-    iterate_snapshots(store, [&out, &store](const VariantKey& sk) {
+    iterate_snapshots(store, [&out, &store, &stream_ids](const VariantKey& sk) {
         ++out.total_snapshots;
         auto snapshot_id = variant_key_id(sk);
         auto snapshot_segment = store->read_sync(sk).second;
         for (size_t idx = 0; idx < snapshot_segment.row_count(); idx++) {
             auto stream_index = read_key_row(snapshot_segment, static_cast<ssize_t>(idx));
-            out.map[stream_index.id()][stream_index].insert(snapshot_id);
+            if (!stream_ids || stream_ids->contains(stream_index.id())) {
+                out.map[stream_index.id()][stream_index].insert(snapshot_id);
+            }
         }
     });
     return out;
 }
 
-MasterSnapshotMap get_master_snapshots_map(std::shared_ptr<Store> store) {
-    return get_master_snapshots_map_with_stats(std::move(store)).map;
+MasterSnapshotMap get_master_snapshots_map(
+        std::shared_ptr<Store> store, const std::optional<std::unordered_set<StreamId>>& stream_ids
+) {
+    return get_master_snapshots_map_with_stats(std::move(store), stream_ids).map;
 }
 
 MasterSnapshotMapAndKeys get_master_snapshots_map_and_keys_in_given_snapshot(

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -109,13 +109,22 @@ struct MasterSnapshotMapAndKeys {
  * Map the index keys in every snapshot, additionally reporting the total number of snapshots iterated.
  *
  * The stats are used by the enterprise repo for delayed-deletes logging.
+ *
+ * @param stream_ids When set, only these symbols are included in the returned map. The full snapshot set is still
+ * iterated (so total_snapshots is unaffected).
  */
-MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(std::shared_ptr<Store> store);
+MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(
+        std::shared_ptr<Store> store, const std::optional<std::unordered_set<StreamId>>& stream_ids = std::nullopt
+);
 
 /**
  * Map the index keys in every snapshot.
+ *
+ * @param stream_ids When set, only these symbols are included in the returned map
  */
-MasterSnapshotMap get_master_snapshots_map(std::shared_ptr<Store> store);
+MasterSnapshotMap get_master_snapshots_map(
+        std::shared_ptr<Store> store, const std::optional<std::unordered_set<StreamId>>& stream_ids = std::nullopt
+);
 
 /**
  * Map the index keys in every snapshot, additionally collecting the index keys contained in the given snapshot.

--- a/cpp/arcticdb/version/snapshot.hpp
+++ b/cpp/arcticdb/version/snapshot.hpp
@@ -100,25 +100,28 @@ struct MasterSnapshotMapWithStats {
     size_t total_snapshots = 0;
 };
 
+struct MasterSnapshotMapAndKeys {
+    MasterSnapshotMap map;
+    std::vector<IndexTypeKey> index_keys_in_given_snapshot;
+};
+
 /**
  * Map the index keys in every snapshot, additionally reporting the total number of snapshots iterated.
  *
  * The stats are used by the enterprise repo for delayed-deletes logging.
  */
-MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(
-        std::shared_ptr<Store> store,
-        const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>&
-                get_keys_in_snapshot = std::nullopt
-);
+MasterSnapshotMapWithStats get_master_snapshots_map_with_stats(std::shared_ptr<Store> store);
 
 /**
  * Map the index keys in every snapshot.
- * @param get_keys_in_snapshot If set, the VariantKey in the tuple should be a SNAPSHOT[_REF] key and the index keys in
- * that snapshot will be passed to the second item.
  */
-MasterSnapshotMap get_master_snapshots_map(
-        std::shared_ptr<Store> store,
-        const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>&
-                get_keys_in_snapshot = std::nullopt
+MasterSnapshotMap get_master_snapshots_map(std::shared_ptr<Store> store);
+
+/**
+ * Map the index keys in every snapshot, additionally collecting the index keys contained in the given snapshot.
+ * @param given_snapshot A SNAPSHOT[_REF] key whose index keys will be returned in index_keys_in_given_snapshot.
+ */
+MasterSnapshotMapAndKeys get_master_snapshots_map_and_keys_in_given_snapshot(
+        std::shared_ptr<Store> store, const SnapshotVariantKey& given_snapshot
 );
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -282,6 +282,7 @@ inline BatchGetVersionResult<SymbolVersion> batch_get_specific_versions(
 
     if (!tombstoned_vers->empty()) {
         std::unordered_set<StreamId> stream_ids;
+        stream_ids.reserve(tombstoned_vers->size());
         for (const auto& [sym_version, key] : *tombstoned_vers) {
             stream_ids.insert(sym_version.first);
         }

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -281,7 +281,11 @@ inline BatchGetVersionResult<SymbolVersion> batch_get_specific_versions(
     );
 
     if (!tombstoned_vers->empty()) {
-        const auto snap_map = get_master_snapshots_map(store);
+        std::unordered_set<StreamId> stream_ids;
+        for (const auto& [sym_version, key] : *tombstoned_vers) {
+            stream_ids.insert(sym_version.first);
+        }
+        const auto snap_map = get_master_snapshots_map(store, stream_ids);
         for (const auto& [sym_version, key] : *tombstoned_vers) {
             auto cit = snap_map.find(sym_version.first);
             if (cit != snap_map.cend() &&

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1022,14 +1022,16 @@ void PythonVersionStore::delete_snapshot(const SnapshotId& snap_name) {
 void PythonVersionStore::delete_snapshot_sync(const SnapshotId& snap_name, const VariantKey& snap_key) {
     ARCTICDB_DEBUG(log::version(), "Deleting data of Snapshot {}", snap_name);
 
-    std::vector<AtomKey> index_keys_in_current_snapshot;
-    auto snap_map = get_master_snapshots_map(store(), std::tie(snap_key, index_keys_in_current_snapshot));
+    auto snap_map_and_keys = get_master_snapshots_map_and_keys_in_given_snapshot(store(), snap_key);
 
     ARCTICDB_DEBUG(log::version(), "Deleting Snapshot {}", snap_name);
     store()->remove_key(snap_key).get();
 
     try {
-        delete_trees_responsibly(store(), version_map(), index_keys_in_current_snapshot, snap_map, snap_name).get();
+        delete_trees_responsibly(
+                store(), version_map(), snap_map_and_keys.index_keys_in_given_snapshot, snap_map_and_keys.map, snap_name
+        )
+                .get();
         ARCTICDB_DEBUG(log::version(), "Deleted orphaned index keys in snapshot {}", snap_name);
     } catch (const std::exception& ex) {
         log::version().warn("Garbage collection of unreachable deleted index keys failed due to: {}", ex.what());

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -487,6 +487,7 @@ void PythonVersionStore::add_to_snapshot(
     write_snapshot_entry(store(), retained_keys, snap_name, user_meta, version_map()->log_changes());
     if (is_delete_keys_immediately) {
         std::unordered_set<StreamId> deleted_stream_ids;
+        deleted_stream_ids.reserve(deleted_keys.size());
         for (const auto& key : deleted_keys) {
             deleted_stream_ids.insert(key.id());
         }
@@ -540,6 +541,7 @@ void PythonVersionStore::remove_from_snapshot(
     write_snapshot_entry(store(), retained_keys, snap_name, user_meta, version_map()->log_changes());
     if (is_delete_keys_immediately) {
         std::unordered_set<StreamId> deleted_stream_ids;
+        deleted_stream_ids.reserve(deleted_keys.size());
         for (const auto& key : deleted_keys) {
             deleted_stream_ids.insert(key.id());
         }

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -486,7 +486,13 @@ void PythonVersionStore::add_to_snapshot(
     std::sort(std::begin(retained_keys), std::end(retained_keys));
     write_snapshot_entry(store(), retained_keys, snap_name, user_meta, version_map()->log_changes());
     if (is_delete_keys_immediately) {
-        delete_trees_responsibly(store(), version_map(), deleted_keys, get_master_snapshots_map(store()), snap_name)
+        std::unordered_set<StreamId> deleted_stream_ids;
+        for (const auto& key : deleted_keys) {
+            deleted_stream_ids.insert(key.id());
+        }
+        delete_trees_responsibly(
+                store(), version_map(), deleted_keys, get_master_snapshots_map(store(), deleted_stream_ids), snap_name
+        )
                 .get();
         if (version_map()->log_changes()) {
             log_delete_snapshot(store(), snap_name);
@@ -533,7 +539,13 @@ void PythonVersionStore::remove_from_snapshot(
 
     write_snapshot_entry(store(), retained_keys, snap_name, user_meta, version_map()->log_changes());
     if (is_delete_keys_immediately) {
-        delete_trees_responsibly(store(), version_map(), deleted_keys, get_master_snapshots_map(store()), snap_name)
+        std::unordered_set<StreamId> deleted_stream_ids;
+        for (const auto& key : deleted_keys) {
+            deleted_stream_ids.insert(key.id());
+        }
+        delete_trees_responsibly(
+                store(), version_map(), deleted_keys, get_master_snapshots_map(store(), deleted_stream_ids), snap_name
+        )
                 .get();
         if (version_map()->log_changes()) {
             log_delete_snapshot(store(), snap_name);

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2728,7 +2728,7 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "setup_cache_key": "modification_functions:308",
+        "setup_cache_key": "modification_functions:307",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2748,10 +2748,10 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "repeat": 3,
+        "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "modification_functions:308",
+        "setup_cache_key": "modification_functions:307",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2716,6 +2716,48 @@
         "version": "9fccfe476a9df615a7647e269f078d8d154caf9a77a75d0666b465c250e09aba",
         "warmup_time": -1
     },
+    "modification_functions.DeleteSymbolWithSnapshots.peakmem_delete": {
+        "code": "class DeleteSymbolWithSnapshots:\n    def peakmem_delete(self, *args):\n        self.lib.delete(\"sym_0\")\n\n    def setup(self, lib_for_storage, storage):\n        lib = lib_for_storage[storage]\n        if lib is None:\n            raise SkipNotImplemented\n        self.lib = lib\n        self.lib._nvs.version_store.clear()\n    \n        df = pd.DataFrame({\"a\": [1]})\n        self.lib.write_batch([WritePayload(f\"sym_{i}\", df) for i in range(self.NUM_SYMBOLS)])\n        for i in range(self.NUM_SNAPSHOTS):\n            self.lib.snapshot(f\"snap_{i}\")\n\n    def setup_cache(self):\n        return create_libraries_across_storages(DeleteSymbolWithSnapshots.storages)",
+        "name": "modification_functions.DeleteSymbolWithSnapshots.peakmem_delete",
+        "param_names": [
+            "storage"
+        ],
+        "params": [
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "setup_cache_key": "modification_functions:308",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "1e62b0196d933641387aa688001666634d0247ccbbbed35c8231abac817b388d"
+    },
+    "modification_functions.DeleteSymbolWithSnapshots.time_delete": {
+        "code": "class DeleteSymbolWithSnapshots:\n    def time_delete(self, *args):\n        self.lib.delete(\"sym_0\")\n\n    def setup(self, lib_for_storage, storage):\n        lib = lib_for_storage[storage]\n        if lib is None:\n            raise SkipNotImplemented\n        self.lib = lib\n        self.lib._nvs.version_store.clear()\n    \n        df = pd.DataFrame({\"a\": [1]})\n        self.lib.write_batch([WritePayload(f\"sym_{i}\", df) for i in range(self.NUM_SYMBOLS)])\n        for i in range(self.NUM_SNAPSHOTS):\n            self.lib.snapshot(f\"snap_{i}\")\n\n    def setup_cache(self):\n        return create_libraries_across_storages(DeleteSymbolWithSnapshots.storages)",
+        "min_run_count": 2,
+        "name": "modification_functions.DeleteSymbolWithSnapshots.time_delete",
+        "number": 1,
+        "param_names": [
+            "storage"
+        ],
+        "params": [
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "repeat": 3,
+        "rounds": 2,
+        "sample_time": 0.01,
+        "setup_cache_key": "modification_functions:308",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "3388d52354676ccb0fb560370e8007f22d2e8dc73b621a0e3a24c41cd1e1b71a",
+        "warmup_time": 0
+    },
     "modification_functions.Deletion.time_delete": {
         "code": "class Deletion:\n    def time_delete(self, *args):\n        assert self.lib.has_symbol(\"sym\")\n        self.lib.delete(\"sym\")\n\n    def setup(self, lib_for_storage, rows_and_cols, storage):\n        lib = lib_for_storage[storage]\n        if lib is None:\n            raise SkipNotImplemented\n        self.lib = lib\n        self.lib._nvs.version_store.clear()\n    \n        rows, cols = rows_and_cols\n        df = generate_random_floats_dataframe_with_index(num_rows=rows, num_cols=cols)\n        self.lib.write(\"sym\", df)\n\n    def setup_cache(self):\n        lib_for_storage = create_libraries_across_storages(Deletion.storages)\n        return lib_for_storage",
         "min_run_count": 2,

--- a/python/benchmarks/modification_functions.py
+++ b/python/benchmarks/modification_functions.py
@@ -11,7 +11,7 @@ import random
 import time
 from shutil import copytree, rmtree
 
-from arcticdb import Arctic
+from arcticdb import Arctic, WritePayload
 from arcticdb.util.test import config_context
 
 import pandas as pd
@@ -288,3 +288,40 @@ class DeleteBatchVersions:
 
     def time_delete_batch_versions(self, *args):
         self.lib.delete_batch(self.delete_requests)
+
+
+class DeleteSymbolWithSnapshots:
+    """Benchmark deleting a single symbol in a library where every version is pinned by snapshots."""
+
+    number = 1  # the deleted symbol is gone after one run, so setup rebuilds the library for each run
+    warmup_time = 0
+    timeout = 600
+    repeat = 3  # each setup writes NUM_SYMBOLS symbols and NUM_SNAPSHOTS snapshots
+
+    NUM_SYMBOLS = 5_000
+    NUM_SNAPSHOTS = 20
+
+    storages = [Storage.LMDB, Storage.AMAZON]
+    params = [storages]
+    param_names = ["storage"]
+
+    def setup_cache(self):
+        return create_libraries_across_storages(DeleteSymbolWithSnapshots.storages)
+
+    def setup(self, lib_for_storage, storage):
+        lib = lib_for_storage[storage]
+        if lib is None:
+            raise SkipNotImplemented
+        self.lib = lib
+        self.lib._nvs.version_store.clear()
+
+        df = pd.DataFrame({"a": [1]})
+        self.lib.write_batch([WritePayload(f"sym_{i}", df) for i in range(self.NUM_SYMBOLS)])
+        for i in range(self.NUM_SNAPSHOTS):
+            self.lib.snapshot(f"snap_{i}")
+
+    def time_delete(self, *args):
+        self.lib.delete("sym_0")
+
+    def peakmem_delete(self, *args):
+        self.lib.delete("sym_0")

--- a/python/benchmarks/modification_functions.py
+++ b/python/benchmarks/modification_functions.py
@@ -296,7 +296,6 @@ class DeleteSymbolWithSnapshots:
     number = 1  # the deleted symbol is gone after one run, so setup rebuilds the library for each run
     warmup_time = 0
     timeout = 600
-    repeat = 3  # each setup writes NUM_SYMBOLS symbols and NUM_SNAPSHOTS snapshots
 
     NUM_SYMBOLS = 5_000
     NUM_SNAPSHOTS = 20

--- a/python/tests/unit/arcticdb/version_store/test_deletion.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion.py
@@ -166,6 +166,39 @@ def test_delete_snapshot(version_store_factory):
         assert k.version_id != 0
 
 
+def test_delete_snapshot_key_shared_with_another_snapshot(version_store_factory):
+    lib = version_store_factory(use_tombstones=True, delayed_deletes=False)
+    lt = lib.library_tool()
+
+    symbol = "test_delete_snapshot_key_shared_with_another_snapshot"
+    snap1 = "snap1"
+    snap2 = "snap2"
+
+    df = sample_dataframe(100)
+    lib.write(symbol, df)  # v0
+    lib.snapshot(snap1)  # snap1 -> v0
+    lib.snapshot(snap2)  # snap2 -> v0
+
+    # Tombstone v0. It survives physically because both snapshots still reference it.
+    lib.delete_version(symbol, 0)
+    versions = lib.list_versions(symbol)
+    assert len(versions) == 1 and versions[0]["deleted"]
+    assert len(lt.find_keys_for_id(KeyType.TABLE_INDEX, symbol)) == 1
+    assert len(lt.find_keys_for_id(KeyType.TABLE_DATA, symbol)) > 0
+
+    # Deleting snap1 must not remove v0's keys: snap2 still references them.
+    lib.delete_snapshot(snap1)
+    assert lib.list_snapshots().keys() == {snap2}
+    assert_frame_equal(lib.read(symbol, as_of=snap2).data, df)
+    assert len(lt.find_keys_for_id(KeyType.TABLE_INDEX, symbol)) == 1
+    assert len(lt.find_keys_for_id(KeyType.TABLE_DATA, symbol)) > 0
+
+    # Deleting the last snapshot referencing v0 removes its keys, as v0 is tombstoned.
+    lib.delete_snapshot(snap2)
+    assert len(lt.find_keys_for_id(KeyType.TABLE_INDEX, symbol)) == 0
+    assert len(lt.find_keys_for_id(KeyType.TABLE_DATA, symbol)) == 0
+
+
 def test_tombstones_deleted_data_keys_prune(lmdb_version_store_prune_previous, sym):
     lib = lmdb_version_store_prune_previous
     assert lib._lib_cfg.lib_desc.version.write_options.prune_previous_version is True


### PR DESCRIPTION
Implementing Ivo's idea here: https://chat-man.slack.com/archives/C02NEG3V38X/p1781081726477429

Support loading snapshots only for particular stream IDs to control memory use. Change add_to_snapshot, remove_from_snapshot and the deletion code paths to supply stream IDs for the snapshot load. Add benchmarks for deletion in the presence of snapshots.

ASV results:

```
  | Benchmark | 140ede53e (baseline) | HEAD | Change |
  |---|---|---|---|
  | `peakmem_delete` (LMDB) | 318M | 310M | −8M (−2.5%) |
  | `time_delete` (LMDB) | 67.2±4ms | 34.6±0.2ms | −32.6ms (≈1.94× faster) |
```

(the memory change is quite low to keep the example at a practical size, I could tune this. The enterprise PR shows a more significant change).

Enterprise PR https://github.com/man-group/arcticdb-enterprise/pull/339 adopts this new API for delayed deletes and has some benchmarking results.

This PR also removes this `const std::optional<const std::tuple<const SnapshotVariantKey&, std::vector<IndexTypeKey>&>>&
                get_keys_in_snapshot = std::nullopt` argument from `get_master_snapshots_map`. It is modified in place to accumulate keys in a particular snapshot, and used only when deleting a snapshot to say that we can still delete these keys as long as no other snapshot holds them live. I just pulled out a dedicated function for that code path that returns the master snapshot map and these keys. I also added a test to cover the case where the snapshot being deleted shares some keys but not others with other snapshots.