### PR TITLE
Fix copying index keys to preserve their start/end index

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1110,6 +1110,7 @@ if(${TEST})
             storage/test/test_path_validation.cpp
             storage/test/common.hpp
             storage/test/test_storage_operations.cpp
+            storage/test/test_storage_utils.cpp
             stream/test/stream_test_common.cpp
             stream/test/test_aggregator.cpp
             stream/test/test_incompletes.cpp

--- a/cpp/arcticdb/storage/storage_utils.cpp
+++ b/cpp/arcticdb/storage/storage_utils.cpp
@@ -1,5 +1,6 @@
 #include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/pipeline/index_writer.hpp>
+#include <arcticdb/stream/index.hpp>
 #include <arcticdb/stream/index_aggregator.hpp>
 #include <arcticdb/async/tasks.hpp>
 #include <folly/futures/Future.h>
@@ -45,52 +46,56 @@ AtomKey write_table_index_tree_from_source_to_target(
     // In
     auto [_, index_seg] = source_store->read_sync(index_key);
     index::IndexSegmentReader index_segment_reader{std::move(index_seg)};
-    // Out
-    index::IndexWriter<stream::RowCountIndex> writer(
-            target_store,
-            {index_key.id(), new_version_id.value_or(index_key.version_id())},
-            std::move(index_segment_reader.mutable_tsd()),
-            /*key_type =*/std::nullopt,
-            /*sync =*/true
-    );
-
-    std::vector<folly::Future<async::CopyCompressedInterStoreTask::ProcessingResult>> futures;
-
-    // Process
-    for (auto iter = index_segment_reader.begin(); iter != index_segment_reader.end(); ++iter) {
-        auto& sk = *iter;
-        auto& key = sk.key();
-        std::optional<entity::AtomKey> key_to_write = atom_key_builder()
-                                                              .version_id(new_version_id.value_or(key.version_id()))
-                                                              .creation_ts(util::SysClock::nanos_since_epoch())
-                                                              .start_index(key.start_index())
-                                                              .end_index(key.end_index())
-                                                              .content_hash(key.content_hash())
-                                                              .build(key.id(), key.type());
-
-        writer.add(*key_to_write, sk.slice()); // Both const ref
-        futures.emplace_back(submit_io_task(async::CopyCompressedInterStoreTask{
-                sk.key(), std::move(key_to_write), false, false, source_store, {target_store}
-        }));
-    }
-
-    const std::vector<async::CopyCompressedInterStoreTask::ProcessingResult> store_results = collect(futures).get();
-    for (const async::CopyCompressedInterStoreTask::ProcessingResult& res : store_results) {
-        util::variant_match(
-                res,
-                [&](const async::CopyCompressedInterStoreTask::FailedTargets& failed) {
-                    log::storage().error(
-                            "Failed to move targets: {} from {} to {}",
-                            failed,
-                            source_store->name(),
-                            target_store->name()
-                    );
-                },
-                [](const auto&) {}
+    auto index = stream::index_type_from_descriptor(index_segment_reader.tsd().as_stream_descriptor());
+    return util::variant_match(index, [&](auto index_type) {
+        using IndexType = decltype(index_type);
+        // Out
+        index::IndexWriter<IndexType> writer(
+                target_store,
+                {index_key.id(), new_version_id.value_or(index_key.version_id())},
+                std::move(index_segment_reader.mutable_tsd()),
+                /*key_type =*/std::nullopt,
+                /*sync =*/true
         );
-    }
-    // FUTURE: clean up already written keys if exception
-    return writer.commit_sync();
+
+        std::vector<folly::Future<async::CopyCompressedInterStoreTask::ProcessingResult>> futures;
+
+        // Process
+        for (auto iter = index_segment_reader.begin(); iter != index_segment_reader.end(); ++iter) {
+            auto& sk = *iter;
+            auto& key = sk.key();
+            std::optional<entity::AtomKey> key_to_write = atom_key_builder()
+                                                                  .version_id(new_version_id.value_or(key.version_id()))
+                                                                  .creation_ts(util::SysClock::nanos_since_epoch())
+                                                                  .start_index(key.start_index())
+                                                                  .end_index(key.end_index())
+                                                                  .content_hash(key.content_hash())
+                                                                  .build(key.id(), key.type());
+
+            writer.add(*key_to_write, sk.slice()); // Both const ref
+            futures.emplace_back(submit_io_task(async::CopyCompressedInterStoreTask{
+                    sk.key(), std::move(key_to_write), false, false, source_store, {target_store}
+            }));
+        }
+
+        const std::vector<async::CopyCompressedInterStoreTask::ProcessingResult> store_results = collect(futures).get();
+        for (const async::CopyCompressedInterStoreTask::ProcessingResult& res : store_results) {
+            util::variant_match(
+                    res,
+                    [&](const async::CopyCompressedInterStoreTask::FailedTargets& failed) {
+                        log::storage().error(
+                                "Failed to move targets: {} from {} to {}",
+                                failed,
+                                source_store->name(),
+                                target_store->name()
+                        );
+                    },
+                    [](const auto&) {}
+            );
+        }
+        // FUTURE: clean up already written keys if exception
+        return writer.commit_sync();
+    });
 }
 
 AtomKey copy_multi_key_from_source_to_target(

--- a/cpp/arcticdb/storage/test/test_storage_utils.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_utils.cpp
@@ -56,14 +56,6 @@ TYPED_TEST(CopyIndexKeyTest, PreservesIndexRange) {
 
     EXPECT_EQ(target_key.start_index(), source_key.start_index());
     EXPECT_EQ(target_key.end_index(), source_key.end_index());
-
-    if constexpr (std::is_same_v<IndexType, stream::TimeseriesIndex>) {
-        EXPECT_EQ(target_key.start_index(), IndexValue{NumericIndex{100}});
-        EXPECT_EQ(target_key.end_index(), IndexValue{NumericIndex{130}});
-    } else {
-        EXPECT_EQ(target_key.start_index(), IndexValue{NumericIndex{0}});
-        EXPECT_EQ(target_key.end_index(), IndexValue{NumericIndex{2}});
-    }
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/storage/test/test_storage_utils.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_utils.cpp
@@ -10,6 +10,7 @@
 
 #include <arcticdb/storage/storage_utils.hpp>
 #include <arcticdb/storage/test/in_memory_store.hpp>
+#include <arcticdb/stream/test/stream_test_common.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/index_writer.hpp>
 #include <arcticdb/stream/index.hpp>
@@ -17,32 +18,52 @@
 namespace arcticdb {
 using namespace arcticdb::pipelines;
 
-// Copying a timeseries index key must preserve its timestamp range rather than rewriting it with a row-count range.
-TEST(StorageUtils, CopyIndexKeyPreservesTimeseriesRange) {
-    const StreamId stream_id{"sym"};
-    const timestamp start = 1'600'000'000'000'000'000;
-    const timestamp end = start + 86'400'000'000'000;
+namespace {
 
-    StreamDescriptor desc{stream_id, IndexDescriptorImpl{IndexDescriptorImpl::Type::TIMESTAMP, 1}};
-    desc.add_field(scalar_field(DataType::NANOSECONDS_UTC64, "time"));
-    desc.add_field(scalar_field(DataType::UINT8, "col"));
+template<typename IndexType>
+AtomKey write_source_index(const std::shared_ptr<Store>& store, const StreamId& stream_id) {
+    const std::array fields{scalar_field(DataType::UINT8, "col")};
     TimeseriesDescriptor tsd;
-    tsd.set_stream_descriptor(desc);
+    tsd.set_stream_descriptor(get_test_descriptor<IndexType>(stream_id, fields));
 
+    index::IndexWriter<IndexType> writer(store, IndexPartialKey{stream_id, 0}, std::move(tsd));
+    for (size_t i = 0; i < 3; ++i) {
+        const timestamp start = 100 + static_cast<timestamp>(i) * 10;
+        writer.add(
+                atom_key_builder().start_index(start).end_index(start + 10).build(stream_id, KeyType::TABLE_DATA),
+                FrameSlice{ColRange{1, 2}, RowRange{i, i + 1}}
+        );
+    }
+    return std::move(writer.commit()).get();
+}
+
+} // namespace
+
+template<typename IndexType>
+class CopyIndexKeyTest : public ::testing::Test {};
+
+using IndexTypes = ::testing::Types<stream::TimeseriesIndex, stream::RowCountIndex>;
+TYPED_TEST_SUITE(CopyIndexKeyTest, IndexTypes);
+
+TYPED_TEST(CopyIndexKeyTest, PreservesIndexRange) {
+    using IndexType = TypeParam;
+    const StreamId stream_id{"sym"};
     auto source = std::make_shared<InMemoryStore>();
     auto target = std::make_shared<InMemoryStore>();
 
-    index::IndexWriter<stream::TimeseriesIndex> writer(source, IndexPartialKey{stream_id, 0}, std::move(tsd));
-    writer.add(
-            atom_key_builder().start_index(start).end_index(end).build(stream_id, KeyType::TABLE_DATA),
-            FrameSlice{ColRange{1, 2}, RowRange{0, 1}}
-    );
-    const auto source_key = std::move(writer.commit()).get();
-
+    const auto source_key = write_source_index<IndexType>(source, stream_id);
     const auto target_key = copy_index_key_recursively(source, target, source_key, std::nullopt);
 
-    EXPECT_EQ(target_key.start_index(), IndexValue{NumericIndex{start}});
-    EXPECT_EQ(target_key.end_index(), IndexValue{NumericIndex{end}});
+    EXPECT_EQ(target_key.start_index(), source_key.start_index());
+    EXPECT_EQ(target_key.end_index(), source_key.end_index());
+
+    if constexpr (std::is_same_v<IndexType, stream::TimeseriesIndex>) {
+        EXPECT_EQ(target_key.start_index(), IndexValue{NumericIndex{100}});
+        EXPECT_EQ(target_key.end_index(), IndexValue{NumericIndex{130}});
+    } else {
+        EXPECT_EQ(target_key.start_index(), IndexValue{NumericIndex{0}});
+        EXPECT_EQ(target_key.end_index(), IndexValue{NumericIndex{2}});
+    }
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/storage/test/test_storage_utils.cpp
+++ b/cpp/arcticdb/storage/test/test_storage_utils.cpp
@@ -1,0 +1,48 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/storage/storage_utils.hpp>
+#include <arcticdb/storage/test/in_memory_store.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/index_writer.hpp>
+#include <arcticdb/stream/index.hpp>
+
+namespace arcticdb {
+using namespace arcticdb::pipelines;
+
+// Copying a timeseries index key must preserve its timestamp range rather than rewriting it with a row-count range.
+TEST(StorageUtils, CopyIndexKeyPreservesTimeseriesRange) {
+    const StreamId stream_id{"sym"};
+    const timestamp start = 1'600'000'000'000'000'000;
+    const timestamp end = start + 86'400'000'000'000;
+
+    StreamDescriptor desc{stream_id, IndexDescriptorImpl{IndexDescriptorImpl::Type::TIMESTAMP, 1}};
+    desc.add_field(scalar_field(DataType::NANOSECONDS_UTC64, "time"));
+    desc.add_field(scalar_field(DataType::UINT8, "col"));
+    TimeseriesDescriptor tsd;
+    tsd.set_stream_descriptor(desc);
+
+    auto source = std::make_shared<InMemoryStore>();
+    auto target = std::make_shared<InMemoryStore>();
+
+    index::IndexWriter<stream::TimeseriesIndex> writer(source, IndexPartialKey{stream_id, 0}, std::move(tsd));
+    writer.add(
+            atom_key_builder().start_index(start).end_index(end).build(stream_id, KeyType::TABLE_DATA),
+            FrameSlice{ColRange{1, 2}, RowRange{0, 1}}
+    );
+    const auto source_key = std::move(writer.commit()).get();
+
+    const auto target_key = copy_index_key_recursively(source, target, source_key, std::nullopt);
+
+    EXPECT_EQ(target_key.start_index(), IndexValue{NumericIndex{start}});
+    EXPECT_EQ(target_key.end_index(), IndexValue{NumericIndex{end}});
+}
+
+} // namespace arcticdb


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Copying index keys via `copy_index_key_recursively` didn't preserve their start/end index keys correctly with timeseries-indexed data - the index type was lost and the copy was made as if the index is a always a row count.

This PR changes the copying to preserve the type so that the resulting index key is correct

This method is used in Enterprise's LibraryCopier, which is how the bug was caught.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
