### PR TITLE
Bug fixes for query builder filtering with ISIN filters over sets with duplicate str representations

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1083,6 +1083,7 @@ if(${TEST})
             pipeline/test/test_column_stats_dispatch_range_vs_range.cpp
             pipeline/test/test_column_stats_isin.cpp
             util/test/test_regex.cpp
+            processing/test/ast_test_helpers.hpp
             processing/test/test_arithmetic_type_promotion.cpp
             processing/test/test_clause.cpp
             processing/test/test_compact_data.cpp
@@ -1094,6 +1095,7 @@ if(${TEST})
             processing/test/test_operation_dispatch.cpp
             processing/test/test_output_schema_aggregator_types.cpp
             processing/test/test_output_schema_ast_validity.cpp
+            processing/test/test_query_planner.cpp
             processing/test/test_output_schema_basic.cpp
             processing/test/test_parallel_processing.cpp
             processing/test/test_resample.cpp

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -40,17 +40,11 @@ using StatsVariantData = std::variant<
 using StatsRowIndices = std::vector<std::optional<size_t>>;
 
 StatsVariantData evaluate_ast_node_against_stats(
-        const VariantNode& node, const ExpressionContext& expression_context, const StatsRowIndices& row_indices,
-        const ColumnStatsData& column_stats
+        const ExpressionNode& node, const StatsRowIndices& row_indices, const ColumnStatsData& column_stats
 );
 
 StatsVariantData dispatch_binary_stats(
         const StatsVariantData& left, const StatsVariantData& right, OperationType operation
-);
-
-StatsVariantData compute_stats(
-        const ExpressionContext& expression_context, const ExpressionNode& node, const StatsRowIndices& row_indices,
-        const ColumnStatsData& column_stats
 );
 
 namespace column_stats_detail {

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -29,26 +29,38 @@ bool ColumnStatsQueryMetadata::should_try_column_stats_read() const {
     return is_column_stats_enabled() && !filter_expressions.empty();
 }
 
+StatsVariantData dispatch_unary_stats(const StatsVariantData& left, OperationType operation);
+
 StatsVariantData evaluate_ast_node_against_stats(
-        const VariantNode& node, const ExpressionContext& expression_context, const StatsRowIndices& row_indices,
-        const ColumnStatsData& column_stats
+        const ExpressionNode& node, const StatsRowIndices& row_indices, const ColumnStatsData& column_stats
 ) {
     return util::variant_match(
-            node,
-            [&](const ColumnName& column_name) -> StatsVariantData {
-                return column_stats.values_for_column(column_name.value, row_indices);
+            node.kind_,
+            [&](const ExpressionNode::Leaf& leaf) -> StatsVariantData {
+                return util::variant_match(
+                        leaf,
+                        [&](const ColumnName& column_name) -> StatsVariantData {
+                            return column_stats.values_for_column(column_name.value, row_indices);
+                        },
+                        [&](const std::shared_ptr<Value>& value) -> StatsVariantData { return value; },
+                        [&](const std::shared_ptr<ValueSet>& value_set) -> StatsVariantData { return value_set; },
+                        [&](const std::shared_ptr<util::RegexGeneric>&) -> StatsVariantData {
+                            return std::vector(row_indices.size(), StatsComparison::UNKNOWN);
+                        }
+                );
             },
-            [&](const ValueName& value_name) -> StatsVariantData {
-                return expression_context.values_.get_value(value_name.value);
-            },
-            [&](const ExpressionName& expression_name) -> StatsVariantData {
-                auto expr = expression_context.expression_nodes_.get_value(expression_name.value);
-                return compute_stats(expression_context, *expr, row_indices, column_stats);
-            },
-            [&](const ValueSetName& value_set_name) -> StatsVariantData {
-                return expression_context.value_sets_.get_value(value_set_name.value);
-            },
-            [&](const auto&) -> StatsVariantData { return std::vector(row_indices.size(), StatsComparison::UNKNOWN); }
+            [&](const ExpressionNode::Operation& op) -> StatsVariantData {
+                if (is_binary_operation(op.operation_type_)) {
+                    auto left = evaluate_ast_node_against_stats(*op.left_, row_indices, column_stats);
+                    auto right = evaluate_ast_node_against_stats(*op.right_, row_indices, column_stats);
+                    return dispatch_binary_stats(left, right, op.operation_type_);
+                }
+                if (is_unary_operation(op.operation_type_)) {
+                    auto left = evaluate_ast_node_against_stats(*op.left_, row_indices, column_stats);
+                    return dispatch_unary_stats(left, op.operation_type_);
+                }
+                return std::vector(row_indices.size(), StatsComparison::UNKNOWN);
+            }
     );
 }
 
@@ -107,22 +119,6 @@ StatsVariantData dispatch_unary_stats(const StatsVariantData& left, OperationTyp
                 }
         );
     }
