### PR TITLE
Refactor WriteToSegmentTask for compact_data_inline

### DIFF
--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -241,22 +241,36 @@ struct TypedTensor : public NativeTensor {
         // The new column shape * the column stride tells us how far to move the data pointer from the origin
 
         ptr = reinterpret_cast<const uint8_t*>(tensor.data()) + (slice_num * stride_offset);
-        check_ptr_within_bounds(tensor, slice_num, stride_offset);
+        check_ptr_within_bounds(tensor, slice_num * stride_offset);
+    }
+
+    TypedTensor(const NativeTensor& tensor, size_t row, ssize_t nvalues) :
+        NativeTensor(
+                nvalues * itemsize(), tensor.ndim(), tensor.strides(), tensor.shape(), tensor.data_type(),
+                tensor.elsize(), nullptr, tensor.expanded_dim()
+        ) {
+        // The above ctor that uses slice_num and regular_slice_size rather than just row is for ndarray column support,
+        // which is not yet available. It is only used in test_tensor.cpp.
+        util::check(ndim() <= 1, "TypedTensor rows ctor should not be called with dim 2 data");
+        shapes_[0] = nvalues;
+        // The new column shape * the column stride tells us how far to move the data pointer from the origin
+        ptr = reinterpret_cast<const uint8_t*>(tensor.data()) + (row * strides(0));
+        check_ptr_within_bounds(tensor, row);
     }
 
     const T* data() const { return static_cast<const T*>(NativeTensor::data()); }
 
   private:
