### PR TITLE
Bound memory used in column stats creation

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -406,6 +406,7 @@ set(arcticdb_srcs
         util/preprocess.hpp
         util/ranges_from_future.hpp
         util/regex_filter.hpp
+        util/segment_residency_tracker.hpp
         util/simple_string_hash.hpp
         util/slab_allocator.hpp
         util/sparse_utils.hpp
@@ -1145,6 +1146,7 @@ if(${TEST})
             util/test/segment_generation_utils.hpp
             util/test/segment_generation_utils.cpp
             version/test/test_append.cpp
+            version/test/test_column_stats.cpp
             version/test/test_key_block.cpp
             version/test/test_sort_index.cpp
             version/test/test_sorting_info_state_machine.cpp

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -468,6 +468,17 @@ class AsyncStore : public Store {
         );
     }
 
+    std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)> make_uncompressed_reader(
+            std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
+    ) override {
+        return [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
+            const auto key = ranges_and_key.key_;
+            return read_and_continue(
+                    key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+            );
+        };
+    }
+
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {
         std::vector<folly::Future<bool>> res;
         res.reserve(keys.size());

--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <arcticdb/async/tasks.hpp>
+#include <arcticdb/util/segment_residency_tracker.hpp>
 
 namespace arcticdb::async {
 
@@ -50,6 +51,7 @@ pipelines::SegmentAndSlice DecodeSliceTask::decode_into_slice(storage::KeySegmen
     SegmentInMemory segment_in_memory(std::move(descriptor));
     decode_into_memory_segment(seg, hdr, segment_in_memory, desc);
     segment_in_memory.set_row_data(std::max(segment_in_memory.row_count() - 1, ranges_and_key_.row_range().diff() - 1));
+    util::SegmentResidencyTracker::instance().on_segment_resident();
     return pipelines::SegmentAndSlice(std::move(ranges_and_key_), std::move(segment_in_memory));
 }
 } // namespace arcticdb::async

--- a/cpp/arcticdb/processing/component_manager.cpp
+++ b/cpp/arcticdb/processing/component_manager.cpp
@@ -9,6 +9,7 @@
 #include <atomic>
 
 #include <arcticdb/processing/component_manager.hpp>
+#include <arcticdb/util/segment_residency_tracker.hpp>
 
 namespace arcticdb {
 
@@ -27,6 +28,7 @@ void ComponentManager::decrement_entity_fetch_count(EntityId id) {
         // shared_mutex, so just decrement the ref count of the only sizeable component, so that when the shared pointer
         // goes out of scope in the calling function, the memory is freed
         registry_.get<std::shared_ptr<SegmentInMemory>>(id).reset();
+        util::SegmentResidencyTracker::instance().on_segment_released();
         ARCTICDB_DEBUG(log::memory(), "Releasing entity {}", id);
         ARCTICDB_DEBUG_CHECK(
                 ErrorCode::E_ASSERTION_FAILURE,

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -73,6 +73,12 @@ struct StreamSource {
             std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
     ) = 0;
 
+    virtual std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)>
+    make_uncompressed_reader(std::shared_ptr<std::unordered_set<std::string>> /*columns_to_decode*/
+    ) {
+        util::raise_rte("make_uncompressed_reader not implemented");
+    }
+
     virtual folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(
             const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}
     ) = 0;

--- a/cpp/arcticdb/util/segment_residency_tracker.hpp
+++ b/cpp/arcticdb/util/segment_residency_tracker.hpp
@@ -1,0 +1,54 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace arcticdb::util {
+
+// Test-only instrumentation for the number of decoded segments resident in the ComponentManager at once.
+class SegmentResidencyTracker {
+  public:
+    static SegmentResidencyTracker& instance() {
+        static SegmentResidencyTracker tracker;
+        return tracker;
+    }
+
+    void set_enabled(bool enabled) { enabled_.store(enabled, std::memory_order_relaxed); }
+
+    void reset() {
+        live_.store(0, std::memory_order_relaxed);
+        high_water_.store(0, std::memory_order_relaxed);
+    }
+
+    void on_segment_resident() {
+        if (!enabled_.load(std::memory_order_relaxed))
+            return;
+        const auto now = live_.fetch_add(1, std::memory_order_relaxed) + 1;
+        auto prev = high_water_.load(std::memory_order_relaxed);
+        while (now > prev && !high_water_.compare_exchange_weak(prev, now, std::memory_order_relaxed)) {
+        }
+    }
+
+    void on_segment_released() {
+        if (!enabled_.load(std::memory_order_relaxed))
+            return;
+        live_.fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    int64_t high_water() const { return high_water_.load(std::memory_order_relaxed); }
+
+  private:
+    std::atomic<bool> enabled_{false};
+    std::atomic<int64_t> live_{0};
+    std::atomic<int64_t> high_water_{0};
+};
+
+} // namespace arcticdb::util

--- a/cpp/arcticdb/version/test/test_column_stats.cpp
+++ b/cpp/arcticdb/version/test/test_column_stats.cpp
@@ -1,0 +1,383 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/version/version_store_api.hpp>
+#include <arcticdb/version/version_core.hpp>
+#include <arcticdb/stream/test/stream_test_common.hpp>
+#include <arcticdb/util/test/generators.hpp>
+#include <arcticdb/pipeline/column_stats.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
+#include <arcticdb/pipeline/slicing.hpp>
+#include <arcticdb/pipeline/query.hpp>
+#include <arcticdb/util/segment_residency_tracker.hpp>
+#include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/variant.hpp>
+#include <arcticdb/processing/clause_utils.hpp>
+#include <arcticdb/async/task_scheduler.hpp>
+
+namespace arcticdb {
+
+namespace {
+constexpr auto PROCESSING_UNITS_BOUND_KEY = "VersionStore.NumProcessingUnitsLive";
+
+void write_sliced_symbol(
+        version_store::PythonVersionStore& pvs, const StreamId& stream_id, size_t num_cols, size_t num_rows,
+        size_t col_per_slice, size_t row_per_slice
+) {
+    // FieldRef holds a string_view into the name, so the name storage must outlive frame construction.
+    std::vector<std::string> names;
+    names.reserve(num_cols);
+    std::vector<entity::FieldRef> fields;
+    fields.reserve(num_cols);
+    for (size_t i = 0; i < num_cols; ++i) {
+        names.emplace_back(fmt::format("col_{}", i));
+        fields.emplace_back(entity::scalar_field(entity::DataType::FLOAT64, names[i]));
+    }
+    auto frame = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, 0);
+    pipelines::SlicingPolicy slicing = pipelines::FixedSlicer{col_per_slice, row_per_slice};
+    pipelines::IndexPartialKey pk{stream_id, 0};
+    auto store = pvs._test_get_store();
+    auto key = pipelines::write_frame(std::move(pk), frame.frame_, slicing, store).get();
+    pvs.write_version_and_prune_previous(false, key, std::nullopt);
+}
+
+struct ResidencyGuard {
+    ResidencyGuard() {
+        util::SegmentResidencyTracker::instance().reset();
+        util::SegmentResidencyTracker::instance().set_enabled(true);
+    }
+    ~ResidencyGuard() { util::SegmentResidencyTracker::instance().set_enabled(false); }
+};
+
+// Runs create_column_stats with admission ceiling k and returns the peak number of resident segments.
+int64_t high_water_for_create_column_stats(
+        version_store::PythonVersionStore& pvs, const StreamId& stream_id, ColumnStats column_stats, int64_t k
+) {
+    ScopedConfig config_guard{PROCESSING_UNITS_BOUND_KEY, k};
+    ResidencyGuard residency_guard;
+    pvs.create_column_stats_version(stream_id, column_stats, VersionQuery{});
+    return util::SegmentResidencyTracker::instance().high_water();
+}
+} // namespace
+
+struct ColumnStatsStoreTest : TestStore {
+  protected:
+    std::string get_name() override { return "test.column_stats"; }
+};
+
+TEST_F(ColumnStatsStoreTest, ResidencyBoundedByAdmission) {
+    const StreamId stream_id{"bounded"};
+    const size_t num_cols = 4;
+    const size_t col_per_slice = 2;
+    const size_t num_rows = 40;
+    const size_t row_per_slice = 2;
+    const size_t max_unit_size = num_cols / col_per_slice; // column slices per row slice
+    const size_t num_segments = (num_rows / row_per_slice) * max_unit_size;
+    const int64_t k = 2;
+
+    write_sliced_symbol(*test_store_, stream_id, num_cols, num_rows, col_per_slice, row_per_slice);
+
+    ColumnStats column_stats{
+            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
+    };
+
+    const int64_t high_water_mark = high_water_for_create_column_stats(*test_store_, stream_id, column_stats, k);
+
+    ASSERT_GT(num_segments, static_cast<size_t>(k) * max_unit_size);
+    EXPECT_GE(high_water_mark, static_cast<int64_t>(max_unit_size));
+    EXPECT_LE(high_water_mark, static_cast<int64_t>(k * max_unit_size));
+}
+
+namespace {
+
+// Builds num_units processing units of unit_size segments each.
+std::shared_ptr<version_store::ProcessingUnitAdmissionHandler> make_admission_handler(
+        size_t num_units, size_t unit_size, size_t k, std::vector<int>& fire_count,
+        std::vector<folly::Promise<pipelines::SegmentAndSlice>>& kept
+) {
+    using namespace arcticdb::pipelines;
+    std::vector<RangesAndKey> ranges;
+    std::vector<std::vector<size_t>> units;
+    for (size_t u = 0; u < num_units; ++u) {
+        std::vector<size_t> unit;
+        for (size_t c = 0; c < unit_size; ++c) {
+            const size_t idx = ranges.size();
+            ranges.emplace_back(RowRange{idx, idx + 1}, ColRange{0, 1}, entity::AtomKey{});
+            unit.push_back(idx);
+        }
+        units.push_back(std::move(unit));
+    }
+    fire_count.assign(num_units * unit_size, 0);
+    version_store::SegmentReader reader = [&fire_count, &kept](RangesAndKey&& rk) {
+        ++fire_count.at(rk.row_range().first);
+        kept.emplace_back();
+        return kept.back().getFuture();
+    };
+    return std::make_shared<version_store::ProcessingUnitAdmissionHandler>(std::move(reader), std::move(ranges), std::move(units), k);
+}
+} // namespace
+
+TEST(ProcessingUnitAdmissionHandlerTest, FiresAtMostKUnitsThenAdvancesOnCompletion) {
+    const size_t num_units = 5;
+    const size_t unit_size = 2;
+    const size_t k = 2;
+    std::vector<int> fire_count;
+    std::vector<folly::Promise<pipelines::SegmentAndSlice>> kept;
+    auto admission = make_admission_handler(num_units, unit_size, k, fire_count, kept);
+
+    admission->admit_initial(k);
+    // Only the first k units are fired up front.
+    for (size_t i = 0; i < num_units * unit_size; ++i) {
+        EXPECT_EQ(fire_count.at(i), i < k * unit_size ? 1 : 0) << "index " << i << " after admit_initial";
+    }
+
+    // Each completion admits exactly one further unit, in order.
+    for (size_t completed = 0; completed < num_units; ++completed) {
+        admission->on_unit_complete();
+        const size_t expected_fired = std::min(k + completed + 1, num_units) * unit_size;
+        for (size_t i = 0; i < num_units * unit_size; ++i) {
+            EXPECT_EQ(fire_count.at(i), i < expected_fired ? 1 : 0)
+                    << "index " << i << " after " << completed + 1 << " completions";
+        }
+    }
+
+    // Extra completions are no-ops
+    admission->on_unit_complete();
+    for (auto count : fire_count) {
+        EXPECT_EQ(count, 1);
+    }
+}
+
+// A segment referenced by two units is loaded once, even though both units are admitted.
+TEST(ProcessingUnitAdmissionHandlerTest, SharedSegmentFiredOnce) {
+    using namespace arcticdb::pipelines;
+    std::vector<RangesAndKey> ranges;
+    for (size_t i = 0; i < 3; ++i) {
+        ranges.emplace_back(RowRange{i, i + 1}, ColRange{0, 1}, entity::AtomKey{});
+    }
+    std::vector<std::vector<size_t>> units{{0, 1}, {1, 2}}; // segment 1 shared
+
+    std::vector<int> fire_count(3, 0);
+    std::vector<folly::Promise<SegmentAndSlice>> kept;
+    version_store::SegmentReader reader = [&fire_count, &kept](RangesAndKey&& rk) {
+        ++fire_count.at(rk.row_range().first);
+        kept.emplace_back();
+        return kept.back().getFuture();
+    };
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader), std::move(ranges), std::move(units), /*k=*/2
+    );
+
+    admission->admit_initial(2);
+    EXPECT_EQ(fire_count.at(0), 1);
+    EXPECT_EQ(fire_count.at(1), 1); // shared, fired once despite two referencing units
+    EXPECT_EQ(fire_count.at(2), 1);
+}
+
+namespace {
+// One IO and one CPU thread, restored on destruction. Mirrors the Python tiny_thread_pool fixture.
+struct TinyThreadPool {
+    TinyThreadPool() {
+        ConfigsMap::instance()->set_int("VersionStore.NumIOThreads", 1);
+        ConfigsMap::instance()->set_int("VersionStore.NumCPUThreads", 1);
+        async::TaskScheduler::reattach_instance();
+    }
+    ~TinyThreadPool() {
+        ConfigsMap::instance()->unset_int("VersionStore.NumIOThreads");
+        ConfigsMap::instance()->unset_int("VersionStore.NumCPUThreads");
+        async::TaskScheduler::reattach_instance();
+    }
+};
+} // namespace
+
+// Overlapping units with a ceiling of 1, driven through real IO/CPU pools (one thread each): the first unit loads the
+// shared segment; the second is admitted only when the first completes, and it does not reload the shared segment.
+// Reaching .get() proves the admit -> process -> advance loop does not deadlock under a constrained pool. This is the
+// case that does not arise from structure_by_row_slice (column stats), so it has no integration coverage.
+TEST(ProcessingUnitAdmissionHandlerTest, OverlappingUnitsAdvanceWithCeilingOne) {
+    using namespace arcticdb::pipelines;
+    TinyThreadPool tiny_pool;
+
+    const std::vector<std::vector<size_t>> units{{0, 1}, {1, 2}}; // segment 1 shared between the two units
+    const size_t num_segments = 3;
+
+    std::vector<RangesAndKey> ranges;
+    for (size_t i = 0; i < num_segments; ++i) {
+        ranges.emplace_back(RowRange{i, i + 1}, ColRange{0, 1}, entity::AtomKey{});
+    }
+
+    std::vector<std::atomic<int>> fire_count(num_segments);
+    for (auto& count : fire_count) {
+        count.store(0);
+    }
+
+    // Each read runs on the IO pool and returns a trivial decoded segment, so unit completion genuinely hops IO -> CPU.
+    version_store::SegmentReader reader = [&fire_count](RangesAndKey&& rk) {
+        const auto idx = rk.row_range().first;
+        return folly::via(&async::io_executor(), [&fire_count, idx, rk = std::move(rk)]() mutable {
+            fire_count[idx].fetch_add(1, std::memory_order_relaxed);
+            return SegmentAndSlice(std::move(rk), SegmentInMemory{});
+        });
+    };
+
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader), std::move(ranges), std::vector<std::vector<size_t>>(units), /*k=*/1
+    );
+
+    // Mirror schedule_first_iteration: split the shared segment's future, then build one future per unit that processes
+    // on the CPU pool and advances admission on completion.
+    auto segment_futures = admission->futures();
+    std::vector<EntityFetchCount> fetch_counts{1, 2, 1}; // segment 1 is referenced by both units
+    auto splitters = split_futures(std::move(segment_futures), fetch_counts);
+
+    std::vector<folly::Future<folly::Unit>> unit_futures;
+    for (const auto& unit : units) {
+        std::vector<folly::Future<SegmentAndSlice>> local;
+        for (auto i : unit) {
+            util::variant_match(
+                    splitters.at(i),
+                    [&local](folly::Future<SegmentAndSlice>& fut) { local.emplace_back(std::move(fut)); },
+                    [&local](folly::FutureSplitter<SegmentAndSlice>& splitter) {
+                        local.emplace_back(splitter.getFuture());
+                    }
+            );
+        }
+        unit_futures.emplace_back(folly::collect(local)
+                                          .via(&async::cpu_executor())
+                                          .thenValue([](auto&&) { return folly::Unit{}; })
+                                          .ensure([admission]() { admission->on_unit_complete(); }));
+    }
+
+    auto all_done = folly::collect(unit_futures).via(&async::io_executor());
+    admission->admit_initial(1);
+    std::move(all_done).get(); // hangs (test times out) if the admit chain deadlocks under the 1+1 pool
+
+    EXPECT_EQ(fire_count.at(0).load(), 1);
+    EXPECT_EQ(fire_count.at(1).load(), 1); // shared, loaded exactly once despite two referencing units
+    EXPECT_EQ(fire_count.at(2).load(), 1);
+}
+
+// Static schema with column_group_size changed between the initial write and a later append, so the appended row slices
+// have a different number of column slices than the original ones. The processing units therefore have different sizes,
+// and the bound must use the max across units to avoid deadlock.
+TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnits) {
+    using namespace arcticdb::pipelines;
+
+    const std::array fields{
+            scalar_field(entity::DataType::FLOAT64, "col_0"),
+            scalar_field(entity::DataType::FLOAT64, "col_1"),
+            scalar_field(entity::DataType::FLOAT64, "col_2"),
+            scalar_field(entity::DataType::FLOAT64, "col_3")
+    };
+
+    arcticdb::proto::storage::VersionStoreConfig cfg;
+    cfg.mutable_write_options()->set_segment_row_size(2);
+    cfg.mutable_write_options()->set_column_group_size(2); // 4 cols -> 2 column slices per row slice
+    auto engine = get_test_engine<version_store::PythonVersionStore>({cfg});
+
+    const StreamId stream_id{"uneven"};
+    const size_t num_rows = 8;
+
+    auto initial = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, 0);
+    engine.write_versioned_dataframe_internal(stream_id, std::move(initial.frame_), false, false, false);
+
+    // Widen the column group so the appended row slices hold all 4 cols in a single column slice (unit size 1), whereas
+    // the original row slices have 2 column slices (unit size 2).
+    auto wide_cfg = engine.cfg();
+    wide_cfg.mutable_write_options()->set_column_group_size(4);
+    engine.configure(std::move(wide_cfg));
+
+    auto appended = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, num_rows);
+    engine.append_internal(stream_id, std::move(appended.frame_), false, false, false);
+
+    // Confirm the slicing: 4 original row slices x 2 column slices + 4 appended row slices x 1 column
+    // slice = 12 data segments. A uniform layout would have 16
+    size_t data_segments = 0;
+    engine._test_get_store()->iterate_type(KeyType::TABLE_DATA, [&data_segments](VariantKey&&) { ++data_segments; });
+    ASSERT_EQ(data_segments, 12u);
+
+    ColumnStats column_stats{
+            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
+    };
+
+    const int64_t k = 2;
+    const size_t max_unit_size = 2; // original row slices span 2 column slices; appended ones span 1
+    const int64_t bound = k * static_cast<int64_t>(max_unit_size);
+
+    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, column_stats, k);
+
+    EXPECT_GT(high_water, 0);
+    EXPECT_LE(high_water, bound);
+
+    auto info = engine.get_column_stats_info_version(stream_id, VersionQuery{});
+    const std::unordered_map<std::string, std::unordered_set<std::string>> expected{
+            {"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}
+    };
+    EXPECT_EQ(info.to_map(), expected);
+}
+
+// As above but with the wider column slice written first, so the largest processing units are the appended (later) row
+// slices.
+TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnitsWiderFirst) {
+    using namespace arcticdb::pipelines;
+
+    const std::array fields{
+            scalar_field(entity::DataType::FLOAT64, "col_0"),
+            scalar_field(entity::DataType::FLOAT64, "col_1"),
+            scalar_field(entity::DataType::FLOAT64, "col_2"),
+            scalar_field(entity::DataType::FLOAT64, "col_3")
+    };
+
+    arcticdb::proto::storage::VersionStoreConfig cfg;
+    cfg.mutable_write_options()->set_segment_row_size(2);
+    cfg.mutable_write_options()->set_column_group_size(4); // 4 cols -> 1 column slice per row slice
+    auto engine = get_test_engine<version_store::PythonVersionStore>({cfg});
+
+    const StreamId stream_id{"uneven_wider_first"};
+    const size_t num_rows = 8;
+
+    auto initial = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, 0);
+    engine.write_versioned_dataframe_internal(stream_id, std::move(initial.frame_), false, false, false);
+
+    // Narrow the column group so the appended row slices have 2 column slices (unit size 2), whereas the original row
+    // slices have 1 (unit size 1).
+    auto narrow_cfg = engine.cfg();
+    narrow_cfg.mutable_write_options()->set_column_group_size(2);
+    engine.configure(std::move(narrow_cfg));
+
+    auto appended = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, num_rows);
+    engine.append_internal(stream_id, std::move(appended.frame_), false, false, false);
+
+    // 4 original row slices x 1 column slice + 4 appended row slices x 2 column slices = 12 data segments.
+    size_t data_segments = 0;
+    engine._test_get_store()->iterate_type(KeyType::TABLE_DATA, [&data_segments](VariantKey&&) { ++data_segments; });
+    ASSERT_EQ(data_segments, 12u);
+
+    ColumnStats column_stats{
+            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
+    };
+
+    const int64_t k = 2;
+    const size_t max_unit_size = 2; // appended row slices span 2 column slices; original ones span 1
+    const int64_t bound = k * static_cast<int64_t>(max_unit_size);
+
+    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, column_stats, k);
+
+    EXPECT_GT(high_water, 0);
+    EXPECT_LE(high_water, bound);
+
+    auto info = engine.get_column_stats_info_version(stream_id, VersionQuery{});
+    const std::unordered_map<std::string, std::unordered_set<std::string>> expected{
+            {"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}
+    };
+    EXPECT_EQ(info.to_map(), expected);
+}
+
+} // namespace arcticdb

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -40,7 +40,10 @@
 #include <arcticdb/processing/component_manager.hpp>
 #include <arcticdb/util/collection_utils.hpp>
 #include <arcticdb/util/format_date.hpp>