-}
-
-StatsVariantData compute_stats(
-        const ExpressionContext& expression_context, const ExpressionNode& node, const StatsRowIndices& row_indices,
-        const ColumnStatsData& column_stats
-) {
-    if (is_binary_operation(node.operation_type_)) {
-        auto left = evaluate_ast_node_against_stats(node.left_, expression_context, row_indices, column_stats);
-        auto right = evaluate_ast_node_against_stats(node.right_, expression_context, row_indices, column_stats);
-        return dispatch_binary_stats(left, right, node.operation_type_);
-    }
-    if (is_unary_operation(node.operation_type_)) {
-        auto left = evaluate_ast_node_against_stats(node.left_, expression_context, row_indices, column_stats);
-        return dispatch_unary_stats(left, node.operation_type_);
-    }
-    return std::vector(row_indices.size(), StatsComparison::UNKNOWN);
 }
 
 namespace {
@@ -437,9 +433,8 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         util::check(row_indices.size() == isr.size(), "Expected row_indices.size() == isr.size()");
 
         // Evaluate the AST
-        StatsVariantData result = evaluate_ast_node_against_stats(
-                expression_context.root_node_name_, expression_context, row_indices, column_stats_data
-        );
+        StatsVariantData result =
+                evaluate_ast_node_against_stats(*expression_context.root_, row_indices, column_stats_data);
         util::check(
                 std::holds_alternative<std::vector<StatsComparison>>(result),
                 "evaluate_ast_node_against_stats should evaluate to a vector<StatsComparison>"

--- a/cpp/arcticdb/pipeline/value_set.cpp
+++ b/cpp/arcticdb/pipeline/value_set.cpp
@@ -103,6 +103,15 @@ ValueSet::ValueSet(NumericSetType&& value_set) : numeric_base_set_(std::move(val
 
 bool ValueSet::empty() const { return empty_; }
 
+size_t ValueSet::size() const {
+    if (typed_set_string_) {
+        return typed_set_string_->size();
+    }
+    return util::variant_match(numeric_base_set_, [](const auto& set_ptr) -> size_t {
+        return set_ptr ? set_ptr->size() : 0;
+    });
+}
+
 const entity::TypeDescriptor& ValueSet::base_type() const { return base_type_; }
 
 std::shared_ptr<std::unordered_set<std::string>> ValueSet::get_fixed_width_string_set(size_t width) {

--- a/cpp/arcticdb/pipeline/value_set.hpp
+++ b/cpp/arcticdb/pipeline/value_set.hpp
@@ -43,6 +43,8 @@ class ValueSet {
 
     bool empty() const;
 
+    size_t size() const;
+
     const entity::TypeDescriptor& base_type() const;
 
     const std::optional<Value>& min_value() const;

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -119,8 +119,10 @@ std::vector<EntityId> FilterClause::process(std::vector<EntityId>&& entity_ids) 
             *component_manager_, std::move(entity_ids)
     );
     proc.set_expression_context(expression_context_);
-    ARCTICDB_RUNTIME_DEBUG(log::memory(), "Doing filter {} for entity ids {}", root_node_name_, entity_ids);
-    auto variant_data = proc.get(root_node_name_);
+    ARCTICDB_RUNTIME_DEBUG(
+            log::memory(), "Doing filter {} for entity ids {}", expression_context_->root_->label_, entity_ids
+    );
+    auto variant_data = expression_context_->root_->compute(proc);
     std::vector<EntityId> output;
     util::variant_match(
             variant_data,
@@ -141,9 +143,7 @@ std::vector<EntityId> FilterClause::process(std::vector<EntityId>&& entity_ids) 
 
 OutputSchema FilterClause::modify_schema(OutputSchema&& output_schema) const {
     check_column_presence(output_schema, *clause_info_.input_columns_, "Filter");
-    auto root_expr = expression_context_->expression_nodes_.get_value(root_node_name_.value);
-    std::variant<BitSetTag, DataType> return_type =
-            root_expr->compute(*expression_context_, output_schema.column_types());
+    std::variant<BitSetTag, DataType> return_type = expression_context_->root_->compute(output_schema.column_types());
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             std::holds_alternative<BitSetTag>(return_type), "FilterClause AST would produce a column, not a bitset"
     );
@@ -151,7 +151,7 @@ OutputSchema FilterClause::modify_schema(OutputSchema&& output_schema) const {
 }
 
 std::string FilterClause::to_string() const {
-    return expression_context_ ? fmt::format("WHERE {}", root_node_name_.value) : "";
+    return expression_context_ ? fmt::format("WHERE {}", expression_context_->root_->label_) : "";
 }
 
 std::vector<EntityId> ProjectClause::process(std::vector<EntityId>&& entity_ids) const {
@@ -163,7 +163,7 @@ std::vector<EntityId> ProjectClause::process(std::vector<EntityId>&& entity_ids)
             *component_manager_, std::move(entity_ids)
     );
     proc.set_expression_context(expression_context_);
-    auto variant_data = proc.get(expression_context_->root_node_name_);
+    auto variant_data = expression_context_->root_->compute(proc);
     std::vector<EntityId> output;
     util::variant_match(
             variant_data,
@@ -216,41 +216,24 @@ std::vector<EntityId> ProjectClause::process(std::vector<EntityId>&& entity_ids)
 
 OutputSchema ProjectClause::modify_schema(OutputSchema&& output_schema) const {
     check_column_presence(output_schema, *clause_info_.input_columns_, "Project");
-    util::variant_match(
-            expression_context_->root_node_name_,
-            [&](const ExpressionName& root_node_name) {
-                auto root_expr = expression_context_->expression_nodes_.get_value(root_node_name.value);
-                std::variant<BitSetTag, DataType> return_type =
-                        root_expr->compute(*expression_context_, output_schema.column_types());
-                user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                        std::holds_alternative<DataType>(return_type),
-                        "ProjectClause AST would produce a bitset, not a column"
-                );
-                output_schema.add_field(output_column_, std::get<DataType>(return_type));
-            },
-            [&](const ValueName& root_node_name) {
-                output_schema.add_field(
-                        output_column_,
-                        expression_context_->values_.get_value(root_node_name.value)->descriptor().data_type()
-                );
-            },
-            [](const auto&) {
-                // Shouldn't make it here due to check in ctor
-                user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("ProjectClause AST would not produce a column");
-            }
-    );
+    const auto& root = *expression_context_->root_;
+    if (root.is_value()) {
+        const auto& value = std::get<std::shared_ptr<Value>>(std::get<ExpressionNode::Leaf>(root.kind_));
+        output_schema.add_field(output_column_, value->descriptor().data_type());
+    } else {
+        std::variant<BitSetTag, DataType> return_type = root.compute(output_schema.column_types());
+        user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                std::holds_alternative<DataType>(return_type), "ProjectClause AST would produce a bitset, not a column"
+        );
+        output_schema.add_field(output_column_, std::get<DataType>(return_type));
+    }
     return output_schema;
 }
 
 [[nodiscard]] std::string ProjectClause::to_string() const {
-    return expression_context_ ? fmt::format(
-                                         "PROJECT Column[\"{}\"] = {}",
-                                         output_column_,
-                                         std::holds_alternative<ExpressionName>(expression_context_->root_node_name_)
-                                                 ? std::get<ExpressionName>(expression_context_->root_node_name_).value
-                                                 : std::get<ValueName>(expression_context_->root_node_name_).value
-                                 )
-                               : "";
+    return expression_context_
+                   ? fmt::format("PROJECT Column[\"{}\"] = {}", output_column_, expression_context_->root_->label_)
+                   : "";
 }
 
 void ProjectClause::add_column(ProcessingUnit& proc, const ColumnWithStrings& col) const {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -143,7 +143,6 @@ struct FilterClause {
     ClauseInfo clause_info_;
     std::shared_ptr<ComponentManager> component_manager_;
     std::shared_ptr<ExpressionContext> expression_context_;
-    ExpressionName root_node_name_;
     PipelineOptimisation optimisation_;
 
     explicit FilterClause(
@@ -153,10 +152,9 @@ struct FilterClause {
         expression_context_(std::make_shared<ExpressionContext>(std::move(expression_context))),
         optimisation_(optimisation.value_or(PipelineOptimisation::SPEED)) {
         user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                std::holds_alternative<ExpressionName>(expression_context_->root_node_name_),
+                expression_context_->root_ && expression_context_->root_->is_operation(),
                 "FilterClause AST would produce a column, not a bitset"
         );
-        root_node_name_ = std::get<ExpressionName>(expression_context_->root_node_name_);
         clause_info_.input_columns_ = std::move(input_columns);
     }
 
@@ -213,8 +211,8 @@ struct ProjectClause {
         output_column_(std::move(output_column)),
         expression_context_(std::make_shared<ExpressionContext>(std::move(expression_context))) {
         user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                std::holds_alternative<ExpressionName>(expression_context_->root_node_name_) ||
-                        std::holds_alternative<ValueName>(expression_context_->root_node_name_),
+                expression_context_->root_ &&
+                        (expression_context_->root_->is_operation() || expression_context_->root_->is_value()),
                 "ProjectClause AST would not produce a column"
         );
         clause_info_.input_columns_ = std::move(input_columns);

--- a/cpp/arcticdb/processing/expression_context.hpp
+++ b/cpp/arcticdb/processing/expression_context.hpp
@@ -9,111 +9,21 @@
 #pragma once
 
 #include <memory>
-#include <string>
-#include <unordered_map>
 
 #include <arcticdb/processing/expression_node.hpp>
-#include <arcticdb/pipeline/value.hpp>
-#include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/util/preconditions.hpp>
-#include <arcticdb/util/variant.hpp>
 
 namespace arcticdb {
 
-// ColumnName refers to a real data column and must never be prefixed. The other leaf kinds name
-// entries in an ExpressionContext's maps, so they are prefixed to match a merge of expression
-// contexts that has `prefix`.
-inline VariantNode prefix_internal_names(const VariantNode& node, const std::string& prefix) {
-    return util::variant_match(
-            node,
-            [](std::monostate empty) -> VariantNode { return empty; },
-            [](const ColumnName& column_name) -> VariantNode { return column_name; },
-            [&](const ValueName& value_name) -> VariantNode { return ValueName{prefix + value_name.value}; },
-            [&](const ValueSetName& value_set_name) -> VariantNode {
-                return ValueSetName{prefix + value_set_name.value};
-            },
-            [&](const ExpressionName& expression_name) -> VariantNode {
-                return ExpressionName{prefix + expression_name.value};
-            },
-            [&](const RegexName& regex_name) -> VariantNode { return RegexName{prefix + regex_name.value}; }
-    );
-}
-
 /*
- * Contains an expression tree as a map of string node names to nodes. Nodes contain leaves which may be references
- * to node names.
- *
- * ExpressionContext also contains the name of the root node as well as a map of node names to constant values.
- *
- * This class effectively contains as AST - there is likely a frontend implementation in a higher level language (for
- * example Python).
+ * An expression tree (an AST).
  */
 struct ExpressionContext {
     ExpressionContext() = default;
 
     ARCTICDB_MOVE_COPY_DEFAULT(ExpressionContext)
 
-    template<class T>
-    class ConstantMap {
-        std::unordered_map<std::string, std::shared_ptr<T>> map_;
-
-      public:
-        void set_value(const std::string& name, std::shared_ptr<T> val) { map_.try_emplace(name, val); }
-        std::shared_ptr<T> get_value(const std::string& name) const { return map_.at(name); }
-        bool contains(const std::string& name) const { return map_.contains(name); }
-
-        template<class Func>
-        void for_each(Func&& func) const {
-            for (const auto& [name, val] : map_) {
-                func(name, val);
-            }
-        }
-    };
-
-    void add_expression_node(const std::string& name, std::shared_ptr<ExpressionNode> expression_node) {
-        expression_nodes_.set_value(name, std::move(expression_node));
-    }
-
-    void add_value(const std::string& name, std::shared_ptr<Value> value) { values_.set_value(name, std::move(value)); }
-
-    void add_value_set(const std::string& name, std::shared_ptr<ValueSet> value_set) {
-        value_sets_.set_value(name, std::move(value_set));
-    }
-
-    void add_regex(const std::string& name, std::shared_ptr<util::RegexGeneric> regex) {
-        regex_matches_.set_value(name, std::move(regex));
-    }
-
-    // Merge another context's entries into this one, prefixing every name so that entries from
-    // separate contexts cannot collide.
-    void merge_from(const ExpressionContext& other, const std::string& prefix) {
-        other.values_.for_each([&](const std::string& name, const auto& val) { values_.set_value(prefix + name, val); }
-        );
-        other.value_sets_.for_each([&](const std::string& name, const auto& val) {
-            value_sets_.set_value(prefix + name, val);
-        });
-        other.regex_matches_.for_each([&](const std::string& name, const auto& val) {
-            regex_matches_.set_value(prefix + name, val);
-        });
-        other.expression_nodes_.for_each([&](const std::string& name, const auto& node) {
-            auto prefixed = std::make_shared<ExpressionNode>(*node);
-            prefixed->condition_ = prefix_internal_names(prefixed->condition_, prefix);
-            prefixed->left_ = prefix_internal_names(prefixed->left_, prefix);
-            prefixed->right_ = prefix_internal_names(prefixed->right_, prefix);
-            util::check(
-                    !expression_nodes_.contains(prefix + name),
-                    "Prefixed expression node {} already present",
-                    prefix + name
-            );
-            add_expression_node(prefix + name, std::move(prefixed));
-        });
-    }
-
-    ConstantMap<ExpressionNode> expression_nodes_;
-    ConstantMap<Value> values_;
-    ConstantMap<ValueSet> value_sets_;
-    ConstantMap<util::RegexGeneric> regex_matches_;
-    VariantNode root_node_name_;
+    std::shared_ptr<ExpressionNode> root_;
     bool dynamic_schema_{false};
 };
 

--- a/cpp/arcticdb/processing/expression_context.hpp
+++ b/cpp/arcticdb/processing/expression_context.hpp
@@ -11,7 +11,7 @@
 #include <memory>
 
 #include <arcticdb/processing/expression_node.hpp>
-#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/util/constructors.hpp>
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/processing/expression_context.hpp
+++ b/cpp/arcticdb/processing/expression_context.hpp
@@ -15,8 +15,29 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
+#include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/util/variant.hpp>
 
 namespace arcticdb {
+
+// ColumnName refers to a real data column and must never be prefixed. The other leaf kinds name
+// entries in an ExpressionContext's maps, so they are prefixed to match a merge of expression
+// contexts that has `prefix`.
+inline VariantNode prefix_internal_names(const VariantNode& node, const std::string& prefix) {
+    return util::variant_match(
+            node,
+            [](std::monostate empty) -> VariantNode { return empty; },
+            [](const ColumnName& column_name) -> VariantNode { return column_name; },
+            [&](const ValueName& value_name) -> VariantNode { return ValueName{prefix + value_name.value}; },
+            [&](const ValueSetName& value_set_name) -> VariantNode {
+                return ValueSetName{prefix + value_set_name.value};
+            },
+            [&](const ExpressionName& expression_name) -> VariantNode {
+                return ExpressionName{prefix + expression_name.value};
+            },
+            [&](const RegexName& regex_name) -> VariantNode { return RegexName{prefix + regex_name.value}; }
+    );
+}
 
 /*
  * Contains an expression tree as a map of string node names to nodes. Nodes contain leaves which may be references
@@ -41,9 +62,10 @@ struct ExpressionContext {
         std::shared_ptr<T> get_value(const std::string& name) const { return map_.at(name); }
         bool contains(const std::string& name) const { return map_.contains(name); }
 
-        void merge_from(const ConstantMap& other) {
-            for (const auto& [name, val] : other.map_) {
-                map_.try_emplace(name, val);
+        template<class Func>
+        void for_each(Func&& func) const {
+            for (const auto& [name, val] : map_) {
+                func(name, val);
             }
         }
     };
@@ -62,11 +84,29 @@ struct ExpressionContext {
         regex_matches_.set_value(name, std::move(regex));
     }
 
-    void merge_from(const ExpressionContext& other) {
-        expression_nodes_.merge_from(other.expression_nodes_);
-        values_.merge_from(other.values_);
-        value_sets_.merge_from(other.value_sets_);
-        regex_matches_.merge_from(other.regex_matches_);
+    // Merge another context's entries into this one, prefixing every name so that entries from
+    // separate contexts cannot collide.
+    void merge_from(const ExpressionContext& other, const std::string& prefix) {
+        other.values_.for_each([&](const std::string& name, const auto& val) { values_.set_value(prefix + name, val); }
+        );
+        other.value_sets_.for_each([&](const std::string& name, const auto& val) {
+            value_sets_.set_value(prefix + name, val);
+        });
+        other.regex_matches_.for_each([&](const std::string& name, const auto& val) {
+            regex_matches_.set_value(prefix + name, val);
+        });
+        other.expression_nodes_.for_each([&](const std::string& name, const auto& node) {
+            auto prefixed = std::make_shared<ExpressionNode>(*node);
+            prefixed->condition_ = prefix_internal_names(prefixed->condition_, prefix);
+            prefixed->left_ = prefix_internal_names(prefixed->left_, prefix);
+            prefixed->right_ = prefix_internal_names(prefixed->right_, prefix);
+            util::check(
+                    !expression_nodes_.contains(prefix + name),
+                    "Prefixed expression node {} already present",
+                    prefix + name
+            );
+            add_expression_node(prefix + name, std::move(prefixed));
+        });
     }
 
     ConstantMap<ExpressionNode> expression_nodes_;

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <arcticdb/util/preconditions.hpp>
+#include <arcticdb/log/log.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/processing/operation_types.hpp>
@@ -75,29 +76,127 @@ ColumnWithStrings::ColumnWithStrings(
     return std::nullopt;
 }
 
-ExpressionNode::ExpressionNode(Leaf leaf, std::string label) : kind_(std::move(leaf)), label_(std::move(label)) {}
+namespace {
+
+std::string label_for(const ExpressionNode::Leaf& leaf) {
+    return util::variant_match(
+            leaf,
+            [](const ColumnName& column_name) { return fmt::format("Column[\"{}\"]", column_name.value); },
+            [](const std::shared_ptr<Value>& value) {
+                return details::visit_type(value->data_type(), [&value](auto tag) {
+                    using info = ScalarTypeInfo<decltype(tag)>;
+                    return fmt::format(
+                            "Val({}:{})", value->data_type(), value->template to_string<typename info::RawType>()
+                    );
+                });
+            },
+            [](const std::shared_ptr<ValueSet>& value_set) {
+                return fmt::format("ValueSet({},n={})", value_set->base_type().data_type(), value_set->size());
+            },
+            [](const std::shared_ptr<util::RegexGeneric>& regex) { return fmt::format("Regex({})", regex->text()); }
+    );
+}
+
+std::string label_for(const ExpressionNode::Operation& op) {
+    if (is_ternary_operation(op.operation_type_)) {
+        return fmt::format("{} if {} else {}", op.left_->label_, op.condition_->label_, op.right_->label_);
+    } else if (is_binary_operation(op.operation_type_)) {
+        return fmt::format("({} {} {})", op.left_->label_, op.operation_type_, op.right_->label_);
+    } else {
+        return fmt::format("{}({})", op.operation_type_, op.left_->label_);
+    }
+}
+
+bool value_sets_equal(ValueSet& a, ValueSet& b) {
+    if (a.empty() != b.empty()) {
+        return false;
+    }
+    if (a.base_type() != b.base_type()) {
+        // This might cause some false negatives but the simplicity is worth it
+        return false;
+    }
+    return details::visit_type(a.base_type().data_type(), [&a, &b](auto tag) {
+        using info = ScalarTypeInfo<decltype(tag)>;
+        if constexpr (is_sequence_type(info::data_type)) {
+            return *a.get_set<std::string>() == *b.get_set<std::string>();
+        } else {
+            return *a.get_set<typename info::RawType>() == *b.get_set<typename info::RawType>();
+        }
+    });
+}
+
+bool nodes_equal(const ExpressionNode& a, const ExpressionNode& b);
+
+bool equal_child(const std::shared_ptr<ExpressionNode>& a, const std::shared_ptr<ExpressionNode>& b) {
+    if (!a && !b) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    return nodes_equal(*a, *b);
+}
+
+bool nodes_equal(const ExpressionNode& a, const ExpressionNode& b) {
+    if (a.kind_.index() != b.kind_.index()) {
+        return false;
+    }
+    // Now we know that a and b hold the same variant type member
+    if (std::holds_alternative<ExpressionNode::Leaf>(a.kind_)) {
+        const auto& leaf_a = std::get<ExpressionNode::Leaf>(a.kind_);
+        const auto& leaf_b = std::get<ExpressionNode::Leaf>(b.kind_);
+        if (leaf_a.index() != leaf_b.index()) {
+            return false;
+        }
+        // Now we know that leaf_a and leaf_b hold the same variant type member
+        return util::variant_match(
+                leaf_a,
+                [&leaf_b](const ColumnName& a_col) { return a_col.value == std::get<ColumnName>(leaf_b).value; },
+                [&leaf_b](const std::shared_ptr<Value>& a_val) {
+                    return *a_val == *std::get<std::shared_ptr<Value>>(leaf_b);
+                },
+                [&leaf_b](const std::shared_ptr<ValueSet>& a_set) {
+                    return value_sets_equal(*a_set, *std::get<std::shared_ptr<ValueSet>>(leaf_b));
+                },
+                [&leaf_b](const std::shared_ptr<util::RegexGeneric>& a_regex) {
+                    return a_regex->text() == std::get<std::shared_ptr<util::RegexGeneric>>(leaf_b)->text();
+                }
+        );
+    }
+    const auto& oa = std::get<ExpressionNode::Operation>(a.kind_);
+    const auto& ob = std::get<ExpressionNode::Operation>(b.kind_);
+    if (oa.operation_type_ != ob.operation_type_) {
+        return false;
+    }
+    return equal_child(oa.condition_, ob.condition_) && equal_child(oa.left_, ob.left_) &&
+           equal_child(oa.right_, ob.right_);
+}
+
+} // namespace
+
+ExpressionNode::ExpressionNode(Leaf leaf) : kind_(std::move(leaf)), label_(label_for(std::get<Leaf>(kind_))) {}
 
 ExpressionNode::ExpressionNode(
         std::shared_ptr<ExpressionNode> condition, std::shared_ptr<ExpressionNode> left,
-        std::shared_ptr<ExpressionNode> right, OperationType op, std::string label
+        std::shared_ptr<ExpressionNode> right, OperationType op
 ) :
-    kind_(Operation{op, std::move(condition), std::move(left), std::move(right)}),
-    label_(std::move(label)) {
+    kind_(Operation{op, std::move(condition), std::move(left), std::move(right)}) {
     util::check(is_ternary_operation(op), "Non-ternary expression provided with three arguments");
+    label_ = label_for(std::get<Operation>(kind_));
 }
 
 ExpressionNode::ExpressionNode(
-        std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op, std::string label
+        std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op
 ) :
-    kind_(Operation{op, nullptr, std::move(left), std::move(right)}),
-    label_(std::move(label)) {
+    kind_(Operation{op, nullptr, std::move(left), std::move(right)}) {
     util::check(is_binary_operation(op), "Non-binary expression provided with two arguments");
+    label_ = label_for(std::get<Operation>(kind_));
 }
 
-ExpressionNode::ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op, std::string label) :
-    kind_(Operation{op, nullptr, std::move(left), nullptr}),
-    label_(std::move(label)) {
+ExpressionNode::ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op) :
+    kind_(Operation{op, nullptr, std::move(left), nullptr}) {
     util::check(is_unary_operation(op), "Non-unary expression provided with single argument");
+    label_ = label_for(std::get<Operation>(kind_));
 }
 
 VariantData ExpressionNode::compute(ProcessingUnit& seg) const {
@@ -112,19 +211,34 @@ VariantData ExpressionNode::compute(ProcessingUnit& seg) const {
                         [](const std::shared_ptr<util::RegexGeneric>& regex) -> VariantData { return regex; }
                 );
             },
-            [&seg](const Operation& op) -> VariantData {
-                if (is_ternary_operation(op.operation_type_)) {
-                    return dispatch_ternary(
-                            op.condition_->compute(seg),
-                            op.left_->compute(seg),
-                            op.right_->compute(seg),
-                            op.operation_type_
-                    );
-                } else if (is_binary_operation(op.operation_type_)) {
-                    return dispatch_binary(op.left_->compute(seg), op.right_->compute(seg), op.operation_type_);
-                } else {
-                    return dispatch_unary(op.left_->compute(seg), op.operation_type_);
+            [&seg, this](const Operation& op) -> VariantData {
+                if (auto it = seg.computed_data_.find(label_); it != seg.computed_data_.end()) {
+                    const auto& [other, cached] = it->second;
+                    if (other == this || nodes_equal(*this, *other)) {
+                        log::version().debug("Memoization hit for {}", label_);
+                        return cached;
+                    }
+                    log::version().debug("Memoization label collision for {}", label_);
                 }
+                log::version().debug("Memoization miss, computing {}", label_);
+                VariantData result = [&seg, &op]() -> VariantData {
+                    if (is_ternary_operation(op.operation_type_)) {
+                        return dispatch_ternary(
+                                op.condition_->compute(seg),
+                                op.left_->compute(seg),
+                                op.right_->compute(seg),
+                                op.operation_type_
+                        );
+                    } else if (is_binary_operation(op.operation_type_)) {
+                        return dispatch_binary(op.left_->compute(seg), op.right_->compute(seg), op.operation_type_);
+                    } else {
+                        return dispatch_unary(op.left_->compute(seg), op.operation_type_);
+                    }
+                }();
+                // On a label collision the slot is already held by a structurally-different node; try_emplace is a
+                // no-op there, so that node keeps the slot and this result simply isn't memoized.
+                seg.computed_data_.try_emplace(label_, this, result);
+                return result;
             }
     );
 }

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -75,43 +75,73 @@ ColumnWithStrings::ColumnWithStrings(
     return std::nullopt;
 }
 
-ExpressionNode::ExpressionNode(VariantNode condition, VariantNode left, VariantNode right, OperationType op) :
-    condition_(std::move(condition)),
-    left_(std::move(left)),
-    right_(std::move(right)),
-    operation_type_(op) {
+ExpressionNode::ExpressionNode(Leaf leaf, std::string label) : kind_(std::move(leaf)), label_(std::move(label)) {}
+
+ExpressionNode::ExpressionNode(
+        std::shared_ptr<ExpressionNode> condition, std::shared_ptr<ExpressionNode> left,
+        std::shared_ptr<ExpressionNode> right, OperationType op, std::string label
+) :
+    kind_(Operation{op, std::move(condition), std::move(left), std::move(right)}),
+    label_(std::move(label)) {
     util::check(is_ternary_operation(op), "Non-ternary expression provided with three arguments");
 }
 
-ExpressionNode::ExpressionNode(VariantNode left, VariantNode right, OperationType op) :
-    left_(std::move(left)),
-    right_(std::move(right)),
-    operation_type_(op) {
+ExpressionNode::ExpressionNode(
+        std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op, std::string label
+) :
+    kind_(Operation{op, nullptr, std::move(left), std::move(right)}),
+    label_(std::move(label)) {
     util::check(is_binary_operation(op), "Non-binary expression provided with two arguments");
 }
 
-ExpressionNode::ExpressionNode(VariantNode left, OperationType op) : left_(std::move(left)), operation_type_(op) {
+ExpressionNode::ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op, std::string label) :
+    kind_(Operation{op, nullptr, std::move(left), nullptr}),
+    label_(std::move(label)) {
     util::check(is_unary_operation(op), "Non-unary expression provided with single argument");
 }
 
 VariantData ExpressionNode::compute(ProcessingUnit& seg) const {
-    if (is_ternary_operation(operation_type_)) {
-        return dispatch_ternary(seg.get(condition_), seg.get(left_), seg.get(right_), operation_type_);
-    } else if (is_binary_operation(operation_type_)) {
-        return dispatch_binary(seg.get(left_), seg.get(right_), operation_type_);
-    } else {
-        return dispatch_unary(seg.get(left_), operation_type_);
-    }
+    return util::variant_match(
+            kind_,
+            [&seg](const Leaf& leaf) -> VariantData {
+                return util::variant_match(
+                        leaf,
+                        [&seg](const ColumnName& column_name) -> VariantData { return seg.get(column_name); },
+                        [](const std::shared_ptr<Value>& value) -> VariantData { return value; },
+                        [](const std::shared_ptr<ValueSet>& value_set) -> VariantData { return value_set; },
+                        [](const std::shared_ptr<util::RegexGeneric>& regex) -> VariantData { return regex; }
+                );
+            },
+            [&seg](const Operation& op) -> VariantData {
+                if (is_ternary_operation(op.operation_type_)) {
+                    return dispatch_ternary(
+                            op.condition_->compute(seg),
+                            op.left_->compute(seg),
+                            op.right_->compute(seg),
+                            op.operation_type_
+                    );
+                } else if (is_binary_operation(op.operation_type_)) {
+                    return dispatch_binary(op.left_->compute(seg), op.right_->compute(seg), op.operation_type_);
+                } else {
+                    return dispatch_unary(op.left_->compute(seg), op.operation_type_);
+                }
+            }
+    );
 }
 
 std::variant<BitSetTag, DataType> ExpressionNode::compute(
-        const ExpressionContext& expression_context,
         const ankerl::unordered_dense::map<std::string, DataType>& column_types
 ) const {
+    if (std::holds_alternative<Leaf>(kind_)) {
+        ValueSetState value_set_state;
+        return leaf_return_type(std::get<Leaf>(kind_), column_types, value_set_state);
+    }
+    const auto& operation = std::get<Operation>(kind_);
+    const OperationType operation_type_ = operation.operation_type_;
     // Default to BitSetTag
     std::variant<BitSetTag, DataType> res;
     ValueSetState left_value_set_state;
-    auto left_type = child_return_type(left_, expression_context, column_types, left_value_set_state);
+    auto left_type = child_return_type(*operation.left_, column_types, left_value_set_state);
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             left_value_set_state == ValueSetState::NOT_A_SET, "Unexpected value set input to {}", operation_type_
     );
@@ -122,7 +152,7 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
             user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                     std::holds_alternative<DataType>(left_type), "Unexpected bitset input to {}", operation_type_
             );
-            details::visit_type(std::get<DataType>(left_type), [this, &res](auto tag) {
+            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res](auto tag) {
                 using type_info = ScalarTypeInfo<decltype(tag)>;
                 if constexpr (is_numeric_type(type_info::data_type)) {
                     if (operation_type_ == OperationType::ABS) {
@@ -166,7 +196,7 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
         }
     } else if (is_binary_operation(operation_type_)) {
         ValueSetState right_value_set_state;
-        auto right_type = child_return_type(right_, expression_context, column_types, right_value_set_state);
+        auto right_type = child_return_type(*operation.right_, column_types, right_value_set_state);
         switch (operation_type_) {
         case OperationType::ADD:
         case OperationType::SUB:
@@ -188,9 +218,9 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     "Unexpected value set input to {}",
                     operation_type_
             );
-            details::visit_type(std::get<DataType>(left_type), [this, &res, right_type](auto left_tag) {
+            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, right_type](auto left_tag) {
                 using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
-                details::visit_type(std::get<DataType>(right_type), [this, &res](auto right_tag) {
+                details::visit_type(std::get<DataType>(right_type), [operation_type_, &res](auto right_tag) {
                     using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
                     if constexpr (is_numeric_type(left_type_info::data_type) &&
                                   is_numeric_type(right_type_info::data_type)) {
@@ -372,10 +402,9 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
     } else {
         // Ternary operation
         ValueSetState condition_value_set_state;
-        auto condition_type =
-                child_return_type(condition_, expression_context, column_types, condition_value_set_state);
+        auto condition_type = child_return_type(*operation.condition_, column_types, condition_value_set_state);
         ValueSetState right_value_set_state;
-        auto right_type = child_return_type(right_, expression_context, column_types, right_value_set_state);
+        auto right_type = child_return_type(*operation.right_, column_types, right_value_set_state);
         user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                 condition_value_set_state == ValueSetState::NOT_A_SET &&
                         right_value_set_state == ValueSetState::NOT_A_SET,
@@ -391,9 +420,9 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
             );
         }
         if (std::holds_alternative<DataType>(left_type) && std::holds_alternative<DataType>(right_type)) {
-            details::visit_type(std::get<DataType>(left_type), [this, &res, right_type](auto left_tag) {
+            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, right_type](auto left_tag) {
                 using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
-                details::visit_type(std::get<DataType>(right_type), [this, &res](auto right_tag) {
+                details::visit_type(std::get<DataType>(right_type), [operation_type_, &res](auto right_tag) {
                     using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
                     if constexpr (is_sequence_type(left_type_info::data_type) &&
                                   is_sequence_type(right_type_info::data_type)) {
@@ -449,13 +478,13 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
     return res;
 }
 
-std::variant<BitSetTag, DataType> ExpressionNode::child_return_type(
-        const VariantNode& child, const ExpressionContext& expression_context,
-        const ankerl::unordered_dense::map<std::string, DataType>& column_types, ValueSetState& value_set_state
-) const {
+std::variant<BitSetTag, DataType> ExpressionNode::leaf_return_type(
+        const Leaf& leaf, const ankerl::unordered_dense::map<std::string, DataType>& column_types,
+        ValueSetState& value_set_state
+) {
     value_set_state = ValueSetState::NOT_A_SET;
     return util::variant_match(
-            child,
+            leaf,
             [&column_types](const ColumnName& column_name) -> std::variant<BitSetTag, DataType> {
                 auto it = column_types.find(column_name.value);
                 if (it == column_types.end()) {
@@ -470,26 +499,26 @@ std::variant<BitSetTag, DataType> ExpressionNode::child_return_type(
                 );
                 return it->second;
             },
-            [&expression_context](const ValueName& value_name) -> std::variant<BitSetTag, DataType> {
-                return expression_context.values_.get_value(value_name.value)->data_type();
-            },
-            [&expression_context,
-             &value_set_state](const ValueSetName& value_set_name) -> std::variant<BitSetTag, DataType> {
-                const auto value_set = expression_context.value_sets_.get_value(value_set_name.value);
+            [](const std::shared_ptr<Value>& value) -> std::variant<BitSetTag, DataType> { return value->data_type(); },
+            [&value_set_state](const std::shared_ptr<ValueSet>& value_set) -> std::variant<BitSetTag, DataType> {
                 value_set_state = value_set->empty() ? ValueSetState::EMPTY_SET : ValueSetState::NON_EMPTY_SET;
                 return value_set->base_type().data_type();
             },
-            [&expression_context,
-             &column_types](const ExpressionName& expression_name) -> std::variant<BitSetTag, DataType> {
-                const auto expr = expression_context.expression_nodes_.get_value(expression_name.value);
-                return expr->compute(expression_context, column_types);
-            },
-            [](const RegexName&) -> std::variant<BitSetTag, DataType> { return DataType::UTF_DYNAMIC64; },
-            [](auto&&) -> std::variant<BitSetTag, DataType> {
-                internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unexpected expression argument type");
-                return {};
+            [](const std::shared_ptr<util::RegexGeneric>&) -> std::variant<BitSetTag, DataType> {
+                return DataType::UTF_DYNAMIC64;
             }
     );
+}
+
+std::variant<BitSetTag, DataType> ExpressionNode::child_return_type(
+        const ExpressionNode& child, const ankerl::unordered_dense::map<std::string, DataType>& column_types,
+        ValueSetState& value_set_state
+) {
+    value_set_state = ValueSetState::NOT_A_SET;
+    if (std::holds_alternative<Leaf>(child.kind_)) {
+        return leaf_return_type(std::get<Leaf>(child.kind_), column_types, value_set_state);
+    }
+    return child.compute(column_types);
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -163,13 +163,13 @@ bool nodes_equal(const ExpressionNode& a, const ExpressionNode& b) {
                 }
         );
     }
-    const auto& oa = std::get<ExpressionNode::Operation>(a.kind_);
-    const auto& ob = std::get<ExpressionNode::Operation>(b.kind_);
-    if (oa.operation_type_ != ob.operation_type_) {
+    const auto& operation_a = std::get<ExpressionNode::Operation>(a.kind_);
+    const auto& operation_b = std::get<ExpressionNode::Operation>(b.kind_);
+    if (operation_a.operation_type_ != operation_b.operation_type_) {
         return false;
     }
-    return equal_child(oa.condition_, ob.condition_) && equal_child(oa.left_, ob.left_) &&
-           equal_child(oa.right_, ob.right_);
+    return equal_child(operation_a.condition_, operation_b.condition_) &&
+           equal_child(operation_a.left_, operation_b.left_) && equal_child(operation_a.right_, operation_b.right_);
 }
 
 } // namespace
@@ -180,7 +180,7 @@ ExpressionNode::ExpressionNode(
         std::shared_ptr<ExpressionNode> condition, std::shared_ptr<ExpressionNode> left,
         std::shared_ptr<ExpressionNode> right, OperationType op
 ) :
-    kind_(Operation{op, std::move(condition), std::move(left), std::move(right)}) {
+    kind_(Operation{op, std::move(left), std::move(right), std::move(condition)}) {
     util::check(is_ternary_operation(op), "Non-ternary expression provided with three arguments");
     label_ = label_for(std::get<Operation>(kind_));
 }
@@ -188,13 +188,13 @@ ExpressionNode::ExpressionNode(
 ExpressionNode::ExpressionNode(
         std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op
 ) :
-    kind_(Operation{op, nullptr, std::move(left), std::move(right)}) {
+    kind_(Operation{op, std::move(left), std::move(right)}) {
     util::check(is_binary_operation(op), "Non-binary expression provided with two arguments");
     label_ = label_for(std::get<Operation>(kind_));
 }
 
 ExpressionNode::ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op) :
-    kind_(Operation{op, nullptr, std::move(left), nullptr}) {
+    kind_(Operation{op, std::move(left)}) {
     util::check(is_unary_operation(op), "Non-unary expression provided with single argument");
     label_ = label_for(std::get<Operation>(kind_));
 }
@@ -215,12 +215,9 @@ VariantData ExpressionNode::compute(ProcessingUnit& seg) const {
                 if (auto it = seg.computed_data_.find(label_); it != seg.computed_data_.end()) {
                     const auto& [other, cached] = it->second;
                     if (other == this || nodes_equal(*this, *other)) {
-                        log::version().debug("Memoization hit for {}", label_);
                         return cached;
                     }
-                    log::version().debug("Memoization label collision for {}", label_);
                 }
-                log::version().debug("Memoization miss, computing {}", label_);
                 VariantData result = [&seg, &op]() -> VariantData {
                     if (is_ternary_operation(op.operation_type_)) {
                         return dispatch_ternary(
@@ -237,7 +234,13 @@ VariantData ExpressionNode::compute(ProcessingUnit& seg) const {
                 }();
                 // On a label collision the slot is already held by a structurally-different node; try_emplace is a
                 // no-op there, so that node keeps the slot and this result simply isn't memoized.
-                seg.computed_data_.try_emplace(label_, this, result);
+                if (!seg.computed_data_.try_emplace(label_, this, result).second) {
+                    log::version().debug(
+                            "Expression label collision for {}; result not memoized, similar queries may see "
+                            "redundant recomputation",
+                            label_
+                    );
+                }
                 return result;
             }
     );

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -73,10 +73,19 @@ struct ExpressionNode {
             ColumnName, std::shared_ptr<Value>, std::shared_ptr<ValueSet>, std::shared_ptr<util::RegexGeneric>>;
 
     struct Operation {
+        Operation(
+                OperationType operation_type, std::shared_ptr<ExpressionNode> left,
+                std::shared_ptr<ExpressionNode> right = nullptr, std::shared_ptr<ExpressionNode> condition = nullptr
+        ) :
+            operation_type_(operation_type),
+            left_(std::move(left)),
+            right_(std::move(right)),
+            condition_(std::move(condition)) {}
+
         OperationType operation_type_;
-        std::shared_ptr<ExpressionNode> condition_;
         std::shared_ptr<ExpressionNode> left_;
         std::shared_ptr<ExpressionNode> right_;
+        std::shared_ptr<ExpressionNode> condition_;
     };
 
     std::variant<Leaf, Operation> kind_;

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -19,24 +19,8 @@
 
 namespace arcticdb {
 
-struct ExpressionContext;
-
 struct ColumnNameTag {};
 using ColumnName = util::StringWrappingValue<ColumnNameTag>;
-
-struct ValueNameTag {};
-using ValueName = util::StringWrappingValue<ValueNameTag>;
-
-struct ValueSetNameTag {};
-using ValueSetName = util::StringWrappingValue<ValueSetNameTag>;
-
-struct ExpressionNameTag {};
-using ExpressionName = util::StringWrappingValue<ExpressionNameTag>;
-
-struct RegexNameTag {};
-using RegexName = util::StringWrappingValue<RegexNameTag>;
-
-using VariantNode = std::variant<std::monostate, ColumnName, ValueName, ValueSetName, ExpressionName, RegexName>;
 
 struct ProcessingUnit;
 class Column;
@@ -85,31 +69,59 @@ struct BitSetTag {};
  * Basic AST node.
  */
 struct ExpressionNode {
-    VariantNode condition_;
-    VariantNode left_;
-    VariantNode right_;
-    OperationType operation_type_;
+    using Leaf = std::variant<
+            ColumnName, std::shared_ptr<Value>, std::shared_ptr<ValueSet>, std::shared_ptr<util::RegexGeneric>>;
 
-    ExpressionNode(VariantNode condition, VariantNode left, VariantNode right, OperationType op);
+    struct Operation {
+        OperationType operation_type_;
+        std::shared_ptr<ExpressionNode> condition_;
+        std::shared_ptr<ExpressionNode> left_;
+        std::shared_ptr<ExpressionNode> right_;
+    };
 
-    ExpressionNode(VariantNode left, VariantNode right, OperationType op);
+    std::variant<Leaf, Operation> kind_;
 
-    ExpressionNode(VariantNode left, OperationType op);
+    // Should be used for debugging only
+    std::string label_;
+
+    explicit ExpressionNode(Leaf leaf, std::string label = "");
+
+    ExpressionNode(
+            std::shared_ptr<ExpressionNode> condition, std::shared_ptr<ExpressionNode> left,
+            std::shared_ptr<ExpressionNode> right, OperationType op, std::string label = ""
+    );
+
+    ExpressionNode(
+            std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op,
+            std::string label = ""
+    );
+
+    ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op, std::string label = "");
+
+    [[nodiscard]] bool is_operation() const { return std::holds_alternative<Operation>(kind_); }
+
+    [[nodiscard]] bool is_value() const {
+        return std::holds_alternative<Leaf>(kind_) &&
+               std::holds_alternative<std::shared_ptr<Value>>(std::get<Leaf>(kind_));
+    }
 
     VariantData compute(ProcessingUnit& seg) const;
 
-    std::variant<BitSetTag, DataType> compute(
-            const ExpressionContext& expression_context,
-            const ankerl::unordered_dense::map<std::string, DataType>& column_types
+    std::variant<BitSetTag, DataType> compute(const ankerl::unordered_dense::map<std::string, DataType>& column_types
     ) const;
 
   private:
     enum class ValueSetState { NOT_A_SET, EMPTY_SET, NON_EMPTY_SET };
 
-    std::variant<BitSetTag, DataType> child_return_type(
-            const VariantNode& child, const ExpressionContext& expression_context,
-            const ankerl::unordered_dense::map<std::string, DataType>& column_types, ValueSetState& value_set_state
-    ) const;
+    static std::variant<BitSetTag, DataType> leaf_return_type(
+            const Leaf& leaf, const ankerl::unordered_dense::map<std::string, DataType>& column_types,
+            ValueSetState& value_set_state
+    );
+
+    static std::variant<BitSetTag, DataType> child_return_type(
+            const ExpressionNode& child, const ankerl::unordered_dense::map<std::string, DataType>& column_types,
+            ValueSetState& value_set_state
+    );
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -81,22 +81,19 @@ struct ExpressionNode {
 
     std::variant<Leaf, Operation> kind_;
 
-    // Should be used for debugging only
+    // Used as a memoization hash key and for debugging
     std::string label_;
 
-    explicit ExpressionNode(Leaf leaf, std::string label = "");
+    explicit ExpressionNode(Leaf leaf);
 
     ExpressionNode(
             std::shared_ptr<ExpressionNode> condition, std::shared_ptr<ExpressionNode> left,
-            std::shared_ptr<ExpressionNode> right, OperationType op, std::string label = ""
+            std::shared_ptr<ExpressionNode> right, OperationType op
     );
 
-    ExpressionNode(
-            std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op,
-            std::string label = ""
-    );
+    ExpressionNode(std::shared_ptr<ExpressionNode> left, std::shared_ptr<ExpressionNode> right, OperationType op);
 
-    ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op, std::string label = "");
+    ExpressionNode(std::shared_ptr<ExpressionNode> left, OperationType op);
 
     [[nodiscard]] bool is_operation() const { return std::holds_alternative<Operation>(kind_); }
 

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -48,56 +48,29 @@ void ProcessingUnit::truncate(size_t start_row, size_t end_row) {
     }
 }
 
-VariantData ProcessingUnit::get(const VariantNode& name) {
+VariantData ProcessingUnit::get(const ColumnName& column_name) {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             segments_.has_value(), "ProcessingUnit::get requires segments to be present"
     );
-    return util::variant_match(
-            name,
-            [&](const ColumnName& column_name) {
-                for (const auto& segment : *segments_) {
-                    segment->init_column_map();
-                    if (const auto opt_idx = segment->column_index_with_name_demangling(column_name.value)) {
-                        return VariantData(ColumnWithStrings(
-                                segment->column_ptr(static_cast<position_t>(*opt_idx)),
-                                segment->string_pool_ptr(),
-                                column_name.value
-                        ));
-                    }
-                }
+    for (const auto& segment : *segments_) {
+        segment->init_column_map();
+        if (const auto opt_idx = segment->column_index_with_name_demangling(column_name.value)) {
+            return VariantData(ColumnWithStrings(
+                    segment->column_ptr(static_cast<position_t>(*opt_idx)),
+                    segment->string_pool_ptr(),
+                    column_name.value
+            ));
+        }
+    }
 
-                if (expression_context_ && !expression_context_->dynamic_schema_) {
-                    internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
-                            "Column {} not found in {}", column_name, segments_->at(0)->descriptor()
-                    );
-                } else {
-                    log::version().debug("Column {} not found in {}", column_name, segments_->at(0)->descriptor());
-                    return VariantData{EmptyResult{}};
-                }
-            },
-            [&](const ValueName& value_name) {
-                return VariantData(expression_context_->values_.get_value(value_name.value));
-            },
-            [&](const ValueSetName& value_set_name) {
-                return VariantData(expression_context_->value_sets_.get_value(value_set_name.value));
-            },
-            [&](const RegexName& regex_name) {
-                return VariantData(expression_context_->regex_matches_.get_value(regex_name.value));
-            },
-            [&](const ExpressionName& expression_name) {
-                if (auto computed = computed_data_.find(expression_name.value); computed != std::end(computed_data_)) {
-                    return computed->second;
-                } else {
-                    auto expr = expression_context_->expression_nodes_.get_value(expression_name.value);
-                    auto data = expr->compute(*this);
-                    computed_data_.try_emplace(expression_name.value, data);
-                    return data;
-                }
-            },
-            [&](const std::monostate&) -> VariantData {
-                util::raise_rte("ProcessingUnit::get called with monostate VariantNode");
-            }
-    );
+    if (expression_context_ && !expression_context_->dynamic_schema_) {
+        internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
+                "Column {} not found in {}", column_name, segments_->at(0)->descriptor()
+        );
+    } else {
+        log::version().debug("Column {} not found in {}", column_name, segments_->at(0)->descriptor());
+        return VariantData{EmptyResult{}};
+    }
 }
 
 std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc) {

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -35,8 +35,6 @@ enum class PipelineOptimisation : uint8_t { SPEED, MEMORY };
  *
  * In addition, the expression context is a constant, representing the AST for computing expressions in filter and
  * projection clauses.
- * computed_data_ holds a map from a string representation of a [sub-]expression of the AST to a computed value
- * of this expression. This way, if an expression appears twice in the AST, we will only compute it once.
  */
 struct ProcessingUnit {
     std::optional<std::vector<std::shared_ptr<SegmentInMemory>>> segments_;
@@ -47,7 +45,6 @@ struct ProcessingUnit {
     std::optional<std::vector<uint64_t>> entity_fetch_count_;
 
     std::shared_ptr<ExpressionContext> expression_context_;
-    std::unordered_map<std::string, VariantData> computed_data_;
 
     ProcessingUnit() = default;
 
@@ -96,10 +93,8 @@ struct ProcessingUnit {
         expression_context_ = expression_context;
     }
 
-    // The name argument to this function is either a column/value name, or uniquely identifies an ExpressionNode
-    // object. If this function has been called before with the same ExpressionNode name, then we cache the result in
-    // the computed_data_ map to avoid duplicating work.
-    VariantData get(const VariantNode& name);
+    // Resolve a data column against the segments in this processing unit.
+    VariantData get(const ColumnName& column_name);
 };
 
 std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc);

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -49,6 +49,9 @@ struct ProcessingUnit {
     /*
      * Memoization of results after applying an ExpressionNode to this processing unit. Keyed on the node's label_ with
      * a deep comparison on hits. One slot per label, colliding writes are dropped.
+     *
+     * The raw ExpressionNode pointers are owned by expression_context_, declared above so it outlives this map, and
+     * the tree is not mutated while computing, so the pointers stay valid for the map's lifetime.
      */
     std::unordered_map<std::string, std::pair<const ExpressionNode*, VariantData>> computed_data_;
 

--- a/cpp/arcticdb/processing/processing_unit.hpp
+++ b/cpp/arcticdb/processing/processing_unit.hpp
@@ -46,6 +46,12 @@ struct ProcessingUnit {
 
     std::shared_ptr<ExpressionContext> expression_context_;
 
+    /*
+     * Memoization of results after applying an ExpressionNode to this processing unit. Keyed on the node's label_ with
+     * a deep comparison on hits. One slot per label, colliding writes are dropped.
+     */
+    std::unordered_map<std::string, std::pair<const ExpressionNode*, VariantData>> computed_data_;
+
     ProcessingUnit() = default;
 
     ProcessingUnit(

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -34,10 +34,15 @@ ExpressionContext and_filter_expression_contexts(
 ) {
     util::check(!expression_contexts.empty(), "Expression context cannot be empty");
     std::shared_ptr<ExpressionNode> root;
+    const bool dynamic_schema = expression_contexts.front()->dynamic_schema_;
     for (const auto& expression_context : expression_contexts) {
         util::check(
                 expression_context->root_ && expression_context->root_->is_operation(),
                 "Only expect to be called with filter expressions"
+        );
+        util::check(
+                expression_context->dynamic_schema_ == dynamic_schema,
+                "Cannot AND-together filter expressions with differing dynamic_schema_"
         );
         if (root) {
             root = std::make_shared<ExpressionNode>(root, expression_context->root_, OperationType::AND);
@@ -48,6 +53,7 @@ ExpressionContext and_filter_expression_contexts(
 
     ExpressionContext res;
     res.root_ = std::move(root);
+    res.dynamic_schema_ = dynamic_schema;
     return res;
 }
 

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -33,35 +33,21 @@ ExpressionContext and_filter_expression_contexts(
         const std::vector<std::shared_ptr<ExpressionContext>>& expression_contexts
 ) {
     util::check(!expression_contexts.empty(), "Expression context cannot be empty");
-    std::optional<ExpressionName> overall_root_name;
-
-    ExpressionContext res;
-    for (auto&& [idx, expression_context] : folly::enumerate(expression_contexts)) {
+    std::shared_ptr<ExpressionNode> root;
+    for (const auto& expression_context : expression_contexts) {
         util::check(
-                std::holds_alternative<ExpressionName>(expression_context->root_node_name_),
+                expression_context->root_ && expression_context->root_->is_operation(),
                 "Only expect to be called with filter expressions"
         );
-        auto prefix = fmt::format("c{}/", idx);
-        res.merge_from(*expression_context, prefix);
-        auto root_name = ExpressionName{prefix + std::get<ExpressionName>(expression_context->root_node_name_).value};
-
-        if (!overall_root_name) {
-            overall_root_name = root_name;
-            continue;
+        if (root) {
+            root = std::make_shared<ExpressionNode>(root, expression_context->root_, OperationType::AND);
+        } else {
+            root = expression_context->root_;
         }
-
-        auto and_node = ExpressionNode{*overall_root_name, root_name, OperationType::AND};
-        auto intermediate_name = fmt::format("combined-{}", idx);
-        util::check(
-                !res.expression_nodes_.contains(intermediate_name),
-                "Expression nodes already contains {}",
-                intermediate_name
-        );
-        res.add_expression_node(intermediate_name, std::make_shared<ExpressionNode>(and_node));
-        overall_root_name = ExpressionName{intermediate_name};
     }
 
-    res.root_node_name_ = *overall_root_name;
+    ExpressionContext res;
+    res.root_ = std::move(root);
     return res;
 }
 

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -41,8 +41,9 @@ ExpressionContext and_filter_expression_contexts(
                 std::holds_alternative<ExpressionName>(expression_context->root_node_name_),
                 "Only expect to be called with filter expressions"
         );
-        res.merge_from(*expression_context);
-        auto root_name = std::get<ExpressionName>(expression_context->root_node_name_);
+        auto prefix = fmt::format("c{}/", idx);
+        res.merge_from(*expression_context, prefix);
+        auto root_name = ExpressionName{prefix + std::get<ExpressionName>(expression_context->root_node_name_).value};
 
         if (!overall_root_name) {
             overall_root_name = root_name;

--- a/cpp/arcticdb/processing/test/ast_test_helpers.hpp
+++ b/cpp/arcticdb/processing/test/ast_test_helpers.hpp
@@ -1,0 +1,52 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/processing/expression_node.hpp>
+#include <arcticdb/pipeline/value.hpp>
+#include <arcticdb/pipeline/value_set.hpp>
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace arcticdb {
+
+// Factories for building expression trees directly as node pointers in C++ tests.
+using ExpressionChild = std::shared_ptr<ExpressionNode>;
+
+inline ExpressionChild col(std::string_view name) {
+    return std::make_shared<ExpressionNode>(ColumnName(std::string(name)));
+}
+
+inline ExpressionChild val(std::shared_ptr<Value> value) { return std::make_shared<ExpressionNode>(std::move(value)); }
+
+template<typename T>
+inline ExpressionChild val(T value, DataType data_type) {
+    return std::make_shared<ExpressionNode>(std::make_shared<Value>(value, data_type));
+}
+
+inline ExpressionChild vset(std::shared_ptr<ValueSet> value_set) {
+    return std::make_shared<ExpressionNode>(std::move(value_set));
+}
+
+inline ExpressionChild node(ExpressionChild left, OperationType op) {
+    return std::make_shared<ExpressionNode>(std::move(left), op);
+}
+
+inline ExpressionChild node(ExpressionChild left, ExpressionChild right, OperationType op) {
+    return std::make_shared<ExpressionNode>(std::move(left), std::move(right), op);
+}
+
+inline ExpressionChild node(ExpressionChild condition, ExpressionChild left, ExpressionChild right, OperationType op) {
+    return std::make_shared<ExpressionNode>(std::move(condition), std::move(left), std::move(right), op);
+}
+
+} // namespace arcticdb

--- a/cpp/arcticdb/processing/test/test_expression.cpp
+++ b/cpp/arcticdb/processing/test/test_expression.cpp
@@ -10,6 +10,7 @@
 #include <arcticdb/processing/expression_context.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
+#include <arcticdb/processing/test/ast_test_helpers.hpp>
 #include <arcticdb/util/test/generators.hpp>
 
 TEST(ExpressionNode, AddBasic) {
@@ -28,19 +29,18 @@ TEST(ExpressionNode, AddBasic) {
     wrapper.aggregator_.commit();
     auto& seg = wrapper.segment();
     ProcessingUnit proc(std::move(seg));
-    auto node = std::make_shared<ExpressionNode>(ColumnName("thing1"), ColumnName("thing2"), OperationType::ADD);
+    auto root = node(col("thing1"), col("thing2"), OperationType::ADD);
     auto expression_context = std::make_shared<ExpressionContext>();
-    expression_context->root_node_name_ = ExpressionName("new_thing");
-    expression_context->add_expression_node("new_thing", node);
+    expression_context->root_ = root;
     proc.set_expression_context(expression_context);
-    auto ret = proc.get(ExpressionName("new_thing"));
-    const auto& col = std::get<ColumnWithStrings>(ret).column_;
+    auto ret = root->compute(proc);
+    const auto& result_col = std::get<ColumnWithStrings>(ret).column_;
 
     for (auto j = 0; j < 20; ++j) {
         auto v1 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 1);
         ASSERT_EQ(v1.value(), j);
         auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 2);
         ASSERT_EQ(v2.value(), j + 1);
-        ASSERT_EQ(col->scalar_at<uint64_t>(j), v1.value() + v2.value());
+        ASSERT_EQ(result_col->scalar_at<uint64_t>(j), v1.value() + v2.value());
     }
 }

--- a/cpp/arcticdb/processing/test/test_expression.cpp
+++ b/cpp/arcticdb/processing/test/test_expression.cpp
@@ -11,7 +11,10 @@
 #include <arcticdb/processing/expression_node.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/processing/test/ast_test_helpers.hpp>
+#include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/util/test/generators.hpp>
+
+#include <unordered_set>
 
 TEST(ExpressionNode, AddBasic) {
     using namespace arcticdb;
@@ -42,5 +45,87 @@ TEST(ExpressionNode, AddBasic) {
         auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 2);
         ASSERT_EQ(v2.value(), j + 1);
         ASSERT_EQ(result_col->scalar_at<uint64_t>(j), v1.value() + v2.value());
+    }
+}
+
+TEST(ExpressionNode, SubexpressionMemoized) {
+    using namespace arcticdb;
+    StreamId symbol("test_longhand");
+    auto wrapper =
+            SinkWrapper(symbol, {scalar_field(DataType::UINT64, "thing1"), scalar_field(DataType::UINT64, "thing2")});
+
+    for (auto j = 0; j < 20; ++j) {
+        wrapper.aggregator_.start_row(timestamp(j))([&](auto&& rb) {
+            rb.set_scalar(1, j);
+            rb.set_scalar(2, j + 1);
+        });
+    }
+
+    wrapper.aggregator_.commit();
+    auto& seg = wrapper.segment();
+    ProcessingUnit proc(std::move(seg));
+
+    auto add1 = node(col("thing1"), col("thing2"), OperationType::ADD);
+    auto add2 = node(col("thing1"), col("thing2"), OperationType::ADD);
+    auto root = node(add1, add2, OperationType::MUL);
+
+    auto expression_context = std::make_shared<ExpressionContext>();
+    expression_context->root_ = root;
+    proc.set_expression_context(expression_context);
+
+    auto ret = root->compute(proc);
+    const auto& result_col = std::get<ColumnWithStrings>(ret).column_;
+
+    for (auto j = 0; j < 20; ++j) {
+        auto v1 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 1).value();
+        auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 2).value();
+        ASSERT_EQ(result_col->scalar_at<uint64_t>(j), (v1 + v2) * (v1 + v2));
+    }
+
+    const std::string add_label = R"((Column["thing1"] ADD Column["thing2"]))";
+    ASSERT_EQ(add1->label_, add_label);
+    ASSERT_EQ(add2->label_, add_label);
+    ASSERT_EQ(proc.computed_data_.count(add_label), 1);
+    const auto* cached_node = proc.computed_data_.at(add_label).first;
+    ASSERT_TRUE(cached_node == add1.get() || cached_node == add2.get());
+    ASSERT_EQ(proc.computed_data_.size(), 2);
+}
+
+TEST(ExpressionNode, NoFalseReuseOnLabelClash) {
+    using namespace arcticdb;
+    StreamId symbol("test_label_clash");
+    auto wrapper = SinkWrapper(symbol, {scalar_field(DataType::INT64, "thing1")});
+
+    for (auto j = 0; j < 20; ++j) {
+        wrapper.aggregator_.start_row(timestamp(j))([&](auto&& rb) { rb.set_scalar(1, static_cast<int64_t>(j)); });
+    }
+
+    wrapper.aggregator_.commit();
+    auto& seg = wrapper.segment();
+    ProcessingUnit proc(std::move(seg));
+
+    auto set_a = std::make_shared<ValueSet>(
+            std::make_shared<std::unordered_set<int64_t>>(std::unordered_set<int64_t>{0, 1, 2})
+    );
+    auto set_b = std::make_shared<ValueSet>(
+            std::make_shared<std::unordered_set<int64_t>>(std::unordered_set<int64_t>{3, 4, 5})
+    );
+
+    auto isin_a = node(col("thing1"), vset(set_a), OperationType::ISIN);
+    auto isin_b = node(col("thing1"), vset(set_b), OperationType::ISIN);
+
+    auto expression_context = std::make_shared<ExpressionContext>();
+    expression_context->root_ = isin_a;
+    proc.set_expression_context(expression_context);
+
+    // The coarse value-set label keys only on dtype and size, so these two operations collide.
+    ASSERT_EQ(isin_a->label_, isin_b->label_);
+
+    auto bitset_a = std::get<util::BitSet>(isin_a->compute(proc));
+    auto bitset_b = std::get<util::BitSet>(isin_b->compute(proc));
+
+    for (size_t idx = 0; idx < 20; ++idx) {
+        ASSERT_EQ(set_a->get_set<int64_t>()->count(static_cast<int64_t>(idx)) > 0, bitset_a.get_bit(idx));
+        ASSERT_EQ(set_b->get_set<int64_t>()->count(static_cast<int64_t>(idx)) > 0, bitset_b.get_bit(idx));
     }
 }

--- a/cpp/arcticdb/processing/test/test_expression.cpp
+++ b/cpp/arcticdb/processing/test/test_expression.cpp
@@ -13,24 +13,22 @@
 #include <arcticdb/processing/test/ast_test_helpers.hpp>
 #include <arcticdb/pipeline/value_set.hpp>
 #include <arcticdb/util/test/generators.hpp>
+#include <arcticdb/util/test/segment_generation_utils.hpp>
 
 #include <unordered_set>
 
 TEST(ExpressionNode, AddBasic) {
     using namespace arcticdb;
     StreamId symbol("test_add");
-    auto wrapper =
-            SinkWrapper(symbol, {scalar_field(DataType::UINT64, "thing1"), scalar_field(DataType::UINT64, "thing2")});
-
-    for (auto j = 0; j < 20; ++j) {
-        wrapper.aggregator_.start_row(timestamp(j))([&](auto&& rb) {
-            rb.set_scalar(1, j);
-            rb.set_scalar(2, j + 1);
-        });
-    }
-
-    wrapper.aggregator_.commit();
-    auto& seg = wrapper.segment();
+    SegmentInMemory seg = create_dense_segment(
+            stream_descriptor(
+                    symbol,
+                    stream::RowCountIndex{},
+                    {scalar_field(DataType::UINT64, "thing1"), scalar_field(DataType::UINT64, "thing2")}
+            ),
+            std::views::iota(uint64_t{0}, uint64_t{20}),
+            std::views::iota(uint64_t{1}, uint64_t{21})
+    );
     ProcessingUnit proc(std::move(seg));
     auto root = node(col("thing1"), col("thing2"), OperationType::ADD);
     auto expression_context = std::make_shared<ExpressionContext>();
@@ -40,9 +38,9 @@ TEST(ExpressionNode, AddBasic) {
     const auto& result_col = std::get<ColumnWithStrings>(ret).column_;
 
     for (auto j = 0; j < 20; ++j) {
-        auto v1 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 1);
+        auto v1 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 0);
         ASSERT_EQ(v1.value(), j);
-        auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 2);
+        auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 1);
         ASSERT_EQ(v2.value(), j + 1);
         ASSERT_EQ(result_col->scalar_at<uint64_t>(j), v1.value() + v2.value());
     }
@@ -51,18 +49,15 @@ TEST(ExpressionNode, AddBasic) {
 TEST(ExpressionNode, SubexpressionMemoized) {
     using namespace arcticdb;
     StreamId symbol("test_longhand");
-    auto wrapper =
-            SinkWrapper(symbol, {scalar_field(DataType::UINT64, "thing1"), scalar_field(DataType::UINT64, "thing2")});
-
-    for (auto j = 0; j < 20; ++j) {
-        wrapper.aggregator_.start_row(timestamp(j))([&](auto&& rb) {
-            rb.set_scalar(1, j);
-            rb.set_scalar(2, j + 1);
-        });
-    }
-
-    wrapper.aggregator_.commit();
-    auto& seg = wrapper.segment();
+    SegmentInMemory seg = create_dense_segment(
+            stream_descriptor(
+                    symbol,
+                    stream::RowCountIndex{},
+                    {scalar_field(DataType::UINT64, "thing1"), scalar_field(DataType::UINT64, "thing2")}
+            ),
+            std::views::iota(uint64_t{0}, uint64_t{20}),
+            std::views::iota(uint64_t{1}, uint64_t{21})
+    );
     ProcessingUnit proc(std::move(seg));
 
     auto add1 = node(col("thing1"), col("thing2"), OperationType::ADD);
@@ -77,15 +72,15 @@ TEST(ExpressionNode, SubexpressionMemoized) {
     const auto& result_col = std::get<ColumnWithStrings>(ret).column_;
 
     for (auto j = 0; j < 20; ++j) {
-        auto v1 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 1).value();
-        auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 2).value();
+        auto v1 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 0).value();
+        auto v2 = proc.segments_->at(0)->scalar_at<uint64_t>(j, 1).value();
         ASSERT_EQ(result_col->scalar_at<uint64_t>(j), (v1 + v2) * (v1 + v2));
     }
 
     const std::string add_label = R"((Column["thing1"] ADD Column["thing2"]))";
     ASSERT_EQ(add1->label_, add_label);
     ASSERT_EQ(add2->label_, add_label);
-    ASSERT_EQ(proc.computed_data_.count(add_label), 1);
+    ASSERT_TRUE(proc.computed_data_.contains(add_label));
     const auto* cached_node = proc.computed_data_.at(add_label).first;
     ASSERT_TRUE(cached_node == add1.get() || cached_node == add2.get());
     ASSERT_EQ(proc.computed_data_.size(), 2);
@@ -94,14 +89,10 @@ TEST(ExpressionNode, SubexpressionMemoized) {
 TEST(ExpressionNode, NoFalseReuseOnLabelClash) {
     using namespace arcticdb;
     StreamId symbol("test_label_clash");
-    auto wrapper = SinkWrapper(symbol, {scalar_field(DataType::INT64, "thing1")});
-
-    for (auto j = 0; j < 20; ++j) {
-        wrapper.aggregator_.start_row(timestamp(j))([&](auto&& rb) { rb.set_scalar(1, static_cast<int64_t>(j)); });
-    }
-
-    wrapper.aggregator_.commit();
-    auto& seg = wrapper.segment();
+    SegmentInMemory seg = create_dense_segment(
+            stream_descriptor(symbol, stream::RowCountIndex{}, {scalar_field(DataType::INT64, "thing1")}),
+            std::views::iota(int64_t{0}, int64_t{20})
+    );
     ProcessingUnit proc(std::move(seg));
 
     auto set_a = std::make_shared<ValueSet>(
@@ -125,7 +116,7 @@ TEST(ExpressionNode, NoFalseReuseOnLabelClash) {
     auto bitset_b = std::get<util::BitSet>(isin_b->compute(proc));
 
     for (size_t idx = 0; idx < 20; ++idx) {
-        ASSERT_EQ(set_a->get_set<int64_t>()->count(static_cast<int64_t>(idx)) > 0, bitset_a.get_bit(idx));
-        ASSERT_EQ(set_b->get_set<int64_t>()->count(static_cast<int64_t>(idx)) > 0, bitset_b.get_bit(idx));
+        ASSERT_EQ(set_a->get_set<int64_t>()->contains(static_cast<int64_t>(idx)), bitset_a.get_bit(idx));
+        ASSERT_EQ(set_b->get_set<int64_t>()->contains(static_cast<int64_t>(idx)), bitset_b.get_bit(idx));
     }
 }

--- a/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
+++ b/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h>
 #include <arcticdb/processing/processing_unit.hpp>
+#include <arcticdb/processing/test/ast_test_helpers.hpp>
 #include <arcticdb/util/test/generators.hpp>
 
 using namespace arcticdb;
@@ -26,22 +27,14 @@ class FilterProjectSparse : public testing::Test {
     }
 
     std::shared_ptr<Column> unary_projection(std::string_view input_column_name, OperationType op) {
-        const std::string output_column("unary projection");
-        expression_context->root_node_name_ = ExpressionName(output_column);
-        auto expression_node = std::make_shared<ExpressionNode>(ColumnName(input_column_name), op);
-        expression_context->add_expression_node(output_column, expression_node);
-
-        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        auto root = node(col(input_column_name), op);
+        auto variant_data = root->compute(proc_unit);
         return std::get<ColumnWithStrings>(variant_data).column_;
     }
 
     util::BitSet unary_filter(std::string_view input_column_name, OperationType op) {
-        const std::string root_node_name("unary filter");
-        expression_context->root_node_name_ = ExpressionName(root_node_name);
-        auto expression_node = std::make_shared<ExpressionNode>(ColumnName(input_column_name), op);
-        expression_context->add_expression_node(root_node_name, expression_node);
-
-        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        auto root = node(col(input_column_name), op);
+        auto variant_data = root->compute(proc_unit);
         return std::get<util::BitSet>(variant_data);
     }
 
@@ -49,36 +42,17 @@ class FilterProjectSparse : public testing::Test {
             std::string_view left_column_name,
             const std::variant<std::string_view, double, std::unordered_set<double>>& right_input, OperationType op
     ) {
-        const std::string root_node_name("binary filter");
-        const std::string value_name("value");
-        const std::string value_set_name("value set");
-        expression_context->root_node_name_ = ExpressionName(root_node_name);
-        std::shared_ptr<ExpressionNode> expression_node;
+        ExpressionChild right;
         util::variant_match(
                 right_input,
-                [&](std::string_view right_column_name) {
-                    expression_node = std::make_shared<ExpressionNode>(
-                            ColumnName(left_column_name), ColumnName(right_column_name), op
-                    );
-                },
-                [&](double value) {
-                    expression_node =
-                            std::make_shared<ExpressionNode>(ColumnName(left_column_name), ValueName(value_name), op);
-                    expression_context->add_value(value_name, std::make_shared<Value>(value, DataType::FLOAT64));
-                },
+                [&](std::string_view right_column_name) { right = col(right_column_name); },
+                [&](double value) { right = val(std::make_shared<Value>(value, DataType::FLOAT64)); },
                 [&](std::unordered_set<double> value_set) {
-                    expression_node = std::make_shared<ExpressionNode>(
-                            ColumnName(left_column_name), ValueSetName(value_set_name), op
-                    );
-                    expression_context->add_value_set(
-                            value_set_name,
-                            std::make_shared<ValueSet>(std::make_shared<std::unordered_set<double>>(value_set))
-                    );
+                    right = vset(std::make_shared<ValueSet>(std::make_shared<std::unordered_set<double>>(value_set)));
                 }
         );
-        expression_context->add_expression_node(root_node_name, expression_node);
-
-        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        auto root = node(col(left_column_name), right, op);
+        auto variant_data = root->compute(proc_unit);
         return std::get<util::BitSet>(variant_data);
     }
 
@@ -86,26 +60,14 @@ class FilterProjectSparse : public testing::Test {
             std::string_view left_column_name, const std::variant<std::string_view, double>& right_input,
             OperationType op
     ) {
-        const std::string output_column("binary filter");
-        const std::string value_name("value");
-        expression_context->root_node_name_ = ExpressionName(output_column);
-        std::shared_ptr<ExpressionNode> expression_node;
+        ExpressionChild right;
         util::variant_match(
                 right_input,
-                [&](std::string_view right_column_name) {
-                    expression_node = std::make_shared<ExpressionNode>(
-                            ColumnName(left_column_name), ColumnName(right_column_name), op
-                    );
-                },
-                [&](double value) {
-                    expression_node =
-                            std::make_shared<ExpressionNode>(ColumnName(left_column_name), ValueName(value_name), op);
-                    expression_context->add_value(value_name, std::make_shared<Value>(value, DataType::FLOAT64));
-                }
+                [&](std::string_view right_column_name) { right = col(right_column_name); },
+                [&](double value) { right = val(std::make_shared<Value>(value, DataType::FLOAT64)); }
         );
-        expression_context->add_expression_node(output_column, expression_node);
-
-        auto variant_data = proc_unit.get(expression_context->root_node_name_);
+        auto root = node(col(left_column_name), right, op);
+        auto variant_data = root->compute(proc_unit);
         return std::get<ColumnWithStrings>(variant_data).column_;
     }
 

--- a/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
+++ b/cpp/arcticdb/processing/test/test_filter_and_project_sparse.cpp
@@ -42,13 +42,12 @@ class FilterProjectSparse : public testing::Test {
             std::string_view left_column_name,
             const std::variant<std::string_view, double, std::unordered_set<double>>& right_input, OperationType op
     ) {
-        ExpressionChild right;
-        util::variant_match(
+        ExpressionChild right = util::variant_match(
                 right_input,
-                [&](std::string_view right_column_name) { right = col(right_column_name); },
-                [&](double value) { right = val(std::make_shared<Value>(value, DataType::FLOAT64)); },
+                [&](std::string_view right_column_name) { return col(right_column_name); },
+                [&](double value) { return val(std::make_shared<Value>(value, DataType::FLOAT64)); },
                 [&](std::unordered_set<double> value_set) {
-                    right = vset(std::make_shared<ValueSet>(std::make_shared<std::unordered_set<double>>(value_set)));
+                    return vset(std::make_shared<ValueSet>(std::make_shared<std::unordered_set<double>>(value_set)));
                 }
         );
         auto root = node(col(left_column_name), right, op);
@@ -60,11 +59,10 @@ class FilterProjectSparse : public testing::Test {
             std::string_view left_column_name, const std::variant<std::string_view, double>& right_input,
             OperationType op
     ) {
-        ExpressionChild right;
-        util::variant_match(
+        ExpressionChild right = util::variant_match(
                 right_input,
-                [&](std::string_view right_column_name) { right = col(right_column_name); },
-                [&](double value) { right = val(std::make_shared<Value>(value, DataType::FLOAT64)); }
+                [&](std::string_view right_column_name) { return col(right_column_name); },
+                [&](double value) { return val(std::make_shared<Value>(value, DataType::FLOAT64)); }
         );
         auto root = node(col(left_column_name), right, op);
         auto variant_data = root->compute(proc_unit);

--- a/cpp/arcticdb/processing/test/test_output_schema_ast_validity.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_ast_validity.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 #include <arcticdb/processing/clause.hpp>
+#include <arcticdb/processing/test/ast_test_helpers.hpp>
 
 using namespace arcticdb;
 using namespace arcticdb::pipelines;
@@ -27,65 +28,58 @@ class AstParsingOutputTypesTest : public testing::Test {
         initial_stream_desc.add_scalar_field(DataType::BOOL8, "bool");
 
         ec = ExpressionContext();
-        ec.root_node_name_ = ExpressionName("root");
     }
 
     OutputSchema initial_schema() { return {initial_stream_desc.clone(), {}}; }
 
-    std::shared_ptr<ExpressionNode> bitset_node() const {
-        return std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::EQ);
-    }
+    ExpressionChild bitset_node() const { return node(col("int32"), col("uint8"), OperationType::EQ); }
 
     StreamDescriptor initial_stream_desc;
     ExpressionContext ec;
 };
 
 TEST_F(AstParsingOutputTypesTest, FilterNotBitset) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ExpressionName("bitset"), OperationType::NOT));
+    ec.root_ = node(bitset_node(), OperationType::NOT);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterNotBoolColumn) {
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("bool"), OperationType::NOT));
+    ec.root_ = node(col("bool"), OperationType::NOT);
     FilterClause filter_clause{{"bool"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterNotNumericColumn) {
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("int32"), OperationType::NOT));
+    ec.root_ = node(col("int32"), OperationType::NOT);
     FilterClause filter_clause{{"int32"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterIsNullStringColumn) {
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("string"), OperationType::ISNULL));
+    ec.root_ = node(col("string"), OperationType::ISNULL);
     FilterClause filter_clause{{"string"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterIsNullNumericColumn) {
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("int32"), OperationType::ISNULL));
+    ec.root_ = node(col("int32"), OperationType::ISNULL);
     FilterClause filter_clause{{"int32"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterIsNullBitset) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ExpressionName("bitset"), OperationType::ISNULL));
+    ec.root_ = node(bitset_node(), OperationType::ISNULL);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterEqNumericCols) {
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::EQ)
-    );
+    ec.root_ = node(col("int32"), col("uint8"), OperationType::EQ);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
@@ -93,10 +87,7 @@ TEST_F(AstParsingOutputTypesTest, FilterEqNumericCols) {
 
 TEST_F(AstParsingOutputTypesTest, FilterEqStringColStringVal) {
     auto value = std::make_shared<Value>(construct_string_value("hello"));
-    ec.add_value("value", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("string"), ValueName("value"), OperationType::EQ)
-    );
+    ec.root_ = node(col("string"), val(value), OperationType::EQ);
     FilterClause filter_clause{{"string"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
@@ -104,10 +95,7 @@ TEST_F(AstParsingOutputTypesTest, FilterEqStringColStringVal) {
 
 TEST_F(AstParsingOutputTypesTest, FilterEqNumericColStringVal) {
     auto value = std::make_shared<Value>(construct_string_value("hello"));
-    ec.add_value("value", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ValueName("value"), OperationType::EQ)
-    );
+    ec.root_ = node(col("int32"), val(value), OperationType::EQ);
     FilterClause filter_clause{{"int32"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -115,20 +103,14 @@ TEST_F(AstParsingOutputTypesTest, FilterEqNumericColStringVal) {
 TEST_F(AstParsingOutputTypesTest, FilterEqColValueSet) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ValueSetName("value_set"), OperationType::EQ)
-    );
+    ec.root_ = node(col("int32"), vset(value_set), OperationType::EQ);
     FilterClause filter_clause{{"int32"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterLessThanNumericColNumericVal) {
     auto value = std::make_shared<Value>(construct_value<uint16_t>(5));
-    ec.add_value("value", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ValueName("value"), OperationType::LT)
-    );
+    ec.root_ = node(col("int32"), val(value), OperationType::LT);
     FilterClause filter_clause{{"int32"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
@@ -136,19 +118,13 @@ TEST_F(AstParsingOutputTypesTest, FilterLessThanNumericColNumericVal) {
 
 TEST_F(AstParsingOutputTypesTest, FilterLessThanStringColStringVal) {
     auto value = std::make_shared<Value>(construct_string_value("hello"));
-    ec.add_value("value", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("string"), ValueName("value"), OperationType::LT)
-    );
+    ec.root_ = node(col("string"), val(value), OperationType::LT);
     FilterClause filter_clause{{"string"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterLessThanNumericColBitset) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ExpressionName("bitset"), OperationType::LT)
-    );
+    ec.root_ = node(col("int32"), bitset_node(), OperationType::LT);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -156,11 +132,7 @@ TEST_F(AstParsingOutputTypesTest, FilterLessThanNumericColBitset) {
 TEST_F(AstParsingOutputTypesTest, FilterIsInNumericColNumericValueSet) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(ColumnName("int32"), ValueSetName("value_set"), OperationType::ISIN)
-    );
+    ec.root_ = node(col("int32"), vset(value_set), OperationType::ISIN);
     FilterClause filter_clause{{"int32"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
@@ -169,11 +141,7 @@ TEST_F(AstParsingOutputTypesTest, FilterIsInNumericColNumericValueSet) {
 TEST_F(AstParsingOutputTypesTest, FilterIsInStringColStringValueSet) {
     std::vector<std::string> raw_set{"hello", "goodbye"};
     auto value_set = std::make_shared<ValueSet>(std::move(raw_set));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(ColumnName("string"), ValueSetName("value_set"), OperationType::ISIN)
-    );
+    ec.root_ = node(col("string"), vset(value_set), OperationType::ISIN);
     FilterClause filter_clause{{"string"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
@@ -181,9 +149,7 @@ TEST_F(AstParsingOutputTypesTest, FilterIsInStringColStringValueSet) {
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowUintUintCols) {
     // uint ^ uint -> uint64
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ColumnName("uint8"), OperationType::POW)
-    );
+    ec.root_ = node(col("uint8"), col("uint8"), OperationType::POW);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -193,9 +159,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowUintUintCols) {
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowIntUintCols) {
     // int ^ uint -> int64
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::POW)
-    );
+    ec.root_ = node(col("int32"), col("uint8"), OperationType::POW);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -205,9 +169,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowIntUintCols) {
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowUintIntCols) {
     // uint ^ int -> double (negative exponent can produce fractional results)
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ColumnName("int32"), OperationType::POW)
-    );
+    ec.root_ = node(col("uint8"), col("int32"), OperationType::POW);
     ProjectClause project_clause{{"uint8", "int32"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -217,9 +179,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowUintIntCols) {
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowIntIntCols) {
     // int ^ int -> double (negative exponent can produce fractional results)
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("int32"), OperationType::POW)
-    );
+    ec.root_ = node(col("int32"), col("int32"), OperationType::POW);
     ProjectClause project_clause{{"int32"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -230,10 +190,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowIntIntCols) {
 TEST_F(AstParsingOutputTypesTest, ProjectionPowNumericColVal) {
     // uint8 ^ uint16 value -> uint64 (unsigned base, unsigned exponent)
     auto value = std::make_shared<Value>(construct_value<uint16_t>(3));
-    ec.add_value("3", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ValueName("3"), OperationType::POW)
-    );
+    ec.root_ = node(col("uint8"), val(value), OperationType::POW);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -242,18 +199,13 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowNumericColVal) {
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowNumericColStringCol) {
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("string"), OperationType::POW)
-    );
+    ec.root_ = node(col("int32"), col("string"), OperationType::POW);
     ProjectClause project_clause{{"int32", "string"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowNumericColBitset) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ExpressionName("bitset"), OperationType::POW)
-    );
+    ec.root_ = node(col("int32"), bitset_node(), OperationType::POW);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -261,19 +213,13 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowNumericColBitset) {
 TEST_F(AstParsingOutputTypesTest, ProjectionPowNumericColValueSet) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ValueSetName("value_set"), OperationType::POW)
-    );
+    ec.root_ = node(col("uint8"), vset(value_set), OperationType::POW);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionPowBitsetNumericCol) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ExpressionName("bitset"), ColumnName("int32"), OperationType::POW)
-    );
+    ec.root_ = node(bitset_node(), col("int32"), OperationType::POW);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -281,10 +227,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowBitsetNumericCol) {
 TEST_F(AstParsingOutputTypesTest, ProjectionPowValueSetNumericCol) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ValueSetName("value_set"), ColumnName("uint8"), OperationType::POW)
-    );
+    ec.root_ = node(vset(value_set), col("uint8"), OperationType::POW);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -292,82 +235,51 @@ TEST_F(AstParsingOutputTypesTest, ProjectionPowValueSetNumericCol) {
 TEST_F(AstParsingOutputTypesTest, FilterIsInNumericColEmptyValueSet) {
     std::vector<std::string> raw_set;
     auto value_set = std::make_shared<ValueSet>(std::move(raw_set));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(ColumnName("int32"), ValueSetName("value_set"), OperationType::ISIN)
-    );
+    ec.root_ = node(col("int32"), vset(value_set), OperationType::ISIN);
     FilterClause filter_clause{{"int32"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterIsInBitsetValueSet) {
-    ec.add_expression_node("bitset", bitset_node());
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(ExpressionName("bitset"), ValueSetName("value_set"), OperationType::ISIN)
-    );
+    ec.root_ = node(bitset_node(), vset(value_set), OperationType::ISIN);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterIsInNumericColNumericValue) {
     auto value = std::make_shared<Value>(construct_value<uint16_t>(5));
-    ec.add_value("value", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ValueName("value"), OperationType::ISIN)
-    );
+    ec.root_ = node(col("int32"), val(value), OperationType::ISIN);
     FilterClause filter_clause{{"int32"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterAndBitsetBitset) {
-    ec.add_expression_node("bitset_1", bitset_node());
-    ec.add_expression_node("bitset_2", bitset_node());
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(ExpressionName("bitset_1"), ExpressionName("bitset_2"), OperationType::AND)
-    );
+    ec.root_ = node(bitset_node(), bitset_node(), OperationType::AND);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterAndBitsetBoolColumn) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ExpressionName("bitset"), ColumnName("bool"), OperationType::AND)
-    );
+    ec.root_ = node(bitset_node(), col("bool"), OperationType::AND);
     FilterClause filter_clause{{"int32", "uint8", "bool"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterAndNumericCols) {
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::AND)
-    );
+    ec.root_ = node(col("int32"), col("uint8"), OperationType::AND);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, FilterComplexExpression) {
     // Equivalent to x AND (y OR z) where x, y, and z are bitsets
-    ec.add_expression_node("bitset_1", bitset_node());
-    ec.add_expression_node("bitset_2", bitset_node());
-    ec.add_expression_node("bitset_3", bitset_node());
-    ec.add_expression_node(
-            "bitset_4",
-            std::make_shared<ExpressionNode>(ExpressionName("bitset_1"), ExpressionName("bitset_2"), OperationType::OR)
-    );
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(ExpressionName("bitset_3"), ExpressionName("bitset_4"), OperationType::AND)
-    );
+    auto bitset_4 = node(bitset_node(), bitset_node(), OperationType::OR);
+    ec.root_ = node(bitset_node(), bitset_4, OperationType::AND);
     FilterClause filter_clause{{"int32", "uint8"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
@@ -375,13 +287,12 @@ TEST_F(AstParsingOutputTypesTest, FilterComplexExpression) {
 
 TEST_F(AstParsingOutputTypesTest, FilterValue) {
     auto value = std::make_shared<Value>(construct_value<uint16_t>(2));
-    ec.add_value("2", value);
-    ec.root_node_name_ = ValueName("2");
+    ec.root_ = val(value);
     ASSERT_THROW(FilterClause({}, ec, {}), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAbsNumeric) {
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("int32"), OperationType::ABS));
+    ec.root_ = node(col("int32"), OperationType::ABS);
     ProjectClause project_clause{{"int32"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -390,24 +301,19 @@ TEST_F(AstParsingOutputTypesTest, ProjectionAbsNumeric) {
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAbsString) {
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ColumnName("string"), OperationType::ABS));
+    ec.root_ = node(col("string"), OperationType::ABS);
     ProjectClause project_clause{{"string"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAbsBitset) {
-    ec.add_expression_node(
-            "bitset", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::EQ)
-    );
-    ec.add_expression_node("root", std::make_shared<ExpressionNode>(ExpressionName("bitset"), OperationType::ABS));
+    ec.root_ = node(node(col("int32"), col("uint8"), OperationType::EQ), OperationType::ABS);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericCols) {
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::ADD)
-    );
+    ec.root_ = node(col("int32"), col("uint8"), OperationType::ADD);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -417,10 +323,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericCols) {
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColVal) {
     auto value = std::make_shared<Value>(construct_value<uint16_t>(5));
-    ec.add_value("5", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ValueName("5"), OperationType::ADD)
-    );
+    ec.root_ = node(col("uint8"), val(value), OperationType::ADD);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -429,18 +332,13 @@ TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColVal) {
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColStringCol) {
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("string"), OperationType::ADD)
-    );
+    ec.root_ = node(col("int32"), col("string"), OperationType::ADD);
     ProjectClause project_clause{{"int32", "string"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColBitset) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("int32"), ExpressionName("bitset"), OperationType::ADD)
-    );
+    ec.root_ = node(col("int32"), bitset_node(), OperationType::ADD);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -448,10 +346,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColBitset) {
 TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColValueSet) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ValueSetName("value_set"), OperationType::ADD)
-    );
+    ec.root_ = node(col("uint8"), vset(value_set), OperationType::ADD);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -459,24 +354,16 @@ TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColValueSet) {
 TEST_F(AstParsingOutputTypesTest, ProjectionAddNumericColEmptyValueSet) {
     std::unordered_set<uint8_t> raw_set;
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ColumnName("uint8"), ValueSetName("value_set"), OperationType::ADD)
-    );
+    ec.root_ = node(col("uint8"), vset(value_set), OperationType::ADD);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, ProjectionComplexExpression) {
     // Equivalent to (col1 + col2) * 2
-    ec.add_expression_node(
-            "product", std::make_shared<ExpressionNode>(ColumnName("int32"), ColumnName("uint8"), OperationType::ADD)
-    );
+    auto product = node(col("int32"), col("uint8"), OperationType::ADD);
     auto value = std::make_shared<Value>(construct_value<uint16_t>(2));
-    ec.add_value("2", value);
-    ec.add_expression_node(
-            "root", std::make_shared<ExpressionNode>(ExpressionName("product"), ValueName("2"), OperationType::MUL)
-    );
+    ec.root_ = node(product, val(value), OperationType::MUL);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -486,8 +373,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionComplexExpression) {
 
 TEST_F(AstParsingOutputTypesTest, ProjectionValue) {
     auto value = std::make_shared<Value>(construct_value<uint16_t>(2));
-    ec.add_value("2", value);
-    ec.root_node_name_ = ValueName("2");
+    ec.root_ = val(value);
     ProjectClause project_clause{{}, "new_col", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -498,13 +384,7 @@ TEST_F(AstParsingOutputTypesTest, ProjectionValue) {
 TEST_F(AstParsingOutputTypesTest, TernaryValueSetCondition) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ValueSetName("value_set"), ColumnName("uint8"), ColumnName("uint8"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(vset(value_set), col("uint8"), col("uint8"), OperationType::TERNARY);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -512,13 +392,7 @@ TEST_F(AstParsingOutputTypesTest, TernaryValueSetCondition) {
 TEST_F(AstParsingOutputTypesTest, TernaryValueSetLeft) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ValueSetName("value_set"), ColumnName("uint8"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), vset(value_set), col("uint8"), OperationType::TERNARY);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
@@ -526,36 +400,19 @@ TEST_F(AstParsingOutputTypesTest, TernaryValueSetLeft) {
 TEST_F(AstParsingOutputTypesTest, TernaryValueSetRight) {
     std::unordered_set<uint8_t> raw_set{1, 2, 3};
     auto value_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<uint8_t>>(std::move(raw_set)));
-    ec.add_value_set("value_set", value_set);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ColumnName("uint8"), ValueSetName("value_set"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), col("uint8"), vset(value_set), OperationType::TERNARY);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryNonBoolColCondition) {
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("uint8"), ColumnName("uint8"), ColumnName("uint8"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("uint8"), col("uint8"), col("uint8"), OperationType::TERNARY);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryBitsetCondition) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ExpressionName("bitset"), ColumnName("int32"), ColumnName("uint8"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(bitset_node(), col("int32"), col("uint8"), OperationType::TERNARY);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -564,12 +421,7 @@ TEST_F(AstParsingOutputTypesTest, TernaryBitsetCondition) {
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryStringColCol) {
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ColumnName("string"), ColumnName("string"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), col("string"), col("string"), OperationType::TERNARY);
     ProjectClause project_clause{{"string"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -579,13 +431,7 @@ TEST_F(AstParsingOutputTypesTest, TernaryStringColCol) {
 
 TEST_F(AstParsingOutputTypesTest, TernaryNumericColVal) {
     auto value = std::make_shared<Value>(construct_value<uint16_t>(5));
-    ec.add_value("5", value);
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ColumnName("uint8"), ValueName("5"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), col("uint8"), val(value), OperationType::TERNARY);
     ProjectClause project_clause{{"uint8"}, "root", ec};
     auto output_schema = project_clause.modify_schema(initial_schema());
     auto stream_desc = initial_schema().stream_descriptor();
@@ -594,50 +440,26 @@ TEST_F(AstParsingOutputTypesTest, TernaryNumericColVal) {
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryNumericColStringCol) {
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ColumnName("int32"), ColumnName("string"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), col("int32"), col("string"), OperationType::TERNARY);
     ProjectClause project_clause{{"int32", "string"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryNumericColBitset) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ColumnName("int32"), ExpressionName("bitset"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), col("int32"), bitset_node(), OperationType::TERNARY);
     ProjectClause project_clause{{"int32", "uint8"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema(initial_schema()), UserInputException);
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryBitsetBoolCol) {
-    ec.add_expression_node("bitset", bitset_node());
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ExpressionName("bitset"), ColumnName("bool"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), bitset_node(), col("bool"), OperationType::TERNARY);
     FilterClause filter_clause{{"int32", "uint8", "bool"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());
 }
 
 TEST_F(AstParsingOutputTypesTest, TernaryBitsetBitset) {
-    ec.add_expression_node("bitset_1", bitset_node());
-    ec.add_expression_node("bitset_2", bitset_node());
-    ec.add_expression_node(
-            "root",
-            std::make_shared<ExpressionNode>(
-                    ColumnName("bool"), ExpressionName("bitset_1"), ExpressionName("bitset_2"), OperationType::TERNARY
-            )
-    );
+    ec.root_ = node(col("bool"), bitset_node(), bitset_node(), OperationType::TERNARY);
     FilterClause filter_clause{{"int32", "uint8", "bool"}, ec, {}};
     auto output_schema = filter_clause.modify_schema(initial_schema());
     ASSERT_EQ(output_schema.stream_descriptor(), initial_schema().stream_descriptor());

--- a/cpp/arcticdb/processing/test/test_output_schema_basic.cpp
+++ b/cpp/arcticdb/processing/test/test_output_schema_basic.cpp
@@ -10,6 +10,7 @@
 
 #include <gtest/gtest.h>
 #include <arcticdb/processing/clause.hpp>
+#include <arcticdb/processing/test/ast_test_helpers.hpp>
 #include <arcticdb/util/test/generators.hpp>
 #include <arcticdb/processing/grouper.hpp>
 
@@ -109,28 +110,22 @@ TEST(OutputSchema, FilterClauseColumnPresence) {
     norm_meta.mutable_df()->mutable_common()->mutable_index()->set_step(1);
 
     // All required columns present in StreamDescriptor
-    auto node = std::make_shared<ExpressionNode>(ColumnName("col1"), ColumnName("col3"), OperationType::EQ);
     ExpressionContext ec;
-    ec.root_node_name_ = ExpressionName("blah");
-    ec.add_expression_node("blah", node);
+    ec.root_ = node(col("col1"), col("col3"), OperationType::EQ);
     FilterClause filter_clause{{"col1", "col3"}, ec, {}};
     auto output_schema = filter_clause.modify_schema({stream_desc.clone(), norm_meta});
     ASSERT_EQ(output_schema.stream_descriptor(), stream_desc);
     ASSERT_TRUE(MessageDifferencer::Equals(output_schema.norm_metadata_, norm_meta));
 
     // Some, but not all required columns present in StreamDescriptor
-    node = std::make_shared<ExpressionNode>(ColumnName("col1"), ColumnName("col4"), OperationType::EQ);
     ec = ExpressionContext();
-    ec.root_node_name_ = ExpressionName("blah");
-    ec.add_expression_node("blah", node);
+    ec.root_ = node(col("col1"), col("col4"), OperationType::EQ);
     filter_clause = FilterClause{{"col1", "col4"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema({stream_desc.clone(), norm_meta}), SchemaException);
 
     // No required columns present in StreamDescriptor
-    node = std::make_shared<ExpressionNode>(ColumnName("col4"), ColumnName("col5"), OperationType::EQ);
     ec = ExpressionContext();
-    ec.root_node_name_ = ExpressionName("blah");
-    ec.add_expression_node("blah", node);
+    ec.root_ = node(col("col4"), col("col5"), OperationType::EQ);
     filter_clause = FilterClause{{"col4", "col5"}, ec, {}};
     ASSERT_THROW(filter_clause.modify_schema({stream_desc.clone(), norm_meta}), SchemaException);
 }
@@ -148,10 +143,8 @@ TEST(OutputSchema, ProjectClauseColumnPresence) {
     norm_meta.mutable_df()->mutable_common()->mutable_index()->set_step(1);
 
     // All required columns present in StreamDescriptor
-    auto node = std::make_shared<ExpressionNode>(ColumnName("col1"), ColumnName("col3"), OperationType::ADD);
     ExpressionContext ec;
-    ec.root_node_name_ = ExpressionName("root");
-    ec.add_expression_node("root", node);
+    ec.root_ = node(col("col1"), col("col3"), OperationType::ADD);
     ProjectClause project_clause{{"col1", "col3"}, "root", ec};
     auto output_schema = project_clause.modify_schema({stream_desc.clone(), norm_meta});
     stream_desc.add_scalar_field(DataType::INT64, "root");
@@ -159,18 +152,14 @@ TEST(OutputSchema, ProjectClauseColumnPresence) {
     ASSERT_TRUE(MessageDifferencer::Equals(output_schema.norm_metadata_, norm_meta));
 
     // Some, but not all required columns present in StreamDescriptor
-    node = std::make_shared<ExpressionNode>(ColumnName("col1"), ColumnName("col4"), OperationType::ADD);
     ec = ExpressionContext();
-    ec.root_node_name_ = ExpressionName("root");
-    ec.add_expression_node("root", node);
+    ec.root_ = node(col("col1"), col("col4"), OperationType::ADD);
     project_clause = ProjectClause{{"col1", "col4"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema({stream_desc.clone(), norm_meta}), SchemaException);
 
     // No required columns present in StreamDescriptor
-    node = std::make_shared<ExpressionNode>(ColumnName("col4"), ColumnName("col5"), OperationType::ADD);
     ec = ExpressionContext();
-    ec.root_node_name_ = ExpressionName("root");
-    ec.add_expression_node("root", node);
+    ec.root_ = node(col("col4"), col("col5"), OperationType::ADD);
     project_clause = ProjectClause{{"col4", "col5"}, "root", ec};
     ASSERT_THROW(project_clause.modify_schema({stream_desc.clone(), norm_meta}), SchemaException);
 }

--- a/cpp/arcticdb/processing/test/test_query_planner.cpp
+++ b/cpp/arcticdb/processing/test/test_query_planner.cpp
@@ -1,0 +1,50 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <arcticdb/processing/query_planner.hpp>
+#include <arcticdb/processing/expression_context.hpp>
+#include <arcticdb/processing/test/ast_test_helpers.hpp>
+#include <arcticdb/util/error_code.hpp>
+
+using namespace arcticdb;
+
+namespace {
+
+std::shared_ptr<ExpressionContext> make_filter_context(bool dynamic_schema) {
+    auto context = std::make_shared<ExpressionContext>();
+    context->root_ = node(col("a"), val(int64_t{0}, DataType::INT64), OperationType::GT);
+    context->dynamic_schema_ = dynamic_schema;
+    return context;
+}
+
+} // namespace
+
+TEST(QueryPlanner, AndFilterExpressionContextsInheritsDynamicSchemaTrue) {
+    std::vector<std::shared_ptr<ExpressionContext>> contexts{make_filter_context(true), make_filter_context(true)};
+    auto merged = and_filter_expression_contexts(contexts);
+    ASSERT_TRUE(merged.root_ && merged.root_->is_operation());
+    ASSERT_TRUE(merged.dynamic_schema_);
+}
+
+TEST(QueryPlanner, AndFilterExpressionContextsInheritsDynamicSchemaFalse) {
+    std::vector<std::shared_ptr<ExpressionContext>> contexts{make_filter_context(false), make_filter_context(false)};
+    auto merged = and_filter_expression_contexts(contexts);
+    ASSERT_FALSE(merged.dynamic_schema_);
+}
+
+TEST(QueryPlanner, AndFilterExpressionContextsSingleInheritsDynamicSchema) {
+    std::vector<std::shared_ptr<ExpressionContext>> contexts{make_filter_context(true)};
+    auto merged = and_filter_expression_contexts(contexts);
+    ASSERT_TRUE(merged.dynamic_schema_);
+}
+
+TEST(QueryPlanner, AndFilterExpressionContextsRejectsInconsistentDynamicSchema) {
+    std::vector<std::shared_ptr<ExpressionContext>> contexts{make_filter_context(true), make_filter_context(false)};
+    ASSERT_THROW(and_filter_expression_contexts(contexts), InternalException);
+}

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -581,27 +581,21 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                                      left,
                              std::shared_ptr<ExpressionNode>
                                      right,
-                             OperationType operation_type,
-                             std::string label) {
+                             OperationType operation_type) {
                 return std::make_shared<ExpressionNode>(
-                        std::move(condition), std::move(left), std::move(right), operation_type, std::move(label)
+                        std::move(condition), std::move(left), std::move(right), operation_type
                 );
             }))
             .def(py::init([](std::shared_ptr<ExpressionNode> left,
                              std::shared_ptr<ExpressionNode>
                                      right,
-                             OperationType operation_type,
-                             std::string label) {
-                return std::make_shared<ExpressionNode>(
-                        std::move(left), std::move(right), operation_type, std::move(label)
-                );
+                             OperationType operation_type) {
+                return std::make_shared<ExpressionNode>(std::move(left), std::move(right), operation_type);
             }))
-            .def(py::init([](std::shared_ptr<ExpressionNode> left, OperationType operation_type, std::string label) {
-                return std::make_shared<ExpressionNode>(std::move(left), operation_type, std::move(label));
+            .def(py::init([](std::shared_ptr<ExpressionNode> left, OperationType operation_type) {
+                return std::make_shared<ExpressionNode>(std::move(left), operation_type);
             }))
-            .def(py::init([](ExpressionNode::Leaf leaf, std::string label) {
-                return std::make_shared<ExpressionNode>(std::move(leaf), std::move(label));
-            }));
+            .def(py::init([](ExpressionNode::Leaf leaf) { return std::make_shared<ExpressionNode>(std::move(leaf)); }));
 
     py::enum_<PipelineOptimisation>(version, "PipelineOptimisation")
             .value("SPEED", PipelineOptimisation::SPEED)

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -575,27 +575,32 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
         return ColumnName(name);
     }));
 
-    py::class_<ValueName>(version, "ValueName").def(py::init([](const std::string& name) { return ValueName(name); }));
-
-    py::class_<ValueSetName>(version, "ValueSetName").def(py::init([](const std::string& name) {
-        return ValueSetName(name);
-    }));
-
-    py::class_<ExpressionName>(version, "ExpressionName").def(py::init([](const std::string& name) {
-        return ExpressionName(name);
-    }));
-
-    py::class_<RegexName>(version, "RegexName").def(py::init([](const std::string& name) { return RegexName(name); }));
-
     py::class_<ExpressionNode, std::shared_ptr<ExpressionNode>>(version, "ExpressionNode")
-            .def(py::init([](VariantNode condition, VariantNode left, VariantNode right, OperationType operation_type) {
-                return ExpressionNode(condition, left, right, operation_type);
+            .def(py::init([](std::shared_ptr<ExpressionNode> condition,
+                             std::shared_ptr<ExpressionNode>
+                                     left,
+                             std::shared_ptr<ExpressionNode>
+                                     right,
+                             OperationType operation_type,
+                             std::string label) {
+                return std::make_shared<ExpressionNode>(
+                        std::move(condition), std::move(left), std::move(right), operation_type, std::move(label)
+                );
             }))
-            .def(py::init([](VariantNode left, VariantNode right, OperationType operation_type) {
-                return ExpressionNode(left, right, operation_type);
+            .def(py::init([](std::shared_ptr<ExpressionNode> left,
+                             std::shared_ptr<ExpressionNode>
+                                     right,
+                             OperationType operation_type,
+                             std::string label) {
+                return std::make_shared<ExpressionNode>(
+                        std::move(left), std::move(right), operation_type, std::move(label)
+                );
             }))
-            .def(py::init([](VariantNode left, OperationType operation_type) {
-                return ExpressionNode(left, operation_type);
+            .def(py::init([](std::shared_ptr<ExpressionNode> left, OperationType operation_type, std::string label) {
+                return std::make_shared<ExpressionNode>(std::move(left), operation_type, std::move(label));
+            }))
+            .def(py::init([](ExpressionNode::Leaf leaf, std::string label) {
+                return std::make_shared<ExpressionNode>(std::move(leaf), std::move(label));
             }));
 
     py::enum_<PipelineOptimisation>(version, "PipelineOptimisation")
@@ -608,11 +613,7 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
 
     py::class_<ExpressionContext, std::shared_ptr<ExpressionContext>>(version, "ExpressionContext")
             .def(py::init())
-            .def("add_expression_node", &ExpressionContext::add_expression_node)
-            .def("add_value", &ExpressionContext::add_value)
-            .def("add_value_set", &ExpressionContext::add_value_set)
-            .def("add_regex", &ExpressionContext::add_regex)
-            .def_readwrite("root_node_name", &ExpressionContext::root_node_name_);
+            .def_readwrite("root", &ExpressionContext::root_);
 
     py::class_<UpdateQuery>(version, "PythonVersionStoreUpdateQuery")
             .def(py::init())

--- a/docs/claude/cpp/PROCESSING.md
+++ b/docs/claude/cpp/PROCESSING.md
@@ -80,9 +80,9 @@ Represents: (a > 5) AND (b < 10)
 
 ### Expression Evaluation
 
-Expressions are evaluated via `compute()` on `ExpressionContext` which holds the expression tree.
+`ExpressionContext` (`expression_context.hpp`) holds the expression tree as a graph of `ExpressionNode`s rooted at `root_`, along with a `dynamic_schema_` flag. Expressions are evaluated by calling `compute()` on `root_`, which recurses into its children. Results of subexpressions are memoized on the `ProcessingUnit` (keyed on each node's `label_`, deep-compared on a hit) so shared subtrees are evaluated only once.
 
-`ExpressionContext` (`expression_context.hpp`) also supports `merge_from()` to combine multiple contexts (used when AND-ing together filter clause expressions for column stats evaluation). `ConstantMap::contains()` checks whether a name is present.
+Multiple filter contexts are combined into one by `and_filter_expression_contexts()` (`query_planner.cpp`), which AND-s their root nodes into a single graph. This is used when AND-ing together filter clause expressions for column stats evaluation.
 
 ## Operation Dispatch
 
@@ -199,7 +199,7 @@ A processing unit holds data being processed through the clause pipeline.
 - `segments_`, `row_ranges_`, `col_ranges_`, `atom_keys_` - Associated data vectors (same length, elements at same index are related)
 - `bucket_` - For partitioned operations
 - `expression_context_` - AST for filter/projection
-- `computed_data_` - Cached expression results
+- `computed_data_` - Memoized expression results, keyed on each node's `label_` (one slot per label, deep-compared on a hit so colliding labels never return a wrong result)
 
 Key methods: `set_segments()`, `set_row_ranges()`, `set_col_ranges()`, `set_atom_keys()`, `apply_filter()`, `truncate()`.
 

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -1278,14 +1278,14 @@ def visit_expression(expr):
         if isinstance(node, ExpressionNode):
             if node.operator == COLUMN:
                 input_columns.add(node.left)
-                return _ExpressionNode(_ColumnName(node.left), 'Column["{}"]'.format(node.left))
+                return _ExpressionNode(_ColumnName(node.left))
             return _visit(node)
         elif isinstance(node, (np.ndarray, list)):
-            return _ExpressionNode(_ValueSet(node), to_string(node))
+            return _ExpressionNode(_ValueSet(node))
         elif isinstance(node, _RegexGeneric):
-            return _ExpressionNode(node, to_string(node))
+            return _ExpressionNode(node)
         else:
-            return _ExpressionNode(create_value(node), to_string(node))
+            return _ExpressionNode(create_value(node))
 
     def _visit(node):
         if isinstance(node, bool):
@@ -1296,12 +1296,12 @@ def visit_expression(expr):
             check(node.right is not None, "Ternary operator requires three inputs")
             condition = _visit_child(node.condition)
             right = _visit_child(node.right)
-            return _ExpressionNode(condition, left, right, node.operator, node.get_name())
+            return _ExpressionNode(condition, left, right, node.operator)
         elif node.right is not None:
             right = _visit_child(node.right)
-            return _ExpressionNode(left, right, node.operator, node.get_name())
+            return _ExpressionNode(left, right, node.operator)
         else:
-            return _ExpressionNode(left, node.operator, node.get_name())
+            return _ExpressionNode(left, node.operator)
 
     expression_context = _ExpressionContext()
     input_columns = set()
@@ -1310,5 +1310,5 @@ def visit_expression(expr):
     elif isinstance(expr, (np.ndarray, list)):
         raise ArcticNativeException("Query cannot create a new column from a list/set/array of values")
     else:
-        expression_context.root = _ExpressionNode(create_value(expr), to_string(expr))
+        expression_context.root = _ExpressionNode(create_value(expr))
     return input_columns, expression_context

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -38,11 +38,7 @@ from arcticdb_ext.version_store import DateRangeClause as _DateRangeClause
 from arcticdb_ext.version_store import ConcatClause as _ConcatClause
 from arcticdb_ext.version_store import JoinType as _JoinType
 from arcticdb_ext.version_store import RowRangeType as _RowRangeType
-from arcticdb_ext.version_store import ExpressionName as _ExpressionName
 from arcticdb_ext.version_store import ColumnName as _ColumnName
-from arcticdb_ext.version_store import ValueName as _ValueName
-from arcticdb_ext.version_store import ValueSetName as _ValueSetName
-from arcticdb_ext.version_store import RegexName as _RegexName
 from arcticdb_ext.version_store import Value as _Value
 from arcticdb_ext.version_store import ValueSet as _ValueSet
 from arcticdb_ext.version_store import (
@@ -1278,89 +1274,41 @@ def to_string(leaf):
 
 
 def visit_expression(expr):
+    def _visit_child(node):
+        if isinstance(node, ExpressionNode):
+            if node.operator == COLUMN:
+                input_columns.add(node.left)
+                return _ExpressionNode(_ColumnName(node.left), 'Column["{}"]'.format(node.left))
+            return _visit(node)
+        elif isinstance(node, (np.ndarray, list)):
+            return _ExpressionNode(_ValueSet(node), to_string(node))
+        elif isinstance(node, _RegexGeneric):
+            return _ExpressionNode(node, to_string(node))
+        else:
+            return _ExpressionNode(create_value(node), to_string(node))
+
     def _visit(node):
-        def _visit_child(node):
-            def _handle_leaf(node):
-                key = to_string(node)
-                if isinstance(node, (np.ndarray, list)):
-                    # There is a possibility that two distinct value sets have the same repr, eiter if the first 100
-                    # chars match, or if the repr is truncated like '[   0    1    2 ... 9997 9998 9999]'
-                    # Append -vX to handle this case, while keeping ValueSet keys short and readable in most cases
-                    if key not in valueset_keys:
-                        valueset_keys[key] = 0
-                    else:
-                        valueset_keys[key] += 1
-                    key = key + "-v" + str(valueset_keys[key])
-                    expression_context.add_value_set(key, _ValueSet(node))
-                    return _ValueSetName(key), key
-                elif isinstance(node, _RegexGeneric):
-                    expression_context.add_regex(key, node)
-                    return _RegexName(key), None
-                else:
-                    expression_context.add_value(key, create_value(node))
-                    return _ValueName(key), None
-
-            if isinstance(node, ExpressionNode):
-                if node.operator == COLUMN:
-                    input_columns.add(node.left)
-                    return _ColumnName(node.left), None
-                else:
-                    child_key = _visit(node)
-                    return _ExpressionName(child_key), child_key
-            else:
-                return _handle_leaf(node)
-
-        # Make sure we disambiguate non-leaf nodes - this is important for ISIN([V1]) - see the -vX
-        # remark above in the leaf node handling.
-        def _operand_name(operand, child_key, use_to_string):
-            if isinstance(operand, ExpressionNode):
-                if operand.operator == COLUMN:
-                    return 'Column["{}"]'.format(operand.left)
-                return child_key
-            if isinstance(operand, (np.ndarray, list)):
-                return child_key
-            return to_string(operand) if use_to_string else str(operand)
-
         if isinstance(node, bool):
             raise ArcticNativeException("Query is trivially {}".format(node))
 
-        left, left_key = _visit_child(node.left)
-        condition_key = right_key = None
+        left = _visit_child(node.left)
         if node.condition is not None:
             check(node.right is not None, "Ternary operator requires three inputs")
-            condition, condition_key = _visit_child(node.condition)
-            right, right_key = _visit_child(node.right)
-            expression_node = _ExpressionNode(condition, left, right, node.operator)
+            condition = _visit_child(node.condition)
+            right = _visit_child(node.right)
+            return _ExpressionNode(condition, left, right, node.operator, node.get_name())
         elif node.right is not None:
-            right, right_key = _visit_child(node.right)
-            expression_node = _ExpressionNode(left, right, node.operator)
+            right = _visit_child(node.right)
+            return _ExpressionNode(left, right, node.operator, node.get_name())
         else:
-            expression_node = _ExpressionNode(left, node.operator)
-
-        if node.operator in [_OperationType.ABS, _OperationType.NEG, _OperationType.NOT]:
-            key = "{}({})".format(node.operator.name, _operand_name(node.left, left_key, False))
-        elif node.operator == _OperationType.TERNARY:
-            key = "{} if {} else {}".format(
-                _operand_name(node.left, left_key, False),
-                _operand_name(node.condition, condition_key, False),
-                _operand_name(node.right, right_key, False),
-            )
-        else:
-            right_name = to_string(None) if node.right is None else _operand_name(node.right, right_key, True)
-            key = "({} {} {})".format(_operand_name(node.left, left_key, True), node.operator.name, right_name)
-        expression_context.add_expression_node(key, expression_node)
-        return key
+            return _ExpressionNode(left, node.operator, node.get_name())
 
     expression_context = _ExpressionContext()
     input_columns = set()
-    valueset_keys = dict()
     if isinstance(expr, ExpressionNode):
-        root_key = _visit(expr)
-        expression_context.root_node_name = _ExpressionName(root_key)
+        expression_context.root = _visit(expr)
     elif isinstance(expr, (np.ndarray, list)):
         raise ArcticNativeException("Query cannot create a new column from a list/set/array of values")
     else:
-        key = to_string(expr)
-        expression_context.add_value(key, create_value(expr))
-        expression_context.root_node_name = _ValueName(key)
+        expression_context.root = _ExpressionNode(create_value(expr), to_string(expr))
     return input_columns, expression_context

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -1292,46 +1292,71 @@ def visit_expression(expr):
                         valueset_keys[key] += 1
                     key = key + "-v" + str(valueset_keys[key])
                     expression_context.add_value_set(key, _ValueSet(node))
-                    return _ValueSetName(key)
+                    return _ValueSetName(key), key
                 elif isinstance(node, _RegexGeneric):
                     expression_context.add_regex(key, node)
-                    return _RegexName(key)
+                    return _RegexName(key), None
                 else:
                     expression_context.add_value(key, create_value(node))
-                    return _ValueName(key)
+                    return _ValueName(key), None
 
             if isinstance(node, ExpressionNode):
                 if node.operator == COLUMN:
                     input_columns.add(node.left)
-                    return _ColumnName(node.left)
+                    return _ColumnName(node.left), None
                 else:
-                    _visit(node)
-                    return _ExpressionName(node.get_name())
+                    child_key = _visit(node)
+                    return _ExpressionName(child_key), child_key
             else:
                 return _handle_leaf(node)
+
+        # Make sure we disambiguate non-leaf nodes - this is important for ISIN([V1]) - see the -vX
+        # remark above in the leaf node handling.
+        def _operand_name(operand, child_key, use_to_string):
+            if isinstance(operand, ExpressionNode):
+                if operand.operator == COLUMN:
+                    return 'Column["{}"]'.format(operand.left)
+                return child_key
+            if isinstance(operand, (np.ndarray, list)):
+                return child_key
+            return to_string(operand) if use_to_string else str(operand)
 
         if isinstance(node, bool):
             raise ArcticNativeException("Query is trivially {}".format(node))
 
-        left = _visit_child(node.left)
+        left, left_key = _visit_child(node.left)
+        condition_key = right_key = None
         if node.condition is not None:
             check(node.right is not None, "Ternary operator requires three inputs")
-            condition = _visit_child(node.condition)
-            right = _visit_child(node.right)
+            condition, condition_key = _visit_child(node.condition)
+            right, right_key = _visit_child(node.right)
             expression_node = _ExpressionNode(condition, left, right, node.operator)
         elif node.right is not None:
-            right = _visit_child(node.right)
+            right, right_key = _visit_child(node.right)
             expression_node = _ExpressionNode(left, right, node.operator)
         else:
             expression_node = _ExpressionNode(left, node.operator)
-        expression_context.add_expression_node(node.get_name(), expression_node)
+
+        if node.operator in [_OperationType.ABS, _OperationType.NEG, _OperationType.NOT]:
+            key = "{}({})".format(node.operator.name, _operand_name(node.left, left_key, False))
+        elif node.operator == _OperationType.TERNARY:
+            key = "{} if {} else {}".format(
+                _operand_name(node.left, left_key, False),
+                _operand_name(node.condition, condition_key, False),
+                _operand_name(node.right, right_key, False),
+            )
+        else:
+            right_name = to_string(None) if node.right is None else _operand_name(node.right, right_key, True)
+            key = "({} {} {})".format(_operand_name(node.left, left_key, True), node.operator.name, right_name)
+        expression_context.add_expression_node(key, expression_node)
+        return key
 
     expression_context = _ExpressionContext()
     input_columns = set()
     valueset_keys = dict()
     if isinstance(expr, ExpressionNode):
-        _visit(expr)
-        expression_context.root_node_name = _ExpressionName(expr.get_name())
+        root_key = _visit(expr)
+        expression_context.root_node_name = _ExpressionName(root_key)
     elif isinstance(expr, (np.ndarray, list)):
         raise ArcticNativeException("Query cannot create a new column from a list/set/array of values")
     else:

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -260,13 +260,29 @@ class ExpressionNode:
                 if isinstance(self.left, ExpressionNode):
                     left = str(self.left)
                 else:
-                    left = to_string(self.left)
+                    left = self.to_string(self.left)
                 if isinstance(self.right, ExpressionNode):
                     right = str(self.right)
                 else:
-                    right = to_string(self.right)
+                    right = self.to_string(self.right)
                 self.name = "({} {} {})".format(left, self.operator.name, right)
         return self.name
+
+    @staticmethod
+    def to_string(leaf):
+        if isinstance(leaf, (np.ndarray, list)):
+            # Truncate value set keys to first 100 characters
+            key = str(leaf)[:100]
+        elif isinstance(leaf, _RegexGeneric):
+            key = "Regex({})".format(leaf.text())
+        else:
+            if isinstance(leaf, str):
+                key = "Str({})".format(leaf)
+            elif isinstance(leaf, bool):
+                key = "Bool({})".format(leaf)
+            else:
+                key = "Num({})".format(leaf)
+        return key
 
 
 def where(condition: Any, left: Any, right: Any) -> ExpressionNode:
@@ -1255,22 +1271,6 @@ def create_value(value):
     else:
         f = _Value
     return f(value)
-
-
-def to_string(leaf):
-    if isinstance(leaf, (np.ndarray, list)):
-        # Truncate value set keys to first 100 characters
-        key = str(leaf)[:100]
-    elif isinstance(leaf, _RegexGeneric):
-        key = "Regex({})".format(leaf.text())
-    else:
-        if isinstance(leaf, str):
-            key = "Str({})".format(leaf)
-        elif isinstance(leaf, bool):
-            key = "Bool({})".format(leaf)
-        else:
-            key = "Num({})".format(leaf)
-    return key
 
 
 def visit_expression(expr):

--- a/python/tests/unit/arcticdb/test_column_stats_isin.py
+++ b/python/tests/unit/arcticdb/test_column_stats_isin.py
@@ -605,7 +605,7 @@ def test_column_stats_isin_and_isnotin_colliding_value_sets_nonreg(
     lib = in_memory_version_store
 
     # value_set_one contains 5; value_set_two does not. The differing element (index 5) lands in
-    # numpy's elided middle, so str() of the two arrays is the same:
+    # numpy's skipped middle (see comments in visit_expression), so str() of the two arrays is the same:
     #
     # >>> str(value_set_one)
     # '[    0     1     2 ... 99997 99998 99999]'

--- a/python/tests/unit/arcticdb/test_column_stats_isin.py
+++ b/python/tests/unit/arcticdb/test_column_stats_isin.py
@@ -521,7 +521,7 @@ def test_column_stats_isin_multiple_clauses(
     lib.append(sym, df1)
     lib.append(sym, df2)
 
-    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+    lib.create_column_stats_experimental(sym)
 
     qs.enable()
     q = QueryBuilder()
@@ -554,7 +554,7 @@ def test_column_stats_isin_and_isnotin(
     lib.append(sym, df1)
     lib.append(sym, df2)
 
-    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+    lib.create_column_stats_experimental(sym)
 
     qs.enable()
     q = QueryBuilder()
@@ -582,7 +582,7 @@ def test_column_stats_isin_and_isnotin_single_valued(
 
     lib.write(sym, df0)
 
-    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+    lib.create_column_stats_experimental(sym)
 
     qs.enable()
     q = QueryBuilder()
@@ -623,7 +623,7 @@ def test_column_stats_isin_and_isnotin_colliding_value_sets_nonreg(
 
     lib.write(sym, df0)
 
-    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+    lib.create_column_stats_experimental(sym)
 
     qs.enable()
     q = QueryBuilder()

--- a/python/tests/unit/arcticdb/test_column_stats_isin.py
+++ b/python/tests/unit/arcticdb/test_column_stats_isin.py
@@ -504,3 +504,136 @@ def test_column_stats_isin_int64_min_not_treated_as_nat(
     expected = full_df[pandas_expr(full_df)]
     assert_frame_equal(expected, result)
     assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA read(s), got {table_data_reads}"
+
+
+def test_column_stats_isin_multiple_clauses(
+    in_memory_version_store,
+    clear_query_stats,
+    column_stats_filtering_enabled,
+):
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"col_1": [5, 10]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"col_1": [20, 30]}, index=pd.date_range("2000-01-03", periods=2))
+    df2 = pd.DataFrame({"col_1": [40, 50]}, index=pd.date_range("2000-01-05", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.append(sym, df2)
+
+    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[q["col_1"].isin([5, 10])]
+    q = q[q["col_1"].isin([5, 20])]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    full_df = pd.concat([df0, df1, df2])
+    expected = full_df[full_df["col_1"].isin([5, 10])]
+    expected = expected[expected["col_1"].isin([5, 20])]
+    assert_frame_equal(expected, result)
+    expected_reads = 1
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA read(s), got {table_data_reads}"
+
+
+def test_column_stats_isin_and_isnotin(
+    in_memory_version_store,
+    clear_query_stats,
+    column_stats_filtering_enabled,
+):
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"col_1": [5, 10]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"col_1": [20, 30]}, index=pd.date_range("2000-01-03", periods=2))
+    df2 = pd.DataFrame({"col_1": [40, 50]}, index=pd.date_range("2000-01-05", periods=2))
+
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.append(sym, df2)
+
+    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[q["col_1"].isin([5, 20, 30])]
+    q = q[q["col_1"].isnotin([20, 21])]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    full_df = pd.concat([df0, df1, df2])
+    expected = full_df[full_df["col_1"].isin([5, 30])]
+    assert_frame_equal(expected, result)
+    expected_reads = 2
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA read(s), got {table_data_reads}"
+
+
+def test_column_stats_isin_and_isnotin_single_valued(
+    in_memory_version_store,
+    clear_query_stats,
+    column_stats_filtering_enabled,
+):
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"col_1": [5, 5]}, index=pd.date_range("2000-01-01", periods=2))
+
+    lib.write(sym, df0)
+
+    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[q["col_1"].isin([5])]
+    q = q[q["col_1"].isnotin([6])]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    assert_frame_equal(df0, result)
+    expected_reads = 1
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA read(s), got {table_data_reads}"
+
+
+def test_column_stats_isin_and_isnotin_colliding_value_sets_nonreg(
+    in_memory_version_store,
+    clear_query_stats,
+    column_stats_filtering_enabled,
+):
+    lib = in_memory_version_store
+
+    # value_set_one contains 5; value_set_two does not. The differing element (index 5) lands in
+    # numpy's elided middle, so str() of the two arrays is the same:
+    #
+    # >>> str(value_set_one)
+    # '[    0     1     2 ... 99997 99998 99999]'
+    #
+    # This is a nonreg tests against a bug where when we merged the two filters together, we clashed on this
+    # value set name and incorrectly used it for both the isin and isnotin clause.
+    value_set_one = np.arange(0, 100000)
+    value_set_two = np.arange(0, 100000).copy()
+    value_set_two[5] = 100000
+    assert str(value_set_one) == str(value_set_two)
+    assert 5 in set(value_set_one.tolist())
+    assert 5 not in set(value_set_two.tolist())
+
+    df0 = pd.DataFrame({"col_1": [5, 5]}, index=pd.date_range("2000-01-01", periods=2))
+
+    lib.write(sym, df0)
+
+    lib.create_column_stats(sym, {"col_1": {"MINMAX"}})
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[q["col_1"].isin(value_set_one)]
+    q = q[q["col_1"].isnotin(value_set_two)]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    # 5 is in value_set_one and not in value_set_two, so both rows survive.
+    assert_frame_equal(df0, result)
+    expected_reads = 1
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA read(s), got {table_data_reads}"

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -570,7 +570,7 @@ def test_filter_isin_clashing_sets_same_column_nonreg(
     vals2_unique_val = 200000
     df = pd.DataFrame({"a": [vals1_unique_val, vals2_unique_val, 5000]}, index=np.arange(3))
     lib.write(symbol, df)
-    lib.create_column_stats(symbol, {"a": {"MINMAX"}})
+    lib.create_column_stats_experimental(symbol)
     q = QueryBuilder()
     vals1 = np.arange(10000, dtype=np.uint64)
     np.put(vals1, 5000, vals1_unique_val)
@@ -580,6 +580,23 @@ def test_filter_isin_clashing_sets_same_column_nonreg(
     q = q[(q["a"].isin(vals1)) | (q["a"].isin(vals2))]
     expected = df[(df["a"].isin(vals1)) | (df["a"].isin(vals2))]
     generic_filter_test(lib, symbol, q, expected)
+
+
+def test_filter_reused_derived_expression(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_filter_reused_derived_expression"
+    df = pd.DataFrame({"bid": np.arange(10, dtype=np.int64), "ask": np.arange(5, 15, dtype=np.int64)})
+    lib.write(sym, df)
+
+    limit = 3
+    q = QueryBuilder()
+    spread = q["bid"] - q["ask"]
+    q = q[(spread > 0) & (spread < limit)]
+
+    pandas_spread = df["bid"] - df["ask"]
+    expected = df[(pandas_spread > 0) & (pandas_spread < limit)].reset_index(drop=True)
+    received = lib.read(sym, query_builder=q).data
+    assert_frame_equal(expected, received)
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -582,6 +582,20 @@ def test_filter_isin_clashing_sets_same_column_nonreg(
     generic_filter_test(lib, symbol, q, expected)
 
 
+def test_filter_isin_same_values_different_columns(lmdb_version_store_v1, any_output_format):
+    # Check we don't conflate them.
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_isin_same_values_different_columns"
+    df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [3, 4, 1, 2]}, index=np.arange(4))
+    lib.write(symbol, df)
+    vals = [1, 2]
+    q = QueryBuilder()
+    q = q[q["a"].isin(vals) | q["b"].isin(vals)]
+    expected = df[df["a"].isin(vals) | df["b"].isin(vals)]
+    generic_filter_test(lib, symbol, q, expected)
+
+
 def test_filter_reused_derived_expression(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_filter_reused_derived_expression"

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -599,7 +599,7 @@ def test_filter_isin_same_values_different_columns(lmdb_version_store_v1, any_ou
 def test_filter_reused_derived_expression(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_filter_reused_derived_expression"
-    df = pd.DataFrame({"bid": np.arange(10, dtype=np.int64), "ask": np.arange(5, 15, dtype=np.int64)})
+    df = pd.DataFrame({"bid": np.arange(0, 20, 2, dtype=np.int64), "ask": np.arange(10, dtype=np.int64)})
     lib.write(sym, df)
 
     limit = 3

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -555,6 +555,33 @@ def test_filter_isin_clashing_sets(
     generic_filter_test(lib, symbol, q, expected)
 
 
+def test_filter_isin_clashing_sets_same_column_nonreg(
+    lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    # Nonreg test for a bug with filtering with isin with sets with the same str() form.
+    # Both isin operands are on the same column with the same operator, so their expression nodes
+    # used to share a name. The two value sets have identical str() (see comments in visit_expression),
+    # so they share a value-set name too. The node name collision meant one isin
+    # operand was dropped and the OR evaluated isin(vals1) | isin(vals1).
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_isin_clashing_sets_same_column"
+    vals1_unique_val = 100000
+    vals2_unique_val = 200000
+    df = pd.DataFrame({"a": [vals1_unique_val, vals2_unique_val, 5000]}, index=np.arange(3))
+    lib.write(symbol, df)
+    lib.create_column_stats(symbol, {"a": {"MINMAX"}})
+    q = QueryBuilder()
+    vals1 = np.arange(10000, dtype=np.uint64)
+    np.put(vals1, 5000, vals1_unique_val)
+    vals2 = np.arange(10000, dtype=np.uint64)
+    np.put(vals2, 5000, vals2_unique_val)
+    assert str(vals1) == str(vals2)
+    q = q[(q["a"].isin(vals1)) | (q["a"].isin(vals2))]
+    expected = df[(df["a"].isin(vals1)) | (df["a"].isin(vals2))]
+    generic_filter_test(lib, symbol, q, expected)
+
+
 @pytest.mark.parametrize(
     "df_col,isin_vals,expected_col",
     [

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -441,3 +441,18 @@ def test_project_fixed_value_dynamic(lmdb_version_store_dynamic_schema_v1, index
     q = QueryBuilder().apply("new_col", value)
     received = lib.read(sym, query_builder=q).data
     assert_frame_equal(expected, received, check_dtype=False)
+
+
+def test_projection_repeated_subexpression(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_projection_repeated_subexpression"
+    df = pd.DataFrame({"a": np.arange(10, dtype=np.int64), "b": np.arange(10, 20, dtype=np.int64)})
+    lib.write(sym, df)
+
+    q = QueryBuilder()
+    q = q.apply("x", (q["a"] + q["b"]) * (q["a"] + q["b"]))
+
+    expected = df.copy()
+    expected["x"] = (df["a"] + df["b"]) * (df["a"] + df["b"])
+    received = lib.read(sym, query_builder=q).data
+    assert_frame_equal(expected, received)

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -1240,11 +1240,11 @@ def test_to_strings():
 
     q = QueryBuilder()
     q["def"] = 2 * q["abc"]
-    assert str(q) == 'PROJECT Column["def"] = (Num(2) MUL Column["abc"])'
+    assert str(q) == 'PROJECT Column["def"] = (Val(UINT8:2) MUL Column["abc"])'
 
     q = QueryBuilder()
     q = q[q["abc"] > 3]
-    assert str(q) == 'WHERE (Column["abc"] GT Num(3))'
+    assert str(q) == 'WHERE (Column["abc"] GT Val(UINT8:3))'
 
     q = QueryBuilder()
     q = q[q["abc"] > 3]
@@ -1252,7 +1252,7 @@ def test_to_strings():
     q.row_range((1, 10))
     assert (
         str(q)
-        == 'WHERE (Column["abc"] GT Num(3)) | WHERE (Column["def"] GT Column["ghi"]) | ROWRANGE: RANGE, start=1, end=10'
+        == 'WHERE (Column["abc"] GT Val(UINT8:3)) | WHERE (Column["def"] GT Column["ghi"]) | ROWRANGE: RANGE, start=1, end=10'
     )
 
     q = QueryBuilder().resample("1min").agg({"col": "sum"})


### PR DESCRIPTION
## Bug 1

Fix for OR filters with isin with value sets with clashing str representations:

```
q = q[(q["a"].isin(vals1)) | (q["a"].isin(vals2))]
```

str(np.ndarray) truncates like [0, 1, 2, ... 99997, 99998, 99999] so it is easy for ValueSet str representations to clash. We have special handling for this to suffix -vX in the ValueSet leaf node, but there was no such handling for the ExpressionNode,

```
ISIN([VALUE_SET_1])
```

This meant that filters,

```
q["a"].isin(V1) | q["a"].isin(V2)
```

would incorrectly create a single node key, `ISIN [1, 2 ... 999]` and one of the two filters would effectively be dropped at evaluation time, since we used these strings to describe the edges in the AST.

## Bug 2

Drop release notes for this part - not user facing as column stats is feature flagged. Fixes expressions like this with column stats in the case where the two value sets have the same `str` representation:

```
    q = QueryBuilder()
    q = q[q["col_1"].isin(value_set_one)]
    q = q[q["col_1"].isnotin(value_set_two)]
```

Column stats AND-s filters together in to one in `and_filter_expression_contexts`., which merged the trees in two ExpressionContext objects together in to a graph, sharing leaf nodes where they matched on names.

These names in the original filter AST come from this in `processing.py`:

```
def to_string(leaf):
    if isinstance(leaf, (np.ndarray, list)):
        # Truncate value set keys to first 100 characters
        key = str(leaf)[:100]
    elif isinstance(leaf, _RegexGeneric):
        key = "Regex({})".format(leaf.text())
    else:
        if isinstance(leaf, str):
            key = "Str({})".format(leaf)
        elif isinstance(leaf, bool):
            key = "Bool({})".format(leaf)
        else:
            key = "Num({})".format(leaf)
    return key
```

so different ValueSets can clash, leading to an incorrect merged tree . Note `str(np.ndarray)` also truncates like `[0, 1, 2, ... 99997, 99998, 99999]`, so the "first 100 chars" is not the only problem.

## Fix

We now form the query AST as a graph in the frontend, rather than relying on string references to encode edges. This gets rid of the need to make the two fixes below.

We keep the concept of memoizing results, ie making sure we only evaluate subtrees once in cases like:

```
  # only want to calculate the isin once
  big = list(range(100_000))
  q = q[q["id"].isin(big) & (q["t"] > 0) | q["id"].isin(big)]

  # only want to calculate the spread once
  spread = q["bid"] - q["ask"]
  q = q[(spread > 0) & (spread < limit)]
```

We do this by looking up expressions that we are going to evaluate in a map of string label name to expression node and result. To guard against conflicts, we do a deep comparison against the node that created the result.