### PR TITLE
Reimplement FixedSlicer in terms of SpecificSlicer

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1072,6 +1072,7 @@ if(${TEST})
             log/test/test_log.cpp
             pipeline/test/test_container.hpp
             pipeline/test/test_pipeline.cpp
+            pipeline/test/test_slicing.cpp
             pipeline/test/test_query.cpp
             pipeline/test/test_frame_allocation.cpp
             pipeline/test/test_rollback.cpp

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -58,23 +58,24 @@ std::pair<size_t, size_t> get_first_and_last_row(const arcticdb::pipelines::Inpu
 std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::InputFrame& frame) const {
     const auto [first_row, last_row] = get_first_and_last_row(frame);
     std::vector<RowRange> row_ranges;
+    row_ranges.reserve((last_row - first_row + row_per_slice_ - 1) / row_per_slice_);
     for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
         auto rdist = std::min(last_row - r, row_per_slice_);
         row_ranges.emplace_back(r, r + rdist);
     }
+    if (row_ranges.empty()) {
+        return {};
+    }
     std::vector<ColRange> col_ranges;
     const auto [index_count, total_field_count] = get_index_and_field_count(frame);
     auto start_col = index_count;
+    // We do not support writing frames with zero columns, and so there will always be at least one column range here
     do {
         auto col_count = std::min(total_field_count - start_col, col_per_slice_);
         col_ranges.emplace_back(start_col, start_col + col_count);
         start_col += col_count;
     } while (start_col < total_field_count);
-    if (row_ranges.empty() || col_ranges.empty()) {
-        return {};
-    } else {
-        return SpecificSlicer{std::move(row_ranges), std::move(col_ranges)}(frame);
-    }
+    return SpecificSlicer{std::move(row_ranges), std::move(col_ranges)}(frame);
 }
 
 SpecificSlicer::SpecificSlicer(std::vector<RowRange>&& row_ranges, std::vector<ColRange>&& col_ranges) :