+#include <atomic>
+#include <functional>
 #include <iterator>
+#include <optional>
 #include <aws/core/utils/stream/ResponseStream.h>
 
 namespace arcticdb::version_store {
@@ -759,13 +762,18 @@ get_entity_ids_and_position_map(
     return std::make_pair(std::move(entity_work_units), std::move(id_to_pos));
 }
 
+// Presence of this request on the read path turns on processing-unit admission (see ProcessingUnitAdmissionHandler) to
+// control memory use. Default-absent so every other read keeps the eager folly::window behaviour. At time of writing
+// only used for manual column stats creation as this has to do a full table scan.
+struct ProcessingUnitAdmissionRequest {};
+
 std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_first_iteration(
         std::shared_ptr<ComponentManager> component_manager, size_t num_segments,
         std::vector<std::vector<EntityId>>&& entities_by_work_unit,
         std::shared_ptr<std::vector<EntityFetchCount>>&& segment_fetch_counts,
         std::vector<FutureOrSplitter>&& segment_and_slice_future_splitters,
         std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>&& id_to_pos,
-        std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses
+        std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses, std::shared_ptr<ProcessingUnitAdmissionHandler> admission
 ) {
     // Used to make sure each entity is only added into the component manager once
     auto slice_added_mtx = std::make_shared<std::vector<std::mutex>>(num_segments);
@@ -792,34 +800,39 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
 
         // Switch to the CPU executor for reasons detailed in the PR description
         // https://github.com/man-group/ArcticDB/pull/3086
-        futures->emplace_back(folly::collect(local_futs)
-                                      .via(&async::cpu_executor())
-                                      .thenValueInline([component_manager,
-                                                        segment_fetch_counts,
-                                                        id_to_pos,
-                                                        slice_added_mtx,
-                                                        slice_added,
-                                                        clauses,
-                                                        entity_ids = std::move(entity_ids
-                                                        )](std::vector<pipelines::SegmentAndSlice>&& segment_and_slices
-                                                       ) mutable {
-                                          for (auto&& [idx, segment_and_slice] : folly::enumerate(segment_and_slices)) {
-                                              auto entity_id = entity_ids[idx];
-                                              auto pos = id_to_pos->at(entity_id);
-                                              std::lock_guard lock{slice_added_mtx->at(pos)};
-                                              if (!(*slice_added)[pos]) {
-                                                  ARCTICDB_DEBUG(log::version(), "Adding entity {}", entity_id);
-                                                  add_slice_to_component_manager(
-                                                          entity_id,
-                                                          segment_and_slice,
-                                                          component_manager,
-                                                          segment_fetch_counts->at(pos)
-                                                  );
-                                                  (*slice_added)[pos] = true;
-                                              }
-                                          }
-                                          return async::MemSegmentProcessingTask(*clauses, std::move(entity_ids))();
-                                      }));
+        auto processing_fut =
+                folly::collect(local_futs)
+                        .via(&async::cpu_executor())
+                        .thenValueInline([component_manager,
+                                          segment_fetch_counts,
+                                          id_to_pos,
+                                          slice_added_mtx,
+                                          slice_added,
+                                          clauses,
+                                          entity_ids = std::move(entity_ids
+                                          )](std::vector<pipelines::SegmentAndSlice>&& segment_and_slices) mutable {
+                            for (auto&& [idx, segment_and_slice] : folly::enumerate(segment_and_slices)) {
+                                auto entity_id = entity_ids[idx];
+                                auto pos = id_to_pos->at(entity_id);
+                                std::lock_guard lock{slice_added_mtx->at(pos)};
+                                if (!(*slice_added)[pos]) {
+                                    ARCTICDB_DEBUG(log::version(), "Adding entity {}", entity_id);
+                                    add_slice_to_component_manager(
+                                            entity_id,
+                                            segment_and_slice,
+                                            component_manager,
+                                            segment_fetch_counts->at(pos)
+                                    );
+                                    (*slice_added)[pos] = true;
+                                }
+                            }
+                            return async::MemSegmentProcessingTask(*clauses, std::move(entity_ids))();
+                        });
+        if (admission) {
+            // Make sure we always mark a unit complete even if it fails, so we don't block loading the next one.
+            processing_fut = std::move(processing_fut).ensure([admission]() { admission->on_unit_complete(); });
+        }
+        futures->emplace_back(std::move(processing_fut));
     }
     return futures;
 }