-    void check_ptr_within_bounds(const NativeTensor& tensor, ssize_t slice_num, ssize_t stride_offset) {
+    void check_ptr_within_bounds(const NativeTensor& tensor, size_t rows) {
         if (tensor.extent(0) == 0) {
             // For empty tensors, we can't perform the normal bounds check
             // Just ensure we're not trying to access beyond the first element
-            util::check(slice_num == 0, "Cannot put slice pointer at position {} in an empty tensor", slice_num);
+            util::check(rows == 0, "Cannot put slice pointer at position {} in an empty tensor", rows);
         } else {
             util::check(
                     ptr < static_cast<const uint8_t*>(tensor.ptr) + std::abs(tensor.extent(0)),
                     "Tensor overflow, cannot put slice pointer at byte {} in a tensor of {} bytes",
-                    slice_num * stride_offset,
+                    rows,
                     tensor.extent(0)
             );
         }

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -87,11 +87,10 @@ TimeseriesDescriptor index_descriptor_from_frame(
 
 template<typename RawType>
 RawType* flatten_tensor(
-        std::optional<ChunkedBuffer>& flattened_buffer, size_t rows_to_write, const NativeTensor& tensor,
-        size_t slice_num, size_t regular_slice_size
+        std::optional<ChunkedBuffer>& flattened_buffer, size_t rows_to_write, const NativeTensor& tensor, size_t row
 ) {
     flattened_buffer = ChunkedBuffer::presized(rows_to_write * sizeof(RawType));
-    TypedTensor<RawType> t(tensor, slice_num, regular_slice_size, rows_to_write);
+    TypedTensor<RawType> t(tensor, row, rows_to_write);
     util::FlattenHelper flattener{t};
     auto dst = reinterpret_cast<RawType*>(flattened_buffer->data());
     flattener.flatten(dst, reinterpret_cast<RawType const*>(t.data()));
@@ -135,8 +134,7 @@ std::variant<position_t, convert::StringEncodingError> add_py_string_to_pool(
 
 template<typename TagType, typename RawType>
 std::optional<convert::StringEncodingError> set_sequence_type(
-        SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        size_t slice_num, size_t regular_slice_size
+        SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row
 ) {
     constexpr auto dt = TagType::DataTypeTag::data_type;
     const auto c_style = util::is_cstyle_array<RawType>(tensor);
@@ -157,8 +155,7 @@ std::optional<convert::StringEncodingError> set_sequence_type(
         auto ptr_data = static_cast<PyObject**>(data);
         ptr_data += row;
         if (!c_style)
-            ptr_data =
-                    flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, slice_num, regular_slice_size);
+            ptr_data = flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, row);
 
         // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
         // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
@@ -186,7 +183,7 @@ std::optional<convert::StringEncodingError> set_sequence_type(
 template<typename TagType, typename RawType>
 void set_integral_scalar_type(
         SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        size_t slice_num, size_t regular_slice_size, bool sparsify_floats
+        bool sparsify_floats
 ) {
     constexpr auto dt = TagType::DataTypeTag::data_type;
     auto ptr = tensor.template ptr_cast<RawType>(row);
@@ -211,7 +208,7 @@ void set_integral_scalar_type(
                     sizeof(RawType)
             );
 
-            TypedTensor<RawType> t(tensor, slice_num, regular_slice_size, rows_to_write);
+            TypedTensor<RawType> t(tensor, row, rows_to_write);
             seg.set_array(col, t);
         }
     }
@@ -219,8 +216,7 @@ void set_integral_scalar_type(
 
 template<typename TagType, typename RawType>
 void set_bool_object_type(
-        SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        size_t slice_num, size_t regular_slice_size
+        SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row
 ) {
     const auto c_style = util::is_cstyle_array<RawType>(tensor);
     std::optional<ChunkedBuffer> flattened_buffer;
@@ -230,7 +226,7 @@ void set_bool_object_type(
     ptr_data += row;
 
     if (!c_style)
-        ptr_data = flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, slice_num, regular_slice_size);
+        ptr_data = flatten_tensor<PyObject*>(flattened_buffer, rows_to_write, tensor, row);
 
     util::BitSet bitset = util::scan_object_type_to_sparse(ptr_data, rows_to_write);
 
@@ -325,7 +321,7 @@ std::optional<convert::StringEncodingError> set_array_type(
 
 inline std::optional<convert::StringEncodingError> segment_set_data(
         const TypeDescriptor& type_desc, const entity::NativeTensor& tensor, SegmentInMemory& seg, size_t col,
-        size_t rows_to_write, size_t row, size_t slice_num, size_t regular_slice_size, bool sparsify_floats
+        size_t rows_to_write, size_t row, bool sparsify_floats
 ) {
     return type_desc.visit_tag([&](auto tag) {
         using TagType = std::decay_t<decltype(tag)>;
@@ -344,20 +340,16 @@ inline std::optional<convert::StringEncodingError> segment_set_data(
             normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(
                     tag.dimension() == Dimension::Dim0, "Multidimensional string types are not supported."
             );
-            auto maybe_error = set_sequence_type<TagType, RawType>(
-                    seg, tensor, col, rows_to_write, row, slice_num, regular_slice_size
-            );
+            auto maybe_error = set_sequence_type<TagType, RawType>(seg, tensor, col, rows_to_write, row);
             if (maybe_error)
                 return maybe_error;
         } else if constexpr ((is_numeric_type(dt) || is_bool_type(dt)) && tag.dimension() == Dimension::Dim0) {
-            set_integral_scalar_type<TagType, RawType>(
-                    seg, tensor, col, rows_to_write, row, slice_num, regular_slice_size, sparsify_floats
-            );
+            set_integral_scalar_type<TagType, RawType>(seg, tensor, col, rows_to_write, row, sparsify_floats);
         } else if constexpr (is_bool_object_type(dt)) {
             normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(
                     tag.dimension() == Dimension::Dim0, "Multidimensional nullable booleans are not supported"
             );
-            set_bool_object_type<TagType, RawType>(seg, tensor, col, rows_to_write, row, slice_num, regular_slice_size);
+            set_bool_object_type<TagType, RawType>(seg, tensor, col, rows_to_write, row);
         } else if constexpr (is_array_type(TypeDescriptor(tag))) {
             auto maybe_error = set_array_type<TagType, RawType>(type_desc, seg, tensor, col, rows_to_write, row);
             if (maybe_error)
@@ -377,11 +369,9 @@ inline std::optional<convert::StringEncodingError> segment_set_data(
 template<typename Aggregator>
 inline std::optional<convert::StringEncodingError> aggregator_set_data(
         const TypeDescriptor& type_desc, const entity::NativeTensor& tensor, Aggregator& agg, size_t col,
-        size_t rows_to_write, size_t row, size_t slice_num, size_t regular_slice_size, bool sparsify_floats
+        size_t rows_to_write, size_t row, bool sparsify_floats
 ) {
-    return segment_set_data(
-            type_desc, tensor, agg.segment(), col, rows_to_write, row, slice_num, regular_slice_size, sparsify_floats
-    );
+    return segment_set_data(type_desc, tensor, agg.segment(), col, rows_to_write, row, sparsify_floats);
 }
 
 size_t adjust_slice_rowcounts(std::vector<pipelines::SliceAndKey>& slice_and_keys);

--- a/cpp/arcticdb/pipeline/slicing.hpp
+++ b/cpp/arcticdb/pipeline/slicing.hpp
@@ -87,29 +87,6 @@ inline auto end_index_generator(T end_index) { // works for both rawtype and raw
     }
 }
 
-inline auto get_partial_key_gen(std::shared_ptr<InputFrame> frame, const TypedStreamVersion& key) {
-    using PartialKey = stream::PartialKey;
-
-    return [frame = std::move(frame), &key](const FrameSlice& s) {
-        if (frame->has_index()) {
-            // This is a bit inefficient if the input data is multiple Arrow record batches, as it has to do a binary
-            // search for the relevant block. An alternative would be to look at the segment that was just generated in
-            // WriteToSegmentTask and similar methods, but this is unlikely to be a bottleneck
-            auto start = frame->index_value_at(slice_begin_pos(s, *frame));
-            const auto end = frame->index_value_at(slice_end_pos(s, *frame));
-            return PartialKey{key.type, key.version_id, key.id, start, end_index_generator(end)};
-        } else {
-            return PartialKey{
-                    key.type,
-                    key.version_id,
-                    key.id,
-                    entity::safe_convert_to_numeric_index(s.row_range.first, "Rows"),
-                    entity::safe_convert_to_numeric_index(s.row_range.second, "Rows")
-            };
-        }
-    };
-}
-
 inline stream::PartialKey get_partial_key_for_segment_slice(
         const IndexDescriptorImpl& index, const TypedStreamVersion& key, const SegmentInMemory& slice
 ) {

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -32,15 +32,12 @@ using namespace arcticdb::stream;
 namespace ranges = std::ranges;
 
 WriteToSegmentTask::WriteToSegmentTask(
-        std::shared_ptr<InputFrame> frame, FrameSlice slice, const SlicingPolicy& slicing,
-        folly::Function<PartialKey(const FrameSlice&)>&& partial_key_gen, size_t slice_num_for_column,
-        bool sparsify_floats
+        std::shared_ptr<InputFrame> frame, FrameSlice slice,
+        const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats
 ) :
     frame_(std::move(frame)),
     slice_(std::move(slice)),
-    slicing_(slicing),
-    partial_key_gen_(std::move(partial_key_gen)),
-    slice_num_for_column_(slice_num_for_column),
+    typed_stream_version_(typed_stream_version),
     sparsify_floats_(sparsify_floats) {
     slice_.check_magic();
 }
@@ -49,10 +46,27 @@ std::tuple<PartialKey, SegmentInMemory, FrameSlice> WriteToSegmentTask::operator
     ARCTICDB_SUBSAMPLE_AGG(WriteSliceCopyToSegment)
     slice_.check_magic();
     magic_.check();
-    auto key = partial_key_gen_(slice_);
     auto seg = slice();
+    auto key = generate_partial_key(seg);
     seg.descriptor().set_id(key.stream_id);
     return {std::move(key), std::move(seg), std::move(slice_)};
+}
+
+PartialKey WriteToSegmentTask::generate_partial_key(const SegmentInMemory& seg) const {
+    if (!typed_stream_version_.has_value()) {
+        return {};
+    }
+    const auto start_index = frame_->has_index()
+                                     ? *seg.column(0).scalar_at<timestamp>(0)
+                                     : entity::safe_convert_to_numeric_index(slice_.row_range.first, "Rows");
+    const auto end_index = frame_->has_index()
+                                   ? end_index_generator(*seg.column(0).scalar_at<timestamp>(seg.row_count() - 1))
+                                   : entity::safe_convert_to_numeric_index(slice_.row_range.second, "Rows");
+    return {typed_stream_version_->type,
+            typed_stream_version_->version_id,
+            typed_stream_version_->id,
+            start_index,
+            end_index};
 }
 
 struct ArrowInputContiguousSlice {
@@ -326,28 +340,13 @@ SegmentInMemory WriteToSegmentTask::slice() const {
     seg.set_offset(offset_in_frame);
     const auto rows_to_write = slice_.row_range.second - slice_.row_range.first;
     const auto index_field_count = frame_->desc().index().field_count();
-    const auto regular_slice_size = util::variant_match(
-            slicing_,
-            [&](const NoSlicing&) { return rows_to_write; },
-            [&](const auto& slicer) { return slicer.row_per_slice(); }
-    );
 
     auto add_tensor_column = [&](size_t abs_col, const NativeTensor& tensor, const Field& fd, bool sparsify) {
         seg.add_column(
                 FieldRef{fd.type(), fd.name()},
                 std::make_shared<Column>(fd.type(), 0, AllocationType::DYNAMIC, Sparsity::NOT_PERMITTED)
         );
-        auto opt_error = segment_set_data(
-                fd.type(),
-                tensor,
-                seg,
-                abs_col,
-                rows_to_write,
-                offset_in_frame,
-                slice_num_for_column_,
-                regular_slice_size,
-                sparsify
-        );
+        auto opt_error = segment_set_data(fd.type(), tensor, seg, abs_col, rows_to_write, offset_in_frame, sparsify);
         if (opt_error.has_value()) {
             opt_error->raise(fd.name(), offset_in_frame);
         }
@@ -389,24 +388,6 @@ SegmentInMemory WriteToSegmentTask::slice() const {
     return seg;
 }
 
-std::vector<std::pair<FrameSlice, size_t>> get_slice_and_rowcount(const std::vector<FrameSlice>& slices) {
-    std::vector<std::pair<FrameSlice, size_t>> slice_and_rowcount;
-    slice_and_rowcount.reserve(slices.size());
-    size_t slice_num_for_column = 0;
-    std::optional<size_t> first_row;
-    for (const auto& slice : slices) {
-        if (!first_row)
-            first_row = slice.row_range.first;
-
-        if (slice.row_range.first == *first_row)
-            slice_num_for_column = 0;
-
-        slice_and_rowcount.emplace_back(slice, slice_num_for_column);
-        ++slice_num_for_column;
-    }
-    return slice_and_rowcount;
-}
-
 int64_t write_window_size() {
     return ConfigsMap::instance()->get_int(
             "VersionStore.BatchWriteWindow", int64_t(2 * async::TaskScheduler::instance()->io_thread_count())
@@ -414,26 +395,17 @@ int64_t write_window_size() {
 }
 
 folly::SemiFuture<std::vector<folly::Try<SliceAndKey>>> write_slices(
-        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, const SlicingPolicy& slicing,
-        TypedStreamVersion&& key, const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map, bool sparsify_floats
+        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, TypedStreamVersion&& key,
+        const std::shared_ptr<stream::StreamSink>& sink, const std::shared_ptr<DeDupMap>& de_dup_map,
+        bool sparsify_floats
 ) {
     ARCTICDB_SAMPLE(WriteSlices, 0)
 
-    auto slice_and_rowcount = get_slice_and_rowcount(slices);
-
     int64_t write_window = write_window_size();
     auto window = folly::window(
-            std::move(slice_and_rowcount),
-            [de_dup_map, frame, slicing, key = std::move(key), sink, sparsify_floats](auto&& slice) {
-                return async::submit_cpu_task(WriteToSegmentTask(
-                                                      frame,
-                                                      slice.first,
-                                                      slicing,
-                                                      get_partial_key_gen(frame, key),
-                                                      slice.second,
-                                                      sparsify_floats
-                                              ))
+            std::move(slices),
+            [de_dup_map, frame, key = std::move(key), sink, sparsify_floats](auto&& slice) {
+                return async::submit_cpu_task(WriteToSegmentTask(frame, slice, key, sparsify_floats))
                         .then([sink, de_dup_map](auto&& ks) {
                             return sink->async_write(std::forward<decltype(ks)>(ks), de_dup_map);
                         });
@@ -455,7 +427,7 @@ folly::Future<std::vector<SliceAndKey>> slice_and_write(
 
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
     TypedStreamVersion tsv{std::move(key.id), key.version_id, KeyType::TABLE_DATA};
-    return write_slices(frame, std::move(slices), slicing, std::move(tsv), sink, de_dup_map, sparsify_floats)
+    return write_slices(frame, std::move(slices), std::move(tsv), sink, de_dup_map, sparsify_floats)
             .via(&async::cpu_executor())
             .thenValue([sink](std::vector<folly::Try<SliceAndKey>>&& ks) {
                 return rollback_slices_on_quota_exceeded(std::move(ks), sink);

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -28,16 +28,14 @@ struct WriteToSegmentTask : public async::BaseTask {
   public:
     std::shared_ptr<InputFrame> frame_;
     const FrameSlice slice_;
-    const SlicingPolicy slicing_;
+    std::optional<TypedStreamVersion> typed_stream_version_;
     folly::Function<PartialKey(const FrameSlice&)> partial_key_gen_;
-    size_t slice_num_for_column_;
     bool sparsify_floats_;
     util::MagicNum<'W', 's', 'e', 'g'> magic_;
 
     WriteToSegmentTask(
-            std::shared_ptr<InputFrame> frame, FrameSlice slice, const SlicingPolicy& slicing,
-            folly::Function<PartialKey(const FrameSlice&)>&& partial_key_gen, size_t slice_num_for_column,
-            bool sparsify_floats
+            std::shared_ptr<InputFrame> frame, FrameSlice slice,
+            const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats = false
     );
 
     std::tuple<PartialKey, SegmentInMemory, FrameSlice> operator()();
@@ -45,6 +43,7 @@ struct WriteToSegmentTask : public async::BaseTask {
   private:
     SegmentInMemory slice() const;
     Column slice_column(const Column& source_column, size_t offset, StringPool& string_pool) const;
+    PartialKey generate_partial_key(const SegmentInMemory& seg) const;
 };
 
 folly::Future<std::vector<SliceAndKey>> slice_and_write(
@@ -56,9 +55,9 @@ folly::Future<std::vector<SliceAndKey>> slice_and_write(
 int64_t write_window_size();
 
 folly::SemiFuture<std::vector<folly::Try<SliceAndKey>>> write_slices(
-        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, const SlicingPolicy& slicing,
-        TypedStreamVersion&& partial_key, const std::shared_ptr<stream::StreamSink>& sink,
-        const std::shared_ptr<DeDupMap>& de_dup_map, bool sparsify_floats
+        const std::shared_ptr<InputFrame>& frame, std::vector<FrameSlice>&& slices, TypedStreamVersion&& partial_key,
+        const std::shared_ptr<stream::StreamSink>& sink, const std::shared_ptr<DeDupMap>& de_dup_map,
+        bool sparsify_floats
 );
 
 folly::Future<entity::AtomKey> write_frame(
@@ -93,8 +92,6 @@ folly::Future<SliceAndKey> async_rewrite_partial_segment(
 std::vector<SliceAndKey> flatten_and_fix_rows(
         const std::array<std::vector<SliceAndKey>, 5>& groups, size_t& global_count
 );
-
-std::vector<std::pair<FrameSlice, size_t>> get_slice_and_rowcount(const std::vector<FrameSlice>& slices);
 
 template<typename T>
 requires std::is_same_v<T, SliceAndKey> || std::is_same_v<T, std::vector<SliceAndKey>>

--- a/cpp/arcticdb/storage/file/file_store.hpp
+++ b/cpp/arcticdb/storage/file/file_store.hpp
@@ -69,25 +69,19 @@ void write_dataframe_to_file_internal(
     auto slices = slice(*frame, slicing);
     ARCTICDB_SUBSAMPLE_DEFAULT(SliceAndWrite)
 
-    auto slice_and_rowcount = get_slice_and_rowcount(slices);
-    auto key_seg_futs = folly::collect(folly::window(
-                                               std::move(slice_and_rowcount),
-                                               [frame,
-                                                slicing,
-                                                key = std::move(partial_key),
-                                                sparsify_floats = options.sparsify_floats](auto&& slice) {
-                                                   return async::submit_cpu_task(pipelines::WriteToSegmentTask(
-                                                           frame,
-                                                           slice.first,
-                                                           slicing,
-                                                           get_partial_key_gen(frame, key),
-                                                           slice.second,
-                                                           sparsify_floats
-                                                   ));
-                                               },
-                                               write_window_size()
-                                       ))
-                                .via(&async::io_executor());
+    auto key_seg_futs =
+            folly::collect(folly::window(
+                                   std::move(slices),
+                                   [frame,
+                                    key = std::move(partial_key),
+                                    sparsify_floats = options.sparsify_floats](auto&& slice) {
+                                       return async::submit_cpu_task(
+                                               pipelines::WriteToSegmentTask(frame, slice, key, sparsify_floats)
+                                       );
+                                   },
+                                   write_window_size()
+                           ))
+                    .via(&async::io_executor());
     auto segments = std::move(key_seg_futs).get();
 
     auto data_size = max_data_size(segments, codec_opts, encoding_version);

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -151,7 +151,6 @@ SegmentInMemory incomplete_segment_from_tensor_frame(
     );
 
     auto offset_in_frame = 0;
-    auto slice_num_for_column = 0;
     const auto num_rows = frame->num_rows;
     const auto index = std::move(frame->index);
 
@@ -200,8 +199,6 @@ SegmentInMemory incomplete_segment_from_tensor_frame(
                             col,
                             num_rows,
                             offset_in_frame,
-                            slice_num_for_column,
-                            num_rows,
                             allow_sparse
                     );
                     if (opt_error.has_value()) {
@@ -394,7 +391,6 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     }
 
     util::check(!slices.empty(), "Unexpected empty slice in write_incomplete_frame");
-    auto slice_and_rowcount = get_slice_and_rowcount(slices);
 
     IndexPartialKey key{stream_id, VersionId(0)};
     auto de_dup_map = std::make_shared<DeDupMap>();
@@ -403,31 +399,21 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     arcticdb::proto::descriptors::NormalizationMetadata norm_meta = frame->norm_meta;
     auto user_meta = frame->user_meta;
     auto bucketize_dynamic = frame->bucketize_dynamic;
-    bool sparsify_floats{false};
 
     TypedStreamVersion typed_stream_version{stream_id, VersionId{0}, KeyType::APPEND_DATA};
     return folly::collect(
                    folly::window(
-                           std::move(slice_and_rowcount),
+                           std::move(slices),
                            [frame,
-                            slicing_policy,
                             key = std::move(key),
                             store,
-                            sparsify_floats,
                             typed_stream_version = std::move(typed_stream_version),
                             bucketize_dynamic,
                             de_dup_map,
                             desc,
                             norm_meta,
                             user_meta](auto&& slice) {
-                               return async::submit_cpu_task(WriteToSegmentTask(
-                                                                     frame,
-                                                                     slice.first,
-                                                                     slicing_policy,
-                                                                     get_partial_key_gen(frame, typed_stream_version),
-                                                                     slice.second,
-                                                                     sparsify_floats
-                                                             ))
+                               return async::submit_cpu_task(WriteToSegmentTask(frame, slice, typed_stream_version))
                                        .thenValue([store, de_dup_map, bucketize_dynamic, desc, norm_meta, user_meta](
                                                           std::tuple<PartialKey, SegmentInMemory, FrameSlice>&& ks
                                                   ) {


### PR DESCRIPTION
#### What does this implement or fix?
Refactors `WriteToSegmentTask` in ways that are needed for the `compact_data_inline` argument to `append`, plus some other cleanups:

- `SlicingPolicy` and `slice_num_for_column` were being used in a roundabout way to calculate the row, which was already available in the `set_*_type` functions
- `get_slice_and_rowcount` was only used to generate the `slice_num_for_column` above, and so is no longer needed
- The `partial_key_gen_` callback was the same everywhere, so this logic can just be part of the `WriteToSegmentTask` class. The `TypedStreamVersion` argument that replaces it is optional as it will not be needed with inline defrag
- The function returned by `get_partial_key_gen` commented on the inefficiency of the implementation, and that it could be improved by using the segment generated in `WriteToSegmentTask`, so this is now how it works
- `sparsify_floats` is always `false` when the task is used for anything except explicit `write` calls, so make this a default
