### PR TITLE
Simplify illegal characters checks on library path and symbols

### DIFF
--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -184,10 +184,12 @@ class AsyncStore : public Store {
         return WriteIfNoneTask{library_}(std::move(encoded));
     }
 
-    std::optional<char> is_path_valid(std::string_view path) const override { return library_->is_path_valid(path); }
+    const std::set<char>& unsupported_symbol_chars() const override { return library_->unsupported_symbol_chars(); }
 
-    std::optional<char> is_library_path_valid(std::string_view path) const override {
-        return library_->is_library_path_valid(path);
+    const std::set<char>& unsupported_library_chars() const override { return library_->unsupported_library_chars(); }
+
+    std::optional<char> verify_library_suffix(std::string_view path) const override {
+        return library_->verify_library_suffix(path);
     }
 
     folly::Future<folly::Unit> write_compressed(storage::KeySegmentPair ks) override {

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -21,7 +21,7 @@
 #include <arcticdb/storage/mock/azure_mock_client.hpp>
 #include <arcticdb/storage/storage_exceptions.hpp>
 
-#include <optional>
+#include <set>
 
 #undef GetMessage
 
@@ -365,12 +365,22 @@ std::string AzureStorage::do_key_path(const VariantKey& key) const {
     return object_path(b.bucketize(key_type_dir, key), key);
 }
 
-std::optional<char> AzureStorage::do_is_path_valid(std::string_view path) const {
+static const std::set<char>& azure_unsupported_chars() {
     // '\' is silently converted to '/' by the Azure Blob service (it is built on .NET's Uri class), so a name
-    // containing it would be stored under a path that no longer matches the recorded name. Disallow it.
-    const auto pos = path.find('\\');
-    return pos == std::string_view::npos ? std::nullopt : std::optional<char>{path[pos]};
+    // containing it would be stored under a path that no longer matches the recorded name. Disallow it on top of the
+    // globally unsupported characters. The library name forms part of the same blob path, so the restriction applies
+    // equally to symbol keys and library names.
+    static const std::set<char> chars = [] {
+        std::set<char> result = GLOBALLY_UNSUPPORTED_CHARS;
+        result.insert('\\');
+        return result;
+    }();
+    return chars;
 }
+
+const std::set<char>& AzureStorage::do_unsupported_symbol_chars() const { return azure_unsupported_chars(); }
+
+const std::set<char>& AzureStorage::do_unsupported_library_chars() const { return azure_unsupported_chars(); }
 
 } // namespace azure
 

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -58,7 +58,9 @@ class AzureStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final;
 
-    std::optional<char> do_is_path_valid(std::string_view path) const final;
+    const std::set<char>& do_unsupported_symbol_chars() const final;
+
+    const std::set<char>& do_unsupported_library_chars() const final;
 
   private:
     std::unique_ptr<AzureClientWrapper> azure_client_;

--- a/cpp/arcticdb/storage/library.hpp
+++ b/cpp/arcticdb/storage/library.hpp
@@ -158,12 +158,16 @@ class Library {
 
     bool key_exists(const VariantKey& key) { return storages_->key_exists(key); }
 
-    [[nodiscard]] std::optional<char> is_path_valid(std::string_view path) const {
-        return storages_->is_path_valid(path);
+    [[nodiscard]] const std::set<char>& unsupported_symbol_chars() const {
+        return storages_->unsupported_symbol_chars();
     }
 
-    [[nodiscard]] std::optional<char> is_library_path_valid(std::string_view path) const {
-        return storages_->is_library_path_valid(path);
+    [[nodiscard]] const std::set<char>& unsupported_library_chars() const {
+        return storages_->unsupported_library_chars();
+    }
+
+    [[nodiscard]] std::optional<char> verify_library_suffix(std::string_view path) const {
+        return storages_->verify_library_suffix(path);
     }
 
     /** Calls VariantStorage::do_key_path on the primary storage */

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -333,20 +333,25 @@ bool LmdbStorage::do_iterate_type_until_match(
     return false;
 }
 
-std::optional<char> LmdbStorage::do_is_library_path_valid(std::string_view path) const {
-    if (auto unsupported = is_path_valid(path)) {
-        return unsupported;
-    }
+const std::set<char>& LmdbStorage::do_unsupported_library_chars() const {
+    // The library name maps onto a Windows directory path, so on Windows the characters disallowed in file/directory
+    // names are rejected on top of the globally unsupported ones. Note that \ and / are valid as they create
+    // subdirectories which are expected to work, and reserved names (COM1, LPT1, AUX, CON, ...) are not disallowed.
+    static const std::set<char> chars = [] {
+        std::set<char> result = GLOBALLY_UNSUPPORTED_CHARS;
 #ifdef _WIN32
-    // Note that \ and / are valid characters as they will create subdirectories which are expected to work.
-    // The filenames such as COM1, LPT1, AUX, CON etc. are reserved but not strictly disallowed by Windows as directory
-    // names. Therefore, paths with these names are allowed.
-    std::string_view invalid_win32_chars = "<>:\"|?*";
-    auto found = path.find_first_of(invalid_win32_chars);
-    if (found != std::string::npos) {
-        return path[found];
-    }
+        for (char c : {':', '"', '|', '?'}) {
+            result.insert(c);
+        }
+#endif
+        return result;
+    }();
+    return chars;
+}
 
+std::optional<char> LmdbStorage::do_verify_library_suffix(std::string_view path ARCTICDB_UNUSED) const {
+#ifdef _WIN32
+    // Windows directory names cannot end in '.' or whitespace.
     if (!path.empty() && (path.back() == '.' || std::isspace(path.back()))) {
         return path.back();
     }

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -65,7 +65,9 @@ class LmdbStorage final : public Storage {
 
     bool do_key_exists(const VariantKey& key) final;
 
-    std::optional<char> do_is_library_path_valid(std::string_view path) const final;
+    const std::set<char>& do_unsupported_library_chars() const final;
+
+    std::optional<char> do_verify_library_suffix(std::string_view path) const final;
 
     ::lmdb::env& env();
 

--- a/cpp/arcticdb/storage/mongo/mongo_storage.cpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.cpp
@@ -199,14 +199,16 @@ bool MongoStorage::do_iterate_type_until_match(
     return false;
 }
 
-std::optional<char> MongoStorage::do_is_library_path_valid(std::string_view path) const {
-    if (auto unsupported = is_path_valid(path)) {
-        return unsupported;
-    }
-    // (Part of) Library name forms the name of mongo database. Some characters are not allowed there
+const std::set<char>& MongoStorage::do_unsupported_library_chars() const {
+    // (Part of) Library name forms the name of mongo database. '/' is not allowed there, on top of the globally
+    // unsupported characters.
     // https://www.mongodb.com/docs/manual/reference/limits/?atlas-provider=aws&atlas-class=general#mongodb-limit-Restrictions-on-Database-Names-for-Unix-and-Linux-Systems
-    const auto pos = path.find('/');
-    return pos == std::string_view::npos ? std::nullopt : std::optional<char>{path[pos]};
+    static const std::set<char> chars = [] {
+        std::set<char> result = GLOBALLY_UNSUPPORTED_CHARS;
+        result.insert('/');
+        return result;
+    }();
+    return chars;
 }
 
 bool MongoStorage::do_key_exists(const VariantKey& key) {

--- a/cpp/arcticdb/storage/mongo/mongo_storage.hpp
+++ b/cpp/arcticdb/storage/mongo/mongo_storage.hpp
@@ -54,7 +54,7 @@ class MongoStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
-    std::optional<char> do_is_library_path_valid(std::string_view path) const final;
+    const std::set<char>& do_unsupported_library_chars() const final;
 
     std::string collection_name(KeyType k);
 

--- a/cpp/arcticdb/storage/storage.hpp
+++ b/cpp/arcticdb/storage/storage.hpp
@@ -16,12 +16,17 @@
 #include <arcticdb/stream/index.hpp>
 
 #include <optional>
+#include <set>
 #include <span>
 
 namespace arcticdb::storage {
 
 using CompressedSize = uint64_t;
 using ObjectSizesVisitor = std::function<void(const VariantKey&, CompressedSize)>;
+
+// '*', '<' and '>' are problematic for S3 and are rejected by every backend, so they form the default set of
+// characters disallowed in names. Backends extend this set by overriding Storage::do_unsupported_*_chars().
+inline const std::set<char> GLOBALLY_UNSUPPORTED_CHARS{'*', '<', '>'};
 
 struct ObjectSizes {
     ObjectSizes(KeyType key_type, uint64_t count, CompressedSize compressed_size) :
@@ -164,11 +169,17 @@ class Storage {
 
     [[nodiscard]] std::string key_path(const VariantKey& key) const { return do_key_path(key); }
 
-    // Returns the first character of `path` that this backend cannot store faithfully in a key, or std::nullopt if the
-    // path is acceptable.
-    [[nodiscard]] std::optional<char> is_path_valid(std::string_view path) const { return do_is_path_valid(path); }
-    [[nodiscard]] std::optional<char> is_library_path_valid(std::string_view path) const {
-        return do_is_library_path_valid(path);
+    // Characters this backend cannot store faithfully in a symbol key or snapshot name (a superset of
+    // GLOBALLY_UNSUPPORTED_CHARS). Fed into verify_name as its unsupported_chars argument.
+    [[nodiscard]] const std::set<char>& unsupported_symbol_chars() const { return do_unsupported_symbol_chars(); }
+    // Characters disallowed in a library name. Defaults to GLOBALLY_UNSUPPORTED_CHARS; backends override to add their
+    // own restrictions (e.g. Mongo database names disallow '/', Azure blob paths disallow '\').
+    [[nodiscard]] const std::set<char>& unsupported_library_chars() const { return do_unsupported_library_chars(); }
+    // Positional (suffix) validation of a library name, complementing the unsupported-character sets above. Returns
+    // the offending trailing character if the name ends in one the backend cannot represent (currently only LMDB's
+    // Windows filesystem rule: no trailing '.' or whitespace).
+    [[nodiscard]] std::optional<char> verify_library_suffix(std::string_view path) const {
+        return do_verify_library_suffix(path);
     }
 
     [[nodiscard]] const LibraryPath& library_path() const { return lib_path_; }
@@ -260,10 +271,13 @@ class Storage {
 
     [[nodiscard]] virtual std::string do_key_path(const VariantKey& key) const = 0;
 
-    [[nodiscard]] virtual std::optional<char> do_is_path_valid(std::string_view) const { return std::nullopt; }
-    [[nodiscard]] virtual std::optional<char> do_is_library_path_valid(std::string_view path) const {
-        return do_is_path_valid(path);
+    [[nodiscard]] virtual const std::set<char>& do_unsupported_symbol_chars() const {
+        return GLOBALLY_UNSUPPORTED_CHARS;
     }
+    [[nodiscard]] virtual const std::set<char>& do_unsupported_library_chars() const {
+        return GLOBALLY_UNSUPPORTED_CHARS;
+    }
+    [[nodiscard]] virtual std::optional<char> do_verify_library_suffix(std::string_view) const { return std::nullopt; }
 
     LibraryPath lib_path_;
     OpenMode mode_;

--- a/cpp/arcticdb/storage/storages.hpp
+++ b/cpp/arcticdb/storage/storages.hpp
@@ -69,12 +69,16 @@ class Storages {
 
     bool key_exists(const VariantKey& key) { return primary().key_exists(key); }
 
-    [[nodiscard]] std::optional<char> is_path_valid(std::string_view path) const {
-        return primary().is_path_valid(path);
+    [[nodiscard]] const std::set<char>& unsupported_symbol_chars() const {
+        return primary().unsupported_symbol_chars();
     }
 
-    [[nodiscard]] std::optional<char> is_library_path_valid(std::string_view path) const {
-        return primary().is_library_path_valid(path);
+    [[nodiscard]] const std::set<char>& unsupported_library_chars() const {
+        return primary().unsupported_library_chars();
+    }
+
+    [[nodiscard]] std::optional<char> verify_library_suffix(std::string_view path) const {
+        return primary().verify_library_suffix(path);
     }
 
     void read_sync_fallthrough(const VariantKey& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -137,9 +137,11 @@ class InMemoryStore : public Store {
         return key;
     }
 
-    std::optional<char> is_path_valid(std::string_view) const override { return std::nullopt; }
+    const std::set<char>& unsupported_symbol_chars() const override { return storage::GLOBALLY_UNSUPPORTED_CHARS; }
 
-    std::optional<char> is_library_path_valid(std::string_view) const override { return std::nullopt; }
+    const std::set<char>& unsupported_library_chars() const override { return storage::GLOBALLY_UNSUPPORTED_CHARS; }
+
+    std::optional<char> verify_library_suffix(std::string_view) const override { return std::nullopt; }
 
     folly::Future<entity::VariantKey> write(
             stream::KeyType key_type, const StreamId& stream_id, SegmentInMemory&& segment

--- a/cpp/arcticdb/storage/test/test_path_validation.cpp
+++ b/cpp/arcticdb/storage/test/test_path_validation.cpp
@@ -37,22 +37,27 @@ std::unique_ptr<Storage> make_memory() {
 
 TEST(PathValidation, AzureRejectsBackslashEverywhere) {
     auto store = make_azure();
-    EXPECT_EQ(store->is_path_valid("a\\b"), '\\');
-    EXPECT_EQ(store->is_library_path_valid("a\\b"), '\\');
-    EXPECT_FALSE(store->is_path_valid("a/b").has_value());
-    EXPECT_FALSE(store->is_library_path_valid("a/b").has_value());
+    // '\' is banned in both symbol keys and library names, on top of the globally unsupported S3 characters.
+    EXPECT_TRUE(store->unsupported_symbol_chars().contains('\\'));
+    EXPECT_TRUE(store->unsupported_library_chars().contains('\\'));
+    EXPECT_TRUE(store->unsupported_symbol_chars().contains('*'));
+    EXPECT_FALSE(store->unsupported_symbol_chars().contains('/'));
 }
 
 TEST(PathValidation, MongoForwardSlashIsLibraryOnly) {
     auto store = make_mongo();
-    EXPECT_FALSE(store->is_path_valid("a/b").has_value());
-    EXPECT_EQ(store->is_library_path_valid("a/b"), '/');
+    // '/' is only disallowed in library names (it forms the Mongo database name), not in symbol keys.
+    EXPECT_FALSE(store->unsupported_symbol_chars().contains('/'));
+    EXPECT_TRUE(store->unsupported_library_chars().contains('/'));
 }
 
-TEST(PathValidation, BackendsWithoutRestrictionsAcceptEverything) {
+TEST(PathValidation, BackendsWithoutRestrictionsHaveNoExtraChars) {
     auto store = make_memory();
-    EXPECT_FALSE(store->is_path_valid("a/b").has_value());
-    EXPECT_FALSE(store->is_path_valid("a\\b").has_value());
-    EXPECT_FALSE(store->is_library_path_valid("a/b").has_value());
-    EXPECT_FALSE(store->is_library_path_valid("a\\b").has_value());
+    // Only the globally unsupported S3 characters apply; no backend-specific extras.
+    EXPECT_FALSE(store->unsupported_symbol_chars().contains('/'));
+    EXPECT_FALSE(store->unsupported_symbol_chars().contains('\\'));
+    EXPECT_FALSE(store->unsupported_library_chars().contains('/'));
+    EXPECT_FALSE(store->unsupported_library_chars().contains('\\'));
+    EXPECT_TRUE(store->unsupported_symbol_chars().contains('<'));
+    EXPECT_FALSE(store->verify_library_suffix("a\\b").has_value());
 }

--- a/cpp/arcticdb/stream/stream_sink.hpp
+++ b/cpp/arcticdb/stream/stream_sink.hpp
@@ -109,9 +109,11 @@ struct StreamSink {
             const std::shared_ptr<DeDupMap>& de_dup_map
     ) = 0;
 
-    virtual std::optional<char> is_path_valid(std::string_view path) const = 0;
+    virtual const std::set<char>& unsupported_symbol_chars() const = 0;
 
-    virtual std::optional<char> is_library_path_valid(std::string_view path) const = 0;
+    virtual const std::set<char>& unsupported_library_chars() const = 0;
+
+    virtual std::optional<char> verify_library_suffix(std::string_view path) const = 0;
 
     [[nodiscard]] virtual folly::Future<folly::Unit> batch_write_compressed(std::vector<storage::KeySegmentPair> kvs
     ) = 0;

--- a/cpp/arcticdb/util/name_validation.cpp
+++ b/cpp/arcticdb/util/name_validation.cpp
@@ -10,17 +10,15 @@
 
 #include <arcticdb/entity/types.hpp>
 #include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/storage/storage.hpp>
 #include <arcticdb/storage/store.hpp>
 
 namespace arcticdb {
 
-// '*', '<' and '>' are problematic for S3
-const auto UNSUPPORTED_S3_CHARS = std::set<char>{'*', '<', '>'};
-
 [[nodiscard]] CheckOutcome verify_name(
-        const std::string& name_type_for_error, const StringId& name, bool check_symbol_out_of_range = true,
-        const std::set<char>& unsupported_chars = UNSUPPORTED_S3_CHARS,
-        std::optional<char> unsupported_prefix = std::nullopt, std::optional<char> unsupported_suffix = std::nullopt
+        const std::string& name_type_for_error, const StringId& name, bool check_symbol_out_of_range,
+        const std::set<char>& unsupported_chars,
+        std::optional<char> unsupported_suffix = std::nullopt
 ) {
     if (name.empty()) {
         return Error{
@@ -72,19 +70,6 @@ const auto UNSUPPORTED_S3_CHARS = std::set<char>{'*', '<', '>'};
         }
     }
 
-    if (unsupported_prefix.has_value() && name[0] == *unsupported_prefix) {
-        return Error{
-                throw_error<ErrorCode::E_INVALID_CHAR_IN_NAME>,
-                fmt::format(
-                        "The {} starts with an unsupported prefix. {}: {} Unsupported prefix: {} ",
-                        name_type_for_error,
-                        name_type_for_error,
-                        name,
-                        *unsupported_prefix
-                )
-        };
-    }
-
     if (unsupported_suffix.has_value() && name[name.size() - 1] == *unsupported_suffix) {
         return Error{
                 throw_error<ErrorCode::E_INVALID_CHAR_IN_NAME>,
@@ -117,24 +102,7 @@ const auto UNSUPPORTED_S3_CHARS = std::set<char>{'*', '<', '>'};
     return util::variant_match(
             id,
             [&](const StringId& name) -> CheckOutcome {
-                CheckOutcome res = verify_name(name_type_for_error, name);
-                if (std::holds_alternative<Error>(res)) {
-                    return res;
-                }
-                if (auto unsupported = store->is_path_valid(name)) {
-                    return Error{
-                            throw_error<ErrorCode::E_INVALID_CHAR_IN_NAME>,
-                            fmt::format(
-                                    "The {} contains character unsupported by storage backend {}. {}: {} BadChar: {}",
-                                    name_type_for_error,
-                                    store->name(),
-                                    name_type_for_error,
-                                    name,
-                                    *unsupported
-                            )
-                    };
-                }
-                return std::monostate{};
+                return verify_name(name_type_for_error, name, true, store->unsupported_symbol_chars());
             },
             [](const auto&) -> CheckOutcome { return std::monostate{}; }
     );
@@ -152,7 +120,7 @@ CheckOutcome verify_snapshot_id(const SnapshotId& snapshot_id, const std::shared
 constexpr auto UNSUPPORTED_LMDB_MONGO_PREFIX = '/';
 
 void verify_library_path(const StringId& library_path, char delim) {
-    CheckOutcome res = verify_name("library name", library_path, false, {}, {}, delim);
+    CheckOutcome res = verify_name("library name", library_path, false, {}, delim);
     if (std::holds_alternative<Error>(res)) {
         std::get<Error>(res).throw_error();
     }
@@ -177,13 +145,13 @@ void verify_library_path_part(const std::string& library_part, char delim) {
 }
 
 void verify_library_path_on_write(const Store* store, const StringId& library_path) {
-    CheckOutcome res = verify_name("library name", library_path, true, UNSUPPORTED_S3_CHARS);
+    CheckOutcome res = verify_name("library name", library_path, true, store->unsupported_library_chars());
     if (std::holds_alternative<Error>(res)) {
         std::get<Error>(res).throw_error();
     }
-    if (auto unsupported = store->is_library_path_valid(library_path)) {
+    if (auto unsupported = store->verify_library_suffix(library_path)) {
         user_input::raise<ErrorCode::E_INVALID_CHAR_IN_NAME>(
-                "The library name contains character unsupported by storage backend {}. Library Name: {} BadChar: {}",
+                "The library name's suffix contains character unsupported by storage backend {}. Library Name: {} BadChar: {}",
                 store->name(),
                 library_path,
                 *unsupported

--- a/cpp/arcticdb/util/name_validation.cpp
+++ b/cpp/arcticdb/util/name_validation.cpp
@@ -17,8 +17,7 @@ namespace arcticdb {
 
 [[nodiscard]] CheckOutcome verify_name(
         const std::string& name_type_for_error, const StringId& name, bool check_symbol_out_of_range,
-        const std::set<char>& unsupported_chars,
-        std::optional<char> unsupported_suffix = std::nullopt
+        const std::set<char>& unsupported_chars, std::optional<char> unsupported_suffix = std::nullopt
 ) {
     if (name.empty()) {
         return Error{
@@ -151,7 +150,8 @@ void verify_library_path_on_write(const Store* store, const StringId& library_pa
     }
     if (auto unsupported = store->verify_library_suffix(library_path)) {
         user_input::raise<ErrorCode::E_INVALID_CHAR_IN_NAME>(
-                "The library name's suffix contains character unsupported by storage backend {}. Library Name: {} BadChar: {}",
+                "The library name's suffix contains character unsupported by storage backend {}. Library Name: {} "
+                "BadChar: {}",
                 store->name(),
                 library_path,
                 *unsupported


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
https://man312219.monday.com/boards/7852509418/pulses/12303955173

Minor refactor on how library path and symbol have the illegal character check. Changes are transparent so no pytest is updated 
#### What does this implement or fix?

#### Any other comments?
| Backend | Illegal Symbol Chars | Illegal Library Name Chars |
|---|---|---|
| All (global baseline) | `*` `<` `>` | `*` `<` `>` |
| S3 | `*` `<` `>` | `*` `<` `>` |
| Azure | `*` `<` `>` `\` | `*` `<` `>` `\` |
| MongoDB | `*` `<` `>` | `*` `<` `>` `/` |
| LMDB (non-Windows) | `*` `<` `>` | `*` `<` `>` |
| LMDB (Windows) | `*` `<` `>` | `*` `<` `>` `:` `"` `\|` `?` + trailing `.` or whitespace |
#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