@@ -871,7 +884,7 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
         std::shared_ptr<ComponentManager> component_manager,
         std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
         std::vector<std::vector<size_t>>&& processing_unit_indexes,
-        std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
+        std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses, std::shared_ptr<ProcessingUnitAdmissionHandler> admission
 ) {
     // All the shared pointers as arguments to this function and created within it are to ensure that resources are
     // correctly kept alive after this function returns its future
@@ -899,7 +912,8 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
             std::move(segment_fetch_counts),
             std::move(segment_and_slice_future_splitters),
             std::move(entity_id_to_segment_pos),
-            clauses
+            clauses,
+            std::move(admission)
     );
 
     return folly::collect(*futures).via(&async::io_executor()).thenValueInline([clauses](auto&& entity_ids_vec) {
@@ -1166,10 +1180,30 @@ static void generate_output_schema_and_save_to_pipeline(
     pipeline_context.default_values_ = std::forward<decltype(default_values)>(default_values);
 }
 
+// Number of processing units allowed in flight at once during column-stats admission.
+// Always >= 1 and <= number of processing units.
+size_t column_stats_admission_units(const std::vector<std::vector<size_t>>& processing_unit_indexes) {
+    size_t max_unit_size = 0;
+    for (const auto& unit : processing_unit_indexes) {
+        max_unit_size = std::max(max_unit_size, unit.size());
+    }
+    if (max_unit_size == 0) {
+        return 1;
+    }
+    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
+    // default_processing_units_limit = ceil(2*io_thread_count / max_unit_size), so ~ 2*io_thread_count segments
+    const int64_t default_processing_units_limit =
+            (2 * io_thread_count + static_cast<int64_t>(max_unit_size) - 1) / static_cast<int64_t>(max_unit_size);
+    const int64_t configured =
+            ConfigsMap::instance()->get_int("VersionStore.NumProcessingUnitsLive", default_processing_units_limit);
+    return static_cast<size_t>(std::max<int64_t>(1, configured));
+}
+
 folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
         const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
-        std::shared_ptr<ComponentManager> component_manager
+        std::shared_ptr<ComponentManager> component_manager,
+        std::optional<ProcessingUnitAdmissionRequest> admission_request = std::nullopt
 ) {
     const ProcessingConfig processing_config{
             opt_false(read_options.dynamic_schema()),
@@ -1194,17 +1228,43 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
     }
 
-    // Start reading as early as possible
-    auto segment_and_slice_futures =
-            generate_segment_and_slice_futures(store, pipeline_context, processing_config, std::move(ranges_and_keys));
+    std::shared_ptr<ProcessingUnitAdmissionHandler> admission;
+    std::vector<folly::Future<pipelines::SegmentAndSlice>> segment_and_slice_futures;
+    size_t max_admitted_processing_units = 0;
+    if (admission_request) {
+        max_admitted_processing_units = column_stats_admission_units(processing_unit_indexes);
+        auto incomplete_bitset = get_incompletes_bitset(ranges_and_keys);
+        admission = std::make_shared<ProcessingUnitAdmissionHandler>(
+                store->make_uncompressed_reader(columns_to_decode(pipeline_context)),
+                std::move(ranges_and_keys),
+                std::vector(processing_unit_indexes),
+                max_admitted_processing_units
+        );
+        segment_and_slice_futures = add_schema_check(
+                pipeline_context, admission->futures(), std::move(incomplete_bitset), processing_config
+        );
+    } else {
+        // Start reading as early as possible
+        segment_and_slice_futures = generate_segment_and_slice_futures(
+                store, pipeline_context, processing_config, std::move(ranges_and_keys)
+        );
+    }
 
-    return schedule_clause_processing(
-                   component_manager,
-                   std::move(segment_and_slice_futures),
-                   std::move(processing_unit_indexes),
-                   std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
-    )
-            .via(&async::cpu_executor());
+    auto processed = schedule_clause_processing(
+            component_manager,
+            std::move(segment_and_slice_futures),
+            std::move(processing_unit_indexes),
+            std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_),
+            admission
+    );
+
+    // Fire the first K units' reads only after the release path (.ensure -> on_unit_complete) is set up above, so a
+    // completing unit always admits the next one.
+    if (admission) {
+        admission->admit_initial(max_admitted_processing_units);
+    }
+
+    return std::move(processed).via(&async::cpu_executor());
 }
 
 /*
@@ -1219,10 +1279,13 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
  */
 folly::Future<std::vector<SliceAndKey>> read_process_and_collect(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
-        const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options
+        const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
+        std::optional<ProcessingUnitAdmissionRequest> admission_request = std::nullopt
 ) {
     auto component_manager = std::make_shared<ComponentManager>();
-    return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
+    return read_and_schedule_processing(
+                   store, pipeline_context, read_query, read_options, component_manager, admission_request
+    )
             .thenValue([component_manager, pipeline_context, read_query](std::vector<EntityId>&& processed_entity_ids) {
                 generate_output_schema_and_save_to_pipeline(*pipeline_context, *read_query);
                 auto proc = gather_entities<
@@ -2029,7 +2092,8 @@ void create_column_stats_impl(
     auto read_query = std::make_shared<ReadQuery>(std::vector{std::make_shared<Clause>(std::move(*clause))});
     read_indexed_keys_to_pipeline(pipeline_context, *read_query, read_options, index_info);
 
-    auto segs = read_process_and_collect(store, pipeline_context, read_query, read_options).get();
+    auto segs =
+            read_process_and_collect(store, pipeline_context, read_query, read_options, ProcessingUnitAdmissionRequest{}).get();
     schema::check<ErrorCode::E_COLUMN_DOESNT_EXIST>(
             !segs.empty(), "Cannot create column stats for nonexistent columns"
     );

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -26,7 +26,14 @@
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/version/version_tasks.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <folly/futures/Future.h>
+#include <folly/futures/Promise.h>
+#include <atomic>
+#include <functional>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace arcticdb::version_store {
 
@@ -102,11 +109,87 @@ folly::Future<std::vector<EntityId>> schedule_remaining_iterations(
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
 );
 
+using SegmentReader = std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)>;
+
+// Bounds memory use by keeping at most K processing units in flight. A unit's reads are launched together
+// (admit), the next unit is admitted when an outstanding one finishes processing (on_unit_complete). Never waits within
+// a unit, so progress holds for any K >= 1 regardless of the processing unit structure (for example, if there is overlap between units).
+// Construct via make_shared (fire captures shared_from_this to keep the controller alive across the async reads).
+class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<ProcessingUnitAdmissionHandler> {
+  public:
+    ProcessingUnitAdmissionHandler(
+            SegmentReader reader, std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
+            std::vector<std::vector<size_t>>&& processing_units, size_t k
+    ) :
+        reader_(std::move(reader)),
+        ranges_and_keys_(std::make_shared<std::vector<pipelines::RangesAndKey>>(std::move(ranges_and_keys))),
+        promises_(std::make_shared<std::vector<folly::Promise<pipelines::SegmentAndSlice>>>(ranges_and_keys_->size())),
+        launched_(std::make_shared<std::vector<std::atomic<bool>>>(ranges_and_keys_->size())),
+        processing_units_(std::move(processing_units)),
+        next_unit_(k) {}
+
+    // Used to chain downstream processing, possibly before any of the work is actually executing.
+    std::vector<folly::Future<pipelines::SegmentAndSlice>> futures() {
+        std::vector<folly::Future<pipelines::SegmentAndSlice>> res;
+        res.reserve(promises_->size());
+        for (auto& promise : *promises_) {
+            res.emplace_back(promise.getFuture());
+        }
+        return res;
+    }
+
+    void admit_initial(const size_t k) {
+        for (size_t u = 0; u < std::min(k, processing_units_.size()); ++u) {
+            admit(u);
+        }
+    }
+
+    void on_unit_complete() {
+        const auto u = next_unit_.fetch_add(1);
+        if (u < processing_units_.size()) {
+            admit(u);
+        }
+    }
+
+  private:
+    // Kick off a unit of work. This will resolve some of the futures and allow them to continue.
+    // A segment may belong to two units (e.g. resample boundaries), so the read must fire at most once.
+    void fire(size_t i) {
+        if (launched_->at(i).exchange(true)) {
+            return;
+        }
+        auto self = shared_from_this();
+        reader_(pipelines::RangesAndKey{ranges_and_keys_->at(i)})
+                .thenTryInline([self, i](folly::Try<pipelines::SegmentAndSlice>&& t) {
+                    self->promises_->at(i).setTry(std::move(t));
+                });
+    }
+
+    // Kick off all units of work within the u-th processing unit.
+    void admit(const size_t u) {
+        for (auto i : processing_units_.at(u)) {
+            fire(i);
+        }
+    }
+
+    SegmentReader reader_;
+    std::shared_ptr<std::vector<pipelines::RangesAndKey>> ranges_and_keys_;
+
+    // We accumulate promises for all processing units up front, but they do not start to execute
+    // until the `fire` call. This lets us set up chains of futures while controlling how many
+    // are actually executing at a given time.
+    std::shared_ptr<std::vector<folly::Promise<pipelines::SegmentAndSlice>>> promises_;
+    std::shared_ptr<std::vector<std::atomic<bool>>> launched_;
+    std::vector<std::vector<size_t>> processing_units_;
+    std::atomic<size_t> next_unit_;
+};
+
 folly::Future<std::vector<EntityId>> schedule_clause_processing(
         std::shared_ptr<ComponentManager> component_manager,
         std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
         std::vector<std::vector<size_t>>&& processing_unit_indexes,
-        std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
+        std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses,
+        std::shared_ptr<ProcessingUnitAdmissionHandler> admission = nullptr
 );
 
 FrameAndDescriptor read_index_impl(const std::shared_ptr<Store>& store, const VersionedItem& version);

--- a/notes.md
+++ b/notes.md
@@ -1,0 +1,63 @@
+## Measurements
+
+Baseline:
+
+```
+(pegasus-adb) aseaton@dlonapatcs502:~/source/ArcticDB-worktree/tree-one/python DEV $ python ./measure_column_stats_memory.py
+baseline VmRSS = 169.5 MiB
+create_column_stats wall = 0.97s
+peak ru_maxrss        = 14496.6 MiB
+peak - baseline       = 14327.1 MiB
+(pegasus-adb) aseaton@dlonapatcs502:~/source/ArcticDB-worktree/tree-one/python DEV $ python ./measure_column_stats_memory.py --zeros
+baseline VmRSS = 169.6 MiB
+create_column_stats wall = 0.84s
+peak ru_maxrss        = 7802.0 MiB
+peak - baseline       = 7632.4 MiB
+```
+
+## Worked example: admission with overlapping units
+
+`on_unit_complete` is wired in `schedule_first_iteration` (version_core.cpp). Each processing unit
+gets one future:
+
+```
+unit_fut = folly::collect(its segment futures)
+             .via(cpu_executor)
+             .thenValueInline(... add segments to ComponentManager; run MemSegmentProcessingTask ...)
+unit_fut = std::move(unit_fut).ensure([admission]{ admission->on_unit_complete(); });
+```
+
+So `on_unit_complete` fires when that unit's `MemSegmentProcessingTask` finishes — i.e. after the
+unit's `ProcessingUnit` is destroyed and its input segments' fetch counts decremented (a shared
+segment is freed only at fetch-count zero). `.ensure` runs on success and failure, so a throwing
+unit still advances the window. Inside, `next_unit_.fetch_add(1)` hands out the next unit index
+atomically and `admit(u)` fires that unit's reads. Admission only ever *submits* IO tasks; it never
+blocks a thread.
+
+### Units `{0,1}, {1,2}` (segment 1 shared), ceiling K=1, tiny thread pool (1 IO, 1 CPU)
+
+`next_unit_` starts at K=1.
+
+1. `admit_initial(1)` admits unit 0 → `fire(0)`, `fire(1)`, each marking `launched_` and submitting
+   a read on the single IO thread. Unit 1 is not admitted, so segment 2 is unfired and unit 1's
+   `collect` is parked on `promise[2]` (and a `FutureSplitter` share of `promise[1]`).
+2. The IO thread decodes segments 0 and 1, fulfilling their promises. Unit 0's `collect` resolves on
+   the CPU thread → both added to the ComponentManager (segment 1 with fetch_count 2, since two
+   units reference it) → `MemSegmentProcessingTask` processes unit 0.
+3. Unit 0's `ProcessingUnit` is destroyed: segment 0 → fetch 0 → freed; **segment 1 → fetch 1, stays
+   resident**. The future resolves, so `.ensure` fires `on_unit_complete` on the CPU thread:
+   `fetch_add` returns 1 → `admit(1)` → `fire(1)` is a no-op (already launched — the dedup) and
+   `fire(2)` submits the one new read.
+4. The IO thread decodes segment 2 → unit 1's `collect` (segment 1 already done, segment 2 now done)
+   resolves → segment 2 added, unit 1 processed → segment 1 → fetch 0 freed, segment 2 freed.
+   `on_unit_complete` fires again: `fetch_add` returns 2, not `< 2`, so no further admit.
+
+No deadlock on the 1+1 pool because nothing blocks: the CPU thread returns after each unit and only
+submits the next reads; the IO thread drains reads sequentially; `.get()` blocks the calling thread,
+not a pool thread. Peak residency is 2 segments (`{0,1}` then `{1,2}`) = `K · max_unit_size`. The
+shared segment 1 carries across the unit0→unit1 boundary, but segment 0 is freed *before* segment 2
+is fired (the free happens inside `MemSegmentProcessingTask`, which precedes `.ensure`), so the bound
+holds. This is the "sharing must be local to the admission window" property: it holds here because
+the co-referencing units are adjacent (true for resample's `i`/`i+1`; column stats' row-slice
+structure never overlaps at all).
+

--- a/python/measure_column_stats_memory.py
+++ b/python/measure_column_stats_memory.py
@@ -1,0 +1,72 @@
+"""Stage B: measure peak RSS for create_column_stats on the symbol written by write_data.py.
+
+Prints VmRSS just before the call (baseline) and ru_maxrss at exit (peak high-water).
+Best run wrapped in `/usr/bin/time -v` as a cross-check.
+"""
+import argparse
+import resource
+import time
+from pathlib import Path
+
+from arcticdb import Arctic
+from arcticdb_ext import set_config_int
+from arcticdb_ext import cpp_async as adb_async
+
+from write_data import LIB_NAME, SYMBOL, SYMBOL_ZEROS, DEFAULT_LMDB
+
+
+def read_vmrss_kb() -> int:
+    with open("/proc/self/status") as f:
+        for line in f:
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1])
+    return -1
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--num-cols", type=int, default=100)
+    p.add_argument("--lmdb-path", default=str(DEFAULT_LMDB))
+    p.add_argument(
+        "--no-cpu-executor",
+        action="store_true",
+        help="set Storage.ProcessOnCpuExecutor=0",
+    )
+    p.add_argument("--io-threads", type=int, default=None)
+    p.add_argument("--cpu-threads", type=int, default=None)
+    p.add_argument("--zeros", action="store_true", help="use the compressible-zeros symbol")
+    args = p.parse_args()
+    symbol = SYMBOL_ZEROS if args.zeros else SYMBOL
+
+    if args.no_cpu_executor:
+        set_config_int("Storage.ProcessOnCpuExecutor", 0)
+    if args.io_threads is not None:
+        set_config_int("VersionStore.NumIOThreads", args.io_threads)
+    if args.cpu_threads is not None:
+        set_config_int("VersionStore.NumCPUThreads", args.cpu_threads)
+    if args.io_threads is not None or args.cpu_threads is not None:
+        adb_async.reinit_task_scheduler()
+
+    ac = Arctic(f"lmdb://{Path(args.lmdb_path)}")
+    lib = ac[LIB_NAME]
+    nvs = lib._nvs
+
+    nvs.drop_column_stats(symbol)
+
+    column_stats = {f"f_{i}": {"MINMAX"} for i in range(args.num_cols)}
+
+    baseline_kb = read_vmrss_kb()
+    print(f"baseline VmRSS = {baseline_kb / 1024:.1f} MiB", flush=True)
+
+    t0 = time.perf_counter()
+    nvs.create_column_stats(symbol, column_stats)
+    dt = time.perf_counter() - t0
+
+    peak_kb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print(f"create_column_stats wall = {dt:.2f}s")
+    print(f"peak ru_maxrss        = {peak_kb / 1024:.1f} MiB")
+    print(f"peak - baseline       = {(peak_kb - baseline_kb) / 1024:.1f} MiB")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -20,8 +20,22 @@ from arcticdb_ext.exceptions import SchemaException, StorageException, UserInput
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
+from arcticdb.util.test import config_context
 
 pytestmark = pytest.mark.pipeline
+
+ADMISSION_KEY = "VersionStore.NumProcessingUnitsLive"
+
+
+def write_many_slices(lib, sym, n_appends):
+    """Writes a symbol of n_appends row slices, each two rows of col_0/col_1/col_2."""
+    base = pd.Timestamp("2000-01-01")
+    for i in range(n_appends):
+        df = pd.DataFrame(
+            {"col_0": [f"a{i}", f"b{i}"], "col_1": [2 * i, 2 * i + 1], "col_2": [i, i + 1]},
+            index=pd.date_range(base + pd.Timedelta(days=2 * i), periods=2),
+        )
+        lib.write(sym, df) if i == 0 else lib.append(sym, df)
 
 
 df0 = pd.DataFrame(
@@ -1323,3 +1337,77 @@ def test_column_stats_drop_tiny_thread_pool(
     lib.drop_column_stats(sym)
     with pytest.raises(StorageException):
         lib.get_column_stats_info(sym)
+
+
+@pytest.mark.parametrize("k", [1, 2, 1000])
+def test_column_stats_create_independent_of_admission_ceiling(
+    version_store_factory, lib_name, encoding_version, any_output_format, k
+):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}_{k}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_admission_ceiling"
+    expected_column_stats = generate_symbol(lib, sym).select(
+        ["start_index", "end_index", "v1_MIN(col_1)", "v1_MAX(col_1)", "v1_MIN(col_2)", "v1_MAX(col_2)"]
+    )
+    column_stats_dict = {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+
+    with config_context(ADMISSION_KEY, k):
+        lib.create_column_stats(sym, column_stats_dict)
+
+    assert lib.get_column_stats_info(sym) == column_stats_dict
+    assert_stats_equal(lib.read_column_stats(sym), expected_column_stats)
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_column_stats_create_admission_tiny_thread_pool(
+    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool, k
+):
+    """Test against deadlock with a small admission limit and single thread pools."""
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}_{k}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_admission_tiny_thread_pool"
+    n_appends = 10
+    write_many_slices(lib, sym, n_appends)
+
+    column_stats_dict = {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+    with config_context(ADMISSION_KEY, k):
+        lib.create_column_stats(sym, column_stats_dict)
+
+    assert lib.get_column_stats_info(sym) == column_stats_dict
+    # One stats row per row slice.
+    assert lib.read_column_stats(sym).num_rows == n_appends
+
+
+def test_column_stats_create_single_unit(version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_single_unit"
+    df = pd.DataFrame({"col_1": [1.0, 3.0]}, index=pd.date_range("2000-01-01", periods=2))
+    lib.write(sym, df)
+    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+        pl.Series("v1_MIN(col_1)", [df["col_1"].min()]),
+        pl.Series("v1_MAX(col_1)", [df["col_1"].max()]),
+    )
+
+    with config_context(ADMISSION_KEY, 1):
+        lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+
+    assert_stats_equal(lib.read_column_stats(sym), expected_column_stats)

--- a/python/write_data.py
+++ b/python/write_data.py
@@ -1,0 +1,61 @@
+"""Stage A: write 10M rows x 100 float64 columns into an LMDB library.
+
+Run once. The library is reused by measure_create_column_stats.py.
+"""
+
+import argparse
+import shutil
+import time
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from arcticdb import Arctic
+
+LIB_NAME = "col_stats_mem"
+SYMBOL = "f64_10m_100c"
+SYMBOL_ZEROS = "f64_10m_100c_zeros"
+DEFAULT_LMDB = Path.home() / ".tmp" / "col_stats_rss_lmdb"
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--rows", type=int, default=10_000_000)
+    p.add_argument("--num-cols", type=int, default=100)
+    p.add_argument("--lmdb-path", default=str(DEFAULT_LMDB))
+    p.add_argument("--reset", action="store_true", help="wipe LMDB before writing")
+    p.add_argument("--zeros", action="store_true", help="write all zeros (compressible)")
+    args = p.parse_args()
+
+    lmdb_path = Path(args.lmdb_path)
+    if args.reset and lmdb_path.exists():
+        shutil.rmtree(lmdb_path)
+    lmdb_path.mkdir(parents=True, exist_ok=True)
+
+    ac = Arctic(f"lmdb://{lmdb_path}")
+    if LIB_NAME not in ac.list_libraries():
+        ac.create_library(LIB_NAME)
+    lib = ac[LIB_NAME]
+
+    symbol = SYMBOL_ZEROS if args.zeros else SYMBOL
+    print(f"Generating {args.rows} rows x {args.num_cols} float64 cols (zeros={args.zeros})...", flush=True)
+    t0 = time.perf_counter()
+    if args.zeros:
+        data = {f"f_{i}": np.zeros(args.rows, dtype=np.float64) for i in range(args.num_cols)}
+    else:
+        rng = np.random.default_rng(0)
+        data = {f"f_{i}": rng.random(args.rows, dtype=np.float64) for i in range(args.num_cols)}
+    df = pd.DataFrame(data)
+    df.index = pd.date_range(end="1/1/2023", periods=args.rows, freq="s")
+    df.index.name = "ts"
+    print(f"  generated in {time.perf_counter() - t0:.2f}s", flush=True)
+
+    t0 = time.perf_counter()
+    lib.write(symbol, df)
+    print(f"  wrote in {time.perf_counter() - t0:.2f}s", flush=True)
+    print(f"lmdb={lmdb_path} lib={LIB_NAME} symbol={symbol}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
In the processing pipeline we currently kick off reads eagerly, meaning that if the in-memory processing does not complete quickly, large numbers of `SegmentInMemory` objects accumulate in the CPU executor's queue. Creating column stats manually considers all the data in a symbol, so we can end up holding the entire symbol's data in memory.

## Impact

See scripts at TODO.

Baseline:

```
(pegasus-adb) aseaton@dlonapatcs502:~/source/ArcticDB-worktree/tree-one/python DEV $ python ./measure_column_stats_memory.py --zeros
baseline VmRSS = 169.6 MiB
create_column_stats wall = 0.84s
peak ru_maxrss        = 7802.0 MiB
```

After, with the config flag set to 4 (4 processing units live in memory):

```
(pegasus-adb) aseaton@dlonapatcs502:~/source/ArcticDB-worktree/tree-one/python DEV $ python ./measure_column_stats_memory.py --zeros
baseline VmRSS = 169.6 MiB
create_column_stats wall = 2.41s
peak ru_maxrss        = 1090.0 MiB
```

## Implementation

This PR adds a new code path in the processing pipeline that is only used for column stats creation at the moment. It is designed to easily generalize to the other paths - we may want to make it the default. In this path we create a special "admission handler" object that provides segment read futures. Importantly, it creates these as promises and only kicks off work for them later, unlike the current eager read pipeline. This design means that everything downstream of the segment load futures in the processing pipeline can be used as-is.

The admission handler only allows K processing units to be live in memory at a time. As each unit finishes it calls `on_unit_complete` (when the `MemSegmentProcessingTask` completes). This kicks off the load of the next unit's segments. Importantly this is not a blocking operation, else it could deadlock.

To give an example, with processing units with an overlap:

```
P = [{0, 1}, {1, 2}]
```

we first call `admit_initial` to load processing unit `0`, i.e. segments `0, 1`. When this unit is complete, the component manager frees segment `0` but not segment `1`. At this point `on_unit_complete` fires. This calls `admit(processing_unit=1)` which calls `fire(segment=1)` (no-op) and `fire(segment=2)` which kicks off a segment load.

## Alternatives

#3138 - discarded as it leaves the CPU pool idle, and is difficult to read (in that the mechanism that bounds memory use is not explicit).