### PR TITLE
Replace SegmentInMemory With Simple Struct When Calculating Column Stats For Single Slice

### DIFF
--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -164,14 +164,6 @@ std::string stat_to_name(ColumnStatType stat) {
     }
 }
 
-std::optional<ColumnStatType> stat_name_to_stat(const std::string& statName) {
-    if (statName == "MINMAX") {
-        return ColumnStatType::MINMAX;
-    }
-
-    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Unknown column stat type provided: {}", statName);
-}
-
 std::string column_and_stat_to_segment_name(const std::string& column, ColumnStatTypeInternal stat) {
     return fmt::format("{}({})", stat_to_operator_string(stat), column);
 }
@@ -310,16 +302,6 @@ ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
         );
     }
     offset_to_stat_info_set_ = true;
-}
-
-std::unordered_set<std::string> get_unmangled_column_names(
-        const std::map<std::string, std::set<ColumnStatType>>& column_name_to_stats
-) {
-    std::unordered_set<std::string> unmangled_names;
-    for (const auto& k : column_name_to_stats | ranges::views::keys) {
-        unmangled_names.insert(k);
-    }
-    return unmangled_names;
 }
 
 }

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -131,12 +131,12 @@ std::string stat_to_name(ColumnStatType stat) {
     }
 }
 
