### PR TITLE
Allow compacting numpy arrays

### DIFF
--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1325,17 +1325,21 @@ void check_can_perform_processing(
             (!read_query.columns && !read_query.row_range &&
              std::holds_alternative<std::monostate>(read_query.row_filter) && read_query.clauses_.empty());
     const bool is_numpy_array = pipeline_context->norm_meta_ && pipeline_context->norm_meta_->has_np();
+    // We do not support processing over numpy arrays in general, but compact_data (either directly, or via the
+    // compact_data_inline argument to append[_batch]) must work with numpy arrays as well as Series/DataFrames
+    const bool is_compaction =
+            !read_query.clauses_.empty() && folly::poly_type(*read_query.clauses_.front()) == typeid(CompactDataClause);
     if (!is_query_empty) {
-        // Exception for filterig pickled data is skipped for now for backward compatibility
+        // Exception for filtering pickled data is skipped for now for backward compatibility
         if (pipeline_context->multi_key_) {
             schema::raise<ErrorCode::E_OPERATION_NOT_SUPPORTED_WITH_RECURSIVE_NORMALIZED_DATA>(
                     "Cannot perform processing such as row/column filtering, projection, aggregation, resampling, "
                     "etc.. on recursively normalized data"
             );
-        } else if (is_numpy_array) {
+        } else if (is_numpy_array && !is_compaction) {
             schema::raise<ErrorCode::E_OPERATION_NOT_SUPPORTED_WITH_NUMPY_ARRAY>(
                     "Cannot perform processing such as row/column filtering, projection, aggregation, resampling, "
-                    "etc.. on recursively numpy array"
+                    "etc.. on numpy array"
             );
         }
     }

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -591,6 +591,17 @@ def test_compact_recursively_normalized_data(lmdb_version_store_v1):
     assert "recursive" in str(e.value) and sym in str(e.value)
 
 
+def test_compact_numpy_arrays(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    sym = "test_compact_numpy_arrays"
+    lib.write(sym, np.arange(10))
+    lib.append(sym, np.arange(10, 20))
+    assert (lib.read(sym).data == np.arange(20)).all()
+    lib.compact_data(sym)
+    assert (lib.read(sym).data == np.arange(20)).all()
+    assert len(lib.read_index(sym)) == 1
+
+
 @pytest.mark.parametrize(
     "first_type", ["uint8", "uint16", "uint32", "uint64", "int8", "int16", "int32", "int64", "float32", "float64"]
 )


### PR DESCRIPTION
#### What does this implement or fix?
Make `compact_data` work with fragmented numpy arrays