### PR TITLE
Bound processing pipeline memory use

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -345,6 +345,7 @@ jobs:
       pytest_xdist_mode: ${{matrix.pytest_xdist_mode}}
       pytest_args: ${{inputs.pytest_args || ''}}
       version_cache_full_test: ${{inputs.version_cache_full_test || false}}
+      serial_admission_test: true
       DEBUG_LOGGING_ENABLED: ${{ needs.storage_type.outputs.DEBUG_LOGGING_ENABLED }}
 
 

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -13,6 +13,7 @@ on:
       pytest_xdist_mode: {default: "", type: string, description: additional argument to pass for pytest-xdist}
       pytest_args:       {default: "", type: string, description: a way to rewrite the pytest args to change what tests are being run}
       version_cache_full_test: {default: false, type: boolean, description: if true - tests will run with both version cache 0 and 2000000000 otherwise only 2000000000}
+      serial_admission_test: {default: false, type: boolean, description: if true - cp311 tests additionally run with VersionStore.NumProcessingUnitsLive=1}
       run_full_matrix_of_persistent_tests: {default: false, type: boolean, description: if true - persistent tests will run for all python versions else only for 12 }
       DEBUG_LOGGING_ENABLED: {default: "0", type: string, required: false, description: 'Enable debug logging "1" (disabled "0")'}
       cmake_extra_args:  {default: "", type: string, required: false, description: 'Additional CMake arguments to pass during configuration'}
@@ -544,10 +545,18 @@ jobs:
         type: ${{fromJSON(vars.TEST_DIRS_OVERRIDE || needs.compile.outputs.test_dirs)}}
         python_deps_id: ${{fromJson(inputs.python_deps_ids)}}
         # Always run with both for cp311
-        version_cache_timeout: ${{ fromJSON((inputs.version_cache_full_test || needs.compile.outputs.python_impl_name == 'cp311') && '["NoCache", "DefaultCache"]' || '["DefaultCache"]') }} 
+        version_cache_timeout: ${{ fromJSON((inputs.version_cache_full_test || needs.compile.outputs.python_impl_name == 'cp311') && '["NoCache", "DefaultCache"]' || '["DefaultCache"]') }}
+        admission_limit: ${{ fromJSON((inputs.serial_admission_test && needs.compile.outputs.python_impl_name == 'cp311') && '["Serial", "Default"]' || '["Default"]') }}
+        # The admission limit is unrelated to the version cache and to the dependency pins, so Serial only runs
+        # against the default cache and the default dependencies
+        exclude:
+          - version_cache_timeout: NoCache
+            admission_limit: Serial
+          - python_deps_id: -compat311
+            admission_limit: Serial
         include:
           ${{fromJSON(inputs.matrix)}}
-    name: ${{matrix.type}}${{matrix.python_deps_id}}-${{matrix.version_cache_timeout}}
+    name: ${{matrix.type}}${{matrix.python_deps_id}}-${{matrix.version_cache_timeout}}${{matrix.admission_limit == 'Serial' && '-Serial' || ''}}
     runs-on: ${{matrix.distro}}
     container: ${{matrix.os == 'linux' &&  matrix.container || null}}
     defaults:
@@ -556,9 +565,9 @@ jobs:
     env:
       SCCACHE_GHA_ENABLED: "true"
       python_impl_name: ${{needs.compile.outputs.python_impl_name}}
-      distinguishing_name: ${{matrix.os}}-${{needs.compile.outputs.python_impl_name}}-${{matrix.type}}${{matrix.python_deps_id}}-${{matrix.version_cache_timeout}}
+      distinguishing_name: ${{matrix.os}}-${{needs.compile.outputs.python_impl_name}}-${{matrix.type}}${{matrix.python_deps_id}}-${{matrix.version_cache_timeout}}${{matrix.admission_limit == 'Serial' && '-Serial' || ''}}
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
-      real_tests_storage_type: ${{(inputs.run_full_matrix_of_persistent_tests || needs.compile.outputs.python_impl_name == 'cp311') && inputs.persistent_storage || 'no'}}
+      real_tests_storage_type: ${{matrix.admission_limit != 'Serial' && (inputs.run_full_matrix_of_persistent_tests || needs.compile.outputs.python_impl_name == 'cp311') && inputs.persistent_storage || 'no'}}
     steps:
       - name: Disk Space Before Clean Up
         if: matrix.os == 'linux'
@@ -717,6 +726,8 @@ jobs:
           STORAGE_TYPE: ${{ env.real_tests_storage_type }}
           # Testing with 0(no version cache) and -1(will use default timeout)
           VERSION_MAP_RELOAD_INTERVAL: ${{matrix.version_cache_timeout == 'NoCache' && 0 || -1}}