-std::optional<ColumnStatType> stat_name_to_stat(const std::string& name) {
-    if (name != "MINMAX") {
-        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Unknown column stat type provided: {}", name);
+std::optional<ColumnStatType> stat_name_to_stat(const std::string& statName) {
+    if (statName == "MINMAX") {
+        return ColumnStatType::MINMAX;
     }
 
-    return ColumnStatType::MINMAX;
+    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Unknown column stat type provided: {}", name);
 }
 
 std::string column_and_stat_to_segment_name(const std::string& column, ColumnStatTypeInternal stat) {

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -8,38 +8,30 @@
 
 namespace arcticdb {
 
-SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& segments) {
-    SegmentInMemory merged(Sparsity::PERMITTED);
-    merged.init_column_map();
-    merged.descriptor().set_index(IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+ankerl::unordered_dense::map<std::string, size_t> map_symbol_fields_to_offsets(const TimeseriesDescriptor& tsd) {
+    ankerl::unordered_dense::map<std::string, size_t> field_to_offset;
+    for (const auto& [index, field] : folly::enumerate(tsd.fields())) {
+        field_to_offset.emplace(std::string{field.name()}, index);
+    }
+    return field_to_offset;
+}
 
-    // Maintain the order of the columns in the input segments
-    ankerl::unordered_dense::map<std::string, size_t> field_name_to_index;
-    std::vector<TypeDescriptor> type_descriptors;
+namespace merge_internal {
+
+struct MergedSchema {
     std::vector<std::string> field_names;
-    std::vector<arcticc::pb2::column_stats_pb2::ColumnStatsType> stat_types;
-    std::vector<size_t> data_col_offsets;
-    for (auto& segment : segments) {
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
-        auto metadata = segment.metadata();
-        util::check(metadata != nullptr, "Column stats segment has no metadata");
-        bool unpacked = metadata->UnpackTo(&header);
-        util::check(unpacked, "Could not unpack column stats metadata?");
+    std::vector<TypeDescriptor> type_descriptors;
+    ankerl::unordered_dense::map<std::string, size_t> name_to_index;
+};
 
-        // Build reverse lookup: stats_seg_offset -> (data_col_offset, type)
-        ankerl::unordered_dense::map<uint32_t, std::pair<uint32_t, arcticc::pb2::column_stats_pb2::ColumnStatsType>>
-                offset_lookup;
-        for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
-            for (const auto& entry : entry_list.entries()) {
-                offset_lookup[entry.stats_seg_offset()] = {data_col_offset, entry.type()};
-            }
-        }
-
-        for (const auto& [idx, field] : folly::enumerate(segment.descriptor().fields())) {
-            auto new_type = field.type();
-
-            if (auto it = field_name_to_index.find(std::string{field.name()}); it != field_name_to_index.end()) {
-                auto& merged_type = type_descriptors.at(field_name_to_index.at(std::string{field.name()}));
+MergedSchema compute_merged_schema(const std::vector<SegmentInMemory>& col_stats_segments) {
+    MergedSchema schema;
+    for (auto& segment : col_stats_segments) {
+        for (const auto& field : segment.descriptor().fields()) {
+            const auto new_type = field.type();
+            const std::string name{field.name()};
+            if (auto it = schema.name_to_index.find(name); it != schema.name_to_index.end()) {
+                auto& merged_type = schema.type_descriptors.at(it->second);
                 auto opt_common_type = has_valid_common_type(merged_type, new_type);
                 internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                         opt_common_type.has_value(),
@@ -50,49 +42,73 @@ SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& 
                 );
                 merged_type = *opt_common_type;
             } else {
-                type_descriptors.emplace_back(new_type);
-                field_name_to_index.emplace(field.name(), type_descriptors.size() - 1);
-                field_names.emplace_back(field.name());
-                auto end_index_offset = static_cast<size_t>(index::Fields::end_index);
-                if (idx > end_index_offset) {
-                    // Skip start_index and end_index which are not statistics
-                    auto& [dcol, stype] = offset_lookup.at(idx);
-                    stat_types.emplace_back(stype);
-                    data_col_offsets.emplace_back(dcol);
-                }
+                schema.name_to_index.emplace(name, schema.type_descriptors.size());
+                schema.type_descriptors.emplace_back(new_type);
+                schema.field_names.emplace_back(name);
             }
         }
     }
+    return schema;
+}
 
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader merged_header;
-    merged_header.set_version(1); // see column_stats.proto for explanation of the versioning scheme
-    auto end_index_offset = static_cast<size_t>(index::Fields::end_index);
-    size_t stat_idx = 0;
-    for (const auto& [idx, type_descriptor] : folly::enumerate(type_descriptors)) {
-        merged.add_column(FieldRef{type_descriptor, field_names.at(idx)}, 0, AllocationType::DYNAMIC);
-        if (idx > end_index_offset) {
-            auto& entry_list = (*merged_header.mutable_stats_by_column())[data_col_offsets.at(stat_idx)];
-            auto* new_entry = entry_list.add_entries();
-            new_entry->set_stats_seg_offset(idx);
-            new_entry->set_type(stat_types.at(stat_idx));
-            ++stat_idx;
+arcticc::pb2::column_stats_pb2::ColumnStatsHeader build_column_stats_header(
+        const MergedSchema& schema, const ankerl::unordered_dense::map<std::string, size_t>& symbol_fields_to_offsets
+) {
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    header.set_version(1); // see column_stats.proto for explanation of the versioning scheme
+    const auto end_index_offset = static_cast<size_t>(index::Fields::end_index);
+    for (const auto& [idx, field_name] : folly::enumerate(schema.field_names)) {
+        if (idx <= end_index_offset) {
+            // start_index and end_index are not statistics
+            continue;
         }
+        auto parsed = parse_segment_column_name(field_name);
+        auto offset_it = symbol_fields_to_offsets.find(parsed.column_name);
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                offset_it != symbol_fields_to_offsets.end(),
+                "Column stats refer to column '{}' which is not present in the data's TimeseriesDescriptor",
+                parsed.column_name
+        );
+        auto& entry_list = (*header.mutable_stats_by_column())[static_cast<uint32_t>(offset_it->second)];
+        auto* new_entry = entry_list.add_entries();
+        new_entry->set_stats_seg_offset(static_cast<uint32_t>(idx));
+        new_entry->set_type(parsed.stat_type);
     }
-    for (auto& segment : segments) {
+    return header;
+}
+
+} // namespace merge_internal
+
+SegmentInMemory merge_column_stats_segments(
+        const std::vector<SegmentInMemory>& col_stats_segments,
+        const ankerl::unordered_dense::map<std::string, size_t>& symbol_fields_to_offsets
+) {
+    using namespace merge_internal;
+
+    auto schema = compute_merged_schema(col_stats_segments);
+
+    SegmentInMemory merged(Sparsity::PERMITTED);
+    merged.init_column_map();
+    merged.descriptor().set_index(IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+    for (const auto& [idx, type_descriptor] : folly::enumerate(schema.type_descriptors)) {
+        merged.add_column(FieldRef{type_descriptor, schema.field_names.at(idx)}, 0, AllocationType::DYNAMIC);
+    }
+    for (auto& segment : col_stats_segments) {
         merged.append(segment);
     }
     merged.set_compacted(true);
     merged.sort(start_index_column_name);
 
+    auto header = build_column_stats_header(schema, symbol_fields_to_offsets);
     google::protobuf::Any any;
-    bool packed = any.PackFrom(merged_header);
-    util::check(packed, "Failed to pack merged_header in to Any?");
+    bool packed = any.PackFrom(header);
+    util::check(packed, "Failed to pack merged column stats header into Any");
     merged.set_metadata(std::move(any));
     return merged;
 }
 
-std::string type_to_operator_string(ColumnStatTypeInternal type) {
-    switch (type) {
+std::string stat_to_operator_string(ColumnStatTypeInternal stat) {
+    switch (stat) {
     case ColumnStatTypeInternal::MIN_V1:
         return "v1_MIN";
     case ColumnStatTypeInternal::MAX_V1:
@@ -106,8 +122,8 @@ std::string type_to_operator_string(ColumnStatTypeInternal type) {
     }
 }
 
-std::string type_to_name(ColumnStatType type) {
-    switch (type) {
+std::string stat_to_name(ColumnStatType stat) {
+    switch (stat) {
     case ColumnStatType::MINMAX:
         return "MINMAX";
     default:
@@ -115,15 +131,45 @@ std::string type_to_name(ColumnStatType type) {
     }
 }
 
-std::optional<ColumnStatType> name_to_type(const std::string& name) {
-    if (name == "MINMAX") {
-        return ColumnStatType::MINMAX;
+std::optional<ColumnStatType> stat_name_to_stat(const std::string& name) {
+    if (name != "MINMAX") {
+        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Unknown column stat type provided: {}", name);
     }
-    return std::nullopt;
+
+    return ColumnStatType::MINMAX;
 }
 
-std::string to_segment_column_name(const std::string& column, ColumnStatTypeInternal type) {
-    return fmt::format("{}({})", type_to_operator_string(type), column);
+std::string column_and_stat_to_segment_name(const std::string& column, ColumnStatTypeInternal stat) {
+    return fmt::format("{}({})", stat_to_operator_string(stat), column);
+}
+
+ParsedSegmentColumnName parse_segment_column_name(std::string_view segment_column_name) {
+    // Expected format: "{prefix}({column_name})". The prefix identifies the stat
+    // type; the column_name is the original (mangled) data-column name.
+    auto open_paren = segment_column_name.find('(');
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            open_paren != std::string_view::npos && !segment_column_name.empty() && segment_column_name.back() == ')',
+            "Malformed column stats segment field name: '{}'",
+            segment_column_name
+    );
+    auto prefix = segment_column_name.substr(0, open_paren);
+    auto column_name = segment_column_name.substr(open_paren + 1, segment_column_name.size() - open_paren - 2);
+
+    ColumnStatTypeInternal stat_type;
+    if (prefix == "v1_MIN") {
+        stat_type = ColumnStatTypeInternal::MIN_V1;
+    } else if (prefix == "v1_MAX") {
+        stat_type = ColumnStatTypeInternal::MAX_V1;
+    } else if (prefix == "v1_NAN_COUNT") {
+        stat_type = ColumnStatTypeInternal::NAN_COUNT_V1;
+    } else if (prefix == "v1_NULL_COUNT") {
+        stat_type = ColumnStatTypeInternal::NULL_COUNT_V1;
+    } else {
+        internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                "Unknown column stats prefix '{}' in segment field name '{}'", prefix, segment_column_name
+        );
+    }
+    return {std::string{column_name}, stat_type};
 }
 
 void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header) {
@@ -161,15 +207,18 @@ ColumnStats::ColumnStats(
                 );
                 continue;
             }
-            if (auto it = offset_to_stat_info_.find(data_col_offset); it != offset_to_stat_info_.end()) {
+
+            auto it = offset_to_input_column_and_stats_.find(data_col_offset);
+
+            if (it != offset_to_input_column_and_stats_.end()) {
                 it->second.column_stats.insert(external_type);
             } else {
                 std::string name{tsd.fields().at(data_col_offset).name()};
-                offset_to_stat_info_.emplace(data_col_offset, NameAndStatTypes{name, {external_type}});
+                offset_to_input_column_and_stats_.emplace(data_col_offset, NameAndStats{name, {external_type}});
             }
         }
     }
-    offset_to_stat_info_set_ = true;
+    offset_to_input_column_and_stats_calculated_ = true;
 }
 
 namespace {
@@ -252,9 +301,23 @@ ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
             }
         }
 
-        offset_to_stat_info_.emplace(field_index, NameAndStatTypes{std::move(field_name), {ColumnStatType::MINMAX}});
+        offset_to_input_column_and_stats.emplace(
+                field_index, NameAndStatTypes{std::move(field_name), {ColumnStatType::MINMAX}}
+        );
     }
     offset_to_stat_info_set_ = true;
+}
+
+std::unordered_set<std::string> get_unmangled_column_names(
+        const std::map<std::string, std::set<ColumnStatType>>& column_name_to_stats
+) {
+    std::unordered_set<std::string> unmangled_names;
+    for (const auto& k : column_name_to_stats | ranges::views::keys) {
+        unmangled_names.insert(k);
+    }
+    return unmangled_names;
+}
+
 }
 
 namespace {
@@ -269,45 +332,72 @@ std::unordered_set<ColumnStatTypeInternal> external_to_internal(ColumnStatType t
         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unknown column stat type");
     }
 }
+
+MinMaxAggregator create_minmax_aggregator(const std::string& input_column_name, size_t input_column_offset) {
+    return MinMaxAggregator(
+            ColumnName(input_column_name),
+            input_column_offset,
+            ColumnName(column_and_stat_to_segment_name(input_column_name, ColumnStatTypeInternal::MIN_V1)),
+            ColumnName(column_and_stat_to_segment_name(input_column_name, ColumnStatTypeInternal::MAX_V1)),
+            ColumnName(column_and_stat_to_segment_name(input_column_name, ColumnStatTypeInternal::NAN_COUNT_V1)),
+            ColumnName(column_and_stat_to_segment_name(input_column_name, ColumnStatTypeInternal::NULL_COUNT_V1))
+    );
+}
+
+ColumnStatsAggregator create_aggregator(
+        const std::string& input_column_name, size_t input_column_offset, ColumnStatType stat
+) {
+    switch (stat) {
+    case ColumnStatType::MINMAX:
+        return create_minmax_aggregator(input_column_name, input_column_offset);
+    default:
+        internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unrecognised ColumnStatType");
+    }
+}
 } // namespace
 
 std::vector<std::string> ColumnStats::drop(const ColumnStats& to_drop, bool warn_if_missing) {
-    util::check(offset_to_stat_info_set_, "Expect this->offset to stat info to be set");
-    util::check(to_drop.offset_to_stat_info_set_, "Expect to_drop.offset to stat info to be set");
+    util::check(
+            offset_to_input_column_and_stats_calculated_, "Expect this->offset to input column and stats to be set"
+    );
+    util::check(
+            to_drop.offset_to_input_column_and_stats_calculated_,
+            "Expect to_drop.offset to input column and stats to be set"
+    );
     std::vector<std::string> dropped_names;
-    for (const auto& [offset, name_and_stat_types] : to_drop.offset_to_stat_info_) {
-        if (auto it = offset_to_stat_info_.find(offset); it == offset_to_stat_info_.end()) {
+    for (const auto& [offset, input_column_and_stats] : to_drop.offset_to_input_column_and_stats_) {
+        if (auto it = offset_to_input_column_and_stats_.find(offset); it == offset_to_input_column_and_stats_.end()) {
             if (warn_if_missing) {
                 log::version().warn(
                         "Requested column stats drop but column '{}' does not have any column stats",
-                        name_and_stat_types.mangled_name
+                        input_column_and_stats.mangled_name
                 );
             }
         } else {
-            for (const auto& column_stat_type : name_and_stat_types.column_stats) {
-                bool none_erased = it->second.column_stats.erase(column_stat_type) == 0;
+            for (const auto& column_stat : input_column_and_stats.column_stats) {
+                bool none_erased = it->second.column_stats.erase(column_stat) == 0;
                 if (none_erased) {
                     if (warn_if_missing) {
                         log::version().warn(
                                 "Requested column stats drop but column '{}' does not have the specified column stat "
                                 "'{}'",
-                                name_and_stat_types.mangled_name,
-                                type_to_name(column_stat_type)
+                                input_column_and_stats.mangled_name,
+                                stat_to_name(column_stat)
                         );
                     }
                 } else {
-                    for (const auto& internal_type : external_to_internal(column_stat_type)) {
+                    for (const auto& internal_type : external_to_internal(column_stat)) {
                         dropped_names.emplace_back(
-                                to_segment_column_name(name_and_stat_types.mangled_name, internal_type)
+                                column_and_stat_to_segment_name(input_column_and_stats.mangled_name, internal_type)
                         );
                     }
                 }
             }
         }
     }
-    for (auto it = offset_to_stat_info_.begin(); it != offset_to_stat_info_.end();) {
+    for (auto it = offset_to_input_column_and_stats_.begin(); it != offset_to_input_column_and_stats_.end();) {
         if (it->second.column_stats.empty()) {
-            it = offset_to_stat_info_.erase(it);
+            it = offset_to_input_column_and_stats_.erase(it);
         } else {
             ++it;
         }
@@ -316,12 +406,14 @@ std::vector<std::string> ColumnStats::drop(const ColumnStats& to_drop, bool warn
 }
 
 std::unordered_map<std::string, std::unordered_set<std::string>> ColumnStats::to_map() const {
-    util::check(offset_to_stat_info_set_, "Expect offset_to_stat_info to be set in to_map");
+    util::check(
+            offset_to_input_column_and_stats_calculated_, "Expect offset_to_input_column_and_stats to be set in to_map"
+    );
     std::unordered_map<std::string, std::unordered_set<std::string>> res;
-    for (const auto& [offset, name_and_stat_types] : offset_to_stat_info_) {
-        auto& entry = res[name_and_stat_types.mangled_name];
-        for (const auto& type : name_and_stat_types.column_stats) {
-            entry.emplace(type_to_name(type));
+    for (const auto& [offset, input_column_and_stats] : offset_to_input_column_and_stats_) {
+        auto& entry = res[input_column_and_stats.mangled_name];
+        for (const auto& stat : input_column_and_stats.column_stats) {
+            entry.emplace(stat_to_name(stat));
         }
     }
     return res;
@@ -331,44 +423,28 @@ std::optional<Clause> ColumnStats::clause() const {
     if (empty()) {
         return std::nullopt;
     }
-    util::check(offset_to_stat_info_set_, "Expect offset_to_stat_info to be set");
-    std::unordered_set<std::string> input_columns;
-    auto index_generation_aggregators = std::make_shared<std::vector<ColumnStatsAggregator>>();
-    for (const auto& [offset, name_and_stat_types] : offset_to_stat_info_) {
-        input_columns.emplace(name_and_stat_types.mangled_name);
 
-        for (const auto& column_stat_type : name_and_stat_types.column_stats) {
-            switch (column_stat_type) {
-            case ColumnStatType::MINMAX:
-                index_generation_aggregators->emplace_back(MinMaxAggregator(
-                        ColumnName(name_and_stat_types.mangled_name),
-                        offset,
-                        ColumnName(
-                                to_segment_column_name(name_and_stat_types.mangled_name, ColumnStatTypeInternal::MIN_V1)
-                        ),
-                        ColumnName(
-                                to_segment_column_name(name_and_stat_types.mangled_name, ColumnStatTypeInternal::MAX_V1)
-                        ),
-                        ColumnName(to_segment_column_name(
-                                name_and_stat_types.mangled_name, ColumnStatTypeInternal::NAN_COUNT_V1
-                        )),
-                        ColumnName(to_segment_column_name(
-                                name_and_stat_types.mangled_name, ColumnStatTypeInternal::NULL_COUNT_V1
-                        ))
-                ));
-                break;
-            default:
-                internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unrecognised ColumnStatType");
-            }
+    util::check(offset_to_input_column_and_stats_calculated_, "Expect offset_to_input_column_and_stats to be set");
+    std::unordered_set<std::string> input_columns;
+    auto aggregators = std::make_shared<std::vector<ColumnStatsAggregator>>();
+
+    for (const auto& [input_column_offset, input_column_and_stats] : offset_to_input_column_and_stats_) {
+        input_columns.emplace(input_column_and_stats.mangled_name);
+
+        for (const auto& column_stat : input_column_and_stats.column_stats) {
+            aggregators->emplace_back(
+                    create_aggregator(input_column_and_stats.mangled_name, input_column_offset, column_stat)
+            );
         }
     }
-    return ColumnStatsGenerationClause(std::move(input_columns), index_generation_aggregators);
+
+    return ColumnStatsGenerationClause(std::move(input_columns), aggregators);
 }
 
-bool ColumnStats::empty() const { return offset_to_stat_info_.empty(); }
+bool ColumnStats::empty() const { return offset_to_input_column_and_stats_.empty(); }
 
 bool ColumnStats::operator==(const ColumnStats& right) const {
-    return offset_to_stat_info_ == right.offset_to_stat_info_;
+        return offset_to_input_column_and_stats_ == right.offset_to_input_column_and_stats_;
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -400,7 +400,7 @@ std::vector<std::string> ColumnStats::drop_old_stats(const ColumnStats& old_stat
         }
 
         auto& new_column_stats = it->second;
-        const auto old_column_stats = old_input_column_and_stats.column_stats;
+        const auto& old_column_stats = old_input_column_and_stats.column_stats;
 
         erase_old_stats(new_column_stats, old_column_stats, warn_if_missing, erased_names);
     }

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -214,7 +214,6 @@ ColumnStats::ColumnStats(
             }
         }
     }
-    offset_to_input_column_and_stats_calculated_ = true;
 }
 
 namespace {
@@ -297,13 +296,10 @@ ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
             }
         }
 
-        offset_to_input_column_and_stats.emplace(
-                field_index, NameAndStatTypes{std::move(field_name), {ColumnStatType::MINMAX}}
+        offset_to_input_column_and_stats_.emplace(
+                field_index, NameAndStats{std::move(field_name), {ColumnStatType::MINMAX}}
         );
     }
-    offset_to_stat_info_set_ = true;
-}
-
 }
 
 namespace {
@@ -413,17 +409,15 @@ std::vector<std::string> ColumnStats::drop_old_stats(const ColumnStats& old_stat
 }
 
 std::unordered_map<std::string, std::unordered_set<std::string>> ColumnStats::to_map() const {
-    util::check(
-            offset_to_input_column_and_stats_calculated_, "Expect offset_to_input_column_and_stats to be set in to_map"
-    );
-    std::unordered_map<std::string, std::unordered_set<std::string>> res;
+    std::unordered_map<std::string, std::unordered_set<std::string>> input_name_to_stats_names;
     for (const auto& [offset, input_column_and_stats] : offset_to_input_column_and_stats_) {
-        auto& entry = res[input_column_and_stats.mangled_name];
+        auto& stats_names = input_name_to_stats_names[input_column_and_stats.mangled_name];
+
         for (const auto& stat : input_column_and_stats.column_stats) {
-            entry.emplace(stat_to_name(stat));
+            stats_names.emplace(stat_to_name(stat));
         }
     }
-    return res;
+    return input_name_to_stats_names;
 }
 
 std::optional<Clause> ColumnStats::clause() const {
@@ -431,7 +425,6 @@ std::optional<Clause> ColumnStats::clause() const {
         return std::nullopt;
     }
 
-    util::check(offset_to_input_column_and_stats_calculated_, "Expect offset_to_input_column_and_stats to be set");
     std::unordered_set<std::string> input_columns;
     auto aggregators = std::make_shared<std::vector<ColumnStatsAggregator>>();
 
@@ -451,7 +444,7 @@ std::optional<Clause> ColumnStats::clause() const {
 bool ColumnStats::empty() const { return offset_to_input_column_and_stats_.empty(); }
 
 bool ColumnStats::operator==(const ColumnStats& right) const {
-        return offset_to_input_column_and_stats_ == right.offset_to_input_column_and_stats_;
+    return offset_to_input_column_and_stats_ == right.offset_to_input_column_and_stats_;
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -8,81 +8,111 @@
 
 namespace arcticdb {
 
-ankerl::unordered_dense::map<std::string, size_t> map_symbol_fields_to_offsets(const TimeseriesDescriptor& tsd) {
-    ankerl::unordered_dense::map<std::string, size_t> field_to_offset;
-    for (const auto& [index, field] : folly::enumerate(tsd.fields())) {
-        field_to_offset.emplace(std::string{field.name()}, index);
-    }
-    return field_to_offset;
-}
-
 namespace merge_internal {
 
 struct MergedSchema {
     std::vector<std::string> field_names;
     std::vector<TypeDescriptor> type_descriptors;
     ankerl::unordered_dense::map<std::string, size_t> name_to_index;
+    std::vector<std::optional<std::pair<uint32_t, ColumnStatTypeInternal>>> stat_info;
 };
+
+arcticc::pb2::column_stats_pb2::ColumnStatsHeader unpack_header(const SegmentInMemory& segment) {
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+
+    auto* metadata = segment.metadata();
+    util::check(metadata != nullptr, "Column stats segment has no metadata");
+    bool unpacked = metadata->UnpackTo(&header);
+    util::check(unpacked, "Could not unpack column stats segment metadata");
+    return header;
+}
+
+using SegOffsetToInputOffsetAndStatMap =
+        ankerl::unordered_dense::map<uint32_t, std::pair<uint32_t, ColumnStatTypeInternal>>;
+
+SegOffsetToInputOffsetAndStatMap invert_stats_header(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header) {
+    SegOffsetToInputOffsetAndStatMap seg_offset_to_input_offset_and_stat;
+
+    for (const auto& [input_column_offset, entry_list] : header.stats_by_column()) {
+        for (const auto& entry : entry_list.entries()) {
+            seg_offset_to_input_offset_and_stat.emplace(
+                    entry.stats_seg_offset(), std::pair{input_column_offset, entry.type()}
+            );
+        }
+    }
+    return seg_offset_to_input_offset_and_stat;
+}
+
+void merge_existing_column_type(MergedSchema& schema, size_t existing_index, const TypeDescriptor& new_type) {
+    auto& merged_type = schema.type_descriptors.at(existing_index);
+    auto opt_common_type = has_valid_common_type(merged_type, new_type);
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            opt_common_type.has_value(),
+            "No valid common type between {} and {} in {}",
+            merged_type,
+            new_type,
+            __FUNCTION__
+    );
+    merged_type = *opt_common_type;
+}
+
+void add_new_column(
+        MergedSchema& schema, const std::string& name, const TypeDescriptor& new_type, size_t seg_offset,
+        const SegOffsetToInputOffsetAndStatMap& seg_offset_to_input_offset_and_stat
+) {
+    schema.name_to_index.emplace(name, schema.type_descriptors.size());
+    schema.type_descriptors.emplace_back(new_type);
+    schema.field_names.emplace_back(name);
+
+    if (auto stat_it = seg_offset_to_input_offset_and_stat.find(static_cast<uint32_t>(seg_offset));
+        stat_it != seg_offset_to_input_offset_and_stat.end()) {
+        schema.stat_info.emplace_back(stat_it->second);
+    } else {
+        schema.stat_info.emplace_back(std::nullopt);
+    }
+}
 
 MergedSchema compute_merged_schema(const std::vector<SegmentInMemory>& col_stats_segments) {
     MergedSchema schema;
+
     for (auto& segment : col_stats_segments) {
-        for (const auto& field : segment.descriptor().fields()) {
+        auto seg_offset_to_input_offset_and_stat = invert_stats_header(unpack_header(segment));
+
+        for (const auto& [idx, field] : folly::enumerate(segment.descriptor().fields())) {
             const auto new_type = field.type();
             const std::string name{field.name()};
+
             if (auto it = schema.name_to_index.find(name); it != schema.name_to_index.end()) {
-                auto& merged_type = schema.type_descriptors.at(it->second);
-                auto opt_common_type = has_valid_common_type(merged_type, new_type);
-                internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                        opt_common_type.has_value(),
-                        "No valid common type between {} and {} in {}",
-                        merged_type,
-                        new_type,
-                        __FUNCTION__
-                );
-                merged_type = *opt_common_type;
+                merge_existing_column_type(schema, it->second, new_type);
             } else {
-                schema.name_to_index.emplace(name, schema.type_descriptors.size());
-                schema.type_descriptors.emplace_back(new_type);
-                schema.field_names.emplace_back(name);
+                add_new_column(schema, name, new_type, idx, seg_offset_to_input_offset_and_stat);
             }
         }
     }
     return schema;
 }
 
-arcticc::pb2::column_stats_pb2::ColumnStatsHeader build_column_stats_header(
-        const MergedSchema& schema, const ankerl::unordered_dense::map<std::string, size_t>& symbol_fields_to_offsets
-) {
+arcticc::pb2::column_stats_pb2::ColumnStatsHeader build_column_stats_header(const MergedSchema& schema) {
     arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
-    header.set_version(1); // see column_stats.proto for explanation of the versioning scheme
-    const auto end_index_offset = static_cast<size_t>(index::Fields::end_index);
-    for (const auto& [idx, field_name] : folly::enumerate(schema.field_names)) {
-        if (idx <= end_index_offset) {
-            // start_index and end_index are not statistics
+    header.set_version(1);
+
+    for (const auto& [idx, info] : folly::enumerate(schema.stat_info)) {
+        if (!info.has_value()) {
             continue;
         }
-        auto parsed = parse_segment_column_name(field_name);
-        auto offset_it = symbol_fields_to_offsets.find(parsed.column_name);
-        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                offset_it != symbol_fields_to_offsets.end(),
-                "Column stats refer to column '{}' which is not present in the data's TimeseriesDescriptor",
-                parsed.column_name
-        );
-        auto& entry_list = (*header.mutable_stats_by_column())[static_cast<uint32_t>(offset_it->second)];
+
+        const auto& [data_col_offset, stat_type] = *info;
+        auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset];
         auto* new_entry = entry_list.add_entries();
         new_entry->set_stats_seg_offset(static_cast<uint32_t>(idx));
-        new_entry->set_type(parsed.stat_type);
+        new_entry->set_type(stat_type);
     }
     return header;
 }
 
 } // namespace merge_internal
 
-SegmentInMemory merge_column_stats_segments(
-        const std::vector<SegmentInMemory>& col_stats_segments,
-        const ankerl::unordered_dense::map<std::string, size_t>& symbol_fields_to_offsets
-) {
+SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& col_stats_segments) {
     using namespace merge_internal;
 
     auto schema = compute_merged_schema(col_stats_segments);
@@ -99,11 +129,14 @@ SegmentInMemory merge_column_stats_segments(
     merged.set_compacted(true);
     merged.sort(start_index_column_name);
 
-    auto header = build_column_stats_header(schema, symbol_fields_to_offsets);
+    auto header = build_column_stats_header(schema);
     google::protobuf::Any any;
     bool packed = any.PackFrom(header);
+
     util::check(packed, "Failed to pack merged column stats header into Any");
+
     merged.set_metadata(std::move(any));
+
     return merged;
 }
 
@@ -136,40 +169,11 @@ std::optional<ColumnStatType> stat_name_to_stat(const std::string& statName) {
         return ColumnStatType::MINMAX;
     }
 
-    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Unknown column stat type provided: {}", name);
+    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Unknown column stat type provided: {}", statName);
 }
 
 std::string column_and_stat_to_segment_name(const std::string& column, ColumnStatTypeInternal stat) {
     return fmt::format("{}({})", stat_to_operator_string(stat), column);
-}
-
-ParsedSegmentColumnName parse_segment_column_name(std::string_view segment_column_name) {
-    // Expected format: "{prefix}({column_name})". The prefix identifies the stat
-    // type; the column_name is the original (mangled) data-column name.
-    auto open_paren = segment_column_name.find('(');
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            open_paren != std::string_view::npos && !segment_column_name.empty() && segment_column_name.back() == ')',
-            "Malformed column stats segment field name: '{}'",
-            segment_column_name
-    );
-    auto prefix = segment_column_name.substr(0, open_paren);
-    auto column_name = segment_column_name.substr(open_paren + 1, segment_column_name.size() - open_paren - 2);
-
-    ColumnStatTypeInternal stat_type;
-    if (prefix == "v1_MIN") {
-        stat_type = ColumnStatTypeInternal::MIN_V1;
-    } else if (prefix == "v1_MAX") {
-        stat_type = ColumnStatTypeInternal::MAX_V1;
-    } else if (prefix == "v1_NAN_COUNT") {
-        stat_type = ColumnStatTypeInternal::NAN_COUNT_V1;
-    } else if (prefix == "v1_NULL_COUNT") {
-        stat_type = ColumnStatTypeInternal::NULL_COUNT_V1;
-    } else {
-        internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
-                "Unknown column stats prefix '{}' in segment field name '{}'", prefix, segment_column_name
-        );
-    }
-    return {std::string{column_name}, stat_type};
 }
 
 void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header) {

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -340,55 +340,76 @@ ColumnStatsAggregator create_aggregator(
         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unrecognised ColumnStatType");
     }
 }
-} // namespace
 
-std::vector<std::string> ColumnStats::drop(const ColumnStats& to_drop, bool warn_if_missing) {
-    util::check(
-            offset_to_input_column_and_stats_calculated_, "Expect this->offset to input column and stats to be set"
-    );
-    util::check(
-            to_drop.offset_to_input_column_and_stats_calculated_,
-            "Expect to_drop.offset to input column and stats to be set"
-    );
-    std::vector<std::string> dropped_names;
-    for (const auto& [offset, input_column_and_stats] : to_drop.offset_to_input_column_and_stats_) {
-        if (auto it = offset_to_input_column_and_stats_.find(offset); it == offset_to_input_column_and_stats_.end()) {
-            if (warn_if_missing) {
-                log::version().warn(
-                        "Requested column stats drop but column '{}' does not have any column stats",
-                        input_column_and_stats.mangled_name
-                );
-            }
-        } else {
-            for (const auto& column_stat : input_column_and_stats.column_stats) {
-                bool none_erased = it->second.column_stats.erase(column_stat) == 0;
-                if (none_erased) {
-                    if (warn_if_missing) {
-                        log::version().warn(
-                                "Requested column stats drop but column '{}' does not have the specified column stat "
-                                "'{}'",
-                                input_column_and_stats.mangled_name,
-                                stat_to_name(column_stat)
-                        );
-                    }
-                } else {
-                    for (const auto& internal_type : external_to_internal(column_stat)) {
-                        dropped_names.emplace_back(
-                                column_and_stat_to_segment_name(input_column_and_stats.mangled_name, internal_type)
-                        );
-                    }
-                }
-            }
-        }
+void warn_if_old_offset_is_not_found(const NameAndStats& old_input_column_and_stats, bool warn_if_missing) {
+    if (warn_if_missing) {
+        log::version().warn(
+                "Old column '{}'s offset is not present in the new column stats offsets!",
+                old_input_column_and_stats.mangled_name
+        );
     }
-    for (auto it = offset_to_input_column_and_stats_.begin(); it != offset_to_input_column_and_stats_.end();) {
+}
+
+void add_erased_column_and_stat_names(
+        std::vector<std::string>& erased_column_and_stat, const std::string& mangled_name, ColumnStatType stat
+) {
+    for (const auto& internal_type : external_to_internal(stat)) {
+        erased_column_and_stat.emplace_back(column_and_stat_to_segment_name(mangled_name, internal_type));
+    }
+}
+
+void warn_if_old_stat_is_missing(const std::string& mangled_name, ColumnStatType stat, bool warn_if_missing) {
+    if (warn_if_missing) {
+        log::version().warn("New column '{}' does not have the old stat '{}'", mangled_name, stat_to_name(stat));
+    }
+}
+
+// Erase the requested stats from an existing column entry, appending the segment names that were actually removed to
+// erased_names.
+void erase_old_stats(
+        NameAndStats& new_column_stats, const std::set<ColumnStatType>& old_column_stats, bool warn_if_missing,
+        std::vector<std::string>& erased_columns_and_stats
+) {
+    for (const auto& old_column_stat : old_column_stats) {
+        bool is_erased = (new_column_stats.column_stats.erase(old_column_stat) != 0);
+
+        if (is_erased) {
+            add_erased_column_and_stat_names(erased_columns_and_stats, new_column_stats.mangled_name, old_column_stat);
+            continue;
+        }
+
+        warn_if_old_stat_is_missing(new_column_stats.mangled_name, old_column_stat, warn_if_missing);
+    }
+}
+
+void remove_columns_without_stats(std::unordered_map<size_t, NameAndStats>& columns) {
+    for (auto it = columns.begin(); it != columns.end();) {
         if (it->second.column_stats.empty()) {
-            it = offset_to_input_column_and_stats_.erase(it);
+            it = columns.erase(it);
         } else {
             ++it;
         }
     }
-    return dropped_names;
+}
+} // namespace
+
+std::vector<std::string> ColumnStats::drop_old_stats(const ColumnStats& old_stats, bool warn_if_missing) {
+    std::vector<std::string> erased_names;
+    for (const auto& [old_offset, old_input_column_and_stats] : old_stats.offset_to_input_column_and_stats_) {
+        auto it = offset_to_input_column_and_stats_.find(old_offset);
+
+        if (it == offset_to_input_column_and_stats_.end()) {
+            warn_if_old_offset_is_not_found(old_input_column_and_stats, warn_if_missing);
+            continue;
+        }
+
+        auto& new_column_stats = it->second;
+        const auto old_column_stats = old_input_column_and_stats.column_stats;
+
+        erase_old_stats(new_column_stats, old_column_stats, warn_if_missing, erased_names);
+    }
+    remove_columns_without_stats(offset_to_input_column_and_stats_);
+    return erased_names;
 }
 
 std::unordered_map<std::string, std::unordered_set<std::string>> ColumnStats::to_map() const {

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -57,9 +57,6 @@ class ColumnStats {
     bool operator==(const ColumnStats& right) const;
 
   private:
-    void map_stats_to_column_name(const std::string& column_name, const std::unordered_set<std::string>& stats_names);
-
-    std::map<std::string, std::set<ColumnStatType>> input_column_name_to_stats_;
     std::unordered_map<size_t, NameAndStats> offset_to_input_column_and_stats_;
     bool offset_to_input_column_and_stats_calculated_{false};
 };

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -13,12 +13,7 @@
 #include <unordered_set>
 
 namespace arcticdb {
-ankerl::unordered_dense::map<std::string, size_t> map_symbol_fields_to_offsets(const TimeseriesDescriptor& tsd);
-
-SegmentInMemory merge_column_stats_segments(
-        const std::vector<SegmentInMemory>& segments,
-        const ankerl::unordered_dense::map<std::string, size_t>& symbol_fields_to_offsets
-);
+SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& segments);
 
 // User facing types - eg users are only allowed to create min and max together, not one or the other
 enum class ColumnStatType { MINMAX };
@@ -42,7 +37,7 @@ struct NameAndStats {
 void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header);
 
 // Produce the segment column name for column and its stat type.
-// For example: the stat MIN for the col "price" will produce "v1_MIN(price)"
+// Example: stat MIN for the column "price" -> "v1_MIN(price)"
 std::string column_and_stat_to_segment_name(const std::string& column, ColumnStatTypeInternal type);
 
 class ColumnStats {
@@ -64,7 +59,6 @@ class ColumnStats {
   private:
     void map_stats_to_column_name(const std::string& column_name, const std::unordered_set<std::string>& stats_names);
 
-    // Use ordered map/set here for consistent ordering in the resulting stats objects
     std::map<std::string, std::set<ColumnStatType>> input_column_name_to_stats_;
     std::unordered_map<size_t, NameAndStats> offset_to_input_column_and_stats_;
     bool offset_to_input_column_and_stats_calculated_{false};

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -48,7 +48,7 @@ class ColumnStats {
     );
 
     // Returns the segment column names of the dropped stats (e.g. "v1_MIN(col)", "v1_MAX(col)")
-    std::vector<std::string> drop(const ColumnStats& to_drop, bool warn_if_missing = true);
+    std::vector<std::string> drop_old_stats(const ColumnStats& old_stats, bool warn_if_missing = true);
 
     std::unordered_map<std::string, std::unordered_set<std::string>> to_map() const;
     std::optional<Clause> clause() const;

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -58,7 +58,6 @@ class ColumnStats {
 
   private:
     std::unordered_map<size_t, NameAndStats> offset_to_input_column_and_stats_;
-    bool offset_to_input_column_and_stats_calculated_{false};
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -8,12 +8,17 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace arcticdb {
+ankerl::unordered_dense::map<std::string, size_t> map_symbol_fields_to_offsets(const TimeseriesDescriptor& tsd);
 
-SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& segments);
+SegmentInMemory merge_column_stats_segments(
+        const std::vector<SegmentInMemory>& segments,
+        const ankerl::unordered_dense::map<std::string, size_t>& symbol_fields_to_offsets
+);
 
 // User facing types - eg users are only allowed to create min and max together, not one or the other
 enum class ColumnStatType { MINMAX };
@@ -25,18 +30,20 @@ static constexpr size_t start_index_column_offset = 0;
 static const char* const end_index_column_name = "end_index";
 static constexpr size_t end_index_column_offset = 1;
 
-struct NameAndStatTypes {
+struct NameAndStats {
     std::string mangled_name;
     std::set<ColumnStatType> column_stats;
 
-    bool operator==(const NameAndStatTypes& right) const {
+    bool operator==(const NameAndStats& right) const {
         return mangled_name == right.mangled_name && column_stats == right.column_stats;
     }
 };
 
 void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header);
 
-std::string to_segment_column_name(const std::string& column, ColumnStatTypeInternal type);
+// Produce the segment column name for column and its stat type.
+// For example: the stat MIN for the col "price" will produce "v1_MIN(price)"
+std::string column_and_stat_to_segment_name(const std::string& column, ColumnStatTypeInternal type);
 
 class ColumnStats {
   public:
@@ -55,8 +62,12 @@ class ColumnStats {
     bool operator==(const ColumnStats& right) const;
 
   private:
-    std::unordered_map<size_t, NameAndStatTypes> offset_to_stat_info_;
-    bool offset_to_stat_info_set_{false};
+    void map_stats_to_column_name(const std::string& column_name, const std::unordered_set<std::string>& stats_names);
+
+    // Use ordered map/set here for consistent ordering in the resulting stats objects
+    std::map<std::string, std::set<ColumnStatType>> input_column_name_to_stats_;
+    std::unordered_map<size_t, NameAndStats> offset_to_input_column_and_stats_;
+    bool offset_to_input_column_and_stats_calculated_{false};
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -437,6 +437,8 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         util::check(row_indices.size() == isr.size(), "Expected row_indices.size() == isr.size()");
 
         // Evaluate the AST
+        StatsVariantData result =
+                evaluate_ast_node_against_stats(expression_context.root_node_name_, expression_context, stats_rows);
         StatsVariantData result = evaluate_ast_node_against_stats(
                 expression_context.root_node_name_, expression_context, row_indices, column_stats_data
         );

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -156,7 +156,7 @@ std::vector<StatsMetadataForColumn> calculate_stats_metadata(
                 );
                 continue;
             }
-            const auto field_name = to_segment_column_name(stats_metadata_for_column.col_name, entry_type);
+            const auto field_name = column_and_stat_to_segment_name(stats_metadata_for_column.col_name, entry_type);
             const auto col_index = segment.column_index(field_name);
             if (!col_index.has_value()) {
                 // Column was filtered out at decode time, or never present in this segment.
@@ -437,8 +437,6 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         util::check(row_indices.size() == isr.size(), "Expected row_indices.size() == isr.size()");
 
         // Evaluate the AST
-        StatsVariantData result =
-                evaluate_ast_node_against_stats(expression_context.root_node_name_, expression_context, stats_rows);
         StatsVariantData result = evaluate_ast_node_against_stats(
                 expression_context.root_node_name_, expression_context, row_indices, column_stats_data
         );
@@ -522,7 +520,7 @@ SegmentInMemory partial_decode_column_stats_segment(
             continue;
         }
         for (const auto& entry : entry_list.entries()) {
-            retain_field_names.insert(to_segment_column_name(col_name, entry.type()));
+            retain_field_names.insert(column_and_stat_to_segment_name(col_name, entry.type()));
         }
     }
 

--- a/cpp/arcticdb/processing/aggregation_interface.hpp
+++ b/cpp/arcticdb/processing/aggregation_interface.hpp
@@ -10,8 +10,21 @@
 
 #include <folly/Poly.h>
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/pipeline/value.hpp>
+#include <arcticdb/column_store/memory_segment.hpp>
+#include <arcticdb/processing/expression_node.hpp>
+#include <optional>
 
 namespace arcticdb {
+
+// Lightweight per slice and per aggregator struct, replacing the previous SegmentInMemory
+struct ColumnStatsAggregatorOutput {
+    std::optional<Value> min;
+    std::optional<Value> max;
+    uint64_t nan_count{0};
+    uint64_t null_count{0};
+    size_t input_column_offset{0};
+};
 
 struct IGroupingAggregatorData {
     template<class Base>
@@ -60,9 +73,7 @@ struct IColumnStatsAggregatorData {
     template<class Base>
     struct Interface : Base {
         void aggregate(const ColumnWithStrings& input_column) { folly::poly_call<0>(*this, input_column); }
-        SegmentInMemory finalize(const std::vector<ColumnName>& output_column_names) const {
-            return folly::poly_call<1>(*this, output_column_names);
-        }
+        ColumnStatsAggregatorOutput finalize() const { return folly::poly_call<1>(*this); }
     };
 
     template<class T>

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -6,6 +6,7 @@
  * will be governed by the Apache License, version 2.0.
  */
 
+#include <array>
 #include <vector>
 #include <variant>
 
@@ -925,10 +926,17 @@ void append_aggregated_stats_as_columns_to_result(
 // First: finalize every aggregator_data and collect the aggregated col stats
 // Second: append the aggregated col stats to result_segment as columns
 // Note: aggregators that produced no min/max, do not append any columns to the result_segment
-void finalize_and_append_stats_cols_to_result(
+// Returns: ColumnStatsHeader describing: <input_column_offset -> [{stat_segment_offset, stat_type}]>
+arcticc::pb2::column_stats_pb2::ColumnStatsHeader finalize_and_append_stats_cols_to_result(
         SegmentInMemory& result_segment, std::vector<ColumnStatsAggregatorData>& aggregators_data,
         const std::vector<ColumnStatsAggregator>& aggregators
 ) {
+    using namespace arcticc::pb2::column_stats_pb2;
+    static constexpr std::array<ColumnStatsType, 4> stat_order{MIN_V1, MAX_V1, NAN_COUNT_V1, NULL_COUNT_V1};
+
+    ColumnStatsHeader header;
+    header.set_version(1);
+
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
         auto aggregated_stats = agg_data->finalize();
         if (!aggregated_stats.min.has_value()) {
@@ -936,8 +944,28 @@ void finalize_and_append_stats_cols_to_result(
         }
 
         const auto& output_column_names = aggregators.at(agg_data.index).get_output_column_names();
+        const auto current_stat_start_offset = result_segment.descriptor().field_count();
+
         append_aggregated_stats_as_columns_to_result(result_segment, aggregated_stats, output_column_names);
+
+        // checks if entry exists for the 'input_column_offset' (create if not)
+        auto& entry_list = (*header.mutable_stats_by_column())[aggregated_stats.input_column_offset];
+
+        // mapping: <input_column_offset -> [{stat_segment_offset, stat_type}]>
+        for (const auto& [i, stat_type] : folly::enumerate(stat_order)) {
+            // example: input_column="price" has offset 3 in the original dataframe, input_column_offset=3
+            // in the header: key=3(input_column_offset), value=[
+            // {stats_seg_offset: 2, MIN_V1} (for "price" the MIN stat is at offset 2+0 in stats_segment)
+            // {stats_seg_offset: 3, MAX_V1} (for "price" the MIN stat is at offset 2+1 in stats_segment)
+            // {stats_seg_offset: 4, NAN_COUNT_V1} (for "price" the NAN_COUNT stat is at offset 2+2 in stats_segment)
+            // {stats_seg_offset: 5, NULL_COUNT_V1} (for "price" the NULL_COUNT stat is at offset 2+2 in stats_segment)]
+
+            auto* entry = entry_list.add_entries();
+            entry->set_stats_seg_offset(current_stat_start_offset + i);
+            entry->set_type(stat_type);
+        }
     }
+    return header;
 }
 
 } // namespace column_stats_internal
@@ -968,7 +996,13 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
 
     // now the result_segment becomes:
     // |start_index|end_index|v1_min(col1)|v1_max(col1)|v1_nan_count(col1)|v1_null_count(col1)|v2_min(col2)|...
-    finalize_and_append_stats_cols_to_result(result_segment, aggregators_data, *column_stats_aggregators_);
+    auto header =
+            finalize_and_append_stats_cols_to_result(result_segment, aggregators_data, *column_stats_aggregators_);
+
+    google::protobuf::Any any;
+    bool packed = any.PackFrom(header);
+    util::check(packed, "Failed to pack column stats header into Any in ColumnStatsGenerationClause::process");
+    result_segment.set_metadata(std::move(any));
 
     result_segment.set_row_id(0);
     return push_entities(*component_manager_, ProcessingUnit(std::move(result_segment)));

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -802,90 +802,176 @@ std::vector<std::vector<EntityId>> MergeClause::structure_for_processing(
 // the rows are sorted by time stamp
 std::vector<EntityId> MergeClause::process(std::vector<EntityId>&& entity_ids) const { return std::move(entity_ids); }
 
-std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>&& entity_ids) const {
-    internal::check<ErrorCode::E_INVALID_ARGUMENT>(
-            !entity_ids.empty(), "ColumnStatsGenerationClause::process does not make sense with no processing units"
-    );
-    auto proc = gather_entities<
-            std::shared_ptr<SegmentInMemory>,
-            std::shared_ptr<RowRange>,
-            std::shared_ptr<ColRange>,
-            std::shared_ptr<AtomKey>>(*component_manager_, std::move(entity_ids));
+namespace column_stats_internal {
+std::vector<ColumnStatsAggregatorData> build_per_slice_aggregators_data(
+        const std::vector<ColumnStatsAggregator>& aggregators
+) {
     std::vector<ColumnStatsAggregatorData> aggregators_data;
-    internal::check<ErrorCode::E_INVALID_ARGUMENT>(
-            static_cast<bool>(column_stats_aggregators_),
-            "ColumnStatsGenerationClause::process does not make sense with no aggregators"
-    );
-    for (const auto& agg : *column_stats_aggregators_) {
+    aggregators_data.reserve(aggregators.size());
+
+    for (const auto& agg : aggregators) {
         aggregators_data.emplace_back(agg.get_aggregator_data());
     }
+    return aggregators_data;
+}
 
+void aggregate_input_columns(
+        ProcessingUnit& processingUnit, std::vector<ColumnStatsAggregatorData>& aggregators_data,
+        const std::vector<ColumnStatsAggregator>& aggregators, bool dynamic_schema
+) {
+    for (auto agg_data : folly::enumerate(aggregators_data)) {
+        const auto& input_column_name = aggregators.at(agg_data.index).get_input_column_name();
+        auto input_column = processingUnit.get(input_column_name);
+
+        if (std::holds_alternative<ColumnWithStrings>(input_column)) {
+            agg_data->aggregate(std::get<ColumnWithStrings>(input_column));
+        } else if (!dynamic_schema) {
+            internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                    "Unable to resolve column denoted by aggregation operator: '{}'", input_column_name
+            );
+        }
+    }
+}
+
+// Collect the start and end indexes from every atom key in the processing unit.
+// Assert if there two different indexes or return the single start/end index pair.
+std::pair<IndexValue, IndexValue> extract_start_and_end_index(const std::vector<std::shared_ptr<AtomKey>>& atom_keys) {
     ankerl::unordered_dense::set<IndexValue> start_indexes;
     ankerl::unordered_dense::set<IndexValue> end_indexes;
 
-    for (const auto& key : proc.atom_keys_.value()) {
+    for (const auto& key : atom_keys) {
         start_indexes.insert(key->start_index());
         end_indexes.insert(key->end_index());
-    }
-    for (auto agg_data : folly::enumerate(aggregators_data)) {
-        auto input_column_name = column_stats_aggregators_->at(agg_data.index).get_input_column_name();
-        auto input_column = proc.get(input_column_name);
-        if (std::holds_alternative<ColumnWithStrings>(input_column)) {
-            auto input_column_with_strings = std::get<ColumnWithStrings>(input_column);
-            agg_data->aggregate(input_column_with_strings);
-        } else {
-            if (!processing_config_.dynamic_schema_)
-                internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
-                        "Unable to resolve column denoted by aggregation operator: '{}'", input_column_name
-                );
-        }
     }
 
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             start_indexes.size() == 1 && end_indexes.size() == 1,
             "Expected all data segments in one processing unit to have same start and end indexes"
     );
-    auto start_index = *start_indexes.begin();
-    auto end_index = *end_indexes.begin();
+
+    return {*start_indexes.begin(), *end_indexes.begin()};
+}
+
+// All segments fed into one column-stats process() call share the same
+// row-slice, which means they share the same start/end index.
+std::pair<NumericIndex, NumericIndex> extract_slice_index_bounds(const std::vector<std::shared_ptr<AtomKey>>& atom_keys
+) {
+    const auto [start_index, end_index] = extract_start_and_end_index(atom_keys);
+
     schema::check<ErrorCode::E_UNSUPPORTED_INDEX_TYPE>(
             std::holds_alternative<NumericIndex>(start_index) && std::holds_alternative<NumericIndex>(end_index),
             "Cannot build column stats over string-indexed symbol"
     );
-    auto start_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    auto end_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    start_index_col->template push_back<NumericIndex>(std::get<NumericIndex>(start_index));
-    end_index_col->template push_back<NumericIndex>(std::get<NumericIndex>(end_index));
-    start_index_col->set_row_data(0);
-    end_index_col->set_row_data(0);
 
-    SegmentInMemory seg;
-    seg.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_index_col);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_index_col);
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader merged_header;
+    return {std::get<NumericIndex>(start_index), std::get<NumericIndex>(end_index)};
+}
+
+std::shared_ptr<Column> make_single_row_index_column(NumericIndex value) {
+    auto col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    col->template push_back<NumericIndex>(value);
+    col->set_row_data(0);
+    return col;
+}
+
+SegmentInMemory build_per_slice_result_segment(NumericIndex start_index, NumericIndex end_index) {
+    SegmentInMemory result_segment;
+
+    result_segment.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
+    result_segment.add_column(
+            scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name),
+            make_single_row_index_column(start_index)
+    );
+    result_segment.add_column(
+            scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), make_single_row_index_column(end_index)
+    );
+    return result_segment;
+}
+
+void append_aggregated_stats_as_columns_to_result(
+        SegmentInMemory& result_segment, const ColumnStatsAggregatorOutput& aggregated_stats,
+        const std::vector<ColumnName>& output_column_names
+) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            output_column_names.size() == 4,
+            "Expected 4 output column names per MinMax aggregator, got {}",
+            output_column_names.size()
+    );
+    details::visit_type(aggregated_stats.min->data_type(), [&](auto col_tag) {
+        using RawType = typename ScalarTypeInfo<decltype(col_tag)>::RawType;
+
+        auto min_col =
+                std::make_shared<Column>(make_scalar_type(aggregated_stats.min->data_type()), Sparsity::PERMITTED);
+        auto max_col =
+                std::make_shared<Column>(make_scalar_type(aggregated_stats.max->data_type()), Sparsity::PERMITTED);
+        auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+        auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+
+        min_col->template push_back<RawType>(aggregated_stats.min->template get<RawType>());
+        max_col->template push_back<RawType>(aggregated_stats.max->template get<RawType>());
+        nan_count_col->template push_back<uint64_t>(aggregated_stats.nan_count);
+        null_count_col->template push_back<uint64_t>(aggregated_stats.null_count);
+
+        result_segment.add_column(
+                scalar_field(aggregated_stats.min->data_type(), output_column_names[0].value), min_col
+        );
+        result_segment.add_column(
+                scalar_field(aggregated_stats.max->data_type(), output_column_names[1].value), max_col
+        );
+        result_segment.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
+        result_segment.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
+    });
+}
+
+// First: finalize every aggregator_data and collect the aggregated col stats
+// Second: append the aggregated col stats to result_segment as columns
+// Note: aggregators that produced no min/max, do not append any columns to the result_segment
+void finalize_and_append_stats_cols_to_result(
+        SegmentInMemory& result_segment, std::vector<ColumnStatsAggregatorData>& aggregators_data,
+        const std::vector<ColumnStatsAggregator>& aggregators
+) {
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
-        auto finalized = agg_data->finalize(column_stats_aggregators_->at(agg_data.index).get_output_column_names());
-        auto offset_base = seg.descriptor().field_count();
-        util::check(finalized.metadata(), "Expect finalized to have metadata, ColumnStatsGenerationClause::process");
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader sub_header;
-        bool unpacked = finalized.metadata()->UnpackTo(&sub_header);
-        util::check(unpacked, "Could not unpack meta to a ColumnStatsHeader in ColumnStatsGenerationClause#process");
-        for (const auto& [data_col_offset, entry_list] : sub_header.stats_by_column()) {
-            auto& merged_entry_list = (*merged_header.mutable_stats_by_column())[data_col_offset];
-            for (const auto& entry : entry_list.entries()) {
-                auto* new_entry = merged_entry_list.add_entries();
-                new_entry->set_stats_seg_offset(entry.stats_seg_offset() + offset_base);
-                new_entry->set_type(entry.type());
-            }
+        auto aggregated_stats = agg_data->finalize();
+        if (!aggregated_stats.min.has_value()) {
+            continue; // Slice had no aggregatable values for this column - no stat column will be created
         }
-        seg.concatenate(std::move(finalized));
+
+        const auto& output_column_names = aggregators.at(agg_data.index).get_output_column_names();
+        append_aggregated_stats_as_columns_to_result(result_segment, aggregated_stats, output_column_names);
     }
-    google::protobuf::Any any;
-    bool packed = any.PackFrom(merged_header);
-    util::check(packed, "Failed to pack merged_header into Any in ColumnStatsGenerationClause#process");
-    seg.set_metadata(std::move(any));
-    seg.set_row_id(0);
-    return push_entities(*component_manager_, ProcessingUnit(std::move(seg)));
+}
+
+} // namespace column_stats_internal
+
+std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>&& entity_ids) const {
+    using namespace column_stats_internal;
+    internal::check<ErrorCode::E_INVALID_ARGUMENT>(
+            !entity_ids.empty(), "ColumnStatsGenerationClause::process does not make sense with no processing units"
+    );
+    internal::check<ErrorCode::E_INVALID_ARGUMENT>(
+            static_cast<bool>(column_stats_aggregators_),
+            "ColumnStatsGenerationClause::process does not make sense with no aggregators"
+    );
+
+    auto proc = gather_entities<
+            std::shared_ptr<SegmentInMemory>,
+            std::shared_ptr<RowRange>,
+            std::shared_ptr<ColRange>,
+            std::shared_ptr<AtomKey>>(*component_manager_, std::move(entity_ids));
+
+    auto aggregators_data = build_per_slice_aggregators_data(*column_stats_aggregators_);
+    aggregate_input_columns(proc, aggregators_data, *column_stats_aggregators_, processing_config_.dynamic_schema_);
+
+    auto [start_index, end_index] = extract_slice_index_bounds(proc.atom_keys_.value());
+
+    // for now only with index columns: |start_index|end_index|
+    auto result_segment = build_per_slice_result_segment(start_index, end_index);
+
+    // now the result_segment becomes:
+    // |start_index|end_index|v1_min(col1)|v1_max(col1)|v1_nan_count(col1)|v1_null_count(col1)|v2_min(col2)|...
+    finalize_and_append_stats_cols_to_result(result_segment, aggregators_data, *column_stats_aggregators_);
+
+    result_segment.set_row_id(0);
+    return push_entities(*component_manager_, ProcessingUnit(std::move(result_segment)));
 }
 
 std::vector<std::vector<size_t>> RowRangeClause::structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -12,7 +12,6 @@
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/constants.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
-#include <column_stats.pb.h>
 
 #include <cmath>
 
@@ -24,134 +23,72 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
     details::visit_type(input_column.column_->type().data_type(), [&](auto col_tag) {
         using type_info = ScalarTypeInfo<decltype(col_tag)>;
         using RawType = typename type_info::RawType;
-        if constexpr (!is_sequence_type(type_info::data_type)) {
-            // null_count_ tracks rows that are genuinely absent (sparse-map gaps from Arrow
-            // validity bitmaps). nan_count_ tracks in-band sentinel values found while iterating
-            // the dense values (NaN for floats, NaT for time types) - see the for_each below.
-            if (input_column.column_->is_sparse()) {
-                const auto sparse_gap_count = input_column.column_->last_row() + 1 - input_column.column_->row_count();
-                null_count_ += static_cast<uint64_t>(sparse_gap_count);
-            }
-            auto is_nat_or_nan = []([[maybe_unused]] RawType v) {
-                if constexpr (is_floating_point_type(type_info::data_type)) {
-                    return std::isnan(v);
-                } else if constexpr (is_time_type(type_info::data_type)) {
-                    return v == NaT;
-                } else {
-                    return false;
-                }
-            };
-            auto missing_value = []() -> RawType {
-                if constexpr (is_floating_point_type(type_info::data_type)) {
-                    return std::numeric_limits<RawType>::quiet_NaN();
-                } else if constexpr (is_time_type(type_info::data_type)) {
-                    return static_cast<RawType>(NaT);
-                } else {
-                    return RawType{};
-                }
-            };
-            [[maybe_unused]] bool any_nan{false};
-            arcticdb::for_each<typename type_info::TDT>(*input_column.column_, [&](auto value) {
-                // In-band sentinel (NaN for floats, NaT for time types) - count it and skip the
-                // min/max update so those reflect only real values.
-                if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
-                    if (is_nat_or_nan(value)) {
-                        ++nan_count_;
-                        any_nan = true;
-                        return;
-                    }
-                }
-                if (ARCTICDB_UNLIKELY(!min_.has_value())) {
-                    min_ = Value{value, type_info::data_type};
-                    max_ = Value{value, type_info::data_type};
-                } else {
-                    min_->set(std::min(min_->get<RawType>(), value));
-                    max_->set(std::max(max_->get<RawType>(), value));
-                }
-            });
-            if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
-                if (any_nan && !min_) {
-                    // Everything in the block is NaN/NaT, reflect this in the stats
-                    min_ = Value{missing_value(), type_info::data_type};
-                    max_ = Value{missing_value(), type_info::data_type};
-                }
-            }
-        } else {
+
+        if constexpr (is_sequence_type(type_info::data_type)) {
             schema::raise<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
                     "Minmax column stat generation not supported with string types"
             );
+            return;
+        }
+
+        if (input_column.column_->is_sparse()) {
+            const auto sparse_gap_count = input_column.column_->last_row() + 1 - input_column.column_->row_count();
+                null_count_ += static_cast<uint64_t>(sparse_gap_count);
+            }
+        }
+
+        auto is_nan_or_nat_sentinel = []([[maybe_unused]] RawType scalar_value) {
+            if constexpr (is_floating_point_type(type_info::data_type)) {
+                return std::isnan(scalar_value);
+            } else if constexpr (is_time_type(type_info::data_type)) {
+                return scalar_value == NaT;
+            } else {
+                return false;
+            }
+        };
+        auto get_sentinel_value = []() -> RawType {
+            if constexpr (is_floating_point_type(type_info::data_type)) {
+                return std::numeric_limits<RawType>::quiet_NaN();
+            } else if constexpr (is_time_type(type_info::data_type)) {
+                return static_cast<RawType>(NaT);
+            } else {
+                return RawType{};
+            }
+        };
+
+        [[maybe_unused]] bool any_nan{false};
+
+        arcticdb::for_each<typename type_info::TDT>(*input_column.column_, [&](auto value) {
+            const auto& scalar_value = static_cast<RawType>(value);
+
+            if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
+                if (is_nan_or_nat_sentinel(scalar_value)) {
+                    ++nan_count_;
+                    any_nan = true;
+                    return;
+                }
+            }
+            if (ARCTICDB_UNLIKELY(!min_.has_value())) {
+                min_ = Value{scalar_value, type_info::data_type};
+                max_ = Value{scalar_value, type_info::data_type};
+            } else {
+                min_->set(std::min(min_->get<RawType>(), scalar_value));
+                max_->set(std::max(max_->get<RawType>(), scalar_value));
+            }
+        });
+
+        if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
+            if (any_nan && !min_) {
+                // Everything in the block is NaN/NaT, reflect this in the stats
+                min_ = Value{get_sentinel_value(), type_info::data_type};
+                max_ = Value{get_sentinel_value(), type_info::data_type};
+            }
         }
     });
 }
 
-SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& output_column_names) const {
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            output_column_names.size() == 4,
-            "Expected 4 output column names in MinMaxAggregatorData::finalize, but got {}",
-            output_column_names.size()
-    );
-    SegmentInMemory seg;
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
-    if (min_.has_value()) {
-        details::visit_type(min_->data_type(), [&output_column_names, &seg, &header, this](auto col_tag) {
-            using RawType = typename ScalarTypeInfo<decltype(col_tag)>::RawType;
-            auto min_col = std::make_shared<Column>(make_scalar_type(min_->data_type()), Sparsity::PERMITTED);
-            min_col->push_back<RawType>(min_->get<RawType>());
-
-            auto max_col = std::make_shared<Column>(make_scalar_type(max_->data_type()), Sparsity::PERMITTED);
-            max_col->push_back<RawType>(max_->get<RawType>());
-
-            auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-            nan_count_col->push_back<uint64_t>(nan_count_);
-
-            auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-            null_count_col->push_back<uint64_t>(null_count_);
-
-            auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset_];
-            auto* min_entry = entry_list.add_entries();
-            min_entry->set_stats_seg_offset(0);
-            min_entry->set_type(arcticc::pb2::column_stats_pb2::MIN_V1);
-            auto* max_entry = entry_list.add_entries();
-            max_entry->set_stats_seg_offset(1);
-            max_entry->set_type(arcticc::pb2::column_stats_pb2::MAX_V1);
-            auto* nan_entry = entry_list.add_entries();
-            nan_entry->set_stats_seg_offset(2);
-            nan_entry->set_type(arcticc::pb2::column_stats_pb2::NAN_COUNT_V1);
-            auto* null_entry = entry_list.add_entries();
-            null_entry->set_stats_seg_offset(3);
-            null_entry->set_type(arcticc::pb2::column_stats_pb2::NULL_COUNT_V1);
-
-            seg.add_column(scalar_field(min_col->type().data_type(), output_column_names[0].value), min_col);
-            seg.add_column(scalar_field(max_col->type().data_type(), output_column_names[1].value), max_col);
-            seg.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
-            seg.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
-        });
-    } else if (null_count_ > 0) { // The whole col in the slice is null
-        auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-        nan_count_col->push_back<uint64_t>(nan_count_);
-
-        auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-        null_count_col->push_back<uint64_t>(null_count_);
-
-        auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset_];
-
-        auto* nan_entry = entry_list.add_entries();
-        nan_entry->set_stats_seg_offset(0);
-        nan_entry->set_type(arcticc::pb2::column_stats_pb2::NAN_COUNT_V1);
-
-        auto* null_entry = entry_list.add_entries();
-        null_entry->set_stats_seg_offset(1);
-        null_entry->set_type(arcticc::pb2::column_stats_pb2::NULL_COUNT_V1);
-
-        seg.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
-        seg.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
-    }
-
-    google::protobuf::Any any;
-    bool packed = any.PackFrom(header);
-    util::check(packed, "Failed to pack header in to Any?");
-    seg.set_metadata(std::move(any));
-    return seg;
+ColumnStatsAggregatorOutput MinMaxAggregatorData::finalize() const {
+    return {min_, max_, nan_count_, null_count_, input_column_offset_};
 }
 
 namespace {

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -33,8 +33,7 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
 
         if (input_column.column_->is_sparse()) {
             const auto sparse_gap_count = input_column.column_->last_row() + 1 - input_column.column_->row_count();
-                null_count_ += static_cast<uint64_t>(sparse_gap_count);
-            }
+            null_count_ += static_cast<uint64_t>(sparse_gap_count);
         }
 
         auto is_nan_or_nat_sentinel = []([[maybe_unused]] RawType scalar_value) {
@@ -46,6 +45,7 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
                 return false;
             }
         };
+
         auto get_sentinel_value = []() -> RawType {
             if constexpr (is_floating_point_type(type_info::data_type)) {
                 return std::numeric_limits<RawType>::quiet_NaN();

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -10,34 +10,35 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/processing/expression_node.hpp>
+#include <arcticdb/processing/aggregation_interface.hpp>
 
 namespace arcticdb {
 class SegmentInMemory;
 class MinMaxAggregatorData {
   public:
-    MinMaxAggregatorData(size_t data_col_offset) : data_col_offset_(data_col_offset) {}
+    MinMaxAggregatorData(size_t input_column_offset) : input_column_offset_(input_column_offset) {}
     ARCTICDB_MOVE_COPY_DEFAULT(MinMaxAggregatorData)
 
     void aggregate(const ColumnWithStrings& input_column);
-    SegmentInMemory finalize(const std::vector<ColumnName>& output_column_names) const;
+    ColumnStatsAggregatorOutput finalize() const;
 
   private:
     std::optional<Value> min_;
     std::optional<Value> max_;
     uint64_t nan_count_{0};
     uint64_t null_count_{0};
-    size_t data_col_offset_;
+    size_t input_column_offset_;
 };
 
 class MinMaxAggregator {
   public:
     explicit MinMaxAggregator(
-            ColumnName column_name, size_t data_col_offset, ColumnName output_column_name_min,
+            ColumnName input_column_name, size_t input_column_offset, ColumnName output_column_name_min,
             ColumnName output_column_name_max, ColumnName output_column_name_nan_count,
             ColumnName output_column_name_null_count
     ) :
-        column_name_(std::move(column_name)),
-        data_col_offset_(data_col_offset),
+        input_column_name_(std::move(input_column_name)),
+        input_column_offset_(input_column_offset),
         output_column_name_min_(std::move(output_column_name_min)),
         output_column_name_max_(std::move(output_column_name_max)),
         output_column_name_nan_count_(std::move(output_column_name_nan_count)),
@@ -45,18 +46,20 @@ class MinMaxAggregator {
 
     ARCTICDB_MOVE_COPY_DEFAULT(MinMaxAggregator)
 
-    [[nodiscard]] ColumnName get_input_column_name() const { return column_name_; }
+    [[nodiscard]] ColumnName get_input_column_name() const { return input_column_name_; }
     [[nodiscard]] std::vector<ColumnName> get_output_column_names() const {
         return {output_column_name_min_,
                 output_column_name_max_,
                 output_column_name_nan_count_,
                 output_column_name_null_count_};
     }
-    [[nodiscard]] MinMaxAggregatorData get_aggregator_data() const { return MinMaxAggregatorData(data_col_offset_); }
+    [[nodiscard]] MinMaxAggregatorData get_aggregator_data() const {
+        return MinMaxAggregatorData(input_column_offset_);
+    }
 
   private:
-    ColumnName column_name_;
-    size_t data_col_offset_;
+    ColumnName input_column_name_;
+    size_t input_column_offset_;
     ColumnName output_column_name_min_;
     ColumnName output_column_name_max_;
     ColumnName output_column_name_nan_count_;

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2067,7 +2067,7 @@ void create_column_stats_impl(
         );
         ColumnStats old_column_stats(old_header, tsd);
         // No need to redo work for any stats that already exist
-        column_stats.drop(old_column_stats, false);
+        column_stats.drop_old_stats(old_column_stats, false);
         // If all the column stats we are being asked to create already exist, there's no work to do
         if (column_stats.empty()) {
             return;

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2050,9 +2050,6 @@ void create_column_stats_impl(
         return;
     }
 
-    // Maps all column names from the symbol to their offset, because later the 'tsd' is moved and the reference becomes invalid
-    auto symbol_fields_to_offsets = map_symbol_fields_to_offsets(tsd);
-
     std::optional<SegmentInMemory> old_segment;
     if (column_stats_try.hasException()) {
         // Old column stats key doesn't exist
@@ -2097,7 +2094,7 @@ void create_column_stats_impl(
     for (auto& slice_and_key : col_stats_slices_and_keys) {
         col_stats_segments.emplace_back(slice_and_key.release_segment(store));
     }
-    SegmentInMemory new_segment = merge_column_stats_segments(col_stats_segments, symbol_fields_to_offsets);
+    SegmentInMemory new_segment = merge_column_stats_segments(col_stats_segments);
     util::check(new_segment.metadata(), "new_segment should always have metadata");
     new_segment.descriptor().set_id(versioned_item.key_.id());
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2050,6 +2050,9 @@ void create_column_stats_impl(
         return;
     }
 
+    // Maps all column names from the symbol to their offset, because later the 'tsd' is moved and the reference becomes invalid
+    auto symbol_fields_to_offsets = map_symbol_fields_to_offsets(tsd);
+
     std::optional<SegmentInMemory> old_segment;
     if (column_stats_try.hasException()) {
         // Old column stats key doesn't exist
@@ -2085,16 +2088,16 @@ void create_column_stats_impl(
     auto read_query = std::make_shared<ReadQuery>(std::vector{std::make_shared<Clause>(std::move(*clause))});
     read_indexed_keys_to_pipeline(pipeline_context, *read_query, read_options, index_info);
 
-    auto segs = read_process_and_collect(store, pipeline_context, read_query, read_options).get();
+    auto col_stats_slices_and_keys = read_process_and_collect(store, pipeline_context, read_query, read_options).get();
     schema::check<ErrorCode::E_COLUMN_DOESNT_EXIST>(
-            !segs.empty(), "Cannot create column stats for nonexistent columns"
+            !col_stats_slices_and_keys.empty(), "Cannot create column stats for nonexistent columns"
     );
 
-    std::vector<SegmentInMemory> segments_in_memory;
-    for (auto& seg : segs) {
-        segments_in_memory.emplace_back(seg.release_segment(store));
+    std::vector<SegmentInMemory> col_stats_segments;
+    for (auto& slice_and_key : col_stats_slices_and_keys) {
+        col_stats_segments.emplace_back(slice_and_key.release_segment(store));
     }
-    SegmentInMemory new_segment = merge_column_stats_segments(segments_in_memory);
+    SegmentInMemory new_segment = merge_column_stats_segments(col_stats_segments, symbol_fields_to_offsets);
     util::check(new_segment.metadata(), "new_segment should always have metadata");
     new_segment.descriptor().set_id(versioned_item.key_.id());
 


### PR DESCRIPTION
### Before
The protobuf `ColumnStatsHeader` (which records, per data-column offset, the list of stat
entries and their offsets within the stats segment) was constructed and carried at
**three** stages:

1. `MinMaxAggregatorData::finalize()` returned a full `SegmentInMemory` for each stats that were calculated per single slice that already embedded a `ColumnStatsHeader` in its metadata, with the input column's `data_col_offset_` baked in.
2. `ColumnStatsGenerationClause::process()` unpacked each finalized segment's header, re-based every `stats_seg_offset` by the running field count, merged them into a combined header, and `concatenate`d the segments.
3. `merge_column_stats_segments()` re-read each segment's protobuf header, built a reverse lookup `stats_seg_offset → (data_col_offset, type)`, and reconstructed the header again while preserving offsets.

The offset of the original data column was effectively passed along inside protobuf at each hop.

### After
The protobuf header is built **once**, at the final merge step, by **parsing the segment column names** and resolving the data-column offset from the symbol layout:

1. `MinMaxAggregatorData::finalize()` now returns a lightweight POD struct
   (`ColumnStatsAggregatorOutput`) — just `min`, `max`, `nan_count`, `null_count`,
   `input_column_offset`. No segment, no protobuf.
2. `ColumnStatsGenerationClause::process()` builds the per-slice result segment directly,
   naming each stat column via `column_and_stat_to_segment_name` (`v1_MIN(col)`,
   `v1_MAX(col)`, `v1_NAN_COUNT(col)`, `v1_NULL_COUNT(col)`). **No protobuf header is built
   here anymore.**
3. `merge_column_stats_segments()` reconstructs the header from the merged column names:
   each name is parsed via `parse_segment_column_name` into `(column_name, stat_type)`,
   and the data-column offset is looked up in a `symbol_fields_to_offsets` map derived from
   the symbol's `TimeseriesDescriptor`.

