### PR TITLE
Bugfix 12337436632: do not orphan data keys in append/update when schemas mismatch

### DIFF
--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -63,7 +63,7 @@ bool InputFrame::has_index() const { return desc().index().field_count() != 0ULL
 
 bool InputFrame::empty() const { return num_rows == 0; }
 
-timestamp InputFrame::index_value_at(size_t row) {
+timestamp InputFrame::index_value_at(size_t row) const {
     util::check(has_index(), "InputFrame::index_value_at should only be called on timeseries data");
     return util::variant_match(
             input_data,

--- a/cpp/arcticdb/pipeline/input_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_frame.hpp
@@ -66,7 +66,7 @@ struct InputFrame {
     void set_offset(ssize_t off) const;
     bool has_index() const;
     bool empty() const;
-    timestamp index_value_at(size_t row);
+    timestamp index_value_at(size_t row) const;
     void set_index_range();
     void set_bucketize_dynamic(bool bucketize);
     bool has_segment() const;

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -508,33 +508,14 @@ folly::Future<entity::AtomKey> write_frame(
 
 folly::Future<AtomKey> append_frame(
         IndexPartialKey&& key, const std::shared_ptr<InputFrame>& frame, const SlicingPolicy& slicing,
-        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema,
-        bool ignore_sort_order
+        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema
 ) {
     ARCTICDB_SAMPLE_DEFAULT(AppendFrame)
-    util::variant_match(
-            frame->index,
-            [&index_segment_reader, &frame, ignore_sort_order](const TimeseriesIndex&) {
-                util::check(frame->has_index(), "Cannot append timeseries without index");
-                if (index_segment_reader.tsd().total_rows() != 0 && frame->num_rows != 0) {
-                    auto first_index = NumericIndex{frame->index_value_at(0)};
-                    auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
-                    util::check(
-                            ignore_sort_order || prev - 1 <= first_index,
-                            "Can't append dataframe with start index {} to existing sequence ending at {}",
-                            util::format_timestamp(first_index),
-                            util::format_timestamp(prev)
-                    );
-                }
-            },
-            [](const auto&) {
-                // Do whatever, but you can't range search it
-            }
-    );
-
     auto existing_slices = unfiltered_index(index_segment_reader);
+    const auto tsd =
+            index::get_merged_tsd(frame->num_rows + frame->offset, dynamic_schema, index_segment_reader.tsd(), frame);
     auto keys_fut = slice_and_write(frame, slicing, IndexPartialKey{key}, store);
-    return std::move(keys_fut).thenValue([dynamic_schema,
+    return std::move(keys_fut).thenValue([tsd = std::move(tsd),
                                           slices_to_write = std::move(existing_slices),
                                           frame = frame,
                                           index_segment_reader = std::move(index_segment_reader),
@@ -546,9 +527,6 @@ folly::Future<AtomKey> append_frame(
                 std::make_move_iterator(std::end(slice_and_keys_to_append))
         );
         ranges::sort(slices_to_write);
-        const auto tsd = index::get_merged_tsd(
-                frame->num_rows + frame->offset, dynamic_schema, index_segment_reader.tsd(), frame
-        );
         return index::write_index(
                 index_type_from_descriptor(tsd.as_stream_descriptor()), tsd, std::move(slices_to_write), key, store
         );

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -70,8 +70,7 @@ folly::Future<entity::AtomKey> write_frame(
 
 folly::Future<entity::AtomKey> append_frame(
         IndexPartialKey&& key, const std::shared_ptr<InputFrame>& frame, const SlicingPolicy& slicing,
-        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema,
-        bool ignore_sort_order
+        index::IndexSegmentReader& index_segment_reader, const std::shared_ptr<Store>& store, bool dynamic_schema
 );
 
 enum class AffectedSegmentPart { START, END };

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -135,7 +135,7 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     return write_frame(std::move(partial_key), frame, slicing_policy, store, de_dup_map, sparsify_floats);
 }
 
-void sorted_data_check_append(const InputFrame& frame, index::IndexSegmentReader& index_segment_reader) {
+void sorted_data_check_append(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
     if (!index_is_not_timeseries_or_is_sorted_ascending(frame)) {
         sorting::raise<ErrorCode::E_UNSORTED_DATA>(
                 "When calling append with validate_index enabled, input data must be sorted"
@@ -146,6 +146,90 @@ void sorted_data_check_append(const InputFrame& frame, index::IndexSegmentReader
                     index_segment_reader.tsd().sorted() == SortedValue::ASCENDING,
             "When calling append with validate_index enabled, the existing data must be sorted"
     );
+}
+
+void check_index_match(const Index& index, const IndexDescriptorImpl& desc) {
+    if (std::holds_alternative<TimeseriesIndex>(index))
+        util::check(
+                desc.type() == IndexDescriptor::Type::TIMESTAMP || desc.type() == IndexDescriptor::Type::EMPTY,
+                "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries"
+        );
+    else
+        util::check(
+                desc.type() == IndexDescriptorImpl::Type::ROWCOUNT,
+                "Index mismatch, cannot update a timeseries with a non-timeseries-indexed frame"
+        );
+}
+
+void check_update_data_is_sorted(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
+    bool is_time_series = std::holds_alternative<stream::TimeseriesIndex>(frame.index);
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            is_time_series, "When calling update, the input data must be a time series."
+    );
+    bool input_data_is_sorted =
+            frame.desc().sorted() == SortedValue::ASCENDING || frame.desc().sorted() == SortedValue::UNKNOWN;
+    // If changing this error message, the corresponding message in _normalization.py::restrict_data_to_date_range_only
+    // should also be updated
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            input_data_is_sorted, "When calling update, the input data must be sorted."
+    );
+    bool existing_data_is_sorted = index_segment_reader.sorted() == SortedValue::ASCENDING ||
+                                   index_segment_reader.sorted() == SortedValue::UNKNOWN;
+    sorting::check<ErrorCode::E_UNSORTED_DATA>(
+            existing_data_is_sorted, "When calling update, the existing data must be sorted."
+    );
+}
+
+static void check_can_append(
+        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
+        const WriteOptions& write_options, bool validate_index, bool empty_types
+) {
+    util::check(
+            update_info.previous_index_key_.has_value(),
+            "Cannot append as there is no previous index key to append into"
+    );
+    util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
+    fix_descriptor_mismatch_or_throw(APPEND, write_options.dynamic_schema, index_segment_reader, frame, empty_types);
+    if (validate_index) {
+        sorted_data_check_append(frame, index_segment_reader);
+    }
+    util::variant_match(
+            frame.index,
+            [&index_segment_reader, &frame, &write_options](const TimeseriesIndex&) {
+                util::check(frame.has_index(), "Cannot append timeseries without index");
+                if (index_segment_reader.tsd().total_rows() != 0 && frame.num_rows != 0) {
+                    auto first_index = NumericIndex{frame.index_value_at(0)};
+                    auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
+                    util::check(
+                            write_options.ignore_sort_order || prev - 1 <= first_index,
+                            "Can't append dataframe with start index {} to existing sequence "
+                            "ending at {}",
+                            util::format_timestamp(first_index),
+                            util::format_timestamp(prev)
+                    );
+                }
+            },
+            [](const auto&) {
+                // Do whatever, but you can't range search it
+            }
+    );
+}
+
+static void check_can_update(
+        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
+        bool dynamic_schema, bool empty_types
+) {
+    util::check(
+            update_info.previous_index_key_.has_value(),
+            "Cannot update as there is no previous index key to update into"
+    );
+    util::check_rte(!index_segment_reader.is_pickled(), "Cannot update to pickled data");
+    check_index_match(frame.index, index_segment_reader.tsd().index());
+    const auto index_desc = index_segment_reader.tsd().index();
+    util::check(index::is_timeseries_index(index_desc), "Update not supported for non-timeseries indexes");
+    check_update_data_is_sorted(frame, index_segment_reader);
+    (void)check_and_mark_slices(index_segment_reader, false, std::nullopt);
+    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame, empty_types);
 }
 
 folly::Future<AtomKey> async_append_impl(
@@ -161,13 +245,8 @@ folly::Future<AtomKey> async_append_impl(
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto row_offset = index_segment_reader.tsd().total_rows();
-    util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
+    check_can_append(*frame, index_segment_reader, update_info, options, validate_index, empty_types);
     frame->set_offset(static_cast<ssize_t>(row_offset));
-    fix_descriptor_mismatch_or_throw(APPEND, options.dynamic_schema, index_segment_reader, *frame, empty_types);
-    if (validate_index) {
-        sorted_data_check_append(*frame, index_segment_reader);
-    }
-
     frame->set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, *frame);
     return append_frame(
@@ -176,8 +255,7 @@ folly::Future<AtomKey> async_append_impl(
             slicing_arg,
             index_segment_reader,
             store,
-            options.dynamic_schema,
-            options.ignore_sort_order
+            options.dynamic_schema
     );
 }
 
@@ -202,19 +280,6 @@ namespace {
 bool is_before(const IndexRange& a, const IndexRange& b) { return a.start_ < b.start_; }
 
 bool is_after(const IndexRange& a, const IndexRange& b) { return a.end_ > b.end_; }
-
-void check_index_match(const Index& index, const IndexDescriptorImpl& desc) {
-    if (std::holds_alternative<TimeseriesIndex>(index))
-        util::check(
-                desc.type() == IndexDescriptor::Type::TIMESTAMP || desc.type() == IndexDescriptor::Type::EMPTY,
-                "Index mismatch, cannot update a non-timeseries-indexed frame with a timeseries"
-        );
-    else
-        util::check(
-                desc.type() == IndexDescriptorImpl::Type::ROWCOUNT,
-                "Index mismatch, cannot update a timeseries with a non-timeseries-indexed frame"
-        );
-}
 
 /// Represents all slices which are intersecting (but not overlapping) with range passed to update
 /// First member is a vector of all segments intersecting with the first row-slice of the update range
@@ -418,25 +483,6 @@ VersionedItem delete_range_impl(
     return versioned_item;
 }
 
-void check_update_data_is_sorted(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
-    bool is_time_series = std::holds_alternative<stream::TimeseriesIndex>(frame.index);
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(
-            is_time_series, "When calling update, the input data must be a time series."
-    );
-    bool input_data_is_sorted =
-            frame.desc().sorted() == SortedValue::ASCENDING || frame.desc().sorted() == SortedValue::UNKNOWN;
-    // If changing this error message, the corresponding message in _normalization.py::restrict_data_to_date_range_only
-    // should also be updated
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(
-            input_data_is_sorted, "When calling update, the input data must be sorted."
-    );
-    bool existing_data_is_sorted = index_segment_reader.sorted() == SortedValue::ASCENDING ||
-                                   index_segment_reader.sorted() == SortedValue::UNKNOWN;
-    sorting::check<ErrorCode::E_UNSORTED_DATA>(
-            existing_data_is_sorted, "When calling update, the existing data must be sorted."
-    );
-}
-
 struct UpdateRanges {
     IndexRange front;
     IndexRange back;
@@ -469,23 +515,6 @@ static UpdateRanges compute_update_ranges(
                 return {};
             }
     );
-}
-
-static void check_can_update(
-        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
-        bool dynamic_schema, bool empty_types
-) {
-    util::check(
-            update_info.previous_index_key_.has_value(),
-            "Cannot update as there is no previous index key to update into"
-    );
-    util::check_rte(!index_segment_reader.is_pickled(), "Cannot update pickled data");
-    check_index_match(frame.index, index_segment_reader.tsd().index());
-    const auto index_desc = index_segment_reader.tsd().index();
-    util::check(index::is_timeseries_index(index_desc), "Update not supported for non-timeseries indexes");
-    check_update_data_is_sorted(frame, index_segment_reader);
-    (void)check_and_mark_slices(index_segment_reader, false, std::nullopt);
-    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame, empty_types);
 }
 
 static std::shared_ptr<std::vector<SliceAndKey>> get_keys_affected_by_update(
@@ -557,6 +586,10 @@ folly::Future<AtomKey> async_update_impl(
                         update_info.previous_index_key_->version_id()
                 );
                 frame->set_bucketize_dynamic(index_segment_reader.bucketize_dynamic());
+                // This also checks that types are compatible, so create with a dummy row-count here, and then modify
+                // the row count later once it is known. This avoids orphaning data keys if this function throws
+                // because of incompatible schemas
+                auto tsd = index::get_merged_tsd(1, dynamic_schema, index_segment_reader.tsd(), frame);
                 return slice_and_write(
                                frame,
                                get_slicing_policy(options, *frame),
@@ -569,8 +602,8 @@ folly::Future<AtomKey> async_update_impl(
                                     query,
                                     frame,
                                     dynamic_schema,
-                                    index_segment_reader = std::move(index_segment_reader
-                                    )](std::vector<SliceAndKey>&& new_slice_and_keys) mutable {
+                                    index_segment_reader = std::move(index_segment_reader),
+                                    tsd = std::move(tsd)](std::vector<SliceAndKey>&& new_slice_and_keys) mutable {
                             std::sort(std::begin(new_slice_and_keys), std::end(new_slice_and_keys));
                             auto affected_keys =
                                     get_keys_affected_by_update(index_segment_reader, *frame, query, dynamic_schema);
@@ -602,7 +635,7 @@ folly::Future<AtomKey> async_update_impl(
                                                 affected_keys = std::move(affected_keys),
                                                 index_segment_reader = std::move(index_segment_reader),
                                                 frame,
-                                                dynamic_schema,
+                                                tsd = std::move(tsd),
                                                 update_info,
                                                 store](IntersectingSegments&& intersecting_segments) mutable {
                                         auto [flattened_slice_and_keys, row_count] = get_slice_and_keys_for_update(
@@ -612,9 +645,7 @@ folly::Future<AtomKey> async_update_impl(
                                                 std::move(intersecting_segments),
                                                 std::move(*new_slice_and_keys_ptr)
                                         );
-                                        auto tsd = index::get_merged_tsd(
-                                                row_count, dynamic_schema, index_segment_reader.tsd(), frame
-                                        );
+                                        tsd.set_total_rows(row_count);
                                         return index::write_index(
                                                 index_type_from_descriptor(tsd.as_stream_descriptor()),
                                                 std::move(tsd),

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -181,13 +181,9 @@ void check_update_data_is_sorted(const InputFrame& frame, const index::IndexSegm
 }
 
 static void check_can_append(
-        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
+        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader,
         const WriteOptions& write_options, bool validate_index, bool empty_types
 ) {
-    util::check(
-            update_info.previous_index_key_.has_value(),
-            "Cannot append as there is no previous index key to append into"
-    );
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
     fix_descriptor_mismatch_or_throw(APPEND, write_options.dynamic_schema, index_segment_reader, frame, empty_types);
     if (validate_index) {
@@ -216,13 +212,9 @@ static void check_can_append(
 }
 
 static void check_can_update(
-        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, const UpdateInfo& update_info,
-        bool dynamic_schema, bool empty_types
+        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, bool dynamic_schema,
+        bool empty_types
 ) {
-    util::check(
-            update_info.previous_index_key_.has_value(),
-            "Cannot update as there is no previous index key to update into"
-    );
     util::check_rte(!index_segment_reader.is_pickled(), "Cannot update to pickled data");
     check_index_match(frame.index, index_segment_reader.tsd().index());
     const auto index_desc = index_segment_reader.tsd().index();
@@ -243,9 +235,9 @@ folly::Future<AtomKey> async_append_impl(
     const StreamId stream_id = frame->desc().id();
     ARCTICDB_DEBUG(log::version(), "append stream_id: {} , version_id: {}", stream_id, update_info.next_version_id_);
     auto index_segment_reader = index::get_index_reader(*(update_info.previous_index_key_), store);
+    check_can_append(*frame, index_segment_reader, options, validate_index, empty_types);
     bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
     auto row_offset = index_segment_reader.tsd().total_rows();
-    check_can_append(*frame, index_segment_reader, update_info, options, validate_index, empty_types);
     frame->set_offset(static_cast<ssize_t>(row_offset));
     frame->set_bucketize_dynamic(bucketize_dynamic);
     auto slicing_arg = get_slicing_policy(options, *frame);
@@ -578,7 +570,7 @@ folly::Future<AtomKey> async_update_impl(
             .thenValue([store, update_info, query, frame, options = std::move(options), dynamic_schema, empty_types](
                                index::IndexSegmentReader&& index_segment_reader
                        ) {
-                check_can_update(*frame, index_segment_reader, update_info, dynamic_schema, empty_types);
+                check_can_update(*frame, index_segment_reader, dynamic_schema, empty_types);
                 ARCTICDB_DEBUG(
                         log::version(),
                         "Update versioned dataframe for stream_id: {} , version_id = {}",

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -20,6 +20,7 @@ from arcticdb.version_store.library import Library
 from arcticdb_ext import set_config_int
 import arcticdb_ext.cpp_async as adb_async
 from arcticdb_ext.storage import KeyType
+from arcticdb_ext.exceptions import SchemaException
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.conftest import Marks
 from tests.util.date import DateRange
@@ -543,3 +544,15 @@ def test_all_snapshots_not_loaded_for_tombstoned_as_of(in_memory_store_factory, 
     assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT_REF") == 1
     assert query_stats_operation_count(stats, "Memory_ListObjects", "SNAPSHOT") == 1
     assert query_stats_operation_count(stats, "Memory_GetObject", "SNAPSHOT_REF") == 1
+
+
+@pytest.mark.parametrize("method", ["append", "update"])
+def test_dynamic_schema_incompatible_types_do_not_orphan_data_keys(in_memory_store_factory, clear_query_stats, method):
+    lib = in_memory_store_factory(dynamic_schema=True)
+    sym = "test_dynamic_schema_incompatible_types_do_not_orphan_data_keys"
+    lib.write(sym, pd.DataFrame({"col": [0]}, index=[pd.Timestamp("2026-01-01")]))
+    lt = lib.library_tool()
+    assert len(lt.find_keys(KeyType.TABLE_DATA)) == 1
+    with pytest.raises(SchemaException):
+        getattr(lib, method)(sym, pd.DataFrame({"col": ["hello"]}, index=[pd.Timestamp("2026-01-02")]))
+    assert len(lt.find_keys(KeyType.TABLE_DATA)) == 1


### PR DESCRIPTION
#### Reference Issues/PRs
[12337436632](https://man312219.monday.com/boards/7852509418/pulses/12337436632)

#### What does this implement or fix?
Part of the compatible schema checks for dynamic schema happen in `get_merged_tsd`. Previously, this was called after `slice_and_write`, resulting in orphaned data keys if an exception was then raised.