+          # 1 admits one processing unit at a time, -1 leaves the residency limit at its default
+          NUM_PROCESSING_UNITS_LIVE: ${{matrix.admission_limit == 'Serial' && 1 || -1}}
           ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: 0
           ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR: all
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,9 @@ When working on a feature branch, maintain a work log in `docs/claude/plans/<bra
 
 Code style is enforced by `make lint` **Always run `make lint` after making code changes.**
 
+Put Python imports at module scope. Do not add function-local ("lazy") imports to defer a cost or to
+tolerate a stale build — including in test helpers.
+
 ### Git Commits
 
 - Do not add "Generated with AI" or "Co-Authored-By" lines to commit messages

--- a/Makefile
+++ b/Makefile
@@ -146,14 +146,27 @@ test-cpp-rapidcheck-debug: $(_DEBUG_BUILD_DIR)/.configure-stamp ## Build and run
 	$(_DEBUG_BUILD_DIR)/arcticdb/arcticdb_rapidcheck_tests $(if $(FILTER),--gtest_filter=$(FILTER))
 
 # ── symlink ──────────────────────────────────────────────────────────────────
-_EXT_SUFFIX := $(shell python3 -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
+# EXT_SUFFIX must come from the interpreter that will import the extension, not whichever python3 is on
+# PATH. Those differ whenever the venv and the system python are different minor versions, e.g. a py311
+# venv with a py310 /usr/bin/python3.
+_EXT_SUFFIX_PYTHON := $(firstword $(wildcard $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV)/bin/python) $(_VENV_PYTHON)) python3)
+_EXT_SUFFIX := $(shell $(_EXT_SUFFIX_PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
+
+define _do_symlink
+	@test -f $(1)/arcticdb/arcticdb_ext$(_EXT_SUFFIX) || { \
+		echo "ERROR: $(1)/arcticdb/arcticdb_ext$(_EXT_SUFFIX) does not exist."; \
+		echo "       EXT_SUFFIX '$(_EXT_SUFFIX)' came from $(_EXT_SUFFIX_PYTHON); built extensions are:"; \
+		ls $(1)/arcticdb/arcticdb_ext*.so 2>/dev/null || echo "       (none — run the build first)"; \
+		exit 1; }
+	ln -sfn ../$(1)/arcticdb/arcticdb_ext$(_EXT_SUFFIX) python/arcticdb_ext$(_EXT_SUFFIX)
+endef
 
 symlink: ## Symlink release arcticdb_ext into python/
-	ln -sf ../cpp/out/$(RELEASE_PRESET)-build/arcticdb/arcticdb_ext$(_EXT_SUFFIX) python/arcticdb_ext$(_EXT_SUFFIX)
+	$(call _do_symlink,$(_RELEASE_BUILD_DIR))
 	@echo "Created python/arcticdb_ext$(_EXT_SUFFIX) -> release build"
 
 symlink-debug: ## Symlink debug arcticdb_ext into python/
-	ln -sf ../cpp/out/$(DEBUG_PRESET)-build/arcticdb/arcticdb_ext$(_EXT_SUFFIX) python/arcticdb_ext$(_EXT_SUFFIX)
+	$(call _do_symlink,$(_DEBUG_BUILD_DIR))
 	@echo "Created python/arcticdb_ext$(_EXT_SUFFIX) -> debug build"
 
 # ── test-py ──────────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ _TMPDIR_ENV := $(if $(TMPDIR_OVERRIDE),TMPDIR=$(TMPDIR_OVERRIDE))
 _PROTOC_ENV := $(if $(PROTOC_VERS),ARCTICDB_PROTOC_VERS=$(PROTOC_VERS))
 # Combined environment prefix for commands that need both
 _ENV        := $(strip $(_TMPDIR_ENV) $(_PROTOC_ENV))
-_VENV_PYTHON := $(firstword $(wildcard $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV)/bin/python)) $(VENV_DIR)/$(VENV_NAME)/bin/python)
+_VENV_ROOT := $(firstword $(wildcard $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV))) $(VENV_DIR)/$(VENV_NAME))
+_VENV_PYTHON := $(_VENV_ROOT)/bin/python
 _VENV_PIP := $(VENV_DIR)/$(VENV_NAME)/bin/pip
 
 # ── Phony targets ────────────────────────────────────────────────────────────

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ _TMPDIR_ENV := $(if $(TMPDIR_OVERRIDE),TMPDIR=$(TMPDIR_OVERRIDE))
 _PROTOC_ENV := $(if $(PROTOC_VERS),ARCTICDB_PROTOC_VERS=$(PROTOC_VERS))
 # Combined environment prefix for commands that need both
 _ENV        := $(strip $(_TMPDIR_ENV) $(_PROTOC_ENV))
-_VENV_PYTHON := $(VENV_DIR)/$(VENV_NAME)/bin/python
+_VENV_PYTHON := $(firstword $(wildcard $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV)/bin/python)) $(VENV_DIR)/$(VENV_NAME)/bin/python)
 _VENV_PIP := $(VENV_DIR)/$(VENV_NAME)/bin/pip
 
 # ── Phony targets ────────────────────────────────────────────────────────────
@@ -146,10 +146,10 @@ test-cpp-rapidcheck-debug: $(_DEBUG_BUILD_DIR)/.configure-stamp ## Build and run
 	$(_DEBUG_BUILD_DIR)/arcticdb/arcticdb_rapidcheck_tests $(if $(FILTER),--gtest_filter=$(FILTER))
 
 # ── symlink ──────────────────────────────────────────────────────────────────
-# EXT_SUFFIX must come from the interpreter that will import the extension, not whichever python3 is on
-# PATH. Those differ whenever the venv and the system python are different minor versions, e.g. a py311
-# venv with a py310 /usr/bin/python3.
-_EXT_SUFFIX_PYTHON := $(firstword $(wildcard $(if $(VIRTUAL_ENV),$(VIRTUAL_ENV)/bin/python) $(_VENV_PYTHON)) python3)
+# EXT_SUFFIX must come from the same interpreter that test-py imports the extension with (_VENV_PYTHON),
+# not whichever python3 is on PATH. Those differ whenever the venv and the system python are different
+# minor versions, e.g. a py311 venv with a py310 /usr/bin/python3.
+_EXT_SUFFIX_PYTHON := $(firstword $(wildcard $(_VENV_PYTHON)) python3)
 _EXT_SUFFIX := $(shell $(_EXT_SUFFIX_PYTHON) -c "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX'))")
 
 define _do_symlink

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -21,6 +21,11 @@ if [ "$VERSION_MAP_RELOAD_INTERVAL" != "-1" ]; then
     export ARCTICDB_VersionMap_ReloadInterval_int=$VERSION_MAP_RELOAD_INTERVAL
 fi
 
+# Unset means default. 0 would be the kill switch (unbounded residency), so it must not be used as the sentinel.
+if [ -n "$NUM_PROCESSING_UNITS_LIVE" ] && [ "$NUM_PROCESSING_UNITS_LIVE" != "-1" ]; then
+    export ARCTICDB_VersionStore_NumProcessingUnitsLive_int=$NUM_PROCESSING_UNITS_LIVE
+fi
+
 # Enable faulthandler so SIGSEGV/SIGBUS dump tracebacks to stderr
 export PYTHONFAULTHANDLER=1
 # Arm a C-level per-test watchdog that dumps tracebacks and kills the worker

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -406,6 +406,7 @@ set(arcticdb_srcs
         util/preprocess.hpp
         util/ranges_from_future.hpp
         util/regex_filter.hpp
+        util/segment_residency_tracker.hpp
         util/simple_string_hash.hpp
         util/slab_allocator.hpp
         util/sparse_utils.hpp
@@ -420,6 +421,7 @@ set(arcticdb_srcs
         util/lazy.hpp
         util/type_traits.hpp
         util/variant.hpp
+        version/admission_handler.hpp
         version/de_dup_map.hpp
         version/op_log.hpp
         version/merge_options.hpp
@@ -585,6 +587,7 @@ set(arcticdb_srcs
         util/trace.cpp
         util/type_handler.cpp
         util/format_date.cpp
+        version/admission_handler.cpp
         version/key_block.hpp
         version/key_block.cpp
         version/local_versioned_engine.cpp
@@ -1146,6 +1149,7 @@ if(${TEST})
             util/test/input_frame_utils.hpp
             util/test/segment_generation_utils.hpp
             util/test/segment_generation_utils.cpp
+            version/test/test_admission_handler.cpp
             version/test/test_append.cpp
             version/test/test_key_block.cpp
             version/test/test_sort_index.cpp

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -419,6 +419,7 @@ set(arcticdb_srcs
         util/preprocess.hpp
         util/ranges_from_future.hpp
         util/regex_filter.hpp
+        util/segment_residency_tracker.hpp
         util/simple_string_hash.hpp
         util/slab_allocator.hpp
         util/sparse_utils.hpp
@@ -433,6 +434,7 @@ set(arcticdb_srcs
         util/lazy.hpp
         util/type_traits.hpp
         util/variant.hpp
+        version/admission_handler.hpp
         version/de_dup_map.hpp
         version/op_log.hpp
         version/merge_options.hpp
@@ -598,6 +600,7 @@ set(arcticdb_srcs
         util/trace.cpp
         util/type_handler.cpp
         util/format_date.cpp
+        version/admission_handler.cpp
         version/key_block.hpp
         version/key_block.cpp
         version/local_versioned_engine.cpp
@@ -1167,6 +1170,7 @@ if(${TEST})
             util/test/input_frame_utils.hpp
             util/test/segment_generation_utils.hpp
             util/test/segment_generation_utils.cpp
+            version/test/test_admission_handler.cpp
             version/test/test_append.cpp
             version/test/test_key_block.cpp
             version/test/test_sort_index.cpp

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -447,27 +447,15 @@ class AsyncStore : public Store {
         );
     }
 
-    std::vector<folly::Future<pipelines::SegmentAndSlice>> batch_read_uncompressed(
-            std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
+    std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)> make_uncompressed_reader(
             std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
     ) override {
-        ARCTICDB_RUNTIME_DEBUG(log::version(), "Reading {} keys", ranges_and_keys.size());
-        // Window the reads for reasons detailed in the PR description https://github.com/man-group/ArcticDB/pull/3086
-        // x2 IO threadpool size is a balance to keep the IO workers busy, without reading data in faster than we can
-        // process it
-        return folly::window(
-                std::move(ranges_and_keys),
-                [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
-                    const auto key = ranges_and_key.key_;
-                    return read_and_continue(
-                            key,
-                            library_,
-                            storage::ReadKeyOpts{},
-                            DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
-                    );
-                },
-                2 * async::TaskScheduler::instance()->io_thread_count()
-        );
+        return [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
+            const auto key = ranges_and_key.key_;
+            return read_and_continue(
+                    key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+            );
+        };
     }
 
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {

--- a/cpp/arcticdb/async/async_store.hpp
+++ b/cpp/arcticdb/async/async_store.hpp
@@ -449,27 +449,15 @@ class AsyncStore : public Store {
         );
     }
 
-    std::vector<folly::Future<pipelines::SegmentAndSlice>> batch_read_uncompressed(
-            std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
+    std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)> make_uncompressed_reader(
             std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
     ) override {
-        ARCTICDB_RUNTIME_DEBUG(log::version(), "Reading {} keys", ranges_and_keys.size());
-        // Window the reads for reasons detailed in the PR description https://github.com/man-group/ArcticDB/pull/3086
-        // x2 IO threadpool size is a balance to keep the IO workers busy, without reading data in faster than we can
-        // process it
-        return folly::window(
-                std::move(ranges_and_keys),
-                [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
-                    const auto key = ranges_and_key.key_;
-                    return read_and_continue(
-                            key,
-                            library_,
-                            storage::ReadKeyOpts{},
-                            DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
-                    );
-                },
-                2 * async::TaskScheduler::instance()->io_thread_count()
-        );
+        return [this, columns_to_decode](pipelines::RangesAndKey&& ranges_and_key) {
+            const auto key = ranges_and_key.key_;
+            return read_and_continue(
+                    key, library_, storage::ReadKeyOpts{}, DecodeSliceTask{std::move(ranges_and_key), columns_to_decode}
+            );
+        };
     }
 
     std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys) override {

--- a/cpp/arcticdb/async/tasks.cpp
+++ b/cpp/arcticdb/async/tasks.cpp
@@ -50,6 +50,7 @@ pipelines::SegmentAndSlice DecodeSliceTask::decode_into_slice(storage::KeySegmen
     SegmentInMemory segment_in_memory(std::move(descriptor));
     decode_into_memory_segment(seg, hdr, segment_in_memory, desc);
     segment_in_memory.set_row_data(std::max(segment_in_memory.row_count() - 1, ranges_and_key_.row_range().diff() - 1));
+    segment_in_memory.mark_from_disk();
     return pipelines::SegmentAndSlice(std::move(ranges_and_key_), std::move(segment_in_memory));
 }
 } // namespace arcticdb::async

--- a/cpp/arcticdb/column_store/memory_segment.cpp
+++ b/cpp/arcticdb/column_store/memory_segment.cpp
@@ -225,6 +225,8 @@ SegmentInMemory SegmentInMemory::clone() const {
     return SegmentInMemory(std::make_shared<SegmentInMemoryImpl>(impl_->clone()));
 }
 
+void SegmentInMemory::mark_from_disk() { impl_->mark_from_disk(); }
+
 void SegmentInMemory::set_string_pool(const std::shared_ptr<StringPool>& string_pool) {
     impl_->set_string_pool(string_pool);
 }

--- a/cpp/arcticdb/column_store/memory_segment.cpp
+++ b/cpp/arcticdb/column_store/memory_segment.cpp
@@ -229,6 +229,8 @@ SegmentInMemory SegmentInMemory::clone() const {
     return SegmentInMemory(std::make_shared<SegmentInMemoryImpl>(impl_->clone()));
 }
 
+void SegmentInMemory::mark_from_disk() { impl_->mark_from_disk(); }
+
 void SegmentInMemory::set_string_pool(const std::shared_ptr<StringPool>& string_pool) {
     impl_->set_string_pool(string_pool);
 }

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -243,6 +243,8 @@ class SegmentInMemory {
 
     [[nodiscard]] SegmentInMemory clone() const;
 
+    void mark_from_disk();
+
     void set_string_pool(const std::shared_ptr<StringPool>& string_pool);
 
     SegmentInMemory filter(util::BitSet&& filter_bitset, bool filter_down_stringpool = false, bool validate = false)

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -245,6 +245,8 @@ class SegmentInMemory {
 
     [[nodiscard]] SegmentInMemory clone() const;
 
+    void mark_from_disk();
+
     void set_string_pool(const std::shared_ptr<StringPool>& string_pool);
 
     SegmentInMemory filter(util::BitSet&& filter_bitset, bool filter_down_stringpool = false, bool validate = false)

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -9,6 +9,7 @@
 #include <arcticdb/column_store/column_algorithms.hpp>
 #include <arcticdb/column_store/memory_segment_impl.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
+#include <arcticdb/util/segment_residency_tracker.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/pipeline/string_pool_utils.hpp>
 #include <arcticdb/util/preconditions.hpp>
@@ -336,7 +337,18 @@ SegmentInMemoryImpl::SegmentInMemoryImpl(
     on_descriptor_change(desc, expected_column_size, allocation_type, allow_sparse, block_config_per_column);
 }
 
-SegmentInMemoryImpl::~SegmentInMemoryImpl() { ARCTICDB_TRACE(log::version(), "Destroying segment in memory"); }
+SegmentInMemoryImpl::~SegmentInMemoryImpl() {
+    ARCTICDB_TRACE(log::version(), "Destroying segment in memory");
+    auto& residency_tracker = util::SegmentResidencyTracker::instance();
+    if (from_disk_.value_ && residency_tracker.enabled()) {
+        residency_tracker.on_segment_released();
+    }
+}
+
+void SegmentInMemoryImpl::mark_from_disk() {
+    from_disk_.value_ = true;
+    util::SegmentResidencyTracker::instance().on_segment_resident();
+}
 
 // Append any columns that exist both in this segment and in the 'other' segment onto the
 // end of the column in this segment. Any columns that exist in this segment but not in the

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -339,15 +339,22 @@ SegmentInMemoryImpl::SegmentInMemoryImpl(
 
 SegmentInMemoryImpl::~SegmentInMemoryImpl() {
     ARCTICDB_TRACE(log::version(), "Destroying segment in memory");
-    auto& residency_tracker = util::SegmentResidencyTracker::instance();
-    if (from_disk_.value_ && residency_tracker.enabled()) {
-        residency_tracker.on_segment_released();
+    if (from_disk_.value_) {
+        util::SegmentResidencyTracker::instance().on_segment_released();
     }
 }
 
 void SegmentInMemoryImpl::mark_from_disk() {
-    from_disk_.value_ = true;
-    util::SegmentResidencyTracker::instance().on_segment_resident();
+    // Only set the flag while tracking, so the destructor cannot release a segment that was never counted. The flag
+    // also makes this idempotent, so a second call cannot count one segment twice against a single destructor.
+    if (from_disk_.value_) {
+        return;
+    }
+    auto& residency_tracker = util::SegmentResidencyTracker::instance();
+    if (residency_tracker.enabled()) {
+        from_disk_.value_ = true;
+        residency_tracker.on_segment_resident();
+    }
 }
 
 // Append any columns that exist both in this segment and in the 'other' segment onto the
@@ -523,6 +530,9 @@ SegmentInMemoryImpl SegmentInMemoryImpl::clone() const {
     output.compacted_ = compacted_;
     if (tsd_)
         output.set_timeseries_descriptor(tsd_->clone());
+    if (from_disk_.value_) {
+        output.mark_from_disk();
+    }
 
     return output;
 }

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -523,6 +523,10 @@ class SegmentInMemoryImpl {
 
     SegmentInMemoryImpl clone() const;
 
+    // Marks this segment as having been decoded from storage, so SegmentResidencyTracker counts it from here until
+    // this object is destroyed. clone() and processing outputs are left unmarked.
+    void mark_from_disk();
+
     void set_string_pool(std::shared_ptr<StringPool> string_pool);
 
     std::shared_ptr<SegmentInMemoryImpl> get_output_segment(size_t num_values, bool pre_allocate = true) const;
@@ -577,6 +581,22 @@ class SegmentInMemoryImpl {
     bool compacted_ = false;
     util::MagicNum<'M', 'S', 'e', 'g'> magic_;
     std::optional<TimeseriesDescriptor> tsd_;
+
+    // Just used for memory tracking in tests, see SegmentResidencyTracker
+    // Clears on move so we do not double count the moved-from instance
+    struct OnDiskFlag {
+        bool value_ = false;
+        OnDiskFlag() = default;
+        OnDiskFlag(OnDiskFlag&& other) noexcept : value_(other.value_) { other.value_ = false; }
+        OnDiskFlag& operator=(OnDiskFlag&& other) noexcept {
+            value_ = other.value_;
+            other.value_ = false;
+            return *this;
+        }
+        OnDiskFlag(const OnDiskFlag&) = delete;
+        OnDiskFlag& operator=(const OnDiskFlag&) = delete;
+    };
+    OnDiskFlag from_disk_;
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -17,6 +17,8 @@
 #include <arcticdb/util/constructors.hpp>
 #include <boost/iterator/iterator_facade.hpp>
 
+#include <utility>
+
 namespace py = pybind11;
 
 namespace arcticdb {
@@ -524,7 +526,8 @@ class SegmentInMemoryImpl {
     SegmentInMemoryImpl clone() const;
 
     // Marks this segment as having been decoded from storage, so SegmentResidencyTracker counts it from here until
-    // this object is destroyed. clone() and processing outputs are left unmarked.
+    // this object is destroyed. A no-op unless the tracker is enabled.
+    // Processing outputs are left unmarked.
     void mark_from_disk();
 
     void set_string_pool(std::shared_ptr<StringPool> string_pool);
@@ -587,10 +590,10 @@ class SegmentInMemoryImpl {
     struct OnDiskFlag {
         bool value_ = false;
         OnDiskFlag() = default;
-        OnDiskFlag(OnDiskFlag&& other) noexcept : value_(other.value_) { other.value_ = false; }
+        OnDiskFlag(OnDiskFlag&& other) noexcept : value_(std::exchange(other.value_, false)) {}
+        // std::exchange rather than read-then-clear so that self-move-assignment leaves value_ set
         OnDiskFlag& operator=(OnDiskFlag&& other) noexcept {
-            value_ = other.value_;
-            other.value_ = false;
+            value_ = std::exchange(other.value_, false);
             return *this;
         }
         OnDiskFlag(const OnDiskFlag&) = delete;

--- a/cpp/arcticdb/pipeline/frame_slice.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice.hpp
@@ -153,7 +153,7 @@ struct FrameSlice {
     util::MagicNum<'F', 's', 'l', 'c'> magic_;
 };
 
-// Collection of these objects is the input to batch_read_uncompressed
+// Collection of these objects is the input to the uncompressed reader (Store::make_uncompressed_reader)
 struct RangesAndKey {
     explicit RangesAndKey(const FrameSlice& frame_slice, entity::AtomKey&& key, bool is_incomplete) :
         row_range_(frame_slice.rows()),
@@ -194,7 +194,7 @@ struct RangesAndKey {
 };
 
 /*
- * The return type of batch_read_uncompressed, the entry point to the processing pipeline.
+ * The return type of the uncompressed reader (Store::make_uncompressed_reader)
  * Intended as a replacement for SliceAndKey without the baggage that class has accumulated, use in preference where
  * possible.
  */

--- a/cpp/arcticdb/processing/test/test_parallel_processing.cpp
+++ b/cpp/arcticdb/processing/test/test_parallel_processing.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/component_manager.hpp>
+#include <arcticdb/version/admission_handler.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/storage/test/in_memory_store.hpp>
 #include <ranges>
@@ -26,6 +27,28 @@ std::shared_ptr<ComponentManager> set_component_manager(const std::span<std::sha
         clause->set_component_manager(component_manager);
     }
     return component_manager;
+}
+
+std::shared_ptr<version_store::ProcessingUnitAdmissionHandler> make_admission_handler(
+        const std::span<folly::Promise<SegmentAndSlice>> segment_and_slice_promises
+) {
+    const size_t num_segments = segment_and_slice_promises.size();
+    std::vector<RangesAndKey> ranges;
+    std::vector<std::vector<size_t>> processing_unit_indexes;
+    for (size_t idx = 0; idx < num_segments; ++idx) {
+        ranges.emplace_back(RowRange{idx, idx + 1}, ColRange{0, 1}, entity::AtomKey{});
+        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
+    }
+    version_store::SegmentReader reader = [segment_and_slice_promises](RangesAndKey&& rk) {
+        return segment_and_slice_promises[rk.row_range().first].getFuture();
+    };
+    return std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::move(processing_unit_indexes),
+            /*max_processing_units_in_flight=*/num_segments,
+            /*read_window=*/num_segments
+    );
 }
 
 void push_segments(const std::span<folly::Promise<SegmentAndSlice>> segment_and_slice_promises) {
@@ -208,23 +231,10 @@ TEST(Clause, ScheduleClauseProcessingStress) {
 
     constexpr static size_t num_segments{2};
     std::array<folly::Promise<SegmentAndSlice>, num_segments> segment_and_slice_promises;
-    std::vector<folly::Future<SegmentAndSlice>> segment_and_slice_futures;
-    std::vector<std::vector<size_t>> processing_unit_indexes;
-    for (size_t idx = 0; idx < num_segments; ++idx) {
-        segment_and_slice_futures.emplace_back(segment_and_slice_promises[idx].getFuture());
-        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
-    }
 
-    // Map from index in segment_and_slice_future_splitters to the number of calls to process in the first clause that
-    // will require that segment
-    auto segment_fetch_counts = generate_segment_fetch_counts(processing_unit_indexes, num_segments);
+    auto admission = make_admission_handler(segment_and_slice_promises);
 
-    auto processed_entity_ids_fut = schedule_clause_processing(
-            component_manager,
-            std::move(segment_and_slice_futures),
-            std::move(processing_unit_indexes),
-            std::move(clauses)
-    );
+    auto processed_entity_ids_fut = schedule_clause_processing(component_manager, admission, std::move(clauses));
     push_segments(segment_and_slice_promises);
     auto processed_entity_ids = std::move(processed_entity_ids_fut).get();
     const auto proc =
@@ -253,19 +263,10 @@ TEST(Clause, ScheduleRowSliceProcessingAndWrite) {
 
     constexpr static size_t num_segments{2};
     std::array<folly::Promise<SegmentAndSlice>, num_segments> segment_and_slice_promises;
-    std::vector<folly::Future<SegmentAndSlice>> segment_and_slice_futures;
-    std::vector<std::vector<size_t>> processing_unit_indexes;
-    for (size_t idx = 0; idx < num_segments; ++idx) {
-        segment_and_slice_futures.emplace_back(segment_and_slice_promises[idx].getFuture());
-        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
-    }
 
-    auto processed_entity_ids_fut = schedule_clause_processing(
-            component_manager,
-            std::move(segment_and_slice_futures),
-            std::move(processing_unit_indexes),
-            std::move(clauses)
-    );
+    auto admission = make_admission_handler(segment_and_slice_promises);
+
+    auto processed_entity_ids_fut = schedule_clause_processing(component_manager, admission, std::move(clauses));
     push_segments(segment_and_slice_promises);
     const auto processed_entity_ids = std::move(processed_entity_ids_fut).get();
     std::vector<folly::Future<SliceAndKey>> write_segments_futures;

--- a/cpp/arcticdb/processing/test/test_parallel_processing.cpp
+++ b/cpp/arcticdb/processing/test/test_parallel_processing.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/component_manager.hpp>
+#include <arcticdb/version/admission_handler.hpp>
 #include <arcticdb/version/version_core.hpp>
 #include <arcticdb/storage/test/in_memory_store.hpp>
 #include <ranges>
@@ -26,6 +27,28 @@ std::shared_ptr<ComponentManager> set_component_manager(const std::span<std::sha
         clause->set_component_manager(component_manager);
     }
     return component_manager;
+}
+
+std::shared_ptr<version_store::ProcessingUnitAdmissionHandler> make_admission_handler(
+        const std::span<folly::Promise<SegmentAndSlice>> segment_and_slice_promises
+) {
+    const size_t num_segments = segment_and_slice_promises.size();
+    std::vector<RangesAndKey> ranges;
+    std::vector<std::vector<size_t>> processing_unit_indexes;
+    for (size_t idx = 0; idx < num_segments; ++idx) {
+        ranges.emplace_back(RowRange{idx, idx + 1}, ColRange{0, 1}, entity::AtomKey{});
+        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
+    }
+    version_store::SegmentReader reader = [segment_and_slice_promises](RangesAndKey&& rk) {
+        return segment_and_slice_promises[rk.row_range().first].getFuture();
+    };
+    return std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::move(processing_unit_indexes),
+            /*max_processing_units_in_flight=*/num_segments,
+            /*read_window=*/num_segments
+    );
 }
 
 void push_segments(const std::span<folly::Promise<SegmentAndSlice>> segment_and_slice_promises) {
@@ -208,19 +231,10 @@ TEST(Clause, ScheduleClauseProcessingStress) {
 
     constexpr static size_t num_segments{2};
     std::array<folly::Promise<SegmentAndSlice>, num_segments> segment_and_slice_promises;
-    std::vector<folly::Future<SegmentAndSlice>> segment_and_slice_futures;
-    std::vector<std::vector<size_t>> processing_unit_indexes;
-    for (size_t idx = 0; idx < num_segments; ++idx) {
-        segment_and_slice_futures.emplace_back(segment_and_slice_promises[idx].getFuture());
-        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
-    }
 
-    auto processed_entity_ids_fut = schedule_clause_processing(
-            component_manager,
-            std::move(segment_and_slice_futures),
-            std::move(processing_unit_indexes),
-            std::move(clauses)
-    );
+    auto admission = make_admission_handler(segment_and_slice_promises);
+
+    auto processed_entity_ids_fut = schedule_clause_processing(component_manager, admission, std::move(clauses));
     push_segments(segment_and_slice_promises);
     auto processed_entity_ids = std::move(processed_entity_ids_fut).get();
     const auto proc =
@@ -249,19 +263,10 @@ TEST(Clause, ScheduleRowSliceProcessingAndWrite) {
 
     constexpr static size_t num_segments{2};
     std::array<folly::Promise<SegmentAndSlice>, num_segments> segment_and_slice_promises;
-    std::vector<folly::Future<SegmentAndSlice>> segment_and_slice_futures;
-    std::vector<std::vector<size_t>> processing_unit_indexes;
-    for (size_t idx = 0; idx < num_segments; ++idx) {
-        segment_and_slice_futures.emplace_back(segment_and_slice_promises[idx].getFuture());
-        processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
-    }
 
-    auto processed_entity_ids_fut = schedule_clause_processing(
-            component_manager,
-            std::move(segment_and_slice_futures),
-            std::move(processing_unit_indexes),
-            std::move(clauses)
-    );
+    auto admission = make_admission_handler(segment_and_slice_promises);
+
+    auto processed_entity_ids_fut = schedule_clause_processing(component_manager, admission, std::move(clauses));
     push_segments(segment_and_slice_promises);
     const auto processed_entity_ids = std::move(processed_entity_ids_fut).get();
     std::vector<folly::Future<SliceAndKey>> write_segments_futures;

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -48,12 +48,6 @@ class InMemoryStore : public Store {
         return storage::OpenMode::DELETE;
     }
 
-    std::vector<folly::Future<pipelines::SegmentAndSlice>>
-    batch_read_uncompressed(std::vector<pipelines::RangesAndKey>&&, std::shared_ptr<std::unordered_set<std::string>>)
-            override {
-        throw std::runtime_error("Not implemented for tests");
-    }
-
     std::vector<folly::Future<VariantKey>>
     batch_read_compressed(std::vector<std::pair<entity::VariantKey, ReadContinuation>>&&, const BatchReadArgs&)
             override {

--- a/cpp/arcticdb/storage/test/in_memory_store.hpp
+++ b/cpp/arcticdb/storage/test/in_memory_store.hpp
@@ -48,6 +48,11 @@ class InMemoryStore : public Store {
         return storage::OpenMode::DELETE;
     }
 
+    std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)>
+    make_uncompressed_reader(std::shared_ptr<std::unordered_set<std::string>>) override {
+        throw std::runtime_error("Not implemented for tests");
+    }
+
     std::vector<folly::Future<VariantKey>>
     batch_read_compressed(std::vector<std::pair<entity::VariantKey, ReadContinuation>>&&, const BatchReadArgs&)
             override {

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -68,10 +68,11 @@ struct StreamSource {
     [[nodiscard]] virtual std::vector<folly::Future<bool>> batch_key_exists(const std::vector<entity::VariantKey>& keys
     ) = 0;
 
-    virtual std::vector<folly::Future<pipelines::SegmentAndSlice>> batch_read_uncompressed(
-            std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
-            std::shared_ptr<std::unordered_set<std::string>> columns_to_decode
-    ) = 0;
+    virtual std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)>
+    make_uncompressed_reader(std::shared_ptr<std::unordered_set<std::string>> /*columns_to_decode*/
+    ) {
+        util::raise_rte("make_uncompressed_reader not implemented");
+    }
 
     virtual folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(
             const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}

--- a/cpp/arcticdb/stream/stream_source.hpp
+++ b/cpp/arcticdb/stream/stream_source.hpp
@@ -69,10 +69,7 @@ struct StreamSource {
     ) = 0;
 
     virtual std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)>
-    make_uncompressed_reader(std::shared_ptr<std::unordered_set<std::string>> /*columns_to_decode*/
-    ) {
-        util::raise_rte("make_uncompressed_reader not implemented");
-    }
+    make_uncompressed_reader(std::shared_ptr<std::unordered_set<std::string>> columns_to_decode) = 0;
 
     virtual folly::Future<std::pair<std::optional<VariantKey>, std::optional<google::protobuf::Any>>> read_metadata(
             const entity::VariantKey& key, storage::ReadKeyOpts opts = storage::ReadKeyOpts{}

--- a/cpp/arcticdb/util/python_bindings.cpp
+++ b/cpp/arcticdb/util/python_bindings.cpp
@@ -8,6 +8,7 @@
 
 #include <arcticdb/util/python_bindings.hpp>
 #include <arcticdb/util/regex_filter.hpp>
+#include <arcticdb/util/segment_residency_tracker.hpp>
 
 namespace arcticdb::util {
 
@@ -17,5 +18,15 @@ void register_bindings(py::module& m) {
     py::class_<RegexGeneric, std::shared_ptr<RegexGeneric>>(tools, "RegexGeneric")
             .def(py::init<const std::string&>(), py::arg("pattern"))
             .def("text", &RegexGeneric::text);
+
+    tools.def(
+            "set_segment_residency_tracking",
+            [](bool enabled) { SegmentResidencyTracker::instance().set_enabled(enabled); },
+            py::arg("enabled"),
+            "Test-only. Enable counting of segments decoded from storage that are resident in memory."
+    );
+    tools.def("reset_segment_residency_tracking", []() { SegmentResidencyTracker::instance().reset(); });
+    tools.def("segment_residency_high_water", []() { return SegmentResidencyTracker::instance().high_water(); });
+    tools.def("segment_residency_live", []() { return SegmentResidencyTracker::instance().live(); });
 }
 } // namespace arcticdb::util

--- a/cpp/arcticdb/util/segment_residency_tracker.hpp
+++ b/cpp/arcticdb/util/segment_residency_tracker.hpp
@@ -1,0 +1,56 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace arcticdb::util {
+
+// Test-only instrumentation for the number of segments decoded from storage that are resident in memory at once.
+class SegmentResidencyTracker {
+  public:
+    static SegmentResidencyTracker& instance() {
+        static SegmentResidencyTracker tracker;
+        return tracker;
+    }
+
+    void set_enabled(bool enabled) { enabled_.store(enabled, std::memory_order_relaxed); }
+
+    bool enabled() const { return enabled_.load(std::memory_order_relaxed); }
+
+    void reset() {
+        live_.store(0, std::memory_order_relaxed);
+        high_water_.store(0, std::memory_order_relaxed);
+    }
+
+    void on_segment_resident() {
+        if (!enabled_.load(std::memory_order_relaxed))
+            return;
+        const auto now = live_.fetch_add(1, std::memory_order_relaxed) + 1;
+        auto prev = high_water_.load(std::memory_order_relaxed);
+        while (now > prev && !high_water_.compare_exchange_weak(prev, now, std::memory_order_relaxed)) {
+        }
+    }
+
+    void on_segment_released() {
+        if (!enabled_.load(std::memory_order_relaxed))
+            return;
+        live_.fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    int64_t high_water() const { return high_water_.load(std::memory_order_relaxed); }
+
+  private:
+    std::atomic<bool> enabled_{false};
+    std::atomic<int64_t> live_{0};
+    std::atomic<int64_t> high_water_{0};
+};
+
+} // namespace arcticdb::util

--- a/cpp/arcticdb/util/segment_residency_tracker.hpp
+++ b/cpp/arcticdb/util/segment_residency_tracker.hpp
@@ -33,19 +33,21 @@ class SegmentResidencyTracker {
     void on_segment_resident() {
         if (!enabled_.load(std::memory_order_relaxed))
             return;
+        // high_water_ = max(high_water_, now), handling concurrent on_segment_resident calls
+        // FUTURE C++26 - replace with std::atomic::fetch_max
         const auto now = live_.fetch_add(1, std::memory_order_relaxed) + 1;
         auto prev = high_water_.load(std::memory_order_relaxed);
         while (now > prev && !high_water_.compare_exchange_weak(prev, now, std::memory_order_relaxed)) {
         }
     }
 
-    void on_segment_released() {
-        if (!enabled_.load(std::memory_order_relaxed))
-            return;
-        live_.fetch_sub(1, std::memory_order_relaxed);
-    }
+    // Deliberately not gated on enabled_: callers only reach here for a segment on_segment_resident counted, so
+    // releasing unconditionally keeps live_ correct when tracking is disabled while counted segments are still alive.
+    void on_segment_released() { live_.fetch_sub(1, std::memory_order_relaxed); }
 
     int64_t high_water() const { return high_water_.load(std::memory_order_relaxed); }
+
+    int64_t live() const { return live_.load(std::memory_order_relaxed); }
 
   private:
     std::atomic<bool> enabled_{false};

--- a/cpp/arcticdb/version/admission_handler.cpp
+++ b/cpp/arcticdb/version/admission_handler.cpp
@@ -1,0 +1,45 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/version/admission_handler.hpp>
+#include <arcticdb/async/task_scheduler.hpp>
+#include <arcticdb/util/configs_map.hpp>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace arcticdb::version_store {
+
+// Residency budget: the number of processing units admitted-but-not-yet-processed at once, bounding decoded segments
+// resident in memory. Always >= 1. The default is a multiple of the read window so that it does not impact
+// normal reads (the read window then governs and the schedule reduces to folly::window), while still capping residency
+// if processing is slow. The IO term ceil(4*io_thread_count / max_unit_size) is ~2x the read window's worth of
+// segments. The 2*cpu_thread_count floor ensures a CPU worker that finishes a unit finds a decoded unit ready.
+size_t max_resident_processing_units(const std::vector<std::vector<size_t>>& processing_unit_indexes) {
+    size_t max_unit_size = 0;
+    for (const auto& unit : processing_unit_indexes) {
+        max_unit_size = std::max(max_unit_size, unit.size());
+    }
+    if (max_unit_size == 0) {
+        return 1;
+    }
+    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
+    const int64_t cpu_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->cpu_thread_count());
+    const int64_t io_read_ahead =
+            (4 * io_thread_count + static_cast<int64_t>(max_unit_size) - 1) / static_cast<int64_t>(max_unit_size);
+    const int64_t default_residency_limit = std::max(2 * cpu_thread_count, io_read_ahead);
+    const int64_t configured =
+            ConfigsMap::instance()->get_int("VersionStore.NumProcessingUnitsLive", default_residency_limit);
+    if (configured == 0) {
+        // A configured value of 0 is a kill switch: residency is unbounded, so the read window alone governs.
+        return processing_unit_indexes.size();
+    }
+    return static_cast<size_t>(std::max<int64_t>(1, configured));
+}
+
+} // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/admission_handler.cpp
+++ b/cpp/arcticdb/version/admission_handler.cpp
@@ -9,6 +9,7 @@
 #include <arcticdb/version/admission_handler.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
 #include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/preconditions.hpp>
 
 #include <algorithm>
 #include <cstdint>
@@ -16,10 +17,14 @@
 namespace arcticdb::version_store {
 
 // Residency budget: the number of processing units admitted-but-not-yet-processed at once, bounding decoded segments
-// resident in memory. Always >= 1. The default is a multiple of the read window so that it does not impact
-// normal reads (the read window then governs and the schedule reduces to folly::window), while still capping residency
-// if processing is slow. The IO term ceil(4*io_thread_count / max_unit_size) is ~2x the read window's worth of
-// segments. The 2*cpu_thread_count floor ensures a CPU worker that finishes a unit finds a decoded unit ready.
+// resident in memory. Always >= 1. The default converts the read window (in segments) into a processing-unit count by
+// dividing by the largest unit size, so it does not impact normal reads (the read window then governs and the schedule
+// reduces to folly::window) while still capping residency if processing is slow.
+//
+// Adding one unit per CPU thread means every thread can hold a unit without taking
+// capacity from the window. It significantly helps performance for large processing units (eg resamples on large
+// buckets) where benchmarking showed an order of magnitude performance regression without this term, as without it we
+// effectively serialize work (for large processing units).
 size_t max_resident_processing_units(const std::vector<std::vector<size_t>>& processing_unit_indexes) {
     size_t max_unit_size = 0;
     for (const auto& unit : processing_unit_indexes) {
@@ -28,18 +33,33 @@ size_t max_resident_processing_units(const std::vector<std::vector<size_t>>& pro
     if (max_unit_size == 0) {
         return 1;
     }
-    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
+    const int64_t read_window = static_cast<int64_t>(segment_read_window());
+    const int64_t units_to_fill_window =
+            (read_window + static_cast<int64_t>(max_unit_size) - 1) / static_cast<int64_t>(max_unit_size);
     const int64_t cpu_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->cpu_thread_count());
-    const int64_t io_read_ahead =
-            (4 * io_thread_count + static_cast<int64_t>(max_unit_size) - 1) / static_cast<int64_t>(max_unit_size);
-    const int64_t default_residency_limit = std::max(2 * cpu_thread_count, io_read_ahead);
+    const int64_t default_residency_limit = units_to_fill_window + cpu_thread_count;
     const int64_t configured =
             ConfigsMap::instance()->get_int("VersionStore.NumProcessingUnitsLive", default_residency_limit);
     if (configured == 0) {
         // A configured value of 0 is a kill switch: residency is unbounded, so the read window alone governs.
         return processing_unit_indexes.size();
     }
-    return static_cast<size_t>(std::max<int64_t>(1, configured));
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            configured > 0, "VersionStore.NumProcessingUnitsLive must be >= 0, got {}", configured
+    );
+    return static_cast<size_t>(configured);
+}
+
+// Read window: the number of segment reads submitted but not completed at any given time. Always >= 1. Defaults to
+// 2*io_thread_count.
+size_t segment_read_window() {
+    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
+    const int64_t default_window = 2 * io_thread_count;
+    const int64_t configured = ConfigsMap::instance()->get_int("VersionStore.SegmentReadWindow", default_window);
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            configured >= 1, "VersionStore.SegmentReadWindow must be >= 1, got {}", configured
+    );
+    return static_cast<size_t>(configured);
 }
 
 } // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/admission_handler.hpp
+++ b/cpp/arcticdb/version/admission_handler.hpp
@@ -1,0 +1,155 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <folly/futures/Future.h>
+#include <folly/futures/Promise.h>
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <vector>
+
+namespace arcticdb::version_store {
+
+using SegmentReader = std::function<folly::Future<pipelines::SegmentAndSlice>(pipelines::RangesAndKey&&)>;
+
+// Feeds segment reads to the IO pool under two independent controls.
+//
+// Residency budget (memory): at most `max_processing_units_in_flight` processing units are admitted but not yet
+// processed at once. A unit is admitted initially or when an outstanding one finishes processing
+// (on_processing_unit_complete), which bounds the decoded segments resident in memory. A value >= the number of units
+// disables the bound.
+//
+// Read window (throughput): at most `read_window` reads are submitted-but-not-decoded at once. A slot frees on read
+// completion, so an admitted unit's segments enter a queue that fill_read_window drains it into the IO pool
+// the way folly::window does. When the residency budget is not the limiting factor, this
+// reduces to folly::window(read_window). This is important to avoid scheduling all the IO work upfront,
+// which can lead to very poor queue fairness as the Folly IO pool schedules work round robin across its threads.
+//
+// Never waits within a unit, so progress continues for any budget >= 1 and window >= 1 regardless of the processing
+// unit structure (for example, if there is overlap between units). Construct via make_shared (reads capture
+// shared_from_this to keep the handler alive across the async reads).
+class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<ProcessingUnitAdmissionHandler> {
+  public:
+    ProcessingUnitAdmissionHandler(
+            SegmentReader reader, std::vector<pipelines::RangesAndKey>&& ranges_and_keys,
+            std::vector<std::vector<size_t>>&& processing_units, size_t max_processing_units_in_flight,
+            size_t read_window
+    ) :
+        reader_(std::move(reader)),
+        ranges_and_keys_(std::make_shared<std::vector<pipelines::RangesAndKey>>(std::move(ranges_and_keys))),
+        promises_(std::make_shared<std::vector<folly::Promise<pipelines::SegmentAndSlice>>>(ranges_and_keys_->size())),
+        i_th_segment_enqueued_(ranges_and_keys_->size(), false),
+        read_window_(std::max<size_t>(1, read_window)),
+        processing_units_(std::move(processing_units)),
+        max_processing_units_in_flight_(max_processing_units_in_flight),
+        next_unit_(max_processing_units_in_flight) {}
+
+    // Used to chain downstream processing, possibly before any of the work is actually executing.
+    // The work then gets kicked off by admit_initial_processing_units or on_processing_unit_complete.
+    std::vector<folly::Future<pipelines::SegmentAndSlice>> futures() const {
+        std::vector<folly::Future<pipelines::SegmentAndSlice>> res;
+        res.reserve(promises_->size());
+        for (auto& promise : *promises_) {
+            res.emplace_back(promise.getFuture());
+        }
+        return res;
+    }
+
+    const std::vector<std::vector<size_t>>& processing_units() const { return processing_units_; }
+
+    void admit_initial_processing_units() {
+        for (size_t u = 0; u < std::min(max_processing_units_in_flight_, processing_units_.size()); ++u) {
+            enqueue_processing_unit(u);
+        }
+        fill_read_window();
+    }
+
+    void on_processing_unit_complete() {
+        const auto u = next_unit_.fetch_add(1);
+        if (u < processing_units_.size()) {
+            enqueue_processing_unit(u);
+        }
+        fill_read_window();
+    }
+
+  private:
+    // Make the u-th unit's segments eligible to read. A segment may belong to two units (e.g. resample boundaries), so
+    // it is enqueued at most once. Segments are enqueued unit-contiguously so folly::collect on a unit is not left
+    // waiting on segments submitted far apart.
+    void enqueue_processing_unit(const size_t u) {
+        std::lock_guard lock{window_mutex_};
+        for (const auto i : processing_units_.at(u)) {
+            if (!i_th_segment_enqueued_.at(i)) {
+                i_th_segment_enqueued_.at(i) = true;
+                segments_queued_for_read_.push_back(i);
+            }
+        }
+    }
+
+    // Launch eligible reads until the read window is full. Called whenever a read completes or a new processing unit
+    // is admitted.
+    void fill_read_window() {
+        std::vector<size_t> to_launch;
+        {
+            std::lock_guard lock{window_mutex_};
+            while (active_reads_ < read_window_ && !segments_queued_for_read_.empty()) {
+                to_launch.push_back(segments_queued_for_read_.front());
+                segments_queued_for_read_.pop_front();
+                ++active_reads_;
+            }
+        }
+        for (const auto i : to_launch) {
+            dispatch_read(i);
+        }
+    }
+
+    void dispatch_read(size_t i) {
+        auto self = shared_from_this();
+        reader_(pipelines::RangesAndKey{ranges_and_keys_->at(i)})
+                .thenTryInline([self, i](folly::Try<pipelines::SegmentAndSlice>&& t) {
+                    self->promises_->at(i).setTry(std::move(t));
+                    self->on_read_complete();
+                });
+    }
+
+    void on_read_complete() {
+        {
+            std::lock_guard lock{window_mutex_};
+            --active_reads_;
+        }
+        fill_read_window();
+    }
+
+    SegmentReader reader_;
+    std::shared_ptr<std::vector<pipelines::RangesAndKey>> ranges_and_keys_;
+
+    // We accumulate promises for all segments up front, but they do not start to execute until the read is dispatched.
+    // This lets us set up chains of futures while controlling how many are actually executing at a given time.
+    std::shared_ptr<std::vector<folly::Promise<pipelines::SegmentAndSlice>>> promises_;
+
+    // State to hand-roll a folly::window over the segment loads on the IO pool
+    std::mutex window_mutex_; // protects the 3 fields below
+    std::vector<bool> i_th_segment_enqueued_;
+    std::deque<size_t> segments_queued_for_read_;
+    size_t active_reads_{0};
+    size_t read_window_;
+
+    // State to manage the number of processing units being processed at a time
+    std::vector<std::vector<size_t>> processing_units_;
+    size_t max_processing_units_in_flight_;
+    std::atomic<size_t> next_unit_;
+};
+
+size_t max_resident_processing_units(const std::vector<std::vector<size_t>>& processing_unit_indexes);
+
+} // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/admission_handler.hpp
+++ b/cpp/arcticdb/version/admission_handler.hpp
@@ -9,9 +9,12 @@
 #pragma once
 
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/util/preconditions.hpp>
+#include <folly/ExceptionWrapper.h>
 #include <folly/futures/Future.h>
 #include <folly/futures/Promise.h>
 #include <atomic>
+#include <exception>
 #include <deque>
 #include <functional>
 #include <memory>
@@ -49,10 +52,19 @@ class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<Proce
         ranges_and_keys_(std::make_shared<std::vector<pipelines::RangesAndKey>>(std::move(ranges_and_keys))),
         promises_(std::make_shared<std::vector<folly::Promise<pipelines::SegmentAndSlice>>>(ranges_and_keys_->size())),
         i_th_segment_enqueued_(ranges_and_keys_->size(), false),
-        read_window_(std::max<size_t>(1, read_window)),
+        read_window_(read_window),
         processing_units_(std::move(processing_units)),
         max_processing_units_in_flight_(max_processing_units_in_flight),
-        next_unit_(max_processing_units_in_flight) {}
+        next_unit_(max_processing_units_in_flight) {
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                read_window >= 1, "ProcessingUnitAdmissionHandler read_window must be >= 1, got {}", read_window
+        );
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                max_processing_units_in_flight >= 1,
+                "ProcessingUnitAdmissionHandler max_processing_units_in_flight must be >= 1, got {}",
+                max_processing_units_in_flight
+        );
+    }
 
     // Used to chain downstream processing, possibly before any of the work is actually executing.
     // The work then gets kicked off by admit_initial_processing_units or on_processing_unit_complete.
@@ -109,7 +121,18 @@ class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<Proce
             }
         }
         for (const auto i : to_launch) {
-            dispatch_read(i);
+            // A reader that throws instead of returning a failed future would otherwise leave the window slot used
+            // and the promise unfulfilled, hanging every consumer of this segment. Catch everything, since losing a
+            // promise here cannot be recovered from.
+            try {
+                dispatch_read(i);
+            } catch (...) {
+                {
+                    std::lock_guard lock{window_mutex_};
+                    --active_reads_;
+                }
+                promises_->at(i).setException(folly::exception_wrapper{std::current_exception()});
+            }
         }
     }
 
@@ -138,6 +161,9 @@ class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<Proce
     std::shared_ptr<std::vector<folly::Promise<pipelines::SegmentAndSlice>>> promises_;
 
     // State to hand-roll a folly::window over the segment loads on the IO pool
+    // We do this so that when the processing unit budget is much higher than the window size, we still
+    // get sensible queuing behaviour on the IO pools. Benchmarking on PR #3191 showed a major performance
+    // penalty without this windowing, due to the round-robin scheduling on the IO thread pools.
     std::mutex window_mutex_; // protects the 3 fields below
     std::vector<bool> i_th_segment_enqueued_;
     std::deque<size_t> segments_queued_for_read_;
@@ -151,5 +177,9 @@ class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<Proce
 };
 
 size_t max_resident_processing_units(const std::vector<std::vector<size_t>>& processing_unit_indexes);
+
+// Read window: the number of segment reads submitted but not completed at any given time. Always >= 1. Defaults to
+// 2*io_thread_count.
+size_t segment_read_window();
 
 } // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/admission_handler.hpp
+++ b/cpp/arcticdb/version/admission_handler.hpp
@@ -111,27 +111,38 @@ class ProcessingUnitAdmissionHandler : public std::enable_shared_from_this<Proce
     // Launch eligible reads until the read window is full. Called whenever a read completes or a new processing unit
     // is admitted.
     void fill_read_window() {
-        std::vector<size_t> to_launch;
-        {
-            std::lock_guard lock{window_mutex_};
-            while (active_reads_ < read_window_ && !segments_queued_for_read_.empty()) {
-                to_launch.push_back(segments_queued_for_read_.front());
-                segments_queued_for_read_.pop_front();
-                ++active_reads_;
-            }
-        }
-        for (const auto i : to_launch) {
-            // A reader that throws instead of returning a failed future would otherwise leave the window slot used
-            // and the promise unfulfilled, hanging every consumer of this segment. Catch everything, since losing a
-            // promise here cannot be recovered from.
-            try {
-                dispatch_read(i);
-            } catch (...) {
-                {
-                    std::lock_guard lock{window_mutex_};
-                    --active_reads_;
+        while (true) {
+            std::vector<size_t> to_launch;
+            {
+                std::lock_guard lock{window_mutex_};
+                while (active_reads_ < read_window_ && !segments_queued_for_read_.empty()) {
+                    to_launch.push_back(segments_queued_for_read_.front());
+                    segments_queued_for_read_.pop_front();
+                    ++active_reads_;
                 }
-                promises_->at(i).setException(folly::exception_wrapper{std::current_exception()});
+            }
+            if (to_launch.empty()) {
+                return;
+            }
+            bool any_read_dispatch_failed = false;
+            for (const auto i : to_launch) {
+                // A reader that throws instead of returning a failed future would otherwise leave the window slot used
+                // and the promise unfulfilled, hanging every consumer of this segment. Catch everything, since losing a
+                // promise here cannot be recovered from.
+                try {
+                    dispatch_read(i);
+                } catch (...) {
+                    {
+                        std::lock_guard lock{window_mutex_};
+                        --active_reads_;
+                    }
+                    promises_->at(i).setException(folly::exception_wrapper{std::current_exception()});
+                    any_read_dispatch_failed = true;
+                }
+            }
+            // If any reads failed go round again for the slots the catch freed, otherwise break the while loop
+            if (!any_read_dispatch_failed) {
+                return;
             }
         }
     }

--- a/cpp/arcticdb/version/test/test_admission_handler.cpp
+++ b/cpp/arcticdb/version/test/test_admission_handler.cpp
@@ -1,0 +1,495 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+#include <arcticdb/version/version_store_api.hpp>
+#include <arcticdb/version/version_core.hpp>
+#include <arcticdb/version/admission_handler.hpp>
+#include <arcticdb/stream/test/stream_test_common.hpp>
+#include <arcticdb/util/test/generators.hpp>
+#include <arcticdb/pipeline/column_stats.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
+#include <arcticdb/pipeline/slicing.hpp>
+#include <arcticdb/pipeline/query.hpp>
+#include <arcticdb/util/segment_residency_tracker.hpp>
+#include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/variant.hpp>
+#include <arcticdb/processing/clause_utils.hpp>
+#include <arcticdb/async/task_scheduler.hpp>
+
+namespace arcticdb {
+
+namespace {
+constexpr auto PROCESSING_UNITS_BOUND_KEY = "VersionStore.NumProcessingUnitsLive";
+
+void write_sliced_symbol(
+        version_store::PythonVersionStore& pvs, const StreamId& stream_id, size_t num_cols, size_t num_rows,
+        size_t col_per_slice, size_t row_per_slice
+) {
+    std::vector<std::string> names;
+    names.reserve(num_cols);
+    std::vector<entity::FieldRef> fields;
+    fields.reserve(num_cols);
+    for (size_t i = 0; i < num_cols; ++i) {
+        names.emplace_back(fmt::format("col_{}", i));
+        fields.emplace_back(entity::scalar_field(entity::DataType::FLOAT64, names[i]));
+    }
+    auto frame = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, 0);
+    pipelines::SlicingPolicy slicing = pipelines::FixedSlicer{col_per_slice, row_per_slice};
+    pipelines::IndexPartialKey pk{stream_id, 0};
+    auto store = pvs._test_get_store();
+    auto key = pipelines::write_frame(std::move(pk), frame.frame_, slicing, store).get();
+    pvs.write_version_and_prune_previous(false, key, std::nullopt);
+}
+
+struct ResidencyGuard {
+    ResidencyGuard() {
+        util::SegmentResidencyTracker::instance().reset();
+        util::SegmentResidencyTracker::instance().set_enabled(true);
+    }
+    ~ResidencyGuard() { util::SegmentResidencyTracker::instance().set_enabled(false); }
+};
+
+// Runs create_column_stats with admission ceiling k and returns the peak number of resident segments.
+int64_t high_water_for_create_column_stats(
+        version_store::PythonVersionStore& pvs, const StreamId& stream_id, ColumnStats column_stats, int64_t k
+) {
+    ScopedConfig config_guard{PROCESSING_UNITS_BOUND_KEY, k};
+    ResidencyGuard residency_guard;
+    pvs.create_column_stats_version(stream_id, column_stats, VersionQuery{});
+    return util::SegmentResidencyTracker::instance().high_water();
+}
+} // namespace
+
+struct ColumnStatsStoreTest : TestStore {
+  protected:
+    std::string get_name() override { return "test.column_stats"; }
+};
+
+TEST_F(ColumnStatsStoreTest, ResidencyBoundedByAdmission) {
+    const StreamId stream_id{"bounded"};
+    const size_t num_cols = 4;
+    const size_t col_per_slice = 2;
+    const size_t num_rows = 40;
+    const size_t row_per_slice = 2;
+    const size_t max_unit_size = num_cols / col_per_slice;
+    const size_t num_segments = (num_rows / row_per_slice) * max_unit_size;
+    const int64_t k = 2;
+
+    write_sliced_symbol(*test_store_, stream_id, num_cols, num_rows, col_per_slice, row_per_slice);
+
+    ColumnStats column_stats{
+            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
+    };
+
+    const int64_t high_water_mark = high_water_for_create_column_stats(*test_store_, stream_id, column_stats, k);
+
+    ASSERT_GT(num_segments, static_cast<size_t>(k) * max_unit_size);
+    EXPECT_GE(high_water_mark, static_cast<int64_t>(max_unit_size));
+    EXPECT_LE(high_water_mark, static_cast<int64_t>(k * max_unit_size));
+}
+
+namespace {
+
+// Builds num_units processing units of unit_size segments each.
+std::shared_ptr<version_store::ProcessingUnitAdmissionHandler> make_admission_handler(
+        size_t num_units, size_t unit_size, size_t max_processing_units_in_flight, size_t read_window,
+        std::vector<int>& fire_count, std::vector<folly::Promise<pipelines::SegmentAndSlice>>& kept
+) {
+    using namespace arcticdb::pipelines;
+    std::vector<RangesAndKey> ranges;
+    std::vector<std::vector<size_t>> units;
+    for (size_t u = 0; u < num_units; ++u) {
+        std::vector<size_t> unit;
+        for (size_t c = 0; c < unit_size; ++c) {
+            const size_t idx = ranges.size();
+            ranges.emplace_back(RowRange{idx, idx + 1}, ColRange{0, 1}, entity::AtomKey{});
+            unit.push_back(idx);
+        }
+        units.push_back(std::move(unit));
+    }
+    fire_count.assign(num_units * unit_size, 0);
+    version_store::SegmentReader reader = [&fire_count, &kept](RangesAndKey&& rk) {
+        ++fire_count.at(rk.row_range().first);
+        kept.emplace_back();
+        return kept.back().getFuture();
+    };
+    return std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader), std::move(ranges), std::move(units), max_processing_units_in_flight, read_window
+    );
+}
+} // namespace
+
+TEST(ProcessingUnitAdmissionHandlerTest, FiresAtMostKUnitsThenAdvancesOnCompletion) {
+    const size_t num_units = 5;
+    const size_t unit_size = 2;
+    const size_t k = 2;
+    // Read window larger than all work, so the residency budget is the only limiter
+    const size_t read_window = num_units * unit_size;
+    std::vector<int> fire_count;
+    std::vector<folly::Promise<pipelines::SegmentAndSlice>> kept;
+    auto admission = make_admission_handler(num_units, unit_size, k, read_window, fire_count, kept);
+
+    admission->admit_initial_processing_units();
+    // Only the first k units are loaded up front.
+    for (size_t i = 0; i < num_units * unit_size; ++i) {
+        EXPECT_EQ(fire_count.at(i), i < k * unit_size ? 1 : 0) << "index " << i << " after admit_initial";
+    }
+
+    // Each completion admits exactly one further unit, in order.
+    for (size_t completed = 0; completed < num_units; ++completed) {
+        admission->on_processing_unit_complete();
+        const size_t expected_fired = std::min(k + completed + 1, num_units) * unit_size;
+        for (size_t i = 0; i < num_units * unit_size; ++i) {
+            EXPECT_EQ(fire_count.at(i), i < expected_fired ? 1 : 0)
+                    << "index " << i << " after " << completed + 1 << " completions";
+        }
+    }
+
+    // Extra completions are no-ops
+    admission->on_processing_unit_complete();
+    for (auto count : fire_count) {
+        EXPECT_EQ(count, 1);
+    }
+}
+
+// A segment referenced by two units is loaded once, even though both units are admitted.
+TEST(ProcessingUnitAdmissionHandlerTest, SharedSegmentFiredOnce) {
+    using namespace arcticdb::pipelines;
+    std::vector<RangesAndKey> ranges;
+    for (size_t i = 0; i < 3; ++i) {
+        ranges.emplace_back(RowRange{i, i + 1}, ColRange{0, 1}, entity::AtomKey{});
+    }
+    std::vector<std::vector<size_t>> units{{0, 1}, {1, 2}}; // segment 1 shared
+
+    std::vector<int> fire_count(3, 0);
+    std::vector<folly::Promise<SegmentAndSlice>> kept;
+    version_store::SegmentReader reader = [&fire_count, &kept](RangesAndKey&& rk) {
+        ++fire_count.at(rk.row_range().first);
+        kept.emplace_back();
+        return kept.back().getFuture();
+    };
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::move(units),
+            /*max_processing_units_in_flight=*/2,
+            /*read_window=*/3
+    );
+
+    admission->admit_initial_processing_units();
+    EXPECT_EQ(fire_count.at(0), 1);
+    EXPECT_EQ(fire_count.at(1), 1); // shared, fired once despite two referencing units
+    EXPECT_EQ(fire_count.at(2), 1);
+}
+
+// With the residency budget non-binding (all units eligible up front), the read window caps the number of reads in
+// flight, and each completed read frees exactly one slot so the next eligible segment is launched.
+TEST(ProcessingUnitAdmissionHandlerTest, ReadWindowLimitsInFlightReads) {
+    using namespace arcticdb::pipelines;
+    const size_t num_units = 4;
+    const size_t unit_size = 2;
+    const size_t total_segments = num_units * unit_size;
+    const size_t k = num_units; // residency non-binding: every unit eligible at once
+    const size_t read_window = 3;
+
+    std::vector<int> fire_count;
+    std::vector<folly::Promise<SegmentAndSlice>> kept;
+    kept.reserve(total_segments);
+    auto admission = make_admission_handler(num_units, unit_size, k, read_window, fire_count, kept);
+
+    auto total_fired = [&fire_count]() {
+        return static_cast<size_t>(std::count_if(fire_count.begin(), fire_count.end(), [](int c) { return c > 0; }));
+    };
+
+    admission->admit_initial_processing_units();
+    EXPECT_EQ(total_fired(), read_window); // window caps reads in flight
+
+    // Completing a read frees exactly one window slot, launching exactly one more until the eligible work runs out.
+    for (size_t completed = 0; completed < total_segments; ++completed) {
+        EXPECT_EQ(total_fired(), std::min(read_window + completed, total_segments))
+                << "before completion " << completed;
+        kept.at(completed).setValue(
+                SegmentAndSlice(RangesAndKey{RowRange{0, 1}, ColRange{0, 1}, entity::AtomKey{}}, SegmentInMemory{})
+        );
+    }
+    EXPECT_EQ(total_fired(), total_segments);
+}
+
+namespace {
+struct TinyThreadPool {
+    TinyThreadPool() {
+        ConfigsMap::instance()->set_int("VersionStore.NumIOThreads", 1);
+        ConfigsMap::instance()->set_int("VersionStore.NumCPUThreads", 1);
+        async::TaskScheduler::reattach_instance();
+    }
+    ~TinyThreadPool() {
+        ConfigsMap::instance()->unset_int("VersionStore.NumIOThreads");
+        ConfigsMap::instance()->unset_int("VersionStore.NumCPUThreads");
+        async::TaskScheduler::reattach_instance();
+    }
+};
+} // namespace
+
+// Overlapping units with a ceiling of 1, and thread pools of size 1. The first unit loads the
+// shared segment, the second is admitted only when the first completes, and it does not reload the shared segment.
+// Reaching .get() shows that the admit -> process -> advance loop does not deadlock.
+TEST(ProcessingUnitAdmissionHandlerTest, OverlappingUnitsAdvanceWithCeilingOne) {
+    using namespace arcticdb::pipelines;
+    TinyThreadPool tiny_pool;
+
+    const std::vector<std::vector<size_t>> units{{0, 1}, {1, 2}}; // segment 1 shared between the two units
+    const size_t num_segments = 3;
+
+    std::vector<RangesAndKey> ranges;
+    for (size_t i = 0; i < num_segments; ++i) {
+        ranges.emplace_back(RowRange{i, i + 1}, ColRange{0, 1}, entity::AtomKey{});
+    }
+
+    std::vector<std::atomic<int>> fire_count(num_segments);
+    for (auto& count : fire_count) {
+        count.store(0);
+    }
+
+    version_store::SegmentReader reader = [&fire_count](RangesAndKey&& rk) {
+        const auto idx = rk.row_range().first;
+        return folly::via(&async::io_executor(), [&fire_count, idx, rk = std::move(rk)]() mutable {
+            fire_count[idx].fetch_add(1, std::memory_order_relaxed);
+            return SegmentAndSlice(std::move(rk), SegmentInMemory{});
+        });
+    };
+
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::vector<std::vector<size_t>>(units),
+            /*max_processing_units_in_flight=*/1,
+            /*read_window=*/num_segments
+    );
+
+    // Mirror schedule_first_iteration: split the shared segment's future, then build one future per unit that processes
+    // on the CPU pool and advances admission on completion.
+    auto segment_futures = admission->futures();
+    std::vector<EntityFetchCount> fetch_counts{1, 2, 1}; // segment 1 is referenced by both units
+    auto splitters = split_futures(std::move(segment_futures), fetch_counts);
+
+    std::vector<folly::Future<folly::Unit>> unit_futures;
+    for (const auto& unit : units) {
+        std::vector<folly::Future<SegmentAndSlice>> local;
+        for (auto i : unit) {
+            util::variant_match(
+                    splitters.at(i),
+                    [&local](folly::Future<SegmentAndSlice>& fut) { local.emplace_back(std::move(fut)); },
+                    [&local](folly::FutureSplitter<SegmentAndSlice>& splitter) {
+                        local.emplace_back(splitter.getFuture());
+                    }
+            );
+        }
+        unit_futures.emplace_back(folly::collect(local)
+                                          .via(&async::cpu_executor())
+                                          .thenValue([](auto&&) { return folly::Unit{}; })
+                                          .ensure([admission]() { admission->on_processing_unit_complete(); }));
+    }
+
+    auto all_done = folly::collect(unit_futures).via(&async::io_executor());
+    admission->admit_initial_processing_units();
+    std::move(all_done).get();
+
+    EXPECT_EQ(fire_count.at(0).load(), 1);
+    EXPECT_EQ(fire_count.at(1).load(), 1);
+    EXPECT_EQ(fire_count.at(2).load(), 1);
+}
+
+// Static schema with column_group_size changed between the initial write and a later append, so the appended row slices
+// have a different number of column slices than the original ones. The processing units therefore have different sizes,
+// and the bound must use the max across units to avoid deadlock.
+TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnits) {
+    using namespace arcticdb::pipelines;
+
+    const std::array fields{
+            scalar_field(entity::DataType::FLOAT64, "col_0"),
+            scalar_field(entity::DataType::FLOAT64, "col_1"),
+            scalar_field(entity::DataType::FLOAT64, "col_2"),
+            scalar_field(entity::DataType::FLOAT64, "col_3")
+    };
+
+    arcticdb::proto::storage::VersionStoreConfig cfg;
+    cfg.mutable_write_options()->set_segment_row_size(2);
+    cfg.mutable_write_options()->set_column_group_size(2); // 4 cols -> 2 column slices per row slice
+    auto engine = get_test_engine<version_store::PythonVersionStore>({cfg});
+
+    const StreamId stream_id{"uneven"};
+    const size_t num_rows = 8;
+
+    auto initial = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, 0);
+    engine.write_versioned_dataframe_internal(stream_id, std::move(initial.frame_), false, false, false);
+
+    // Widen the column group so the appended row slices hold all 4 cols in a single column slice (unit size 1), whereas
+    // the original row slices have 2 column slices (unit size 2).
+    auto wide_cfg = engine.cfg();
+    wide_cfg.mutable_write_options()->set_column_group_size(4);
+    engine.configure(std::move(wide_cfg));
+
+    auto appended = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, num_rows);
+    engine.append_internal(stream_id, std::move(appended.frame_), false, false, false);
+
+    // Confirm the slicing: 4 original row slices x 2 column slices + 4 appended row slices x 1 column
+    // slice = 12 data segments. A uniform layout would have 16
+    size_t data_segments = 0;
+    engine._test_get_store()->iterate_type(KeyType::TABLE_DATA, [&data_segments](VariantKey&&) { ++data_segments; });
+    ASSERT_EQ(data_segments, 12u);
+
+    ColumnStats column_stats{
+            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
+    };
+
+    const int64_t k = 2;
+    const size_t max_unit_size = 2; // original row slices span 2 column slices; appended ones span 1
+    const int64_t bound = k * static_cast<int64_t>(max_unit_size);
+
+    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, column_stats, k);
+
+    EXPECT_GT(high_water, 0);
+    EXPECT_LE(high_water, bound);
+
+    auto info = engine.get_column_stats_info_version(stream_id, VersionQuery{});
+    const std::unordered_map<std::string, std::unordered_set<std::string>> expected{
+            {"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}
+    };
+    EXPECT_EQ(info.to_map(), expected);
+}
+
+// As above but with the wider column slice written first, so the largest processing units are the later row
+// slices.
+TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnitsWiderFirst) {
+    using namespace arcticdb::pipelines;
+
+    const std::array fields{
+            scalar_field(entity::DataType::FLOAT64, "col_0"),
+            scalar_field(entity::DataType::FLOAT64, "col_1"),
+            scalar_field(entity::DataType::FLOAT64, "col_2"),
+            scalar_field(entity::DataType::FLOAT64, "col_3")
+    };
+
+    arcticdb::proto::storage::VersionStoreConfig cfg;
+    cfg.mutable_write_options()->set_segment_row_size(2);
+    cfg.mutable_write_options()->set_column_group_size(4); // 4 cols -> 1 column slice per row slice
+    auto engine = get_test_engine<version_store::PythonVersionStore>({cfg});
+
+    const StreamId stream_id{"uneven_wider_first"};
+    const size_t num_rows = 8;
+
+    auto initial = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, 0);
+    engine.write_versioned_dataframe_internal(stream_id, std::move(initial.frame_), false, false, false);
+
+    // Narrow the column group so the appended row slices have 2 column slices (unit size 2), whereas the original row
+    // slices have 1 (unit size 1).
+    auto narrow_cfg = engine.cfg();
+    narrow_cfg.mutable_write_options()->set_column_group_size(2);
+    engine.configure(std::move(narrow_cfg));
+
+    auto appended = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, num_rows);
+    engine.append_internal(stream_id, std::move(appended.frame_), false, false, false);
+
+    // 4 original row slices x 1 column slice + 4 appended row slices x 2 column slices = 12 data segments.
+    size_t data_segments = 0;
+    engine._test_get_store()->iterate_type(KeyType::TABLE_DATA, [&data_segments](VariantKey&&) { ++data_segments; });
+    ASSERT_EQ(data_segments, 12u);
+
+    ColumnStats column_stats{
+            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
+    };
+
+    const int64_t k = 2;
+    const size_t max_unit_size = 2; // appended row slices span 2 column slices
+    const int64_t bound = k * static_cast<int64_t>(max_unit_size);
+
+    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, column_stats, k);
+
+    EXPECT_GT(high_water, 0);
+    EXPECT_LE(high_water, bound);
+
+    auto info = engine.get_column_stats_info_version(stream_id, VersionQuery{});
+    const std::unordered_map<std::string, std::unordered_set<std::string>> expected{
+            {"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}
+    };
+    EXPECT_EQ(info.to_map(), expected);
+}
+
+namespace {
+struct ScopedThreadCounts {
+    ScopedThreadCounts(int64_t cpu, int64_t io) {
+        ConfigsMap::instance()->set_int("VersionStore.NumCPUThreads", cpu);
+        ConfigsMap::instance()->set_int("VersionStore.NumIOThreads", io);
+        async::TaskScheduler::reattach_instance();
+    }
+    ~ScopedThreadCounts() {
+        ConfigsMap::instance()->unset_int("VersionStore.NumCPUThreads");
+        ConfigsMap::instance()->unset_int("VersionStore.NumIOThreads");
+        async::TaskScheduler::reattach_instance();
+    }
+};
+} // namespace
+
+// Many column slices in each processing unit make the IO read-ahead term go to 1. The 2*cpu_thread_count floor must
+// keep the default from starving the CPU pool.
+TEST(MaxResidentProcessingUnits, CpuFloorAppliesForWideUnits) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/2};
+    const std::vector<std::vector<size_t>> wide_units{{0, 1, 2, 3, 4, 5, 6, 7}}; // max_unit_size = 8
+    // io_read_ahead = ceil(4*2 / 8) = 1; cpu floor = 2*4 = 8
+    EXPECT_EQ(version_store::max_resident_processing_units(wide_units), 8u);
+}
+
+// Narrow units keep the IO read-ahead term large, so it wins over the cpu floor.
+TEST(MaxResidentProcessingUnits, IoReadAheadDominatesForNarrowUnits) {
+    ScopedThreadCounts threads{/*cpu=*/2, /*io=*/8};
+    const std::vector<std::vector<size_t>> narrow_units{{0}, {1}, {2}}; // max_unit_size = 1
+    // io_read_ahead = ceil(4*8 / 1) = 32; cpu floor = 2*2 = 4
+    EXPECT_EQ(version_store::max_resident_processing_units(narrow_units), 32u);
+}
+
+// An explicit config override takes precedence over the default.
+TEST(MaxResidentProcessingUnits, ConfigOverrideTakesPrecedence) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
+    ScopedConfig override_guard{"VersionStore.NumProcessingUnitsLive", 3};
+    const std::vector<std::vector<size_t>> units{{0, 1}, {2, 3}};
+    EXPECT_EQ(version_store::max_resident_processing_units(units), 3u);
+}
+
+// A configured value of 0 is a kill switch: residency is unbounded (the limit becomes the total number of processing
+// units, so every unit is eligible at once) and the read window alone governs.
+TEST(MaxResidentProcessingUnits, ZeroAdmitsAllUnits) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
+    ScopedConfig override_guard{"VersionStore.NumProcessingUnitsLive", 0};
+    const std::vector<std::vector<size_t>> units{{0, 1}, {2, 3}, {4, 5}};
+    EXPECT_EQ(version_store::max_resident_processing_units(units), units.size());
+}
+
+// The read window defaults to 2*io_thread_count, matching the old folly::window(2*io) read path.
+TEST(SegmentReadWindow, DefaultsToTwiceIoThreads) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
+    EXPECT_EQ(version_store::segment_read_window(), 16u);
+}
+
+// An explicit config override takes precedence, and the window never drops below 1.
+TEST(SegmentReadWindow, ConfigOverrideAndFloor) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
+    {
+        ScopedConfig override_guard{"VersionStore.SegmentReadWindow", 5};
+        EXPECT_EQ(version_store::segment_read_window(), 5u);
+    }
+    {
+        ScopedConfig override_guard{"VersionStore.SegmentReadWindow", 0};
+        EXPECT_EQ(version_store::segment_read_window(), 1u);
+    }
+}
+
+} // namespace arcticdb

--- a/cpp/arcticdb/version/test/test_admission_handler.cpp
+++ b/cpp/arcticdb/version/test/test_admission_handler.cpp
@@ -509,10 +509,6 @@ TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowDoesNotHang) {
     EXPECT_TRUE(results.at(1).hasValue());
 }
 
-// Throwing on the *first* segment of a unit leaves the unit's other segment sitting in the read queue with the window
-// slot already freed, which the failed dispatch itself does not re-check. Recovery comes from the .ensure: the
-// exception fails unit 0's collect fast, on_processing_unit_complete calls fill_read_window unconditionally, and the
-// queued segment is drained. Nothing else would drain it, so this pins that coupling down.
 TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowOnFirstSegmentOfUnitDoesNotHang) {
     TinyThreadPool tiny_pool;
     const auto results = run_synchronous_read_throw_case(/*throwing_segment=*/0); // first segment of unit 0

--- a/cpp/arcticdb/version/test/test_admission_handler.cpp
+++ b/cpp/arcticdb/version/test/test_admission_handler.cpp
@@ -9,6 +9,11 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
+#include <deque>
+#include <memory>
+#include <stdexcept>
+#include <utility>
 
 #include <arcticdb/version/version_store_api.hpp>
 #include <arcticdb/version/version_core.hpp>
@@ -20,7 +25,9 @@
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/pipeline/query.hpp>
 #include <arcticdb/util/segment_residency_tracker.hpp>
+#include <arcticdb/column_store/memory_segment_impl.hpp>
 #include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/error_code.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/processing/clause_utils.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
@@ -52,22 +59,94 @@ void write_sliced_symbol(
 
 struct ResidencyGuard {
     ResidencyGuard() {
+        // A non-zero count here means a previous test leaked a counted segment past its own guard. Left unchecked, the
+        // stray release drives live_ negative and every upper-bound assertion below passes vacuously.
+        EXPECT_EQ(util::SegmentResidencyTracker::instance().live(), 0) << "counted segment leaked from an earlier test";
         util::SegmentResidencyTracker::instance().reset();
         util::SegmentResidencyTracker::instance().set_enabled(true);
     }
-    ~ResidencyGuard() { util::SegmentResidencyTracker::instance().set_enabled(false); }
+    ~ResidencyGuard() {
+        util::SegmentResidencyTracker::instance().set_enabled(false);
+        util::SegmentResidencyTracker::instance().reset();
+    }
 };
 
 // Runs create_column_stats with admission ceiling k and returns the peak number of resident segments.
 int64_t high_water_for_create_column_stats(
-        version_store::PythonVersionStore& pvs, const StreamId& stream_id, ColumnStats column_stats, int64_t k
+        version_store::PythonVersionStore& pvs, const StreamId& stream_id, int64_t k
 ) {
     ScopedConfig config_guard{PROCESSING_UNITS_BOUND_KEY, k};
     ResidencyGuard residency_guard;
-    pvs.create_column_stats_version(stream_id, column_stats, VersionQuery{});
+    pvs.create_column_stats_version(stream_id, VersionQuery{});
     return util::SegmentResidencyTracker::instance().high_water();
 }
 } // namespace
+
+TEST(SegmentResidencyTracking, HighWaterIsPeakNotTotal) {
+    ResidencyGuard residency_guard;
+    auto& tracker = util::SegmentResidencyTracker::instance();
+    tracker.on_segment_resident();
+    tracker.on_segment_resident();
+    tracker.on_segment_released();
+    tracker.on_segment_resident();
+    tracker.on_segment_released();
+    tracker.on_segment_resident();
+    EXPECT_EQ(tracker.high_water(), 2);
+}
+
+TEST(SegmentResidencyTracking, SelfMoveAssignmentKeepsSegmentCounted) {
+    ResidencyGuard residency_guard;
+    {
+        SegmentInMemoryImpl segment{};
+        segment.mark_from_disk();
+        // -Wpragmas first because GCC before 13 does not know -Wself-move and -Werror is on
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wself-move"
+        segment = std::move(segment);
+#pragma GCC diagnostic pop
+    }
+    SegmentInMemoryImpl later{};
+    later.mark_from_disk();
+    EXPECT_EQ(util::SegmentResidencyTracker::instance().high_water(), 1);
+}
+
+TEST(SegmentResidencyTracking, MarkedWhileDisabledIsNotReleased) {
+    util::SegmentResidencyTracker::instance().set_enabled(false);
+    auto marked_while_disabled = std::make_unique<SegmentInMemoryImpl>();
+    marked_while_disabled->mark_from_disk();
+
+    ResidencyGuard residency_guard;
+    marked_while_disabled.reset();
+
+    SegmentInMemoryImpl resident{};
+    resident.mark_from_disk();
+    EXPECT_EQ(util::SegmentResidencyTracker::instance().high_water(), 1);
+}
+
+// A clone of a counted segment is a second copy of the decoded data, so it is counted too. Otherwise destroying the
+// source would take the count back to zero while the data is still resident in the clone.
+TEST(SegmentResidencyTracking, CloneOfMarkedSegmentIsCounted) {
+    ResidencyGuard residency_guard;
+    auto& tracker = util::SegmentResidencyTracker::instance();
+    {
+        auto source = std::make_unique<SegmentInMemoryImpl>();
+        source->mark_from_disk();
+        auto clone = source->clone();
+        EXPECT_EQ(tracker.high_water(), 2);
+        source.reset();
+        EXPECT_EQ(tracker.live(), 1);
+    }
+    EXPECT_EQ(tracker.live(), 0);
+    EXPECT_EQ(tracker.high_water(), 2);
+}
+
+TEST(SegmentResidencyTracking, CloneOfUnmarkedSegmentIsNotCounted) {
+    ResidencyGuard residency_guard;
+    SegmentInMemoryImpl source{};
+    auto clone = source.clone();
+    EXPECT_EQ(util::SegmentResidencyTracker::instance().high_water(), 0);
+}
 
 struct ColumnStatsStoreTest : TestStore {
   protected:
@@ -86,11 +165,7 @@ TEST_F(ColumnStatsStoreTest, ResidencyBoundedByAdmission) {
 
     write_sliced_symbol(*test_store_, stream_id, num_cols, num_rows, col_per_slice, row_per_slice);
 
-    ColumnStats column_stats{
-            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
-    };
-
-    const int64_t high_water_mark = high_water_for_create_column_stats(*test_store_, stream_id, column_stats, k);
+    const int64_t high_water_mark = high_water_for_create_column_stats(*test_store_, stream_id, k);
 
     ASSERT_GT(num_segments, static_cast<size_t>(k) * max_unit_size);
     EXPECT_GE(high_water_mark, static_cast<int64_t>(max_unit_size));
@@ -102,7 +177,7 @@ namespace {
 // Builds num_units processing units of unit_size segments each.
 std::shared_ptr<version_store::ProcessingUnitAdmissionHandler> make_admission_handler(
         size_t num_units, size_t unit_size, size_t max_processing_units_in_flight, size_t read_window,
-        std::vector<int>& fire_count, std::vector<folly::Promise<pipelines::SegmentAndSlice>>& kept
+        std::vector<int>& fire_count, std::deque<folly::Promise<pipelines::SegmentAndSlice>>& kept
 ) {
     using namespace arcticdb::pipelines;
     std::vector<RangesAndKey> ranges;
@@ -135,7 +210,7 @@ TEST(ProcessingUnitAdmissionHandlerTest, FiresAtMostKUnitsThenAdvancesOnCompleti
     // Read window larger than all work, so the residency budget is the only limiter
     const size_t read_window = num_units * unit_size;
     std::vector<int> fire_count;
-    std::vector<folly::Promise<pipelines::SegmentAndSlice>> kept;
+    std::deque<folly::Promise<pipelines::SegmentAndSlice>> kept;
     auto admission = make_admission_handler(num_units, unit_size, k, read_window, fire_count, kept);
 
     admission->admit_initial_processing_units();
@@ -171,7 +246,7 @@ TEST(ProcessingUnitAdmissionHandlerTest, SharedSegmentFiredOnce) {
     std::vector<std::vector<size_t>> units{{0, 1}, {1, 2}}; // segment 1 shared
 
     std::vector<int> fire_count(3, 0);
-    std::vector<folly::Promise<SegmentAndSlice>> kept;
+    std::deque<folly::Promise<SegmentAndSlice>> kept;
     version_store::SegmentReader reader = [&fire_count, &kept](RangesAndKey&& rk) {
         ++fire_count.at(rk.row_range().first);
         kept.emplace_back();
@@ -202,8 +277,9 @@ TEST(ProcessingUnitAdmissionHandlerTest, ReadWindowLimitsInFlightReads) {
     const size_t read_window = 3;
 
     std::vector<int> fire_count;
-    std::vector<folly::Promise<SegmentAndSlice>> kept;
-    kept.reserve(total_segments);
+    // setValue below holds a reference into this deque while its continuation dispatches the next read, which appends
+    // here. A vector would reallocate under that reference; a deque never invalidates references to existing elements.
+    std::deque<folly::Promise<SegmentAndSlice>> kept;
     auto admission = make_admission_handler(num_units, unit_size, k, read_window, fire_count, kept);
 
     auto total_fired = [&fire_count]() {
@@ -308,6 +384,141 @@ TEST(ProcessingUnitAdmissionHandlerTest, OverlappingUnitsAdvanceWithCeilingOne) 
     EXPECT_EQ(fire_count.at(2).load(), 1);
 }
 
+TEST(ProcessingUnitAdmissionHandlerTest, AdvancesWithReadWindowOfOne) {
+    using namespace arcticdb::pipelines;
+    TinyThreadPool tiny_pool;
+
+    const size_t num_units = 3;
+    const size_t unit_size = 2;
+    const size_t num_segments = num_units * unit_size;
+
+    std::vector<RangesAndKey> ranges;
+    std::vector<std::vector<size_t>> units;
+    for (size_t u = 0; u < num_units; ++u) {
+        std::vector<size_t> unit;
+        for (size_t c = 0; c < unit_size; ++c) {
+            const size_t idx = ranges.size();
+            ranges.emplace_back(RowRange{idx, idx + 1}, ColRange{0, 1}, entity::AtomKey{});
+            unit.push_back(idx);
+        }
+        units.push_back(std::move(unit));
+    }
+
+    std::vector<std::atomic<int>> fire_count(num_segments);
+    for (auto& count : fire_count) {
+        count.store(0);
+    }
+
+    version_store::SegmentReader reader = [&fire_count](RangesAndKey&& rk) {
+        const auto idx = rk.row_range().first;
+        return folly::via(&async::io_executor(), [&fire_count, idx, rk = std::move(rk)]() mutable {
+            fire_count[idx].fetch_add(1, std::memory_order_relaxed);
+            return SegmentAndSlice(std::move(rk), SegmentInMemory{});
+        });
+    };
+
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::vector<std::vector<size_t>>(units),
+            /*max_processing_units_in_flight=*/1,
+            /*read_window=*/1
+    );
+
+    auto segment_futures = admission->futures();
+    std::vector<folly::Future<folly::Unit>> unit_futures;
+    for (const auto& unit : units) {
+        std::vector<folly::Future<SegmentAndSlice>> local;
+        for (auto i : unit) {
+            local.emplace_back(std::move(segment_futures.at(i)));
+        }
+        unit_futures.emplace_back(folly::collect(local)
+                                          .via(&async::cpu_executor())
+                                          .thenValue([](auto&&) { return folly::Unit{}; })
+                                          .ensure([admission]() { admission->on_processing_unit_complete(); }));
+    }
+
+    auto all_done = folly::collect(unit_futures).via(&async::io_executor());
+    admission->admit_initial_processing_units();
+    std::move(all_done).get(std::chrono::seconds(30));
+
+    for (size_t i = 0; i < num_segments; ++i) {
+        EXPECT_EQ(fire_count.at(i).load(), 1) << "segment " << i;
+    }
+}
+
+namespace {
+// Two units of two segments each, a ceiling and window of 1, and a reader that throws synchronously for
+// throwing_segment. Mirrors schedule_first_iteration, including the .ensure that advances admission whether the unit
+// succeeded or failed.
+std::vector<folly::Try<folly::Unit>> run_synchronous_read_throw_case(size_t throwing_segment) {
+    using namespace arcticdb::pipelines;
+    const std::vector<std::vector<size_t>> units{{0, 1}, {2, 3}};
+    const size_t num_segments = 4;
+
+    std::vector<RangesAndKey> ranges;
+    for (size_t i = 0; i < num_segments; ++i) {
+        ranges.emplace_back(RowRange{i, i + 1}, ColRange{0, 1}, entity::AtomKey{});
+    }
+
+    version_store::SegmentReader reader = [throwing_segment](RangesAndKey&& rk) -> folly::Future<SegmentAndSlice> {
+        if (rk.row_range().first == throwing_segment) {
+            throw std::runtime_error("synchronous read failure");
+        }
+        return folly::via(&async::io_executor(), [rk = std::move(rk)]() mutable {
+            return SegmentAndSlice(std::move(rk), SegmentInMemory{});
+        });
+    };
+
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::vector<std::vector<size_t>>(units),
+            /*max_processing_units_in_flight=*/1,
+            /*read_window=*/1
+    );
+
+    auto segment_futures = admission->futures();
+    std::vector<folly::Future<folly::Unit>> unit_futures;
+    for (const auto& unit : units) {
+        std::vector<folly::Future<SegmentAndSlice>> local;
+        for (auto i : unit) {
+            local.emplace_back(std::move(segment_futures.at(i)));
+        }
+        unit_futures.emplace_back(folly::collect(local)
+                                          .via(&async::cpu_executor())
+                                          .thenValue([](auto&&) { return folly::Unit{}; })
+                                          .ensure([admission]() { admission->on_processing_unit_complete(); }));
+    }
+
+    auto all_done = folly::collectAll(unit_futures).via(&async::io_executor());
+    admission->admit_initial_processing_units();
+    return std::move(all_done).get(std::chrono::seconds(30));
+}
+} // namespace
+
+// A reader that throws synchronously rather than returning a failed future must still free its window slot and complete
+// its promise. Otherwise the slot is taken forever and nothing ever satisfies the collect for that segment, so with a
+// window of 1 the whole pipeline stops. Unit 1 completing shows that the window recovered, because with a
+// ceiling of 1 it is only admitted once unit 0 has finished.
+TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowDoesNotHang) {
+    TinyThreadPool tiny_pool;
+    const auto results = run_synchronous_read_throw_case(/*throwing_segment=*/1); // second segment of unit 0
+    EXPECT_TRUE(results.at(0).hasException());
+    EXPECT_TRUE(results.at(1).hasValue());
+}
+
+// Throwing on the *first* segment of a unit leaves the unit's other segment sitting in the read queue with the window
+// slot already freed, which the failed dispatch itself does not re-check. Recovery comes from the .ensure: the
+// exception fails unit 0's collect fast, on_processing_unit_complete calls fill_read_window unconditionally, and the
+// queued segment is drained. Nothing else would drain it, so this pins that coupling down.
+TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowOnFirstSegmentOfUnitDoesNotHang) {
+    TinyThreadPool tiny_pool;
+    const auto results = run_synchronous_read_throw_case(/*throwing_segment=*/0); // first segment of unit 0
+    EXPECT_TRUE(results.at(0).hasException());
+    EXPECT_TRUE(results.at(1).hasValue());
+}
+
 // Static schema with column_group_size changed between the initial write and a later append, so the appended row slices
 // have a different number of column slices than the original ones. The processing units therefore have different sizes,
 // and the bound must use the max across units to avoid deadlock.
@@ -339,7 +550,7 @@ TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnits) {
     engine.configure(std::move(wide_cfg));
 
     auto appended = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, num_rows);
-    engine.append_internal(stream_id, std::move(appended.frame_), false, false, false);
+    engine.append_internal(stream_id, std::move(appended.frame_), version_store::AppendOptions{});
 
     // Confirm the slicing: 4 original row slices x 2 column slices + 4 appended row slices x 1 column
     // slice = 12 data segments. A uniform layout would have 16
@@ -347,15 +558,11 @@ TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnits) {
     engine._test_get_store()->iterate_type(KeyType::TABLE_DATA, [&data_segments](VariantKey&&) { ++data_segments; });
     ASSERT_EQ(data_segments, 12u);
 
-    ColumnStats column_stats{
-            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
-    };
-
     const int64_t k = 2;
     const size_t max_unit_size = 2; // original row slices span 2 column slices; appended ones span 1
     const int64_t bound = k * static_cast<int64_t>(max_unit_size);
 
-    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, column_stats, k);
+    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, k);
 
     EXPECT_GT(high_water, 0);
     EXPECT_LE(high_water, bound);
@@ -397,22 +604,18 @@ TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnitsWiderFirst) {
     engine.configure(std::move(narrow_cfg));
 
     auto appended = get_test_frame<stream::TimeseriesIndex>(stream_id, fields, num_rows, num_rows);
-    engine.append_internal(stream_id, std::move(appended.frame_), false, false, false);
+    engine.append_internal(stream_id, std::move(appended.frame_), version_store::AppendOptions{});
 
     // 4 original row slices x 1 column slice + 4 appended row slices x 2 column slices = 12 data segments.
     size_t data_segments = 0;
     engine._test_get_store()->iterate_type(KeyType::TABLE_DATA, [&data_segments](VariantKey&&) { ++data_segments; });
     ASSERT_EQ(data_segments, 12u);
 
-    ColumnStats column_stats{
-            {{"col_0", {"MINMAX"}}, {"col_1", {"MINMAX"}}, {"col_2", {"MINMAX"}}, {"col_3", {"MINMAX"}}}
-    };
-
     const int64_t k = 2;
     const size_t max_unit_size = 2; // appended row slices span 2 column slices
     const int64_t bound = k * static_cast<int64_t>(max_unit_size);
 
-    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, column_stats, k);
+    int64_t high_water = high_water_for_create_column_stats(engine, stream_id, k);
 
     EXPECT_GT(high_water, 0);
     EXPECT_LE(high_water, bound);
@@ -439,21 +642,24 @@ struct ScopedThreadCounts {
 };
 } // namespace
 
-// Many column slices in each processing unit make the IO read-ahead term go to 1. The 2*cpu_thread_count floor must
-// keep the default from starving the CPU pool.
-TEST(MaxResidentProcessingUnits, CpuFloorAppliesForWideUnits) {
+// Dividing the window by a wide unit size rounds down to almost nothing, so the per-CPU-thread term is what keeps
+// enough units admitted to occupy the CPU pool.
+TEST(MaxResidentProcessingUnits, CpuTermDominatesForWideUnits) {
     ScopedThreadCounts threads{/*cpu=*/4, /*io=*/2};
     const std::vector<std::vector<size_t>> wide_units{{0, 1, 2, 3, 4, 5, 6, 7}}; // max_unit_size = 8
-    // io_read_ahead = ceil(4*2 / 8) = 1; cpu floor = 2*4 = 8
-    EXPECT_EQ(version_store::max_resident_processing_units(wide_units), 8u);
+    // read_window = 2*2 = 4; ceil(4 / 8) = 1, plus cpu_thread_count = 4
+    EXPECT_EQ(version_store::max_resident_processing_units(wide_units), 5u);
+    EXPECT_GE(version_store::max_resident_processing_units(wide_units), 4u);
 }
 
-// Narrow units keep the IO read-ahead term large, so it wins over the cpu floor.
-TEST(MaxResidentProcessingUnits, IoReadAheadDominatesForNarrowUnits) {
+// For single-segment units the budget must exceed the read window, so segments stay queued ahead of it and read
+// completion keeps dispatching without waiting on a processing unit to finish.
+TEST(MaxResidentProcessingUnits, ExceedsReadWindowForNarrowUnits) {
     ScopedThreadCounts threads{/*cpu=*/2, /*io=*/8};
     const std::vector<std::vector<size_t>> narrow_units{{0}, {1}, {2}}; // max_unit_size = 1
-    // io_read_ahead = ceil(4*8 / 1) = 32; cpu floor = 2*2 = 4
-    EXPECT_EQ(version_store::max_resident_processing_units(narrow_units), 32u);
+    // read_window = 2*8 = 16; ceil(16 / 1) = 16, plus cpu_thread_count = 2
+    EXPECT_EQ(version_store::max_resident_processing_units(narrow_units), 18u);
+    EXPECT_GT(version_store::max_resident_processing_units(narrow_units), version_store::segment_read_window());
 }
 
 // An explicit config override takes precedence over the default.
@@ -473,22 +679,38 @@ TEST(MaxResidentProcessingUnits, ZeroAdmitsAllUnits) {
     EXPECT_EQ(version_store::max_resident_processing_units(units), units.size());
 }
 
+// A negative value is neither a valid budget nor the 0 kill switch, so it is rejected rather than silently floored.
+TEST(MaxResidentProcessingUnits, NegativeConfigThrows) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
+    ScopedConfig override_guard{"VersionStore.NumProcessingUnitsLive", -1};
+    const std::vector<std::vector<size_t>> units{{0, 1}, {2, 3}};
+    EXPECT_THROW(version_store::max_resident_processing_units(units), UserInputException);
+}
+
 // The read window defaults to 2*io_thread_count, matching the old folly::window(2*io) read path.
 TEST(SegmentReadWindow, DefaultsToTwiceIoThreads) {
     ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
     EXPECT_EQ(version_store::segment_read_window(), 16u);
 }
 
-// An explicit config override takes precedence, and the window never drops below 1.
-TEST(SegmentReadWindow, ConfigOverrideAndFloor) {
+// An explicit config override takes precedence.
+TEST(SegmentReadWindow, ConfigOverrideTakesPrecedence) {
+    ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
+    ScopedConfig override_guard{"VersionStore.SegmentReadWindow", 5};
+    EXPECT_EQ(version_store::segment_read_window(), 5u);
+}
+
+// Zero and negative values are rejected rather than silently floored to 1, since unlike NumProcessingUnitsLive there
+// is no kill-switch meaning for 0 here.
+TEST(SegmentReadWindow, NonPositiveConfigThrows) {
     ScopedThreadCounts threads{/*cpu=*/4, /*io=*/8};
     {
-        ScopedConfig override_guard{"VersionStore.SegmentReadWindow", 5};
-        EXPECT_EQ(version_store::segment_read_window(), 5u);
+        ScopedConfig override_guard{"VersionStore.SegmentReadWindow", 0};
+        EXPECT_THROW(version_store::segment_read_window(), UserInputException);
     }
     {
-        ScopedConfig override_guard{"VersionStore.SegmentReadWindow", 0};
-        EXPECT_EQ(version_store::segment_read_window(), 1u);
+        ScopedConfig override_guard{"VersionStore.SegmentReadWindow", -1};
+        EXPECT_THROW(version_store::segment_read_window(), UserInputException);
     }
 }
 

--- a/cpp/arcticdb/version/test/test_admission_handler.cpp
+++ b/cpp/arcticdb/version/test/test_admission_handler.cpp
@@ -31,6 +31,7 @@
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/processing/clause_utils.hpp>
 #include <arcticdb/async/task_scheduler.hpp>
+#include <folly/executors/QueuedImmediateExecutor.h>
 
 namespace arcticdb {
 
@@ -515,6 +516,63 @@ TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowDoesNotHang) {
 TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowOnFirstSegmentOfUnitDoesNotHang) {
     TinyThreadPool tiny_pool;
     const auto results = run_synchronous_read_throw_case(/*throwing_segment=*/0); // first segment of unit 0
+    EXPECT_TRUE(results.at(0).hasException());
+    EXPECT_TRUE(results.at(1).hasValue());
+}
+
+TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowStillDrainsRestOfUnit) {
+    using namespace arcticdb::pipelines;
+    const std::vector<std::vector<size_t>> units{{0, 1}, {2, 3}};
+    std::vector<RangesAndKey> ranges;
+    for (size_t i = 0; i < 4; ++i) {
+        ranges.emplace_back(RowRange{i, i + 1}, ColRange{0, 1}, entity::AtomKey{});
+    }
+
+    std::vector<int> fire_count(4, 0);
+    version_store::SegmentReader reader = [&fire_count](RangesAndKey&& rk) -> folly::Future<SegmentAndSlice> {
+        const auto i = rk.row_range().first;
+        ++fire_count.at(i);
+        if (i == 0) {
+            throw std::runtime_error("synchronous read failure");
+        }
+        return folly::makeFuture(SegmentAndSlice(std::move(rk), SegmentInMemory{}));
+    };
+
+    auto admission = std::make_shared<version_store::ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges),
+            std::vector<std::vector<size_t>>(units),
+            /*max_processing_units_in_flight=*/1,
+            /*read_window=*/1
+    );
+
+    auto& executor = folly::QueuedImmediateExecutor::instance();
+    auto segment_futures = admission->futures();
+    std::vector<folly::Future<folly::Unit>> unit_futures;
+    for (const auto& unit : units) {
+        std::vector<folly::Future<SegmentAndSlice>> local;
+        for (auto i : unit) {
+            local.emplace_back(std::move(segment_futures.at(i)));
+        }
+        unit_futures.emplace_back(folly::collectAll(local)
+                                          .via(&executor)
+                                          .thenValue([](std::vector<folly::Try<SegmentAndSlice>>&& tries) {
+                                              for (const auto& t : tries) {
+                                                  t.throwUnlessValue();
+                                              }
+                                              return folly::Unit{};
+                                          })
+                                          .ensure([admission]() { admission->on_processing_unit_complete(); }));
+    }
+    auto all_done = folly::collectAll(unit_futures).via(&executor);
+
+    admission->admit_initial_processing_units();
+
+    const std::vector<int> expected_fire_counts(4, 1);
+    EXPECT_EQ(expected_fire_counts, fire_count);
+    // Before the get, which has no timeout and so would hang rather than fail if a unit never completed.
+    ASSERT_TRUE(all_done.isReady()) << "stalled: unit 0 never completed, so unit 1 was never admitted";
+    const auto results = std::move(all_done).get();
     EXPECT_TRUE(results.at(0).hasException());
     EXPECT_TRUE(results.at(1).hasValue());
 }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -40,7 +40,10 @@
 #include <arcticdb/processing/component_manager.hpp>
 #include <arcticdb/util/collection_utils.hpp>
 #include <arcticdb/util/format_date.hpp>
+#include <atomic>
+#include <functional>
 #include <iterator>
+#include <optional>
 #include <aws/core/utils/stream/ResponseStream.h>
 
 namespace arcticdb::version_store {
@@ -763,7 +766,7 @@ void remove_processed_clauses(std::vector<std::shared_ptr<Clause>>& clauses) {
 std::pair<std::vector<std::vector<EntityId>>, std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>>
 get_entity_ids_and_position_map(
         std::shared_ptr<ComponentManager>& component_manager, size_t num_segments,
-        std::vector<std::vector<size_t>>&& processing_unit_indexes
+        const std::vector<std::vector<size_t>>& processing_unit_indexes
 ) {
     // Map from entity id to position in segment_and_slice_futures
     auto id_to_pos = std::make_shared<ankerl::unordered_dense::map<EntityId, size_t>>();
@@ -798,8 +801,12 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
         std::shared_ptr<std::vector<EntityFetchCount>>&& segment_fetch_counts,
         std::vector<FutureOrSplitter>&& segment_and_slice_future_splitters,
         std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>&& id_to_pos,
-        std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses
+        std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses,
+        std::shared_ptr<ProcessingUnitAdmissionHandler> admission
 ) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            static_cast<bool>(admission), "schedule_first_iteration requires an admission handler"
+    );
     // Used to make sure each entity is only added into the component manager once
     auto slice_added_mtx = std::make_shared<std::vector<std::mutex>>(num_segments);
     auto slice_added = std::make_shared<std::vector<bool>>(num_segments, false);
@@ -825,34 +832,37 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
 
         // Switch to the CPU executor for reasons detailed in the PR description
         // https://github.com/man-group/ArcticDB/pull/3086
-        futures->emplace_back(folly::collect(local_futs)
-                                      .via(&async::cpu_executor())
-                                      .thenValueInline([component_manager,
-                                                        segment_fetch_counts,
-                                                        id_to_pos,
-                                                        slice_added_mtx,
-                                                        slice_added,
-                                                        clauses,
-                                                        entity_ids = std::move(entity_ids
-                                                        )](std::vector<pipelines::SegmentAndSlice>&& segment_and_slices
-                                                       ) mutable {
-                                          for (auto&& [idx, segment_and_slice] : folly::enumerate(segment_and_slices)) {
-                                              auto entity_id = entity_ids[idx];
-                                              auto pos = id_to_pos->at(entity_id);
-                                              std::lock_guard lock{slice_added_mtx->at(pos)};
-                                              if (!(*slice_added)[pos]) {
-                                                  ARCTICDB_DEBUG(log::version(), "Adding entity {}", entity_id);
-                                                  add_slice_to_component_manager(
-                                                          entity_id,
-                                                          segment_and_slice,
-                                                          component_manager,
-                                                          segment_fetch_counts->at(pos)
-                                                  );
-                                                  (*slice_added)[pos] = true;
-                                              }
-                                          }
-                                          return async::MemSegmentProcessingTask(*clauses, std::move(entity_ids))();
-                                      }));
+        auto processing_fut =
+                folly::collect(local_futs)
+                        .via(&async::cpu_executor())
+                        .thenValueInline([component_manager,
+                                          segment_fetch_counts,
+                                          id_to_pos,
+                                          slice_added_mtx,
+                                          slice_added,
+                                          clauses,
+                                          entity_ids = std::move(entity_ids
+                                          )](std::vector<pipelines::SegmentAndSlice>&& segment_and_slices) mutable {
+                            for (auto&& [idx, segment_and_slice] : folly::enumerate(segment_and_slices)) {
+                                auto entity_id = entity_ids[idx];
+                                auto pos = id_to_pos->at(entity_id);
+                                std::lock_guard lock{slice_added_mtx->at(pos)};
+                                if (!(*slice_added)[pos]) {
+                                    ARCTICDB_DEBUG(log::version(), "Adding entity {}", entity_id);
+                                    add_slice_to_component_manager(
+                                            entity_id,
+                                            segment_and_slice,
+                                            component_manager,
+                                            segment_fetch_counts->at(pos)
+                                    );
+                                    (*slice_added)[pos] = true;
+                                }
+                            }
+                            return async::MemSegmentProcessingTask(*clauses, std::move(entity_ids))();
+                        });
+        // Make sure we always mark a unit complete even if it fails, so we don't block loading the next one.
+        processing_fut = std::move(processing_fut).ensure([admission]() { admission->on_processing_unit_complete(); });
+        futures->emplace_back(std::move(processing_fut));
     }
     return futures;
 }
@@ -901,13 +911,16 @@ folly::Future<std::vector<EntityId>> schedule_remaining_iterations(
 }
 
 folly::Future<std::vector<EntityId>> schedule_clause_processing(
-        std::shared_ptr<ComponentManager> component_manager,
-        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
-        std::vector<std::vector<size_t>>&& processing_unit_indexes,
+        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<ProcessingUnitAdmissionHandler> admission,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
 ) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            static_cast<bool>(admission), "schedule_clause_processing requires an admission handler"
+    );
     // All the shared pointers as arguments to this function and created within it are to ensure that resources are
     // correctly kept alive after this function returns its future
+    auto segment_and_slice_futures = admission->futures();
+    const auto& processing_unit_indexes = admission->processing_units();
     const auto num_segments = segment_and_slice_futures.size();
 
     // Map from index in segment_and_slice_future_splitters to the number of calls to process in the first clause that
@@ -918,7 +931,7 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
             split_futures(std::move(segment_and_slice_futures), *segment_fetch_counts);
 
     auto [entities_by_work_unit, entity_id_to_segment_pos] =
-            get_entity_ids_and_position_map(component_manager, num_segments, std::move(processing_unit_indexes));
+            get_entity_ids_and_position_map(component_manager, num_segments, processing_unit_indexes);
 
     // At this point we have a set of entity ids grouped by the work units produced by the original
     // structure_for_processing, and a map of those ids to the position in the vector of futures or future-splitters
@@ -932,8 +945,13 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
             std::move(segment_fetch_counts),
             std::move(segment_and_slice_future_splitters),
             std::move(entity_id_to_segment_pos),
-            clauses
+            clauses,
+            admission
     );
+
+    // Fire the first K units' reads only after the release path (.ensure -> on_unit_complete) is set up in
+    // schedule_first_iteration, so a completing unit always admits the next one.
+    admission->admit_initial_processing_units();
 
     return folly::collect(*futures).via(&async::io_executor()).thenValueInline([clauses](auto&& entity_ids_vec) {
         remove_processed_clauses(*clauses);
@@ -1078,58 +1096,6 @@ std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_con
     return res;
 }
 
-util::BitSet get_incompletes_bitset(const std::vector<RangesAndKey>& all_ranges) {
-    util::BitSet output(all_ranges.size());
-    util::BitSet::bulk_insert_iterator it(output);
-    for (auto&& [index, range] : folly::enumerate(all_ranges)) {
-        if (range.is_incomplete())
-            it = index;
-    }
-    it.flush();
-    return output;
-}
-
-std::vector<folly::Future<pipelines::SegmentAndSlice>> add_schema_check(
-        const std::shared_ptr<PipelineContext>& pipeline_context,
-        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
-        util::BitSet&& incomplete_bitset, const ProcessingConfig& processing_config
-) {
-    std::vector<folly::Future<pipelines::SegmentAndSlice>> res;
-    res.reserve(segment_and_slice_futures.size());
-    for (size_t i = 0; i < segment_and_slice_futures.size(); ++i) {
-        auto&& fut = segment_and_slice_futures.at(i);
-        const bool is_incomplete = incomplete_bitset[i];
-        if (is_incomplete) {
-            res.push_back(std::move(fut).thenValueInline([pipeline_desc = pipeline_context->descriptor(),
-                                                          processing_config](SegmentAndSlice&& read_result) {
-                if (!processing_config.dynamic_schema_) {
-                    auto check =
-                            check_schema_matches_incomplete(read_result.segment_in_memory_.descriptor(), pipeline_desc);
-                    if (std::holds_alternative<Error>(check)) {
-                        std::get<Error>(check).throw_error();
-                    }
-                }
-                return std::move(read_result);
-            }));
-        } else {
-            res.push_back(std::move(fut));
-        }
-    }
-    return res;
-}
-
-std::vector<folly::Future<pipelines::SegmentAndSlice>> generate_segment_and_slice_futures(
-        const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
-        const ProcessingConfig& processing_config, std::vector<RangesAndKey>&& all_ranges
-) {
-    auto incomplete_bitset = get_incompletes_bitset(all_ranges);
-    auto segment_and_slice_futures =
-            store->batch_read_uncompressed(std::move(all_ranges), columns_to_decode(pipeline_context));
-    return add_schema_check(
-            pipeline_context, std::move(segment_and_slice_futures), std::move(incomplete_bitset), processing_config
-    );
-}
-
 static StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
     const StreamDescriptor& desc = pipeline_context.descriptor();
     // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
@@ -1199,6 +1165,15 @@ static void generate_output_schema_and_save_to_pipeline(
     pipeline_context.default_values_ = std::forward<decltype(default_values)>(default_values);
 }
 
+// Read window: the number of segment reads submitted but not completed at any given time. Always >= 1. Defaults to
+// 2*io_thread_count.
+size_t segment_read_window() {
+    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
+    const int64_t default_window = 2 * io_thread_count;
+    const int64_t configured = ConfigsMap::instance()->get_int("VersionStore.SegmentReadWindow", default_window);
+    return static_cast<size_t>(std::max<int64_t>(1, configured));
+}
+
 folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
         const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
@@ -1227,17 +1202,39 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
     }
 
-    // Start reading as early as possible
-    auto segment_and_slice_futures =
-            generate_segment_and_slice_futures(store, pipeline_context, processing_config, std::move(ranges_and_keys));
+    const size_t max_processing_units_in_flight = max_resident_processing_units(processing_unit_indexes);
+    const size_t read_window = segment_read_window();
 
-    return schedule_clause_processing(
-                   component_manager,
-                   std::move(segment_and_slice_futures),
-                   std::move(processing_unit_indexes),
-                   std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
-    )
-            .via(&async::cpu_executor());
+    auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
+    SegmentReader reader = [base_reader = std::move(base_reader),
+                            pipeline_desc = pipeline_context->descriptor(),
+                            processing_config](pipelines::RangesAndKey&& rk) {
+        const bool is_incomplete = rk.is_incomplete();
+        return base_reader(std::move(rk))
+                .thenValueInline([pipeline_desc, processing_config, is_incomplete](pipelines::SegmentAndSlice&& r) {
+                    if (is_incomplete && !processing_config.dynamic_schema_) {
+                        auto check = check_schema_matches_incomplete(r.segment_in_memory_.descriptor(), pipeline_desc);
+                        if (std::holds_alternative<Error>(check)) {
+                            std::get<Error>(check).throw_error();
+                        }
+                    }
+                    return std::move(r);
+                });
+    };
+
+    auto admission = std::make_shared<ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges_and_keys),
+            std::move(processing_unit_indexes),
+            max_processing_units_in_flight,
+            read_window
+    );
+
+    auto processed = schedule_clause_processing(
+            component_manager, admission, std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
+    );
+
+    return std::move(processed).via(&async::cpu_executor());
 }
 
 /*

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1317,15 +1317,6 @@ static void generate_output_schema_and_save_to_pipeline(
     pipeline_context.default_values_ = std::forward<decltype(default_values)>(default_values);
 }
 
-// Read window: the number of segment reads submitted but not completed at any given time. Always >= 1. Defaults to
-// 2*io_thread_count.
-size_t segment_read_window() {
-    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
-    const int64_t default_window = 2 * io_thread_count;
-    const int64_t configured = ConfigsMap::instance()->get_int("VersionStore.SegmentReadWindow", default_window);
-    return static_cast<size_t>(std::max<int64_t>(1, configured));
-}
-
 folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
         const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -40,7 +40,10 @@
 #include <arcticdb/processing/component_manager.hpp>
 #include <arcticdb/util/collection_utils.hpp>
 #include <arcticdb/util/format_date.hpp>
+#include <atomic>
+#include <functional>
 #include <iterator>
+#include <optional>
 #include <aws/core/utils/stream/ResponseStream.h>
 #include <arcticdb/util/bitset.hpp>
 
@@ -916,7 +919,7 @@ void remove_processed_clauses(std::vector<std::shared_ptr<Clause>>& clauses) {
 std::pair<std::vector<std::vector<EntityId>>, std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>>
 get_entity_ids_and_position_map(
         std::shared_ptr<ComponentManager>& component_manager, size_t num_segments,
-        std::vector<std::vector<size_t>>&& processing_unit_indexes
+        const std::vector<std::vector<size_t>>& processing_unit_indexes
 ) {
     // Map from entity id to position in segment_and_slice_futures
     auto id_to_pos = std::make_shared<ankerl::unordered_dense::map<EntityId, size_t>>();
@@ -951,8 +954,12 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
         std::shared_ptr<std::vector<EntityFetchCount>>&& segment_fetch_counts,
         std::vector<FutureOrSplitter>&& segment_and_slice_future_splitters,
         std::shared_ptr<ankerl::unordered_dense::map<EntityId, size_t>>&& id_to_pos,
-        std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses
+        std::shared_ptr<std::vector<std::shared_ptr<Clause>>>& clauses,
+        std::shared_ptr<ProcessingUnitAdmissionHandler> admission
 ) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            static_cast<bool>(admission), "schedule_first_iteration requires an admission handler"
+    );
     // Used to make sure each entity is only added into the component manager once
     auto slice_added_mtx = std::make_shared<std::vector<std::mutex>>(num_segments);
     auto slice_added = std::make_shared<std::vector<bool>>(num_segments, false);
@@ -978,34 +985,37 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
 
         // Switch to the CPU executor for reasons detailed in the PR description
         // https://github.com/man-group/ArcticDB/pull/3086
-        futures->emplace_back(folly::collect(local_futs)
-                                      .via(&async::cpu_executor())
-                                      .thenValueInline([component_manager,
-                                                        segment_fetch_counts,
-                                                        id_to_pos,
-                                                        slice_added_mtx,
-                                                        slice_added,
-                                                        clauses,
-                                                        entity_ids = std::move(entity_ids
-                                                        )](std::vector<pipelines::SegmentAndSlice>&& segment_and_slices
-                                                       ) mutable {
-                                          for (auto&& [idx, segment_and_slice] : folly::enumerate(segment_and_slices)) {
-                                              auto entity_id = entity_ids[idx];
-                                              auto pos = id_to_pos->at(entity_id);
-                                              std::lock_guard lock{slice_added_mtx->at(pos)};
-                                              if (!(*slice_added)[pos]) {
-                                                  ARCTICDB_DEBUG(log::version(), "Adding entity {}", entity_id);
-                                                  add_slice_to_component_manager(
-                                                          entity_id,
-                                                          segment_and_slice,
-                                                          component_manager,
-                                                          segment_fetch_counts->at(pos)
-                                                  );
-                                                  (*slice_added)[pos] = true;
-                                              }
-                                          }
-                                          return async::MemSegmentProcessingTask(*clauses, std::move(entity_ids))();
-                                      }));
+        auto processing_fut =
+                folly::collect(local_futs)
+                        .via(&async::cpu_executor())
+                        .thenValueInline([component_manager,
+                                          segment_fetch_counts,
+                                          id_to_pos,
+                                          slice_added_mtx,
+                                          slice_added,
+                                          clauses,
+                                          entity_ids = std::move(entity_ids
+                                          )](std::vector<pipelines::SegmentAndSlice>&& segment_and_slices) mutable {
+                            for (auto&& [idx, segment_and_slice] : folly::enumerate(segment_and_slices)) {
+                                auto entity_id = entity_ids[idx];
+                                auto pos = id_to_pos->at(entity_id);
+                                std::lock_guard lock{slice_added_mtx->at(pos)};
+                                if (!(*slice_added)[pos]) {
+                                    ARCTICDB_DEBUG(log::version(), "Adding entity {}", entity_id);
+                                    add_slice_to_component_manager(
+                                            entity_id,
+                                            segment_and_slice,
+                                            component_manager,
+                                            segment_fetch_counts->at(pos)
+                                    );
+                                    (*slice_added)[pos] = true;
+                                }
+                            }
+                            return async::MemSegmentProcessingTask(*clauses, std::move(entity_ids))();
+                        });
+        // Make sure we always mark a unit complete even if it fails, so we don't block loading the next one.
+        processing_fut = std::move(processing_fut).ensure([admission]() { admission->on_processing_unit_complete(); });
+        futures->emplace_back(std::move(processing_fut));
     }
     return futures;
 }
@@ -1054,13 +1064,16 @@ folly::Future<std::vector<EntityId>> schedule_remaining_iterations(
 }
 
 folly::Future<std::vector<EntityId>> schedule_clause_processing(
-        std::shared_ptr<ComponentManager> component_manager,
-        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
-        std::vector<std::vector<size_t>>&& processing_unit_indexes,
+        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<ProcessingUnitAdmissionHandler> admission,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
 ) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            static_cast<bool>(admission), "schedule_clause_processing requires an admission handler"
+    );
     // All the shared pointers as arguments to this function and created within it are to ensure that resources are
     // correctly kept alive after this function returns its future
+    auto segment_and_slice_futures = admission->futures();
+    const auto& processing_unit_indexes = admission->processing_units();
     const auto num_segments = segment_and_slice_futures.size();
 
     // Map from index in segment_and_slice_future_splitters to the number of calls to process in the first clause that
@@ -1071,7 +1084,7 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
             split_futures(std::move(segment_and_slice_futures), *segment_fetch_counts);
 
     auto [entities_by_work_unit, entity_id_to_segment_pos] =
-            get_entity_ids_and_position_map(component_manager, num_segments, std::move(processing_unit_indexes));
+            get_entity_ids_and_position_map(component_manager, num_segments, processing_unit_indexes);
 
     // At this point we have a set of entity ids grouped by the work units produced by the original
     // structure_for_processing, and a map of those ids to the position in the vector of futures or future-splitters
@@ -1085,8 +1098,13 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
             std::move(segment_fetch_counts),
             std::move(segment_and_slice_future_splitters),
             std::move(entity_id_to_segment_pos),
-            clauses
+            clauses,
+            admission
     );
+
+    // Fire the first K units' reads only after the release path (.ensure -> on_unit_complete) is set up in
+    // schedule_first_iteration, so a completing unit always admits the next one.
+    admission->admit_initial_processing_units();
 
     return folly::collect(*futures).via(&async::io_executor()).thenValueInline([clauses](auto&& entity_ids_vec) {
         remove_processed_clauses(*clauses);
@@ -1232,58 +1250,6 @@ std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_con
     return res;
 }
 
-util::BitSet get_incompletes_bitset(const std::vector<RangesAndKey>& all_ranges) {
-    util::BitSet output(all_ranges.size());
-    util::BitSet::bulk_insert_iterator it(output);
-    for (auto&& [index, range] : folly::enumerate(all_ranges)) {
-        if (range.is_incomplete())
-            it = index;
-    }
-    it.flush();
-    return output;
-}
-
-std::vector<folly::Future<pipelines::SegmentAndSlice>> add_schema_check(
-        const std::shared_ptr<PipelineContext>& pipeline_context,
-        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
-        util::BitSet&& incomplete_bitset, const ProcessingConfig& processing_config
-) {
-    std::vector<folly::Future<pipelines::SegmentAndSlice>> res;
-    res.reserve(segment_and_slice_futures.size());
-    for (size_t i = 0; i < segment_and_slice_futures.size(); ++i) {
-        auto&& fut = segment_and_slice_futures.at(i);
-        const bool is_incomplete = incomplete_bitset[i];
-        if (is_incomplete) {
-            res.push_back(std::move(fut).thenValueInline([pipeline_desc = pipeline_context->descriptor(),
-                                                          processing_config](SegmentAndSlice&& read_result) {
-                if (!processing_config.dynamic_schema_) {
-                    auto check =
-                            check_schema_matches_incomplete(read_result.segment_in_memory_.descriptor(), pipeline_desc);
-                    if (std::holds_alternative<Error>(check)) {
-                        std::get<Error>(check).throw_error();
-                    }
-                }
-                return std::move(read_result);
-            }));
-        } else {
-            res.push_back(std::move(fut));
-        }
-    }
-    return res;
-}
-
-std::vector<folly::Future<pipelines::SegmentAndSlice>> generate_segment_and_slice_futures(
-        const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
-        const ProcessingConfig& processing_config, std::vector<RangesAndKey>&& all_ranges
-) {
-    auto incomplete_bitset = get_incompletes_bitset(all_ranges);
-    auto segment_and_slice_futures =
-            store->batch_read_uncompressed(std::move(all_ranges), columns_to_decode(pipeline_context));
-    return add_schema_check(
-            pipeline_context, std::move(segment_and_slice_futures), std::move(incomplete_bitset), processing_config
-    );
-}
-
 static StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
     const StreamDescriptor& desc = pipeline_context.descriptor();
     // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
@@ -1351,6 +1317,15 @@ static void generate_output_schema_and_save_to_pipeline(
     pipeline_context.default_values_ = std::forward<decltype(default_values)>(default_values);
 }
 
+// Read window: the number of segment reads submitted but not completed at any given time. Always >= 1. Defaults to
+// 2*io_thread_count.
+size_t segment_read_window() {
+    const int64_t io_thread_count = static_cast<int64_t>(async::TaskScheduler::instance()->io_thread_count());
+    const int64_t default_window = 2 * io_thread_count;
+    const int64_t configured = ConfigsMap::instance()->get_int("VersionStore.SegmentReadWindow", default_window);
+    return static_cast<size_t>(std::max<int64_t>(1, configured));
+}
+
 folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
         const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
@@ -1379,17 +1354,39 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
     }
 
-    // Start reading as early as possible
-    auto segment_and_slice_futures =
-            generate_segment_and_slice_futures(store, pipeline_context, processing_config, std::move(ranges_and_keys));
+    const size_t max_processing_units_in_flight = max_resident_processing_units(processing_unit_indexes);
+    const size_t read_window = segment_read_window();
 
-    return schedule_clause_processing(
-                   component_manager,
-                   std::move(segment_and_slice_futures),
-                   std::move(processing_unit_indexes),
-                   std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
-    )
-            .via(&async::cpu_executor());
+    auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
+    SegmentReader reader = [base_reader = std::move(base_reader),
+                            pipeline_desc = pipeline_context->descriptor(),
+                            processing_config](pipelines::RangesAndKey&& rk) {
+        const bool is_incomplete = rk.is_incomplete();
+        return base_reader(std::move(rk))
+                .thenValueInline([pipeline_desc, processing_config, is_incomplete](pipelines::SegmentAndSlice&& r) {
+                    if (is_incomplete && !processing_config.dynamic_schema_) {
+                        auto check = check_schema_matches_incomplete(r.segment_in_memory_.descriptor(), pipeline_desc);
+                        if (std::holds_alternative<Error>(check)) {
+                            std::get<Error>(check).throw_error();
+                        }
+                    }
+                    return std::move(r);
+                });
+    };
+
+    auto admission = std::make_shared<ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges_and_keys),
+            std::move(processing_unit_indexes),
+            max_processing_units_in_flight,
+            read_window
+    );
+
+    auto processed = schedule_clause_processing(
+            component_manager, admission, std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
+    );
+
+    return std::move(processed).via(&async::cpu_executor());
 }
 
 /*

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -986,8 +986,19 @@ std::shared_ptr<std::vector<folly::Future<std::vector<EntityId>>>> schedule_firs
         // Switch to the CPU executor for reasons detailed in the PR description
         // https://github.com/man-group/ArcticDB/pull/3086
         auto processing_fut =
-                folly::collect(local_futs)
+                // collectAll rather than collect so that a unit is never reported complete, admitting the next one,
+                // while its own reads are still in flight
+                folly::collectAll(local_futs)
                         .via(&async::cpu_executor())
+                        .thenValueInline([](std::vector<folly::Try<pipelines::SegmentAndSlice>>&& segment_and_slice_trys
+                                         ) {
+                            std::vector<pipelines::SegmentAndSlice> segment_and_slices;
+                            segment_and_slices.reserve(segment_and_slice_trys.size());
+                            for (auto& segment_and_slice_try : segment_and_slice_trys) {
+                                segment_and_slices.emplace_back(std::move(segment_and_slice_try).value());
+                            }
+                            return segment_and_slices;
+                        })
                         .thenValueInline([component_manager,
                                           segment_fetch_counts,
                                           id_to_pos,

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -26,7 +26,17 @@
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/version/version_tasks.hpp>
+#include <arcticdb/version/admission_handler.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <folly/futures/Future.h>
+#include <folly/futures/Promise.h>
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
 #include <string>
+#include <vector>
 
 namespace arcticdb::version_store {
 
@@ -103,11 +113,11 @@ folly::Future<std::vector<EntityId>> schedule_remaining_iterations(
 );
 
 folly::Future<std::vector<EntityId>> schedule_clause_processing(
-        std::shared_ptr<ComponentManager> component_manager,
-        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
-        std::vector<std::vector<size_t>>&& processing_unit_indexes,
+        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<ProcessingUnitAdmissionHandler> admission,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
 );
+
+size_t segment_read_window();
 
 FrameAndDescriptor read_index_impl(const std::shared_ptr<Store>& store, const VersionedItem& version);
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -26,9 +26,19 @@
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/version/version_tasks.hpp>
+#include <arcticdb/version/admission_handler.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <folly/futures/Future.h>
+#include <folly/futures/Promise.h>
+#include <atomic>
+#include <deque>
+#include <functional>
+#include <memory>
+#include <mutex>
 #include <string>
 #include <chrono>
 #include <arcticdb/util/configs_map.hpp>
+#include <vector>
 
 namespace arcticdb::version_store {
 
@@ -93,11 +103,11 @@ folly::Future<std::vector<EntityId>> schedule_remaining_iterations(
 );
 
 folly::Future<std::vector<EntityId>> schedule_clause_processing(
-        std::shared_ptr<ComponentManager> component_manager,
-        std::vector<folly::Future<pipelines::SegmentAndSlice>>&& segment_and_slice_futures,
-        std::vector<std::vector<size_t>>&& processing_unit_indexes,
+        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<ProcessingUnitAdmissionHandler> admission,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
 );
+
+size_t segment_read_window();
 
 FrameAndDescriptor read_index_impl(const std::shared_ptr<Store>& store, const VersionedItem& version);
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -29,12 +29,7 @@
 #include <arcticdb/version/admission_handler.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <folly/futures/Future.h>
-#include <folly/futures/Promise.h>
-#include <atomic>
-#include <deque>
-#include <functional>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <chrono>
 #include <arcticdb/util/configs_map.hpp>
@@ -106,8 +101,6 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
         std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<ProcessingUnitAdmissionHandler> admission,
         std::shared_ptr<std::vector<std::shared_ptr<Clause>>> clauses
 );
-
-size_t segment_read_window();
 
 FrameAndDescriptor read_index_impl(const std::shared_ptr<Store>& store, const VersionedItem& version);
 

--- a/docs/claude/cpp/PIPELINE.md
+++ b/docs/claude/cpp/PIPELINE.md
@@ -116,6 +116,15 @@ In `cpp/arcticdb/pipeline/read_frame.hpp`:
 - `fetch_data()` - Fetch and decode data from keys
 - `decode_into_frame()` - Decode segment into SegmentInMemory
 
+### Direct read vs processing pipeline
+
+`do_direct_read_or_process()` in `version_core.cpp` branches on whether the `ReadQuery` has clauses. With
+none it takes the direct path above (`fetch_data()`); with clauses it goes through
+`read_process_and_collect()` and the clause pipeline, whose reads are gated by
+`ProcessingUnitAdmissionHandler` (see [PROCESSING.md](PROCESSING.md#read-admission-control)). The two paths
+have separate read-concurrency controls — `VersionStore.SegmentReadWindow` and
+`VersionStore.NumProcessingUnitsLive` apply only to the clause pipeline.
+
 ## Column Stats Filtering
 
 ### Location

--- a/docs/claude/cpp/PROCESSING.md
+++ b/docs/claude/cpp/PROCESSING.md
@@ -219,6 +219,72 @@ Key methods:
 - `get_entities_and_decrement_refcount(ids)` - Get entities (removed when fetch count reaches 0)
 - `get<T>(id)` - Get a single component for an entity
 
+## Read Admission Control
+
+### Location
+
+`cpp/arcticdb/version/admission_handler.hpp`, `cpp/arcticdb/version/admission_handler.cpp`
+
+### Purpose
+
+`ProcessingUnitAdmissionHandler` decides when each row-slice read is submitted to the IO pool. Reads used
+to be submitted eagerly for every slice at once, so if clause processing could not keep up, decoded
+`SegmentInMemory` objects accumulated ahead of it — for a whole-symbol operation such as manual column
+stats creation, up to the entire symbol.
+
+The handler is created in `read_and_schedule_processing()` and drives the futures that
+`schedule_clause_processing()` chains clause execution onto. It applies two independent limits:
+
+| Limit | Unit | Freed when | Config |
+|-------|------|-----------|--------|
+| Residency budget | processing units admitted but not yet processed | a unit finishes processing (`on_processing_unit_complete`) | `VersionStore.NumProcessingUnitsLive` |
+| Read window | segment reads submitted but not yet decoded | a read completes (`on_read_complete`) | `VersionStore.SegmentReadWindow` |
+
+The residency budget is what bounds memory: a unit's segments are decoded and held until its
+`MemSegmentProcessingTask` completes. The read window reproduces the `folly::window(2*io_threads)`
+behaviour the eager path had, and matters when the budget is much larger than the window — submitting all
+the IO up front gives poor queue fairness, because the Folly IO pool schedules round-robin across threads.
+
+### Mechanism
+
+Reads are backed by promises created up front, so the whole downstream future chain can be built before
+any work starts:
+
+```
+futures()                    ← one Future per row slice, from an unfulfilled Promise
+   │                            (schedule_first_iteration builds the clause chain on these)
+   ▼
+admit_initial_processing_units()   ← makes the first K units' segments eligible
+   │
+   ▼
+fill_read_window()           ← drains the eligible queue into the IO pool, up to read_window
+   │
+   ▼  read completes → promise fulfilled → slot freed → fill_read_window()
+   │
+   ▼  unit processed → .ensure → on_processing_unit_complete() → admit next unit
+```
+
+Two ordering constraints are load-bearing:
+
+- `admit_initial_processing_units()` must be called *after* `schedule_first_iteration()`, so the
+  `.ensure` release path exists before any unit can complete.
+- `on_processing_unit_complete()` must not block. It runs inline on a CPU pool thread at the end of a
+  processing task, and only submits IO work.
+
+A segment shared by two units (resample bucket boundaries, for example) is enqueued once, tracked by
+`i_th_segment_enqueued_`, and consumed by both units via `folly::splitFuture`. Because window slots are
+freed on read completion rather than unit completion, a unit never waits on a segment it has itself
+blocked, so any budget >= 1 and window >= 1 makes progress regardless of unit shape.
+
+### Test instrumentation
+
+`util::SegmentResidencyTracker` (`cpp/arcticdb/util/segment_residency_tracker.hpp`) counts segments
+decoded from storage that are live in memory, and records a high-water mark. `DecodeSliceTask` calls
+`SegmentInMemory::mark_from_disk()`; the `SegmentInMemoryImpl` destructor releases the count. Clause
+outputs and `clone()` results are deliberately unmarked, so the tracker measures exactly what admission
+controls. It is compiled into release builds but disabled by default, costing one relaxed atomic load per
+segment destruction.
+
 ## Query Building (C++)
 
 Build filters using `ExpressionNode` with `ExpressionNodeType::BINARY_OP` and column/constant nodes. Create clauses like `FilterClause(expr)` or `AggregationClause` with grouping and aggregation settings. See `cpp/arcticdb/processing/expression_node.hpp` and `cpp/arcticdb/processing/clause.hpp` for details.
@@ -239,6 +305,8 @@ Build filters using `ExpressionNode` with `ExpressionNodeType::BINARY_OP` and co
 | `aggregation_utils.cpp` | Aggregation helpers |
 | `operation_types.hpp` | Operator structs, `StatsComparison`, `ValueRange` |
 | `query_planner.cpp` | `plan_query()`, `and_filter_expression_contexts()` |
+| `../version/admission_handler.hpp` | `ProcessingUnitAdmissionHandler`, residency budget and read window defaults |
+| `../util/segment_residency_tracker.hpp` | Test-only decoded-segment residency high-water mark |
 
 ## Python Integration
 

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -199,8 +199,8 @@ Values:
 
 Bounds how many segment reads can be submitted to the IO threadpool but not yet completed at any one time.
 
-Applies to the same operations as `VersionStore.NumProcessingUnitsLive`, that is `QueryBuilder` reads and manual column
-stats creation. A plain `read` with no `QueryBuilder` takes a different code path and is not affected by either setting.
+Applies to the same operations as `VersionStore.NumProcessingUnitsLive`, that is `QueryBuilder` reads.
+A plain `read` with no `QueryBuilder` takes a different code path and is not affected by either setting.
 
 Defaults to `2 * VersionStore.NumIOThreads`.
 

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -173,7 +173,7 @@ fire for those safe cases too.
 
 ### VersionStore.NumProcessingUnitsLive
 
-`QueryBuilder` operations (`filter`, `groupby`, `resample`, etc.) and manual column stats creation read data in units of one or
+`QueryBuilder` operations (`filter`, `groupby`, `resample`, etc.) read data in units of one or
 more segments. This setting bounds how many of those units can be admitted into memory at once: an admitted unit's segments
 are decoded and held in memory until processing on that unit finishes. Without this bound, if in-memory processing falls
 behind the read rate, decoded segments for the whole symbol can accumulate in memory.
@@ -188,8 +188,7 @@ threadpools the default is correspondingly large and will not meaningfully reduc
 against processing falling a long way behind reads, not a tight bound.
 
 **To bound memory in absolute terms, set this explicitly to a small value** such as 8. That can have a huge effect, but
-costs wall time: benchmarking a 100M row x 100 column symbol on S3 measured `K=8` cutting peak memory by
-80-85% for manual column stats creation and 57-73% for `resample`, for a 54-217% increase in wall time.
+costs wall time.
 
 Values:
 * A positive integer: the maximum number of processing units resident in memory at once.

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -171,6 +171,42 @@ The warning is only present in builds for Python 3.12 and later, the version whe
 `forkserver`), which is indistinguishable from an unsafe fork at the point the warning would be logged, so it would
 fire for those safe cases too.
 
+### VersionStore.NumProcessingUnitsLive
+
+`QueryBuilder` operations (`filter`, `groupby`, `resample`, etc.) and manual column stats creation read data in units of one or
+more segments. This setting bounds how many of those units can be admitted into memory at once: an admitted unit's segments
+are decoded and held in memory until processing on that unit finishes. Without this bound, if in-memory processing falls
+behind the read rate, decoded segments for the whole symbol can accumulate in memory.
+
+Defaults to `VersionStore.SegmentReadWindow` divided by the largest number of segments in a single processing unit
+(rounded up), plus `VersionStore.NumCPUThreads`. The first term admits enough units to keep the read window full; the
+second lets every CPU thread hold a unit for processing without taking capacity away from the window, so reads are not
+gated on processing completing.
+
+Note that the first term scales with `NumIOThreads` and the second with `NumCPUThreads`, so on a machine with large
+threadpools the default is correspondingly large and will not meaningfully reduce peak memory use. It is a guard-rail
+against processing falling a long way behind reads, not a tight bound.
+
+**To bound memory in absolute terms, set this explicitly to a small value** such as 8. That can have a huge effect, but
+costs wall time: benchmarking a 100M row x 100 column symbol on S3 measured `K=8` cutting peak memory by
+80-85% for manual column stats creation and 57-73% for `resample`, for a 54-217% increase in wall time.
+
+Values:
+* A positive integer: the maximum number of processing units resident in memory at once.
+* `0`: disables the bound (residency is unbounded, so `SegmentReadWindow` alone governs how many segment reads are in
+  flight).
+
+### VersionStore.SegmentReadWindow
+
+Bounds how many segment reads can be submitted to the IO threadpool but not yet completed at any one time.
+
+Applies to the same operations as `VersionStore.NumProcessingUnitsLive`, that is `QueryBuilder` reads and manual column
+stats creation. A plain `read` with no `QueryBuilder` takes a different code path and is not affected by either setting.
+
+Defaults to `2 * VersionStore.NumIOThreads`.
+
+Must be at least 1.
+
 ### VersionStore.WillItemBePickledWarningMsg
 
 Control whether a detailed message explaining how the item is normalized is logged when calling the `will_item_be_pickled` function.

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -7,10 +7,11 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import copy
+import gc
 import os
 import sys
 from contextlib import contextmanager
-from typing import Mapping, Any, Optional, NamedTuple, List, AnyStr, Union, Dict
+from typing import Mapping, Any, Iterator, Optional, NamedTuple, List, AnyStr, Union, Dict
 import numpy as np
 import pandas as pd
 from pandas import DateOffset, Timedelta
@@ -54,6 +55,12 @@ from arcticdb_ext import (
     get_config_string,
     set_config_string,
     unset_config_string,
+)
+from arcticdb_ext.util import (
+    reset_segment_residency_tracking,
+    segment_residency_high_water,
+    segment_residency_live,
+    set_segment_residency_tracking,
 )
 from packaging.version import Version
 from arcticdb.version_store._store import MergeStrategy, normalize_merge_strategy
@@ -402,6 +409,46 @@ def config_context_multi(config: Dict[str, int]):
                 set_config_int(name, initial[name])
             else:
                 unset_config_int(name)
+
+
+class SegmentResidency:
+    """View of the process-wide SegmentResidencyTracker counters."""
+
+    @property
+    def high_water(self) -> int:
+        return segment_residency_high_water()
+
+    @property
+    def live(self) -> int:
+        return segment_residency_live()
+
+
+@contextmanager
+def segment_residency_tracking() -> Iterator[SegmentResidency]:
+    """Count segments decoded from storage by the processing pipeline that are resident in memory at once.
+
+    Read `high_water` inside the block: the counters are reset on exit.
+
+    Test-only instrumentation, disabled outside this block. Only `DecodeSliceTask` marks segments, so a plain read
+    (which decodes straight into the output frame) counts nothing; this measures `QueryBuilder` reads and the other
+    clause-pipeline entry points.
+    """
+    live = segment_residency_live()
+    assert live == 0, f"counted segment leaked from an earlier block: live={live}"
+    reset_segment_residency_tracking()
+    set_segment_residency_tracking(True)
+    try:
+        yield SegmentResidency()
+        # On a clean exit every read has completed and every clause has run, so the count is already zero. The poll
+        # only covers a release landing on another thread as the read unwinds, hence the short deadline.
+        gc.collect()
+        deadline = time.time() + 2.0
+        while segment_residency_live() != 0 and time.time() < deadline:
+            time.sleep(0.01)
+        assert segment_residency_live() == 0, f"segments still resident after the block: {segment_residency_live()}"
+    finally:
+        set_segment_residency_tracking(False)
+        reset_segment_residency_tracking()
 
 
 @contextmanager

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -20,8 +20,22 @@ from arcticdb_ext.exceptions import SchemaException, StorageException, UserInput
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
+from arcticdb.util.test import config_context
 
 pytestmark = pytest.mark.pipeline
+
+ADMISSION_KEY = "VersionStore.NumProcessingUnitsLive"
+
+
+def write_many_slices(lib, sym, n_appends):
+    """Writes a symbol of n_appends row slices, each two rows of col_0/col_1/col_2."""
+    base = pd.Timestamp("2000-01-01")
+    for i in range(n_appends):
+        df = pd.DataFrame(
+            {"col_0": [f"a{i}", f"b{i}"], "col_1": [2 * i, 2 * i + 1], "col_2": [i, i + 1]},
+            index=pd.date_range(base + pd.Timedelta(days=2 * i), periods=2),
+        )
+        lib.write(sym, df) if i == 0 else lib.append(sym, df)
 
 
 df0 = pd.DataFrame(
@@ -1096,3 +1110,76 @@ def test_column_stats_drop_tiny_thread_pool(
     lib.drop_column_stats_experimental(sym)
     with pytest.raises(StorageException):
         lib.get_column_stats_info_experimental(sym)
+
+
+# k=0 is the kill switch: it admits every processing unit at once, disabling the memory bound.
+@pytest.mark.parametrize("k", [0, 1, 2, 1000])
+def test_column_stats_create_independent_of_admission_ceiling(
+    version_store_factory, lib_name, encoding_version, any_output_format, k
+):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}_{k}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_admission_ceiling"
+    expected_column_stats = generate_symbol(lib, sym)
+
+    with config_context(ADMISSION_KEY, k):
+        lib.create_column_stats_experimental(sym)
+
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_column_stats_create_admission_tiny_thread_pool(
+    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool, k
+):
+    """Test against deadlock with a small admission limit and single thread pools."""
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}_{k}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_admission_tiny_thread_pool"
+    n_appends = 10
+    write_many_slices(lib, sym, n_appends)
+
+    with config_context(ADMISSION_KEY, k):
+        lib.create_column_stats_experimental(sym)
+
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+    # One stats row per row slice.
+    assert lib.read_column_stats_experimental(sym).num_rows == n_appends
+
+
+def test_column_stats_create_single_unit(
+    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool
+):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_single_unit"
+    df = pd.DataFrame({"col_1": [1.0, 3.0]}, index=pd.date_range("2000-01-01", periods=2))
+    lib.write(sym, df)
+    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+        pl.Series("v1_MIN(col_1)", [df["col_1"].min()]),
+        pl.Series("v1_MAX(col_1)", [df["col_1"].max()]),
+    )
+
+    with config_context(ADMISSION_KEY, 1):
+        lib.create_column_stats_experimental(sym)
+
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -24,8 +24,22 @@ from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
 from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked
+from arcticdb.util.test import config_context
 
 pytestmark = pytest.mark.pipeline
+
+ADMISSION_KEY = "VersionStore.NumProcessingUnitsLive"
+
+
+def write_many_slices(lib, sym, n_appends):
+    """Writes a symbol of n_appends row slices, each two rows of col_0/col_1/col_2."""
+    base = pd.Timestamp("2000-01-01")
+    for i in range(n_appends):
+        df = pd.DataFrame(
+            {"col_0": [f"a{i}", f"b{i}"], "col_1": [2 * i, 2 * i + 1], "col_2": [i, i + 1]},
+            index=pd.date_range(base + pd.Timedelta(days=2 * i), periods=2),
+        )
+        lib.write(sym, df) if i == 0 else lib.append(sym, df)
 
 
 df0 = pd.DataFrame(
@@ -1299,3 +1313,76 @@ def test_column_stats_drop_tiny_thread_pool(
     lib.drop_column_stats_experimental(sym)
     with pytest.raises(StorageException):
         lib.get_column_stats_info_experimental(sym)
+
+
+# k=0 is the kill switch: it admits every processing unit at once, disabling the memory bound.
+@pytest.mark.parametrize("k", [0, 1, 2, 1000])
+def test_column_stats_create_independent_of_admission_ceiling(
+    version_store_factory, lib_name, encoding_version, any_output_format, k
+):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}_{k}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_admission_ceiling"
+    expected_column_stats = generate_symbol(lib, sym)
+
+    with config_context(ADMISSION_KEY, k):
+        lib.create_column_stats_experimental(sym)
+
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_column_stats_create_admission_tiny_thread_pool(
+    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool, k
+):
+    """Test against deadlock with a small admission limit and single thread pools."""
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}_{k}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_admission_tiny_thread_pool"
+    n_appends = 10
+    write_many_slices(lib, sym, n_appends)
+
+    with config_context(ADMISSION_KEY, k):
+        lib.create_column_stats_experimental(sym)
+
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+    # One stats row per row slice.
+    assert lib.read_column_stats_experimental(sym).num_rows == n_appends
+
+
+def test_column_stats_create_single_unit(
+    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool
+):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_single_unit"
+    df = pd.DataFrame({"col_1": [1.0, 3.0]}, index=pd.date_range("2000-01-01", periods=2))
+    lib.write(sym, df)
+    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+        pl.Series("v1_MIN(col_1)", [df["col_1"].min()]),
+        pl.Series("v1_MAX(col_1)", [df["col_1"].max()]),
+    )
+
+    with config_context(ADMISSION_KEY, 1):
+        lib.create_column_stats_experimental(sym)
+
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)

--- a/python/tests/unit/arcticdb/test_env_vars.py
+++ b/python/tests/unit/arcticdb/test_env_vars.py
@@ -9,7 +9,9 @@ As of the Change Date specified in that file, in accordance with the Business So
 import pytest
 
 from unittest.mock import patch
+from arcticdb_ext import get_config_int
 from arcticdb.tools import set_config_from_env_vars, _ARCTICDB_ENV_VAR_PREFIX, _ARCTIC_NATIVE_ENV_VAR_PREFIX
+from arcticdb.util.test import config_context
 from arcticdb.util.utils import strtobool
 
 _MODULE = set_config_from_env_vars.__module__  # Insulate the tests from any move of the function
@@ -42,6 +44,15 @@ def test_bad_format(key, value, mocks):
 
     for setter in mocks.values():
         setter.assert_not_called()
+
+
+def test_serial_admission_env_var_reaches_config():
+    """build_tooling/parallel_test.sh sets this env var for the CI serial admission run."""
+    label = "VersionStore.NumProcessingUnitsLive"
+    # config_context restores the value the CI run's env var set at import, rather than leaving the key unset
+    with config_context(label, -1):
+        set_config_from_env_vars({"ARCTICDB_VersionStore_NumProcessingUnitsLive_int": "1"})
+        assert get_config_int(label) == 1
 
 
 @pytest.fixture()

--- a/python/tests/unit/arcticdb/version_store/test_processing_residency.py
+++ b/python/tests/unit/arcticdb/version_store/test_processing_residency.py
@@ -1,0 +1,357 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from arcticdb import LibraryOptions, QueryBuilder, concat
+from arcticdb.util.test import (
+    assert_frame_equal,
+    config_context,
+    config_context_multi,
+    generic_aggregation_test,
+    generic_resample_test,
+    segment_residency_tracking,
+)
+from arcticdb_ext.util import reset_segment_residency_tracking, set_segment_residency_tracking
+
+pytestmark = pytest.mark.pipeline
+
+RESIDENCY_KEY = "VersionStore.NumProcessingUnitsLive"
+READ_WINDOW_KEY = "VersionStore.SegmentReadWindow"
+
+NUM_ROWS = 200
+SEGMENT_ROW_SIZE = 10
+NUM_ROW_SLICES = NUM_ROWS // SEGMENT_ROW_SIZE
+
+# The frame has fewer columns than the default column_group_size, so each row slice is a single column slice and a
+# processing unit is one segment for every clause structured by row slice. That makes the expected residency an exact
+# number rather than a multiple of the column slice count, and assert_one_segment_per_row_slice checks it holds.
+# Column slicing interacting with the bound is covered in C++ by
+# ColumnStatsMixedColSlicing.ResidencyBoundedWithUnevenUnits.
+SYM = "residency_sym"
+
+
+def sample_df():
+    n = np.arange(NUM_ROWS)
+    floats = n.astype(np.float64) / 8.0
+    floats[n % 7 == 3] = np.nan
+    return pd.DataFrame(
+        {
+            # 0..9 within every row slice, so a "< 5" filter selects exactly half of every row slice
+            "int_col": (n % 10).astype(np.int64),
+            "uint_col": (n % 4).astype(np.uint32),
+            "float_col": floats,
+            "str_col": [f"g{i % 4}" for i in n],
+            "sparse_str": [None if i % 11 == 0 else f"s{i % 3}" for i in n],
+            "bool_col": n % 3 != 0,
+            "dt_col": pd.to_datetime("2020-01-01") + pd.to_timedelta(n, unit="h"),
+        },
+        index=pd.date_range("2024-01-02", periods=NUM_ROWS, freq="min"),
+    )
+
+
+def assert_one_segment_per_row_slice(lib, symbol):
+    index_df = lib.read_index(symbol).reset_index()
+    assert index_df["start_row"].nunique() == NUM_ROW_SLICES
+    assert len(index_df) == NUM_ROW_SLICES, "expected a single column slice per row slice"
+
+
+@pytest.fixture
+def residency_lib(version_store_factory):
+    lib = version_store_factory(segment_row_size=SEGMENT_ROW_SIZE, dynamic_strings=True)
+    df = sample_df()
+    lib.write(SYM, df)
+    assert_one_segment_per_row_slice(lib, SYM)
+    return lib, df
+
+
+@pytest.fixture(autouse=True)
+def residency_tracking_off():
+    """Leave the process-wide tracker disabled and zeroed even if a test fails inside a tracking block."""
+    yield
+    set_segment_residency_tracking(False)
+    reset_segment_residency_tracking()
+
+
+def high_water_for_read(lib, query, k):
+    with config_context(RESIDENCY_KEY, k):
+        with segment_residency_tracking() as residency:
+            received = lib.read(SYM, query_builder=query).data
+            high_water = residency.high_water
+            del received
+    return high_water
+
+
+# k units are in flight, and the next unit is admitted when the previous one finishes processing rather than when its
+# segments are destructed, so an outgoing unit can still be draining when the incoming unit's reads land. The straddling
+# case below reaches (k + 1) * max_unit_size locally, so allow two units of slack. What these bounds establish is that
+# residency does not scale with NUM_ROW_SLICES.
+def residency_bound(k, max_unit_size):
+    return (k + 2) * max_unit_size
+
+
+# Every row slice overlaps the single daily bucket, so they all land in one processing unit and folly::collect holds
+# all of them at once regardless of the admission budget. Without this the bounds asserted below would also hold
+# against a tracker that could never report more than one.
+def test_single_processing_unit_holds_every_segment(residency_lib):
+    lib, _ = residency_lib
+    q = QueryBuilder().resample("1D").agg({"int_col": "sum"})
+    assert high_water_for_read(lib, q, k=1) == NUM_ROW_SLICES
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_filter_residency_bounded_by_admission(residency_lib, k):
+    lib, _ = residency_lib
+    max_unit_size = 1
+    bound = residency_bound(k, max_unit_size)
+    assert NUM_ROW_SLICES > bound
+
+    q = QueryBuilder()
+    # int_col holds 0..9 in every row slice, so this is a strict non-empty subset everywhere. A predicate matching a
+    # whole row slice takes FilterClause's FullResult branch, which re-pushes the decoded segment instead of
+    # replacing it, and residency would then not be bounded at all.
+    q = q[q["int_col"] < 5]
+    high_water = high_water_for_read(lib, q, k)
+
+    assert high_water >= max_unit_size, "tracker recorded nothing"
+    assert high_water <= bound
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_groupby_residency_bounded_by_admission(residency_lib, k):
+    lib, _ = residency_lib
+    max_unit_size = 1
+    bound = residency_bound(k, max_unit_size)
+    assert NUM_ROW_SLICES > bound
+
+    q = QueryBuilder().groupby("str_col").agg({"int_col": "sum", "float_col": "mean"})
+    high_water = high_water_for_read(lib, q, k)
+
+    assert high_water >= max_unit_size, "tracker recorded nothing"
+    assert high_water <= bound
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_aligned_resample_residency_bounded_by_admission(residency_lib, k):
+    lib, _ = residency_lib
+    # Buckets are the same width as a row slice and share its boundaries, so no bucket spans two row slices
+    max_unit_size = 1
+    bound = residency_bound(k, max_unit_size)
+    assert NUM_ROW_SLICES > bound
+
+    q = QueryBuilder().resample("10min", closed="left").agg({"int_col": "sum"})
+    high_water = high_water_for_read(lib, q, k)
+
+    assert high_water >= max_unit_size, "tracker recorded nothing"
+    assert high_water <= bound
+
+
+@pytest.mark.parametrize("k", [1, 2])
+def test_straddling_resample_residency_bounded_by_admission(residency_lib, k):
+    lib, _ = residency_lib
+    # A 7 minute bucket over 10 minute row slices can pull in at most ceil(7/10) = 1 following slice, so a unit is at
+    # most two segments
+    max_unit_size = 2
+    bound = residency_bound(k, max_unit_size)
+    assert NUM_ROW_SLICES > bound
+
+    q = QueryBuilder().resample("7min", closed="left").agg({"int_col": "sum"})
+    high_water = high_water_for_read(lib, q, k)
+
+    # The lower bound is the important half: it fails if bucket generation stops straddling row slices and this case
+    # silently degenerates into the aligned one above.
+    assert high_water >= max_unit_size, f"expected a straddling unit of {max_unit_size} segments, got {high_water}"
+    assert high_water <= bound
+
+
+AGGS = {"int_col": "sum", "uint_col": "max", "float_col": "mean", "dt_col": "min", "bool_col": "count"}
+
+# generic_resample_test feeds these to pandas' agg as named aggregators
+NAMED_AGGS = {
+    "int_total": ("int_col", "sum"),
+    "uint_peak": ("uint_col", "max"),
+    "float_mean": ("float_col", "mean"),
+    "dt_first": ("dt_col", "min"),
+    "bool_count": ("bool_col", "count"),
+}
+
+
+def assert_read_matches(lib, query, expected):
+    # assert_frame_equal rather than generic_filter_test because the frame carries NaNs and Nones, which
+    # np.array_equal treats as unequal to themselves
+    assert_frame_equal(expected, lib.read(SYM, query_builder=query).data, check_dtype=False)
+
+
+def case_filter_numeric(lib, df):
+    q = QueryBuilder()
+    q = q[q["int_col"] < 5]
+    assert_read_matches(lib, q, df[df["int_col"] < 5])
+
+
+def case_filter_string_isin(lib, df):
+    q = QueryBuilder()
+    q = q[q["str_col"].isin(["g0", "g2"])]
+    assert_read_matches(lib, q, df[df["str_col"].isin(["g0", "g2"])])
+
+
+def case_filter_none_strings(lib, df):
+    q = QueryBuilder()
+    q = q[q["sparse_str"] == "s1"]
+    assert_read_matches(lib, q, df[df["sparse_str"] == "s1"])
+
+
+def case_filter_compound(lib, df):
+    q = QueryBuilder()
+    q = q[(q["int_col"] >= 3) & q["bool_col"]]
+    assert_read_matches(lib, q, df[(df["int_col"] >= 3) & df["bool_col"]])
+
+
+def case_filter_matching_whole_slices(lib, df):
+    # Matches every row, so FilterClause takes the FullResult branch on every row slice
+    q = QueryBuilder()
+    q = q[q["int_col"] >= 0]
+    assert_read_matches(lib, q, df[df["int_col"] >= 0])
+
+
+def case_project(lib, df):
+    q = QueryBuilder()
+    q = q.apply("proj", (q["int_col"] * q["float_col"]) + 1)
+    expected = df.copy()
+    expected["proj"] = (df["int_col"] * df["float_col"]) + 1
+    assert_read_matches(lib, q, expected)
+
+
+def case_filter_then_project(lib, df):
+    q = QueryBuilder()
+    q = q[q["int_col"] < 5]
+    q = q.apply("proj", q["int_col"] + q["uint_col"])
+    expected = df[df["int_col"] < 5].copy()
+    expected["proj"] = expected["int_col"] + expected["uint_col"]
+    assert_read_matches(lib, q, expected)
+
+
+def case_groupby_string_key(lib, df):
+    generic_aggregation_test(lib, SYM, df, "str_col", AGGS)
+
+
+def case_filter_then_groupby(lib, df):
+    q = QueryBuilder()
+    q = q[q["bool_col"]]
+    q = q.groupby("str_col").agg({"int_col": "sum"})
+    expected = df[df["bool_col"]].groupby("str_col").agg({"int_col": "sum"})
+    received = lib.read(SYM, query_builder=q).data
+    received.sort_index(inplace=True)
+    assert_frame_equal(expected, received, check_dtype=False)
+
+
+def case_resample_aligned(lib, df):
+    generic_resample_test(lib, SYM, "10min", NAMED_AGGS, df, closed="left")
+
+
+def case_resample_straddling(lib, df):
+    # origin pinned because 7 minutes does not divide a day, so ArcticDB's epoch-phased buckets would otherwise land
+    # elsewhere than pandas' start_day-phased ones
+    generic_resample_test(lib, SYM, "7min", NAMED_AGGS, df, closed="left", label="right", origin="epoch")
+
+
+def case_resample_single_bucket(lib, df):
+    generic_resample_test(lib, SYM, "1D", NAMED_AGGS, df, closed="left")
+
+
+def case_date_range_clause(lib, df):
+    # Both ends fall part way through a row slice, so those units truncate rather than passing the segment through
+    start, end = df.index[13], df.index[157]
+    q = QueryBuilder().date_range((start, end))
+    assert_read_matches(lib, q, df.loc[start:end])
+
+
+def case_head(lib, df):
+    q = QueryBuilder().head(37)
+    assert_read_matches(lib, q, df.head(37))
+
+
+QUERY_CASES = [
+    case_filter_numeric,
+    case_filter_string_isin,
+    case_filter_none_strings,
+    case_filter_compound,
+    case_filter_matching_whole_slices,
+    case_project,
+    case_filter_then_project,
+    case_groupby_string_key,
+    case_filter_then_groupby,
+    case_resample_aligned,
+    case_resample_straddling,
+    case_resample_single_bucket,
+    case_date_range_clause,
+    case_head,
+]
+
+ADMISSION_CONFIGS = [
+    pytest.param({}, id="defaults"),
+    pytest.param({RESIDENCY_KEY: 1}, id="k1"),
+    pytest.param({READ_WINDOW_KEY: 1}, id="window1"),
+    pytest.param({RESIDENCY_KEY: 1, READ_WINDOW_KEY: 1}, id="k1_window1"),
+    pytest.param({RESIDENCY_KEY: 0}, id="killswitch"),
+]
+
+
+# A budget of one processing unit and a read window of one segment is where any failure to advance admission
+# deadlocks rather than merely running slowly, so the timeout is what makes that a test failure.
+@pytest.mark.timeout(120)
+@pytest.mark.parametrize("case", QUERY_CASES, ids=lambda case: case.__name__[len("case_") :])
+@pytest.mark.parametrize("admission_config", ADMISSION_CONFIGS)
+def test_query_correct_under_admission_config(residency_lib, case, admission_config):
+    lib, df = residency_lib
+    with config_context_multi(admission_config):
+        case(lib, df)
+
+
+@pytest.mark.timeout(120)
+def test_query_correct_with_single_thread_pools(residency_lib, tiny_thread_pool):
+    lib, df = residency_lib
+    with config_context_multi({RESIDENCY_KEY: 1, READ_WINDOW_KEY: 1}):
+        case_filter_numeric(lib, df)
+        case_resample_straddling(lib, df)
+
+
+@pytest.fixture
+def sliced_library(lmdb_library_factory):
+    return lmdb_library_factory(LibraryOptions(rows_per_segment=SEGMENT_ROW_SIZE))
+
+
+# Multi-symbol reads build one admission handler per symbol, so several are live at once.
+@pytest.mark.timeout(120)
+def test_symbol_concat_under_admission_config(sliced_library):
+    df = sample_df()[["int_col", "float_col"]]
+    chunk = NUM_ROWS // 2
+    sliced_library.write("concat_0", df.iloc[:chunk])
+    sliced_library.write("concat_1", df.iloc[chunk:])
+
+    with config_context_multi({RESIDENCY_KEY: 1, READ_WINDOW_KEY: 1}):
+        with segment_residency_tracking() as residency:
+            received = concat(sliced_library.read_batch(["concat_0", "concat_1"], lazy=True)).collect().data
+            # This test is only worth anything if the read went through the admission handler at all
+            assert residency.high_water > 0, "read did not go through the admission handler"
+    assert_frame_equal(df, received, check_dtype=False)
+
+
+@pytest.mark.timeout(120)
+def test_sort_and_finalize_staged_data_under_admission_config(sliced_library):
+    df = sample_df()[["int_col", "float_col"]]
+    for start in range(0, NUM_ROWS, SEGMENT_ROW_SIZE):
+        sliced_library.stage(SYM, df.iloc[start : start + SEGMENT_ROW_SIZE])
+
+    with config_context_multi({RESIDENCY_KEY: 1, READ_WINDOW_KEY: 1}):
+        with segment_residency_tracking() as residency:
+            sliced_library.sort_and_finalize_staged_data(SYM)
+            assert residency.high_water == NUM_ROW_SLICES
+
+    assert_frame_equal(df, sliced_library.read(SYM).data, check_dtype=False)


### PR DESCRIPTION
In the processing pipeline we currently kick off reads eagerly, meaning that if the in-memory processing does not complete quickly, large numbers of `SegmentInMemory` objects accumulate in the CPU executor's queue. Creating column stats manually considers all the data in a symbol, so we can end up holding the entire symbol's data in memory.

# Implementation

This PR adds a new "admission handler" to control memory use in the processing pipeline. This affects all QueryBuilder operations, not just column stats. We now create a special "admission handler" object that provides segment read futures. Importantly, it creates these as promises and only kicks off work for them later, unlike the current eager read pipeline. This design means that everything downstream of the segment load futures in the processing pipeline can be used as-is.

The admission handler only allows K processing units to be live in memory at a time. As each unit finishes it calls `on_unit_complete` (when the `MemSegmentProcessingTask` completes). This kicks off the load of the next unit's segments. Importantly this is not a blocking operation, else it could deadlock.

To give an example, with processing units with an overlap:

```
P = [{0, 1}, {1, 2}]
```

we first call `admit_initial` to load processing unit `0`, i.e. segments `0, 1`. When this unit is complete, the component manager frees segment `0` but not segment `1`. At this point `on_unit_complete` fires. This calls `admit(processing_unit=1)` which calls `fire(segment=1)` (no-op) and `fire(segment=2)` which kicks off a segment load.

We also make sure that we effectively `folly::window` over the IO work that we kick off, rather than letting it all pile up on the IO queues when K is large, which gives worse queuing behaviour and regressed performance compared to `folly::window`.

For testing, I add a class `SegmentResidencyTracker` that measures how many segments were live in memory over an operation. This is compiled in to release builds but is a no-op - it only does anything in testing. Its cost is just reading a boolean that's always false.

# Impact

## Measurements

Each table cell is **peak `ru_maxrss` (MiB) / wall time (s)** for one operation. Every cell is a separate process running a single operation, so `ru_maxrss` (peak RSS over the process lifetime) is a clean high-water mark for that one operation.
`master` has no admission bound, so it has a single column. `fixes` varies the residency budget `K` (`VersionStore.NumProcessingUnitsLive`, the max processing units in flight):
`K=0` is the kill switch (bound disabled), `K=8` a tight bound, `K=default` the computed default; the read window `W` (`VersionStore.SegmentReadWindow`) is left at its default of `2*io`.
Each build is run under three process allocators: glibc default, glibc with `MALLOC_ARENA_MAX=4`, and tcmalloc (`LD_PRELOAD`). `IO:CPU` is the IO/CPU threadpool sizes (`VersionStore.NumIOThreads` / `NumCPUThreads`).

## Data

One symbol, `f64_100m_100c_zeros`, on PURE (S3): **100,000,000 rows x 100 `float64` data columns** (`f_0`..`f_99`), all zeros, plus an `int64` `category` column cycling through values 1-5,
indexed by a nanosecond `DatetimeIndex` at 1-second frequency. Written with default slicing (100k rows/segment, all columns in one column slice), giving 1000 row-slice segments.

Each segment is about 80MiB decoded, the symbol is about 80GiB decoded.

## Operations

- **filter**: `read` with `QueryBuilder()[q["f_0"] == -1.0]`. `-1.0` never occurs (data is zeros), so the result is empty and does not contribute to RSS
- **column_stats**: build MINMAX column statistics for each row-slice
- **resample**: `read` with `QueryBuilder().resample("30D").agg(sum)` summing all 100 float columns into ~30-day buckets (a few dozen output rows).
- **groupby**: `read` with `QueryBuilder().groupby("category").agg(sum)` summing all 100 float columns across the 5 `category` groups (5 output rows).

## Findings

- *Allocator makes a big difference* glibc default inflates peak RSS badly as there are so many arenas on the build servers, arena cap or tcmalloc cut RSS significantly. arena4 means glibc with MALLOC_ARENA_MAX=4
- *K=0 reproduces master timings so the kill switch works*
- Shows improved memory use for default K without a penalty on wall clock time

### 1. No Time Penalty with default or kill switch

Similarly performance with K=0 also matches current master.

Timing results with the default value:

| measure | io:cpu | glibc | arena4 | tcmalloc |
|---|---|---|---|---|
| filter | 8:12 | -7.0% / +2.5% | +3.2% / +2.9% | -3.6% / +1.0% |
| filter | 16:24 | -18.2% / +0.9% | -4.1% / -1.2% | -17.2% / +0.2% |
| filter | 64:96 | +26.6% / -0.4% | -0.6% / +3.4% | +1.2% / +10.5% |
| column_stats | 8:12 | -6.5% / +6.1% | -17.3% / +4.9% | -13.5% / +1.0% |
| column_stats | 16:24 | -6.1% / +22.8% | -10.1% / +3.7% | -6.0% / +9.9% |
| column_stats | 64:96 | -4.7% / -44.3% | +1.9% / -3.4% | -2.7% / -0.6% |
| resample | 8:12 | -3.7% / +8.2% | -5.4% / +6.9% | -3.1% / -0.2% |
| resample | 16:24 | +0.0% / +10.4% | +4.9% / -1.6% | +0.9% / +0.6% |
| resample | 64:96 | -1.1% / +2.6% | -1.6% / +0.5% | -0.4% / +2.4% |
| groupby | 8:12 | -6.1% / -17.6% | +0.9% / -0.9% | +18.6% / -0.4% |
| groupby | 16:24 | -9.0% / -21.6% | -5.0% / -0.1% | -12.0% / -0.9% |
| groupby | 64:96 | -11.7% / -19.0% | -9.9% / -0.1% | +7.3% / +0.4% |

### 2. The default only reduces memory for column stats on large hosts

I tried several other defaults, but they imposed a performance penalty on `filter`. I think that at least to start with, a default that does not affect wall-clock time will be easier to roll out.

Timing results:

| measure | io:cpu | glibc | arena4 | tcmalloc |
|---|---|---|---|---|
| filter | 8:12 | +1% | +1% | +1% |
| filter | 16:24 | -1% | -3% | +7% |
| filter | 64:96 | +1% | +1% | +2% |
| column_stats | 8:12 | -0% | +3% | -1% |
| column_stats | 16:24 | +8% | +7% | +2% |
| column_stats | 64:96 | -52% | -3% | +5% |
| resample | 8:12 | -14% | -4% | -2% |
| resample | 16:24 | +2% | -5% | +1% |
| resample | 64:96 | +1% | +2% | +2% |
| groupby | 8:12 | -21% | -1% | -0% |
| groupby | 16:24 | -23% | +0% | -1% |
| groupby | 64:96 | -23% | +0% | +0% |

### 3. `K=8` shows reduced memory use vs `K=0`:

Memory:

| measure | io:cpu | glibc | arena4 | tcmalloc |
|---|---|---|---|---|
| filter | 8:12 | -2% | -1% | +14% |
| filter | 16:24 | -6% | -26% | -38% |
| filter | 64:96 | -24% | -79% | -83% |
| column_stats | 8:12 | -31% | -23% | -16% |
| column_stats | 16:24 | -45% | -42% | -39% |
| column_stats | 64:96 | -87% | -83% | -79% |
| resample | 8:12 | -42% | -37% | -33% |
| resample | 16:24 | -56% | -48% | -46% |
| resample | 64:96 | -72% | -64% | -56% |
| groupby | 8:12 | -23% | -3% | -2% |
| groupby | 16:24 | -26% | -4% | -6% |
| groupby | 64:96 | -31% | -4% | -9% |

The next sections show the raw results:

### glibc default - peak MiB / wall s

| measure | io:cpu | pre-PR | K=0 | K=8 | K=default |
|---|---|---|---|---|---|
| filter | 8:12 | 771.1 / 3.45 | 782.2 / 3.28 | 770.1 / 3.93 | 790.0 / 3.21 |
| filter | 16:24 | 1315.2 / 2.75 | 1335.2 / 2.20 | 1254.8 / 4.00 | 1326.4 / 2.25 |
| filter | 64:96 | 4829.5 / 1.54 | 4772.2 / 2.01 | 3632.8 / 4.76 | 4811.0 / 1.95 |
| column_stats | 8:12 | 2362.4 / 4.94 | 2510.9 / 4.70 | 1724.2 / 8.14 | 2506.4 / 4.62 |
| column_stats | 16:24 | 3517.2 / 3.79 | 4007.0 / 3.22 | 2216.3 / 8.36 | 4319.5 / 3.56 |
| column_stats | 64:96 | 29444.4 / 2.77 | 33952.8 / 2.61 | 4572.4 / 8.84 | 16407.3 / 2.64 |
| resample | 8:12 | 24297.3 / 4.81 | 30551.6 / 4.31 | 17675.5 / 5.71 | 26278.1 / 4.63 |
| resample | 16:24 | 37070.6 / 3.46 | 40023.7 / 3.49 | 17784.2 / 5.53 | 40934.7 / 3.46 |
| resample | 64:96 | 67539.6 / 2.61 | 68373.3 / 2.51 | 19150.5 / 5.54 | 69289.1 / 2.58 |
| groupby | 8:12 | 97413.2 / 18.55 | 102016.0 / 17.48 | 78824.1 / 18.59 | 80275.6 / 17.41 |
| groupby | 16:24 | 104967.1 / 19.52 | 106864.1 / 19.74 | 79279.2 / 19.34 | 82289.8 / 17.77 |
| groupby | 64:96 | 112363.5 / 22.26 | 117741.9 / 21.78 | 81718.5 / 19.67 | 90961.0 / 19.66 |

### MALLOC_ARENA_MAX=4 - peak MiB / wall s

| measure | io:cpu | pre-PR | K=0 | K=8 | K=default |
|---|---|---|---|---|---|
| filter | 8:12 | 728.3 / 3.42 | 743.5 / 3.45 | 737.4 / 5.70 | 749.5 / 3.53 |
| filter | 16:24 | 1235.9 / 2.19 | 1258.1 / 2.07 | 936.1 / 3.40 | 1220.6 / 2.10 |
| filter | 64:96 | 3608.7 / 1.70 | 3704.0 / 1.59 | 780.2 / 3.11 | 3730.1 / 1.69 |
| column_stats | 8:12 | 2170.2 / 5.85 | 2219.8 / 4.89 | 1701.4 / 7.73 | 2276.5 / 4.84 |
| column_stats | 16:24 | 3222.2 / 4.07 | 3121.2 / 3.89 | 1795.0 / 7.78 | 3341.3 / 3.66 |
| column_stats | 64:96 | 10458.1 / 3.19 | 10412.7 / 3.12 | 1756.8 / 7.90 | 10098.1 / 3.25 |
| resample | 8:12 | 24621.5 / 5.14 | 27348.3 / 4.97 | 17238.9 / 5.96 | 26319.0 / 4.86 |
| resample | 16:24 | 32312.4 / 3.90 | 33639.9 / 3.77 | 17477.6 / 5.92 | 31804.6 / 4.09 |
| resample | 64:96 | 47186.8 / 3.87 | 46374.2 / 3.63 | 16925.7 / 6.15 | 47429.8 / 3.81 |
| groupby | 8:12 | 81737.9 / 17.72 | 81832.9 / 23.38 | 79250.6 / 19.79 | 81027.6 / 17.88 |
| groupby | 16:24 | 82548.4 / 18.06 | 82222.0 / 18.98 | 79323.1 / 20.41 | 82486.2 / 17.15 |
| groupby | 64:96 | 83289.1 / 20.80 | 82928.8 / 18.51 | 79212.4 / 26.04 | 83237.5 / 18.74 |

### tcmalloc - peak MiB / wall s

| measure | io:cpu | pre-PR | K=0 | K=8 | K=default |
|---|---|---|---|---|---|
| filter | 8:12 | 679.4 / 3.05 | 682.0 / 2.61 | 774.2 / 3.10 | 686.0 / 2.94 |
| filter | 16:24 | 1278.0 / 2.38 | 1201.7 / 2.10 | 741.5 / 3.29 | 1280.8 / 1.97 |
| filter | 64:96 | 4133.9 / 1.67 | 4474.0 / 1.68 | 745.7 / 2.83 | 4566.4 / 1.69 |
| column_stats | 8:12 | 1970.2 / 5.98 | 2005.1 / 5.16 | 1677.0 / 7.68 | 1989.9 / 5.17 |
| column_stats | 16:24 | 2635.0 / 4.30 | 2829.1 / 3.85 | 1716.4 / 7.82 | 2896.5 / 4.04 |
| column_stats | 64:96 | 8333.5 / 2.58 | 7890.6 / 2.48 | 1691.8 / 7.73 | 8282.7 / 2.51 |
| resample | 8:12 | 24522.3 / 5.76 | 24855.6 / 6.01 | 16537.7 / 6.77 | 24461.8 / 5.58 |
| resample | 16:24 | 30446.7 / 4.62 | 30418.5 / 4.64 | 16525.2 / 6.38 | 30635.5 / 4.66 |
| resample | 64:96 | 37634.2 / 4.48 | 37847.3 / 4.46 | 16494.6 / 6.11 | 38528.1 / 4.46 |
| groupby | 8:12 | 85290.0 / 18.46 | 85312.0 / 17.87 | 83639.0 / 23.53 | 84987.6 / 21.89 |
| groupby | 16:24 | 89116.7 / 18.23 | 88824.0 / 18.07 | 83568.6 / 21.20 | 88325.0 / 16.05 |
| groupby | 64:96 | 92362.7 / 16.08 | 92379.7 / 15.44 | 83730.6 / 23.94 | 92752.0 / 17.25 |

### Aside: Slow Processing

I accidentally did one benchmark run against a debug build `K=default` vs `K=0` peak, glibc, debug build, which had these memory results:

| measure | 8:12 | 16:24 | 64:96 |
|---|---|---|---|
| filter | -2% | +1% | -2% |
| column_stats | -97% | -94% | -82% |
| resample | -67% | -37% | +0% |
| groupby | -27% | -40% | -27% |

This shows a big performance difference with the default K when processing is slow.

# Alternatives

#3138 - discarded as it leaves the CPU pool idle, and is difficult to read (in that the mechanism that bounds memory use is not explicit).

Originally I wanted to pass a semaphore in to `batch_read_uncompressed`, and acquire it for segment reads, and release it after a segment is processed, like compacting staged data does, always allowing at least `n_col_slices` to be loaded. This did not work because we kick off all the segment reads in parallel so your `n_col_slices` budget can be split across segments in different processing units while leaving no processing unit able to load completely and continue. This PR is instead explicit about allowing loads per processing unit.