--- a/cpp/arcticdb/pipeline/slicing.cpp
+++ b/cpp/arcticdb/pipeline/slicing.cpp
@@ -13,7 +13,7 @@
 
 namespace arcticdb::pipelines {
 
-std::pair<int64_t, int64_t> get_index_and_field_count(const arcticdb::pipelines::InputFrame& frame) {
+std::pair<size_t, size_t> get_index_and_field_count(const arcticdb::pipelines::InputFrame& frame) {
     return {frame.desc().index().field_count(), frame.desc().fields().size()};
 }
 
@@ -56,25 +56,59 @@ std::pair<size_t, size_t> get_first_and_last_row(const arcticdb::pipelines::Inpu
 }
 
 std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::InputFrame& frame) const {
+    const auto [first_row, last_row] = get_first_and_last_row(frame);
+    std::vector<RowRange> row_ranges;
+    for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
+        auto rdist = std::min(last_row - r, row_per_slice_);
+        row_ranges.emplace_back(r, r + rdist);
+    }
+    std::vector<ColRange> col_ranges;
     const auto [index_count, total_field_count] = get_index_and_field_count(frame);
-    auto field_count = total_field_count - index_count;
+    auto start_col = index_count;
+    do {
+        auto col_count = std::min(total_field_count - start_col, col_per_slice_);
+        col_ranges.emplace_back(start_col, start_col + col_count);
+        start_col += col_count;
+    } while (start_col < total_field_count);
+    if (row_ranges.empty() || col_ranges.empty()) {
+        return {};
+    } else {
+        return SpecificSlicer{std::move(row_ranges), std::move(col_ranges)}(frame);
+    }
+}
+
+SpecificSlicer::SpecificSlicer(std::vector<RowRange>&& row_ranges, std::vector<ColRange>&& col_ranges) :
+    row_ranges_(std::move(row_ranges)),
+    col_ranges_(std::move(col_ranges)) {
+    util::check(
+            !row_ranges_.empty() && !col_ranges_.empty(), "Expected non-empty row and col ranges in SpecificSlicer ctor"
+    );
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            std::ranges::is_sorted(row_ranges_) && std::ranges::is_sorted(col_ranges_),
+            "SpecificSlicer ctor expects sorted input row and col ranges"
+    );
+}
+
+std::vector<FrameSlice> SpecificSlicer::operator()(const arcticdb::pipelines::InputFrame& frame) const {
+    util::check(
+            row_ranges_.front().first >= frame.offset && row_ranges_.back().second <= frame.offset + frame.num_rows,
+            "SpecificSlicer expected row ranges to lie within input frame"
+    );
     auto fields_pos = std::begin(frame.desc().fields());
-    std::advance(fields_pos, index_count);
+    std::advance(fields_pos, col_ranges_.front().first);
 
     auto id = frame.desc().id();
     auto index = frame.desc().index();
 
     std::vector<FrameSlice> slices;
-    slices.reserve((field_count + col_per_slice_ - 1) / col_per_slice_);
-
-    const auto [first_row, last_row] = get_first_and_last_row(frame);
-
+    slices.reserve(row_ranges_.size() * col_ranges_.size());
     // order of the frame slices is used in the mark_index_slices impl. If slices are not grouped and ordered the same
     // way, one will need to modify the mark_index_slices method to use two passes instead of one
-    auto col = index_count;
-    do {
+    auto col = col_ranges_.front().first;
+    for (const auto& col_range : col_ranges_) {
         auto fields_next = fields_pos;
-        auto distance = std::min(size_t(std::distance(fields_pos, std::end(frame.desc().fields()))), col_per_slice_);
+        auto distance = std::min(size_t(std::distance(fields_pos, std::end(frame.desc().fields()))), col_range.diff());
         std::advance(fields_next, distance);
 
         // systematically writing the index in the column group
@@ -87,14 +121,18 @@ std::vector<FrameSlice> FixedSlicer::operator()(const arcticdb::pipelines::Input
         }
 
         auto desc = std::make_shared<StreamDescriptor>(id, index, current_fields);
-        for (std::size_t r = first_row, end = last_row; r < end; r += row_per_slice_) {
-            auto rdist = std::min(last_row - r, row_per_slice_);
-            slices.push_back(FrameSlice(desc, ColRange{col, col + distance}, RowRange{r, r + rdist}));
+        for (const auto& row_range : row_ranges_) {
+            slices.push_back(FrameSlice(desc, ColRange{col, col + distance}, row_range));
         }
-
-        col += col_per_slice_;
+        col += col_range.diff();
         fields_pos = fields_next;
-    } while (fields_pos != std::end(frame.desc().fields()));
+    }
+    util::check(
+            slices.size() == row_ranges_.size() * col_ranges_.size(),
+            "SpecificSlicer produced wrong number of slices {} != {}",
+            slices.size(),
+            row_ranges_.size() * col_ranges_.size()
+    );
     return slices;
 }
 

--- a/cpp/arcticdb/pipeline/slicing.hpp
+++ b/cpp/arcticdb/pipeline/slicing.hpp
@@ -28,11 +28,22 @@ class FixedSlicer {
 
     std::vector<FrameSlice> operator()(const InputFrame& frame) const;
 
-    auto row_per_slice() const { return row_per_slice_; }
-
   private:
     size_t col_per_slice_;
     size_t row_per_slice_;
+};
+
+// Note that the input row_ranges and col_ranges are expected to cover contiguous row/col ranges
+// i.e. *_ranges[i].second == *_ranges[i+1].first
+class SpecificSlicer {
+  public:
+    SpecificSlicer(std::vector<RowRange>&& row_ranges, std::vector<ColRange>&& col_ranges);
+
+    std::vector<FrameSlice> operator()(const InputFrame& frame) const;
+
+  private:
+    std::vector<RowRange> row_ranges_;
+    std::vector<ColRange> col_ranges_;
 };
 
 class HashedSlicer {
@@ -45,8 +56,6 @@ class HashedSlicer {
 
     size_t num_buckets() const { return num_buckets_; }
 
-    auto row_per_slice() const { return row_per_slice_; }
-
   private:
     size_t num_buckets_;
     size_t row_per_slice_;
@@ -54,7 +63,7 @@ class HashedSlicer {
 
 class NoSlicing {};
 
-using SlicingPolicy = std::variant<NoSlicing, FixedSlicer, HashedSlicer>;
+using SlicingPolicy = std::variant<NoSlicing, FixedSlicer, SpecificSlicer, HashedSlicer>;
 
 SlicingPolicy get_slicing_policy(const WriteOptions& options, const arcticdb::pipelines::InputFrame& frame);
 

--- a/cpp/arcticdb/pipeline/test/test_slicing.cpp
+++ b/cpp/arcticdb/pipeline/test/test_slicing.cpp
@@ -1,0 +1,151 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/entity/types.hpp>
+#include <arcticdb/pipeline/input_frame.hpp>
+#include <arcticdb/pipeline/slicing.hpp>
+
+using namespace arcticdb;
+using namespace arcticdb::pipelines;
+
+InputFrame create_frame(
+        const StreamId& symbol, size_t offset, size_t num_rows, size_t num_columns, const IndexDescriptorImpl& index
+) {
+    InputFrame frame;
+    frame.offset = offset;
+    frame.num_rows = num_rows;
+    frame.desc().set_id(symbol);
+    frame.desc().set_index(index);
+    if (index.type() == IndexDescriptor::Type::TIMESTAMP) {
+        frame.desc().add_scalar_field(DataType::NANOSECONDS_UTC64, "ts");
+    }
+    for (size_t idx = 0; idx < num_columns; ++idx) {
+        frame.desc().add_scalar_field(DataType::INT64, fmt::format("col_{}", idx));
+    }
+    return frame;
+}
+
+TEST(SpecificSlicer, SingleSliceRowTangeIndexed) {
+    StreamId symbol{"my symbol"};
+    const auto frame = create_frame(symbol, 0, 10, 10, IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+    SpecificSlicer slicer{{{1, 9}}, {{2, 5}}};
+    auto slices = slicer(frame);
+    ASSERT_EQ(slices.size(), 1);
+    const auto& slice = slices.front();
+    ASSERT_EQ(slice.desc()->id(), symbol);
+    ASSERT_EQ(slice.rows(), RowRange(1, 9));
+    ASSERT_EQ(slice.columns(), ColRange(2, 5));
+    for (size_t idx = 0; idx < 3; ++idx) {
+        const auto& field = slice.desc()->field(idx);
+        ASSERT_EQ(field.name(), fmt::format("col_{}", idx + 2));
+        ASSERT_EQ(field.type(), make_scalar_type(DataType::INT64));
+    }
+}
+
+TEST(SpecificSlicer, SingleSliceTimeseries) {
+    StreamId symbol{"my symbol"};
+    const auto frame = create_frame(symbol, 0, 10, 10, IndexDescriptorImpl{IndexDescriptor::Type::TIMESTAMP, 1});
+    SpecificSlicer slicer{{{1, 9}}, {{2, 5}}};
+    auto slices = slicer(frame);
+    ASSERT_EQ(slices.size(), 1);
+    const auto& slice = slices.front();
+    ASSERT_EQ(slice.desc()->id(), symbol);
+    ASSERT_EQ(slice.rows(), RowRange(1, 9));
+    ASSERT_EQ(slice.columns(), ColRange(2, 5));
+    const auto& index_field = slice.desc()->field(0);
+    ASSERT_EQ(index_field.name(), "ts");
+    ASSERT_EQ(index_field.type(), make_scalar_type(DataType::NANOSECONDS_UTC64));
+    for (size_t idx = 1; idx < 4; ++idx) {
+        const auto& field = slice.desc()->field(idx);
+        ASSERT_EQ(field.name(), fmt::format("col_{}", idx));
+        ASSERT_EQ(field.type(), make_scalar_type(DataType::INT64));
+    }
+}
+
+TEST(SpecificSlicer, SingleSliceTimeseriesFirstColSlice) {
+    StreamId symbol{"my symbol"};
+    const auto frame = create_frame(symbol, 0, 10, 10, IndexDescriptorImpl{IndexDescriptor::Type::TIMESTAMP, 1});
+    SpecificSlicer slicer{{{1, 9}}, {{1, 5}}};
+    auto slices = slicer(frame);
+    ASSERT_EQ(slices.size(), 1);
+    const auto& slice = slices.front();
+    ASSERT_EQ(slice.desc()->id(), symbol);
+    ASSERT_EQ(slice.rows(), RowRange(1, 9));
+    ASSERT_EQ(slice.columns(), ColRange(1, 5));
+    const auto& index_field = slice.desc()->field(0);
+    ASSERT_EQ(index_field.name(), "ts");
+    ASSERT_EQ(index_field.type(), make_scalar_type(DataType::NANOSECONDS_UTC64));
+    for (size_t idx = 1; idx < 5; ++idx) {
+        const auto& field = slice.desc()->field(idx);
+        ASSERT_EQ(field.name(), fmt::format("col_{}", idx - 1));
+        ASSERT_EQ(field.type(), make_scalar_type(DataType::INT64));
+    }
+}
+
+TEST(SpecificSlicer, InvalidRowRangeStart) {
+    StreamId symbol{"my symbol"};
+    const auto frame = create_frame(symbol, 5, 10, 10, IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+    SpecificSlicer slicer{{{1, 12}}, {{2, 5}}};
+    ASSERT_THROW(slicer(frame), InternalException);
+}
+
+TEST(SpecificSlicer, InvalidRowRangeEnd) {
+    StreamId symbol{"my symbol"};
+    const auto frame = create_frame(symbol, 0, 10, 10, IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+    SpecificSlicer slicer{{{1, 12}}, {{2, 5}}};
+    ASSERT_THROW(slicer(frame), InternalException);
+}
+
+TEST(SpecificSlicer, MultipleSlicesRowTangeIndexed) {
+    StreamId symbol{"my symbol"};
+    const auto frame =
+            create_frame(symbol, 100'000, 180'000, 100, IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+    SpecificSlicer slicer{{{100'000, 190'000}, {190'000, 280'000}}, {{0, 50}, {50, 100}}};
+    auto slices = slicer(frame);
+    ASSERT_EQ(slices.size(), 4);
+    for (size_t idx = 0; idx < 4; ++idx) {
+        const auto& slice = slices.at(idx);
+        const bool left_col_slice = idx < 2;
+        const bool top_row_slice = (idx % 2) == 0;
+        ASSERT_EQ(slice.desc()->id(), symbol);
+        ASSERT_EQ(slice.rows(), top_row_slice ? RowRange(100'000, 190'000) : RowRange(190'000, 280'000));
+        ASSERT_EQ(slice.columns(), left_col_slice ? ColRange(0, 50) : ColRange(50, 100));
+        for (size_t field_idx = 0; field_idx < 50; ++field_idx) {
+            const auto& field = slice.desc()->field(field_idx);
+            ASSERT_EQ(field.name(), fmt::format("col_{}", field_idx + (left_col_slice ? 0 : 50)));
+            ASSERT_EQ(field.type(), make_scalar_type(DataType::INT64));
+        }
+    }
+}
+
+TEST(SpecificSlicer, MultipleSlicesTimeseries) {
+    StreamId symbol{"my symbol"};
+    const auto frame =
+            create_frame(symbol, 100'000, 180'000, 100, IndexDescriptorImpl{IndexDescriptor::Type::TIMESTAMP, 1});
+    SpecificSlicer slicer{{{100'000, 190'000}, {190'000, 280'000}}, {{1, 51}, {51, 101}}};
+    auto slices = slicer(frame);
+    ASSERT_EQ(slices.size(), 4);
+    for (size_t idx = 0; idx < 4; ++idx) {
+        const auto& slice = slices.at(idx);
+        const bool left_col_slice = idx < 2;
+        const bool top_row_slice = (idx % 2) == 0;
+        ASSERT_EQ(slice.desc()->id(), symbol);
+        ASSERT_EQ(slice.rows(), top_row_slice ? RowRange(100'000, 190'000) : RowRange(190'000, 280'000));
+        ASSERT_EQ(slice.columns(), left_col_slice ? ColRange(1, 51) : ColRange(51, 101));
+        const auto& index_field = slice.desc()->field(0);
+        ASSERT_EQ(index_field.name(), "ts");
+        ASSERT_EQ(index_field.type(), make_scalar_type(DataType::NANOSECONDS_UTC64));
+        for (size_t field_idx = 0; field_idx < 50; ++field_idx) {
+            const auto& field = slice.desc()->field(field_idx + 1);
+            ASSERT_EQ(field.name(), fmt::format("col_{}", field_idx + (left_col_slice ? 0 : 50)));
+            ASSERT_EQ(field.type(), make_scalar_type(DataType::INT64));
+        }
+    }
+}


### PR DESCRIPTION
#### What does this implement or fix?
Adds a new `SpecificSlicer` that takes collections of row-ranges and column-ranges, and slices input frames using the cartesian product of these ranges.

`FixedSlicer` is then just a special case of `SpecificSlicer`, and so now just constructs appropriate collections of row-ranges and column-ranges and then uses `SpecificSlicer`.

This is in preparation for the `compact_data_inline` argument to `append`, which requires slicing more flexibly than `FixedSlicer` in order to maintain the invariant that every resulting row slice has `rows_per_segment ± 33%` rows.