### PR TITLE
Support staging arrow strings with sorting

### DIFF
--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -53,6 +53,12 @@ struct JiveTable {
 
 enum class ExtraBufferType : uint8_t { OFFSET, STRING, ARRAY, BITMAP };
 
+// Controls whether external blocks get constructed via owning memcpy or with a non owning pointer assignment
+// ALWAYS - Always copies, result owns its memory
+// IF_NEEDED - Uses a non owning view when possible (e.g. numeric types). Copies when memory layout is different (e.g.
+// strings)
+enum class CopyMode : uint8_t { ALWAYS, IF_NEEDED };
+
 // Specifies a way to index extra buffers.
 // We can attach extra buffers to each offset and type. This is used for OutputFormat::ARROW to store the extra buffers
 // required to construct a string buffer.
@@ -313,7 +319,7 @@ class Column {
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_external_block(ssize_t row_offset, T* val, size_t size) {
+    void set_external_block(ssize_t row_offset, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
         util::check_arg(
                 last_logical_row_ + 1 == row_offset,
                 "set_external_block expected row {}, actual {} ",
@@ -321,7 +327,15 @@ class Column {
                 row_offset
         );
         auto bytes = sizeof(T) * size;
-        const_cast<ChunkedBuffer&>(data_.buffer()).add_external_block(reinterpret_cast<const uint8_t*>(val), bytes);
+        const auto* val_bytes_ptr = reinterpret_cast<const uint8_t*>(val);
+        if (copy_mode == CopyMode::ALWAYS) {
+            auto owned_data = allocate_data(bytes);
+            memcpy(owned_data, val_bytes_ptr, bytes);
+        } else {
+            auto& buffer = const_cast<ChunkedBuffer&>(data_.buffer());
+            buffer.add_external_block(val_bytes_ptr, bytes);
+        }
+        advance_data(bytes);
         last_logical_row_ += static_cast<ssize_t>(size);
         last_physical_row_ = last_logical_row_;
     }

--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -319,10 +319,10 @@ class Column {
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_external_block(ssize_t row_offset, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
+    void set_dense_block(ssize_t row_offset, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
         util::check_arg(
                 last_logical_row_ + 1 == row_offset,
-                "set_external_block expected row {}, actual {} ",
+                "set_dense_block expected row {}, actual {} ",
                 last_logical_row_ + 1,
                 row_offset
         );

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -175,8 +175,8 @@ class SegmentInMemory {
 
     template<class T>
     requires std::integral<T> || std::floating_point<T>
-    void set_external_block(position_t idx, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
-        impl_->set_external_block(idx, val, size, copy_mode);
+    void set_dense_block(position_t idx, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
+        impl_->set_dense_block(idx, val, size, copy_mode);
     }
 
     template<class T>

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -175,8 +175,8 @@ class SegmentInMemory {
 
     template<class T>
     requires std::integral<T> || std::floating_point<T>
-    void set_external_block(position_t idx, T* val, size_t size) {
-        impl_->set_external_block(idx, val, size);
+    void set_external_block(position_t idx, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
+        impl_->set_external_block(idx, val, size, copy_mode);
     }
 
     template<class T>

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -335,8 +335,8 @@ class SegmentInMemoryImpl {
 
     template<class T>
     requires std::integral<T> || std::floating_point<T>
-    void set_external_block(position_t idx, T* val, size_t size) {
-        column_unchecked(idx).set_external_block(row_id_ + 1, val, size);
+    void set_external_block(position_t idx, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
+        column_unchecked(idx).set_external_block(row_id_ + 1, val, size, copy_mode);
     }
 
     template<class T>

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -335,8 +335,8 @@ class SegmentInMemoryImpl {
 
     template<class T>
     requires std::integral<T> || std::floating_point<T>
-    void set_external_block(position_t idx, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
-        column_unchecked(idx).set_external_block(row_id_ + 1, val, size, copy_mode);
+    void set_dense_block(position_t idx, T* val, size_t size, CopyMode copy_mode = CopyMode::IF_NEEDED) {
+        column_unchecked(idx).set_dense_block(row_id_ + 1, val, size, copy_mode);
     }
 
     template<class T>

--- a/cpp/arcticdb/column_store/test/test_column.cpp
+++ b/cpp/arcticdb/column_store/test/test_column.cpp
@@ -286,8 +286,8 @@ TEST(ColumnData, IteratorSkipsTrailingEmptyBlock) {
 
     Column col(static_cast<TypeDescriptor>(TDT{}), 0, AllocationType::DYNAMIC, Sparsity::PERMITTED);
     std::array<int64_t, 3> data{10, 20, 30};
-    col.set_external_block(0, data.data(), data.size());
-    col.set_external_block(static_cast<ssize_t>(data.size()), static_cast<int64_t*>(nullptr), 0);
+    col.set_dense_block(0, data.data(), data.size());
+    col.set_dense_block(static_cast<ssize_t>(data.size()), static_cast<int64_t*>(nullptr), 0);
     ASSERT_EQ(col.buffer().num_blocks(), 2u);
     ASSERT_EQ(col.buffer().blocks()[0]->logical_size(), data.size() * sizeof(int64_t));
     ASSERT_EQ(col.buffer().blocks()[1]->logical_size(), 0u);
@@ -310,7 +310,7 @@ TEST(ColumnData, IteratorOnAllEmptyColumn) {
 
     // A single zero-size external block. begin must compare equal to end.
     Column empty_col(static_cast<TypeDescriptor>(TDT{}), 0, AllocationType::DYNAMIC, Sparsity::PERMITTED);
-    empty_col.set_external_block(0, static_cast<int64_t*>(nullptr), 0);
+    empty_col.set_dense_block(0, static_cast<int64_t*>(nullptr), 0);
     ASSERT_EQ(empty_col.buffer().num_blocks(), 1u);
     ASSERT_EQ(empty_col.buffer().blocks()[0]->logical_size(), 0u);
     auto empty_data = empty_col.data();
@@ -327,8 +327,8 @@ TEST(ColumnData, IteratorEqualityAcrossSharedExternalMemory) {
     Column col(static_cast<TypeDescriptor>(TDT{}), 0, AllocationType::DYNAMIC, Sparsity::NOT_PERMITTED);
 
     std::array<int64_t, 3> shared{100, 200, 300};
-    col.set_external_block(0, shared.data(), shared.size());
-    col.set_external_block(static_cast<ssize_t>(shared.size()), shared.data(), shared.size());
+    col.set_dense_block(0, shared.data(), shared.size());
+    col.set_dense_block(static_cast<ssize_t>(shared.size()), shared.data(), shared.size());
 
     auto column_data = col.data();
     auto it_in_block0 = column_data.citerator_at<TDT>(1);                 // (block 0, offset 1)

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -75,7 +75,7 @@ TimeseriesDescriptor index_descriptor_from_frame(
 ) {
     return make_timeseries_descriptor(
             frame->num_rows + existing_rows,
-            frame->desc_for_tsd(),
+            frame->compute_desc_for_tsd(),
             frame->norm_meta,
             std::move(frame->user_meta),
             std::move(next_key),

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -15,9 +15,9 @@ namespace arcticdb {
 TimeseriesDescriptor make_timeseries_descriptor(
         // TODO: It would be more explicit to use uint64_t instead of size_t. Not doing now as it involves a lot of type
         // changes and needs to be done carefully.
-        size_t total_rows, const StreamDescriptor& desc, proto::descriptors::NormalizationMetadata&& norm_meta,
-        std::optional<proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& prev_key,
-        std::optional<AtomKey>&& next_key, bool bucketize_dynamic
+        size_t total_rows, const StreamDescriptor& desc, const proto::descriptors::NormalizationMetadata& norm_meta,
+        std::optional<proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& next_key,
+        bool bucketize_dynamic
 ) {
     auto frame_desc = std::make_shared<FrameDescriptorImpl>();
     frame_desc->total_rows_ = total_rows;
@@ -33,9 +33,6 @@ TimeseriesDescriptor make_timeseries_descriptor(
     if (user_meta)
         *proto->mutable_user_meta() = std::move(*user_meta);
 
-    if (prev_key)
-        proto->mutable_next_key()->CopyFrom(key_to_proto(prev_key.value()));
-
     if (next_key)
         proto->mutable_next_key()->CopyFrom(key_to_proto(next_key.value()));
 
@@ -46,50 +43,42 @@ TimeseriesDescriptor make_timeseries_descriptor(
 }
 
 TimeseriesDescriptor make_timeseries_descriptor(
-        size_t total_rows, StreamDescriptor&& desc, proto::descriptors::NormalizationMetadata&& norm_meta,
-        std::optional<proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& prev_key,
-        std::optional<AtomKey>&& next_key, bool bucketize_dynamic
+        size_t total_rows, StreamDescriptor&& desc, const proto::descriptors::NormalizationMetadata& norm_meta,
+        std::optional<proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& next_key,
+        bool bucketize_dynamic
 ) {
     return make_timeseries_descriptor(
-            total_rows,
-            desc,
-            std::move(norm_meta),
-            std::move(um),
-            std::move(prev_key),
-            std::move(next_key),
-            bucketize_dynamic
+            total_rows, desc, norm_meta, std::move(um), std::move(next_key), bucketize_dynamic
     );
 }
 
 TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
-        const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, std::optional<AtomKey>&& prev_key,
+        const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, std::optional<AtomKey>&& next_key,
         bool bucketize_dynamic
 ) {
     return make_timeseries_descriptor(
             pipeline_context->total_rows_,
             pipeline_context->descriptor(),
-            std::move(*pipeline_context->norm_meta_),
+            *pipeline_context->norm_meta_,
             pipeline_context->user_meta_ ? std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>(
                                                    std::move(*pipeline_context->user_meta_)
                                            )
                                          : std::nullopt,
-            std::move(prev_key),
-            std::nullopt,
+            std::move(next_key),
             bucketize_dynamic
     );
 }
 
 TimeseriesDescriptor index_descriptor_from_frame(
         const std::shared_ptr<pipelines::InputFrame>& frame, size_t existing_rows,
-        std::optional<entity::AtomKey>&& prev_key
+        std::optional<entity::AtomKey>&& next_key
 ) {
     return make_timeseries_descriptor(
             frame->num_rows + existing_rows,
             frame->desc_for_tsd(),
-            std::move(frame->norm_meta),
+            frame->norm_meta,
             std::move(frame->user_meta),
-            std::move(prev_key),
-            std::nullopt,
+            std::move(next_key),
             frame->bucketize_dynamic
     );
 }

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -198,7 +198,7 @@ void set_integral_scalar_type(
         const auto c_style = util::is_cstyle_array<RawType>(tensor);
         if (c_style) {
             ARCTICDB_SAMPLE_DEFAULT(SetDataZeroCopy)
-            seg.set_external_block(col, ptr, rows_to_write, copy_mode);
+            seg.set_dense_block(col, ptr, rows_to_write, copy_mode);
         } else {
             ARCTICDB_SAMPLE_DEFAULT(SetDataFlatten)
             ARCTICDB_DEBUG(

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -57,17 +57,18 @@ inline size_t get_max_string_size(
 
 TimeseriesDescriptor make_timeseries_descriptor(
         size_t total_rows, const StreamDescriptor& desc,
-        arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta,
-        std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& prev_key,
-        std::optional<AtomKey>&& next_key, bool bucketize_dynamic
+        const arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
+        std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& next_key,
+        bool bucketize_dynamic
 );
 
 // The overload above returns a TSD that shares a std::shared_ptr<FieldCollection> with the input StreamDescriptor,
 // which is error-prone. However, it is sometimes the desired behaviour, so needs to still be available.
 TimeseriesDescriptor make_timeseries_descriptor(
-        size_t total_rows, StreamDescriptor&& desc, arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta,
-        std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& prev_key,
-        std::optional<AtomKey>&& next_key, bool bucketize_dynamic
+        size_t total_rows, StreamDescriptor&& desc,
+        const arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
+        std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& next_key,
+        bool bucketize_dynamic
 );
 
 TimeseriesDescriptor timseries_descriptor_from_index_segment(
@@ -76,13 +77,13 @@ TimeseriesDescriptor timseries_descriptor_from_index_segment(
 );
 
 TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
-        const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, std::optional<AtomKey>&& prev_key,
+        const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, std::optional<AtomKey>&& next_key,
         bool bucketize_dynamic
 );
 
 TimeseriesDescriptor index_descriptor_from_frame(
         const std::shared_ptr<pipelines::InputFrame>& frame, size_t existing_rows,
-        std::optional<entity::AtomKey>&& prev_key = {}
+        std::optional<entity::AtomKey>&& next_key = {}
 );
 
 template<typename RawType>

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -183,7 +183,7 @@ std::optional<convert::StringEncodingError> set_sequence_type(
 template<typename TagType, typename RawType>
 void set_integral_scalar_type(
         SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row,
-        bool sparsify_floats
+        bool sparsify_floats, CopyMode copy_mode
 ) {
     constexpr auto dt = TagType::DataTypeTag::data_type;
     auto ptr = tensor.template ptr_cast<RawType>(row);
@@ -197,7 +197,7 @@ void set_integral_scalar_type(
         const auto c_style = util::is_cstyle_array<RawType>(tensor);
         if (c_style) {
             ARCTICDB_SAMPLE_DEFAULT(SetDataZeroCopy)
-            seg.set_external_block(col, ptr, rows_to_write);
+            seg.set_external_block(col, ptr, rows_to_write, copy_mode);
         } else {
             ARCTICDB_SAMPLE_DEFAULT(SetDataFlatten)
             ARCTICDB_DEBUG(
@@ -321,7 +321,7 @@ std::optional<convert::StringEncodingError> set_array_type(
 
 inline std::optional<convert::StringEncodingError> segment_set_data(
         const TypeDescriptor& type_desc, const entity::NativeTensor& tensor, SegmentInMemory& seg, size_t col,
-        size_t rows_to_write, size_t row, bool sparsify_floats
+        size_t rows_to_write, size_t row, bool sparsify_floats, CopyMode copy_mode = CopyMode::IF_NEEDED
 ) {
     return type_desc.visit_tag([&](auto tag) {
         using TagType = std::decay_t<decltype(tag)>;
@@ -344,7 +344,9 @@ inline std::optional<convert::StringEncodingError> segment_set_data(
             if (maybe_error)
                 return maybe_error;
         } else if constexpr ((is_numeric_type(dt) || is_bool_type(dt)) && tag.dimension() == Dimension::Dim0) {
-            set_integral_scalar_type<TagType, RawType>(seg, tensor, col, rows_to_write, row, sparsify_floats);
+            set_integral_scalar_type<TagType, RawType>(
+                    seg, tensor, col, rows_to_write, row, sparsify_floats, copy_mode
+            );
         } else if constexpr (is_bool_object_type(dt)) {
             normalization::check<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(
                     tag.dimension() == Dimension::Dim0, "Multidimensional nullable booleans are not supported"

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -156,16 +156,17 @@ TimeseriesDescriptor get_merged_tsd(
 ) {
     auto existing_descriptor = existing_tsd.as_stream_descriptor();
     auto merged_descriptor = existing_descriptor;
+    const auto new_frame_desc = new_frame->desc_for_tsd();
     if (existing_tsd.total_rows() == 0) {
         // If the existing dataframe is empty, we use the descriptor of the new_frame
-        merged_descriptor = new_frame->desc_for_tsd();
+        merged_descriptor = new_frame_desc;
     } else if (dynamic_schema) {
         // In case of dynamic schema
-        const std::array fields_ptr = {new_frame->desc_for_tsd().fields_ptr()};
+        const std::array fields_ptr = {new_frame_desc.fields_ptr()};
         merged_descriptor = merge_descriptors(existing_descriptor, fields_ptr, {});
     } else {
         // In case of static schema, we only promote empty types and fixed->dynamic strings
-        const auto& new_fields = new_frame->desc_for_tsd().fields();
+        const auto& new_fields = new_frame_desc.fields();
         for (size_t i = 0; i < new_fields.size(); ++i) {
             const auto& new_type = new_fields.at(i).type();
             TypeDescriptor& result_type = merged_descriptor.mutable_field(i).mutable_type();
@@ -181,13 +182,12 @@ TimeseriesDescriptor get_merged_tsd(
             }
         }
     }
-    merged_descriptor.set_sorted(deduce_sorted(existing_descriptor.sorted(), new_frame->desc_for_tsd().sorted()));
+    merged_descriptor.set_sorted(deduce_sorted(existing_descriptor.sorted(), new_frame_desc.sorted()));
     return make_timeseries_descriptor(
             row_count,
             std::move(merged_descriptor),
             merge_normalization_metadata(existing_tsd, *new_frame),
             std::move(new_frame->user_meta),
-            std::nullopt,
             std::nullopt,
             new_frame->bucketize_dynamic
     );

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -156,7 +156,7 @@ TimeseriesDescriptor get_merged_tsd(
 ) {
     auto existing_descriptor = existing_tsd.as_stream_descriptor();
     auto merged_descriptor = existing_descriptor;
-    const auto new_frame_desc = new_frame->desc_for_tsd();
+    const auto new_frame_desc = new_frame->compute_desc_for_tsd();
     if (existing_tsd.total_rows() == 0) {
         // If the existing dataframe is empty, we use the descriptor of the new_frame
         merged_descriptor = new_frame_desc;

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -75,13 +75,6 @@ void InputFrame::set_from_columns(
     }
 
     num_rows = cols.empty() ? 0 : cols[0].row_count();
-    desc_for_tsd_ = desc_.clone();
-    for (auto& field : desc_for_tsd_->fields()) {
-        if (field.type().data_type() == DataType::UTF_DYNAMIC32) {
-            field.mutable_type() = TypeDescriptor(DataType::UTF_DYNAMIC64, field.type().dimension());
-        }
-    }
-
     columns_ = std::vector<FieldData>(std::make_move_iterator(cols.begin()), std::make_move_iterator(cols.end()));
     arrow_buffer_owners_ = std::move(arrow_buffer_owners);
     has_only_tensors_ = false;
@@ -91,7 +84,17 @@ StreamDescriptor& InputFrame::desc() { return desc_; }
 
 const StreamDescriptor& InputFrame::desc() const { return const_cast<InputFrame*>(this)->desc(); }
 
-const StreamDescriptor& InputFrame::desc_for_tsd() { return desc_for_tsd_.has_value() ? *desc_for_tsd_ : desc_; }
+StreamDescriptor InputFrame::desc_for_tsd() const {
+    if (has_only_tensors_)
+        return desc_;
+    auto result = desc_.clone();
+    for (auto& field : result.fields()) {
+        if (field.type().data_type() == DataType::UTF_DYNAMIC32) {
+            field.mutable_type() = TypeDescriptor(DataType::UTF_DYNAMIC64, field.type().dimension());
+        }
+    }
+    return result;
+}
 
 void InputFrame::set_offset(ssize_t off) const { offset = off; }
 

--- a/cpp/arcticdb/pipeline/input_frame.cpp
+++ b/cpp/arcticdb/pipeline/input_frame.cpp
@@ -84,7 +84,7 @@ StreamDescriptor& InputFrame::desc() { return desc_; }
 
 const StreamDescriptor& InputFrame::desc() const { return const_cast<InputFrame*>(this)->desc(); }
 
-StreamDescriptor InputFrame::desc_for_tsd() const {
+StreamDescriptor InputFrame::compute_desc_for_tsd() const {
     if (has_only_tensors_)
         return desc_;
     auto result = desc_.clone();

--- a/cpp/arcticdb/pipeline/input_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_frame.hpp
@@ -86,9 +86,10 @@ struct InputFrame {
     );
     StreamDescriptor& desc();
     const StreamDescriptor& desc() const;
-    // The descriptor of the input frame can differ than that for the timeseries descriptor in the index key for Arrow
-    // at least if there are string columns, and potentially in other cases as more type support is added
-    const StreamDescriptor& desc_for_tsd();
+    // The descriptor of the input frame can differ from that for the timeseries descriptor in the index key for
+    // Arrow string columns. Namely InputFrame may store offsets as 32bit integers, whereas on storage we always store
+    // 64bit offsets.
+    StreamDescriptor desc_for_tsd() const;
     void set_offset(ssize_t off) const;
     bool has_index() const;
     bool empty() const;
@@ -115,7 +116,6 @@ struct InputFrame {
     std::vector<FieldData> columns_;
     std::vector<sparrow::record_batch> arrow_buffer_owners_;
     StreamDescriptor desc_;
-    std::optional<StreamDescriptor> desc_for_tsd_;
 
     bool has_only_tensors_{true};
 };

--- a/cpp/arcticdb/pipeline/input_frame.hpp
+++ b/cpp/arcticdb/pipeline/input_frame.hpp
@@ -89,7 +89,7 @@ struct InputFrame {
     // The descriptor of the input frame can differ from that for the timeseries descriptor in the index key for
     // Arrow string columns. Namely InputFrame may store offsets as 32bit integers, whereas on storage we always store
     // 64bit offsets.
-    StreamDescriptor desc_for_tsd() const;
+    StreamDescriptor compute_desc_for_tsd() const;
     void set_offset(ssize_t off) const;
     bool has_index() const;
     bool empty() const;

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -35,12 +35,13 @@ namespace ranges = std::ranges;
 
 WriteToSegmentTask::WriteToSegmentTask(
         std::shared_ptr<InputFrame> frame, FrameSlice slice,
-        const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats
+        const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats, CopyMode copy_mode
 ) :
     frame_(std::move(frame)),
     slice_(std::move(slice)),
     typed_stream_version_(typed_stream_version),
-    sparsify_floats_(sparsify_floats) {
+    sparsify_floats_(sparsify_floats),
+    copy_mode_(copy_mode) {
     slice_.check_magic();
 }
 
@@ -352,9 +353,10 @@ Column WriteToSegmentTask::slice_column(const Column& source_column, size_t offs
         dest_column_type = make_scalar_type(DataType::BOOL8);
     } else if (is_sequence_type(source_column.type().data_type())) {
         dest_column_type = make_scalar_type(DataType::UTF_DYNAMIC64);
-    } else if (num_nulls == 0 && contiguous_slices.size() == 1) {
+    } else if (copy_mode_ == CopyMode::IF_NEEDED && num_nulls == 0 && contiguous_slices.size() == 1) {
         // Dense numeric column consisting of a single contiguous slice of memory is the only
-        // case where we can zero copy construct the result column.
+        // case where we can zero copy construct the result column. When CopyMode::ALWAYS is requested we fall through
+        // to the general path below, which allocates an owned column and copies the data into it.
         const auto& slice = contiguous_slices.front();
         ChunkedBuffer chunked_buffer;
         chunked_buffer.add_external_block(slice.block->ptr(slice.start_pos * type_size), slice.size * type_size);
@@ -394,7 +396,8 @@ SegmentInMemory WriteToSegmentTask::slice() const {
                 FieldRef{fd.type(), fd.name()},
                 std::make_shared<Column>(fd.type(), 0, AllocationType::DYNAMIC, Sparsity::NOT_PERMITTED)
         );
-        auto opt_error = segment_set_data(fd.type(), tensor, seg, abs_col, rows_to_write, offset_in_frame, sparsify);
+        auto opt_error =
+                segment_set_data(fd.type(), tensor, seg, abs_col, rows_to_write, offset_in_frame, sparsify, copy_mode_);
         if (opt_error.has_value()) {
             opt_error->raise(fd.name(), offset_in_frame);
         }

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -31,11 +31,14 @@ struct WriteToSegmentTask : public async::BaseTask {
     std::optional<TypedStreamVersion> typed_stream_version_;
     folly::Function<PartialKey(const FrameSlice&)> partial_key_gen_;
     bool sparsify_floats_;
+    // Controls whether the result SegmentInMemory can share memory with frame_ or must be explicitly copied
+    CopyMode copy_mode_;
     util::MagicNum<'W', 's', 'e', 'g'> magic_;
 
     WriteToSegmentTask(
             std::shared_ptr<InputFrame> frame, FrameSlice slice,
-            const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats = false
+            const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats = false,
+            CopyMode copy_mode = CopyMode::IF_NEEDED
     );
 
     std::tuple<PartialKey, SegmentInMemory, FrameSlice> operator()();

--- a/cpp/arcticdb/stream/aggregator.hpp
+++ b/cpp/arcticdb/stream/aggregator.hpp
@@ -219,8 +219,8 @@ class Aggregator {
     auto& segment() { return segment_; }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>
-    void set_external_block(std::size_t pos, T* val, size_t size) {
-        segment_.set_external_block(pos, val, size);
+    void set_dense_block(std::size_t pos, T* val, size_t size) {
+        segment_.set_dense_block(pos, val, size);
     }
 
     template<class T, std::enable_if_t<std::is_integral_v<T> || std::is_floating_point_v<T>, int> = 0>

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -132,23 +132,20 @@ std::set<StreamId> get_active_incomplete_refs(const std::shared_ptr<Store>& stor
 
 TimeseriesDescriptor pack_timeseries_descriptor(
         const StreamDescriptor& descriptor, size_t total_rows, std::optional<AtomKey>&& next_key,
-        arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta
+        const arcticdb::proto::descriptors::NormalizationMetadata& norm_meta
 ) {
-    auto tsd = make_timeseries_descriptor(
-            total_rows, descriptor, std::move(norm_meta), std::nullopt, std::nullopt, std::move(next_key), false
-    );
-    return tsd;
+    return make_timeseries_descriptor(total_rows, descriptor, norm_meta, std::nullopt, std::move(next_key), false);
 }
 
 SegmentInMemory incomplete_segment_from_frame(
-        const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& prev_key,
+        const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& next_key,
         bool sparsify_floats, CopyMode copy_mode
 ) {
     using namespace arcticdb::stream;
 
     const auto num_rows = frame->num_rows;
-    auto copy_prev_key = prev_key;
-    auto timeseries_desc = index_descriptor_from_frame(frame, 0, std::move(prev_key));
+    auto copy_next_key = next_key;
+    auto timeseries_desc = index_descriptor_from_frame(frame, 0, std::move(next_key));
     util::check(!timeseries_desc.fields().empty(), "Expected fields not to be empty in incomplete segment");
     auto norm_meta = timeseries_desc.proto().normalization();
     auto descriptor = timeseries_desc.as_stream_descriptor();
@@ -164,7 +161,7 @@ SegmentInMemory incomplete_segment_from_frame(
     auto output = std::move(std::get<SegmentInMemory>(result));
     output.descriptor().set_id(descriptor.id());
     output.set_timeseries_descriptor(
-            pack_timeseries_descriptor(descriptor, num_rows, std::move(copy_prev_key), std::move(norm_meta))
+            pack_timeseries_descriptor(descriptor, num_rows, std::move(copy_next_key), norm_meta)
     );
 
     ARCTICDB_DEBUG(
@@ -209,7 +206,6 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     // JiveTable This will avoid doing the extra copy and allocation we're doing here for sorting. It will also allow us
     // to unify `write_incomplete_with_sorting` with `write_incomple_frame`
     auto segment = incomplete_segment_from_frame(frame, std::nullopt, /*sparsify_floats=*/false, CopyMode::ALWAYS);
-    segment.descriptor().set_id(stream_id);
     if (options.sort_on_index) {
         util::check(frame->has_index(), "Sort requested on index but no index supplied");
         std::vector<std::string> cols;
@@ -227,11 +223,8 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
         do_sort(segment, *options.sort_columns);
     }
 
-    auto timeseries_desc = index_descriptor_from_frame(frame, 0, std::nullopt);
     auto stream_desc = frame->desc();
-    auto norm_meta = timeseries_desc.proto().normalization();
-    auto tsd = pack_timeseries_descriptor(frame->desc(), frame->num_rows, std::nullopt, std::move(norm_meta));
-    segment.set_timeseries_descriptor(tsd);
+    auto norm_meta = frame->norm_meta;
 
     bool is_timestamp_index = std::holds_alternative<stream::TimeseriesIndex>(frame->index);
     bool is_sorted = is_timestamp_index &&
@@ -247,10 +240,9 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
 
                 return folly::window(
                         std::move(segments),
-                        [is_sorted, stream_id, store, norm_meta, stream_desc](SegmentInMemory&& seg) mutable {
-                            auto tsd = pack_timeseries_descriptor(
-                                    stream_desc, seg.row_count(), std::nullopt, std::move(norm_meta)
-                            );
+                        [is_sorted, stream_id, store, norm_meta, stream_desc](SegmentInMemory&& seg) {
+                            auto tsd =
+                                    pack_timeseries_descriptor(stream_desc, seg.row_count(), std::nullopt, norm_meta);
                             seg.set_timeseries_descriptor(tsd);
                             if (is_sorted) {
                                 seg.descriptor().set_sorted(SortedValue::ASCENDING);
@@ -313,8 +305,7 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
         SegmentInMemory output{
                 FixedSchema{descriptor, index}.default_descriptor(), 0, AllocationType::DYNAMIC, Sparsity::NOT_PERMITTED
         };
-        output.set_timeseries_descriptor(
-                pack_timeseries_descriptor(descriptor, existing_rows, std::nullopt, std::move(norm_meta))
+        output.set_timeseries_descriptor(pack_timeseries_descriptor(descriptor, existing_rows, std::nullopt, norm_meta)
         );
         return store
                 ->write(KeyType::APPEND_DATA,
@@ -354,16 +345,12 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
                                                           std::tuple<PartialKey, SegmentInMemory, FrameSlice>&& ks
                                                   ) {
                                            auto& seg = std::get<SegmentInMemory>(ks);
-                                           auto norm_meta_copy = norm_meta;
-                                           auto prev_key = std::nullopt;
-                                           auto next_key = std::nullopt;
                                            TimeseriesDescriptor tsd = make_timeseries_descriptor(
                                                    seg.row_count(),
                                                    desc,
-                                                   std::move(norm_meta_copy),
+                                                   norm_meta,
                                                    user_meta,
-                                                   prev_key,
-                                                   next_key,
+                                                   std::nullopt,
                                                    bucketize_dynamic
                                            );
                                            seg.set_timeseries_descriptor(tsd);

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -140,77 +140,31 @@ TimeseriesDescriptor pack_timeseries_descriptor(
     return tsd;
 }
 
-SegmentInMemory incomplete_segment_from_tensor_frame(
-        const std::shared_ptr<pipelines::InputFrame>& frame, size_t existing_rows,
-        std::optional<entity::AtomKey>&& prev_key, bool allow_sparse
+SegmentInMemory incomplete_segment_from_frame(
+        const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& prev_key,
+        bool sparsify_floats, CopyMode copy_mode
 ) {
     using namespace arcticdb::stream;
-    util::check(
-            frame->has_only_tensors(),
-            "incomplete_segment_from_tensor_frame should not be called with InputFrame backed by SegmentInMemory"
-    );
 
-    auto offset_in_frame = 0;
     const auto num_rows = frame->num_rows;
-    const auto index = std::move(frame->index);
+    auto copy_prev_key = prev_key;
+    auto timeseries_desc = index_descriptor_from_frame(frame, 0, std::move(prev_key));
+    util::check(!timeseries_desc.fields().empty(), "Expected fields not to be empty in incomplete segment");
+    auto norm_meta = timeseries_desc.proto().normalization();
+    auto descriptor = timeseries_desc.as_stream_descriptor();
 
-    auto output = std::visit(
-            [&](const auto& idx) {
-                using IdxType = std::decay_t<decltype(idx)>;
-                using SingleSegmentAggregator = Aggregator<IdxType, FixedSchema, NeverSegmentPolicy>;
-                auto copy_prev_key = prev_key;
-                auto timeseries_desc = index_descriptor_from_frame(frame, existing_rows, std::move(prev_key));
-                util::check(!timeseries_desc.fields().empty(), "Expected fields not to be empty in incomplete segment");
-                auto norm_meta = timeseries_desc.proto().normalization();
-                auto descriptor = timeseries_desc.as_stream_descriptor();
-
-                SegmentInMemory output;
-                if (num_rows == 0) {
-                    output = SegmentInMemory(
-                            FixedSchema{descriptor, index}.default_descriptor(),
-                            0,
-                            AllocationType::DYNAMIC,
-                            Sparsity::NOT_PERMITTED
-                    );
-                    output.set_timeseries_descriptor(pack_timeseries_descriptor(
-                            descriptor, existing_rows, std::move(copy_prev_key), std::move(norm_meta)
-                    ));
-                    return output;
-                }
-
-                SingleSegmentAggregator agg{FixedSchema{descriptor, index}, [&](auto&& segment) {
-                                                auto tsd = pack_timeseries_descriptor(
-                                                        descriptor,
-                                                        existing_rows + num_rows,
-                                                        std::move(copy_prev_key),
-                                                        std::move(norm_meta)
-                                                );
-                                                segment.set_timeseries_descriptor(tsd);
-                                                output = std::forward<SegmentInMemory>(segment);
-                                            }};
-
-                // columns_[0] is the index (if present), columns_[1..] are data — mirrors the descriptor.
-                for (auto col = 0u; col < frame->num_columns(); ++col) {
-                    const auto& tensor = frame->get_tensor(col);
-                    auto opt_error = aggregator_set_data(
-                            agg.descriptor().field(col).type(),
-                            tensor,
-                            agg,
-                            col,
-                            num_rows,
-                            offset_in_frame,
-                            allow_sparse
-                    );
-                    if (opt_error.has_value()) {
-                        opt_error->raise(agg.descriptor().field(col).name());
-                    }
-                }
-
-                agg.end_block_write(num_rows);
-                agg.commit();
-                return output;
-            },
-            index
+    const auto index_field_count = frame->desc().index().field_count();
+    const auto field_count = frame->desc().field_count();
+    FrameSlice full_slice{
+            std::make_shared<StreamDescriptor>(frame->desc().clone()),
+            ColRange{index_field_count, field_count},
+            RowRange{0, num_rows}
+    };
+    auto result = WriteToSegmentTask(frame, std::move(full_slice), std::nullopt, sparsify_floats, copy_mode)();
+    auto output = std::move(std::get<SegmentInMemory>(result));
+    output.descriptor().set_id(descriptor.id());
+    output.set_timeseries_descriptor(
+            pack_timeseries_descriptor(descriptor, num_rows, std::move(copy_prev_key), std::move(norm_meta))
     );
 
     ARCTICDB_DEBUG(
@@ -247,33 +201,15 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     auto index_range = frame->index_range;
     const auto index = std::move(frame->index);
 
-    bool sparsify_floats{false};
-
-    auto next_key = std::nullopt;
-    // This clone is unnecessarily expensive. We should have a sort method that produces a new segment (current one is
-    // in-place)
-    // Note that we do not set `next_key` in the has_segment() case as that is only used by the library tool
-    // TODO: This clone is also insufficient if there are string columns in the input frame, fix with 18190648152
-    // Ideally remove incomplete_segment_from_tensor_frame entirely and just use WriteToSegmentTask
-    auto segment = [&]() -> SegmentInMemory {
-        if (frame->has_only_tensors()) {
-            return incomplete_segment_from_tensor_frame(frame, 0, next_key, sparsify_floats);
-        }
-        SegmentInMemory seg;
-        seg.descriptor().set_id(stream_id);
-        if (frame->has_index()) {
-            seg.descriptor().set_index({IndexDescriptorImpl::Type::TIMESTAMP, 1});
-        } else {
-            seg.descriptor().set_index({IndexDescriptorImpl::Type::ROWCOUNT, 0});
-        }
-        for (size_t i = 0; i < frame->num_columns(); ++i) {
-            seg.add_column(frame->desc().fields(i).name(), std::make_shared<Column>(frame->get_column(i).clone()));
-        }
-        if (frame->num_rows > 0) {
-            seg.set_row_data(frame->num_rows - 1);
-        }
-        return seg;
-    }();
+    // We use `CopyMode::ALWAYS` so that the resulting `segment` owns its buffers and we can sort inplace below.
+    // This is inefficient because `split` below would also copy the memory
+    // TODO: A better approach would be to:
+    // 1. Produce a JiveTable for the InputFrame directly
+    // 2. Modify WriteToSegmentTask to accept a JiveTable so it can copy from InputFrame and reorder according to the
+    // JiveTable This will avoid doing the extra copy and allocation we're doing here for sorting. It will also allow us
+    // to unify `write_incomplete_with_sorting` with `write_incomple_frame`
+    auto segment = incomplete_segment_from_frame(frame, std::nullopt, /*sparsify_floats=*/false, CopyMode::ALWAYS);
+    segment.descriptor().set_id(stream_id);
     if (options.sort_on_index) {
         util::check(frame->has_index(), "Sort requested on index but no index supplied");
         std::vector<std::string> cols;
@@ -592,7 +528,7 @@ void append_incomplete(
     auto desc = frame->desc().clone();
 
     auto index_range = frame->index_range;
-    auto segment = incomplete_segment_from_tensor_frame(frame, 0, std::move(next_key), false);
+    auto segment = incomplete_segment_from_frame(frame, std::move(next_key), false);
 
     auto new_key = store->write(KeyType::APPEND_DATA,
                                 VersionId(0),

--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -137,6 +137,15 @@ TimeseriesDescriptor pack_timeseries_descriptor(
     return make_timeseries_descriptor(total_rows, descriptor, norm_meta, std::nullopt, std::move(next_key), false);
 }
 
+static SegmentInMemory create_empty_segment(const StreamDescriptor& descriptor) {
+    return SegmentInMemory{
+            FixedSchema{descriptor, stream::index_type_from_descriptor(descriptor)}.default_descriptor(),
+            0,
+            AllocationType::DYNAMIC,
+            Sparsity::NOT_PERMITTED
+    };
+}
+
 SegmentInMemory incomplete_segment_from_frame(
         const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& next_key,
         bool sparsify_floats, CopyMode copy_mode
@@ -150,15 +159,20 @@ SegmentInMemory incomplete_segment_from_frame(
     auto norm_meta = timeseries_desc.proto().normalization();
     auto descriptor = timeseries_desc.as_stream_descriptor();
 
-    const auto index_field_count = frame->desc().index().field_count();
-    const auto field_count = frame->desc().field_count();
-    FrameSlice full_slice{
-            std::make_shared<StreamDescriptor>(frame->desc().clone()),
-            ColRange{index_field_count, field_count},
-            RowRange{0, num_rows}
-    };
-    auto result = WriteToSegmentTask(frame, std::move(full_slice), std::nullopt, sparsify_floats, copy_mode)();
-    auto output = std::move(std::get<SegmentInMemory>(result));
+    SegmentInMemory output;
+    if (frame->empty()) {
+        output = create_empty_segment(descriptor);
+    } else {
+        const auto index_field_count = frame->desc().index().field_count();
+        const auto field_count = frame->desc().field_count();
+        FrameSlice full_slice{
+                std::make_shared<StreamDescriptor>(frame->desc().clone()),
+                ColRange{index_field_count, field_count},
+                RowRange{0, num_rows}
+        };
+        auto result = WriteToSegmentTask(frame, std::move(full_slice), std::nullopt, sparsify_floats, copy_mode)();
+        output = std::move(std::get<SegmentInMemory>(result));
+    }
     output.descriptor().set_id(descriptor.id());
     output.set_timeseries_descriptor(
             pack_timeseries_descriptor(descriptor, num_rows, std::move(copy_next_key), norm_meta)
@@ -181,6 +195,21 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
         mutable_seg.sort(sort_columns);
 }
 
+static folly::Future<std::vector<AtomKey>> write_empty_incomplete_frame(
+        const std::shared_ptr<Store>& store, const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame,
+        const IndexRange& index_range
+) {
+    auto segment = incomplete_segment_from_frame(frame, std::nullopt, /*sparsify_floats=*/false);
+    return store
+            ->write(KeyType::APPEND_DATA,
+                    VersionId(0),
+                    stream_id,
+                    index_range.start_,
+                    index_range.end_,
+                    std::move(segment))
+            .thenValueInline([](VariantKey&& res) { return std::vector<AtomKey>{to_atom(std::move(res))}; });
+}
+
 [[nodiscard]] folly::Future<std::vector<arcticdb::entity::AtomKey>> write_incomplete_frame_with_sorting(
         const std::shared_ptr<Store>& store, const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame,
         const WriteIncompleteOptions& options
@@ -197,6 +226,11 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
 
     auto index_range = frame->index_range;
     const auto index = std::move(frame->index);
+
+    if (frame->empty())
+        // We still write in this case because a user might only stage empty segments. After the user finalizes
+        // they will just get an empty dataframe.
+        return write_empty_incomplete_frame(store, stream_id, frame, index_range);
 
     // We use `CopyMode::ALWAYS` so that the resulting `segment` owns its buffers and we can sort inplace below.
     // This is inefficient because `split` below would also copy the memory
@@ -284,7 +318,6 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     );
 
     auto index_range = frame->index_range;
-    const auto index = frame->index;
 
     WriteOptions write_options = options.write_options;
     write_options.column_group_size =
@@ -297,24 +330,7 @@ void do_sort(SegmentInMemory& mutable_seg, const std::vector<std::string> sort_c
     if (slices.empty()) {
         // We still write in this case because a user might only stage empty segments. After the user finalizes
         // they will just get an empty dataframe.
-        size_t existing_rows = 0;
-        auto timeseries_desc = index_descriptor_from_frame(frame, existing_rows, std::nullopt);
-        util::check(!timeseries_desc.fields().empty(), "Expected fields not to be empty in incomplete segment");
-        auto norm_meta = timeseries_desc.proto().normalization();
-        auto descriptor = timeseries_desc.as_stream_descriptor();
-        SegmentInMemory output{
-                FixedSchema{descriptor, index}.default_descriptor(), 0, AllocationType::DYNAMIC, Sparsity::NOT_PERMITTED
-        };
-        output.set_timeseries_descriptor(pack_timeseries_descriptor(descriptor, existing_rows, std::nullopt, norm_meta)
-        );
-        return store
-                ->write(KeyType::APPEND_DATA,
-                        VersionId(0),
-                        stream_id,
-                        index_range.start_,
-                        index_range.end_,
-                        std::move(output))
-                .thenValueInline([](VariantKey&& res) { return std::vector<AtomKey>{to_atom(std::move(res))}; });
+        return write_empty_incomplete_frame(store, stream_id, frame, index_range);
     }
 
     util::check(!slices.empty(), "Unexpected empty slice in write_incomplete_frame");

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -149,7 +149,7 @@ void append_incomplete(
 );
 
 SegmentInMemory incomplete_segment_from_frame(
-        const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& prev_key,
+        const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& next_key,
         bool sparsify_floats, CopyMode copy_mode = CopyMode::IF_NEEDED
 );
 

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -139,16 +139,18 @@ std::vector<AtomKey> write_parallel_impl(
 
 void write_head(const std::shared_ptr<Store>& store, const AtomKey& next_key, size_t total_rows);
 
+// Used by tick collector. Maintains a linked list of append_data keys
 void append_incomplete_segment(const std::shared_ptr<Store>& store, const StreamId& stream_id, SegmentInMemory&& seg);
 
+// Allows simulating tick collector appends from python. Not used by user facing APIs
 void append_incomplete(
         const std::shared_ptr<Store>& store, const StreamId& stream_id,
         const std::shared_ptr<pipelines::InputFrame>& frame, bool validate_index
 );
 
-SegmentInMemory incomplete_segment_from_tensor_frame(
-        const std::shared_ptr<pipelines::InputFrame>& frame, size_t existing_rows,
-        std::optional<entity::AtomKey>&& prev_key, bool allow_sparse
+SegmentInMemory incomplete_segment_from_frame(
+        const std::shared_ptr<pipelines::InputFrame>& frame, std::optional<entity::AtomKey>&& prev_key,
+        bool sparsify_floats, CopyMode copy_mode = CopyMode::IF_NEEDED
 );
 
 std::optional<int64_t> latest_incomplete_timestamp(const std::shared_ptr<Store>& store, const StreamId& stream_id);

--- a/cpp/arcticdb/stream/test/test_incompletes.cpp
+++ b/cpp/arcticdb/stream/test/test_incompletes.cpp
@@ -44,6 +44,22 @@ TEST(Append, Simple) {
     ASSERT_EQ(allocated_frame.row_count(), frame->num_rows);
 }
 
+TEST(Append, Empty) {
+    using namespace arcticdb;
+    using namespace arcticdb::pipelines;
+
+    // An empty (0-row) frame must not throw when building the incomplete segment: its tensors have null data pointers,
+    // so incomplete_segment_from_frame builds an empty segment directly rather than reading the tensors.
+    auto store = std::make_shared<InMemoryStore>();
+    StreamId stream_id{"test_append_empty"};
+    auto wrapper = get_test_simple_frame(stream_id, 0, 0);
+    append_incomplete(store, stream_id, wrapper.frame_, true);
+
+    auto entries = load_via_list(store, stream_id, false);
+    ASSERT_EQ(entries.size(), 1);
+    ASSERT_EQ(entries[0].total_rows_, 0);
+}
+
 TEST(Append, MergeDescriptorsPromote) {
     using namespace arcticdb;
 

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -93,9 +93,8 @@ SegmentInMemory LibraryTool::item_to_segment_in_memory(
             engine_.cfg().write_options().empty_types(),
             pipelines::SortednessScan::SKIP
     );
-    auto segment_in_memory = incomplete_segment_from_tensor_frame(
-            frame, 0, std::move(next_key), engine_.cfg().write_options().allow_sparse()
-    );
+    auto segment_in_memory =
+            incomplete_segment_from_frame(frame, std::move(next_key), engine_.cfg().write_options().allow_sparse());
     return segment_in_memory;
 }
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -690,9 +690,8 @@ VersionedItem LocalVersionedEngine::sort_index(
     auto time_series = make_timeseries_descriptor(
             total_rows,
             StreamDescriptor{tsd.as_stream_descriptor()},
-            std::move(*tsd.mutable_proto().mutable_normalization()),
+            tsd.proto().normalization(),
             std::move(*tsd.mutable_proto().mutable_user_meta()),
-            std::nullopt,
             std::nullopt,
             bucketize_dynamic
     );

--- a/cpp/arcticdb/version/test/test_sparse.cpp
+++ b/cpp/arcticdb/version/test/test_sparse.cpp
@@ -128,13 +128,7 @@ void append_incomplete_segment_backwards_compat(
     auto desc = stream_descriptor(stream_id, RowCountIndex{}, {});
 
     auto tsd = arcticdb::make_timeseries_descriptor(
-            seg_row_count,
-            std::move(desc),
-            NormalizationMetadata{},
-            std::nullopt,
-            std::nullopt,
-            std::move(next_key),
-            false
+            seg_row_count, std::move(desc), NormalizationMetadata{}, std::nullopt, std::move(next_key), false
     );
 
     seg.set_timeseries_descriptor(std::move(tsd));

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -3094,9 +3094,8 @@ folly::Future<VersionedItem> read_modify_write_impl(
                 const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                         row_count,
                         pipeline_context->descriptor(),
-                        std::move(*pipeline_context->norm_meta_),
+                        *pipeline_context->norm_meta_,
                         std::move(user_meta_proto),
-                        std::nullopt,
                         std::nullopt,
                         write_options.bucketize_dynamic
                 );
@@ -3173,9 +3172,8 @@ folly::Future<VersionedItem> merge_update_impl(
                 const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                         row_count,
                         pipeline_context->descriptor(),
-                        std::move(*pipeline_context->norm_meta_),
+                        *pipeline_context->norm_meta_,
                         pipeline_context->user_meta_ ? std::make_optional(std::move(source->user_meta)) : std::nullopt,
-                        std::nullopt,
                         std::nullopt,
                         write_options.bucketize_dynamic
                 );
@@ -3323,11 +3321,10 @@ folly::Future<std::optional<VersionedItem>> compact_data_impl(
                         TimeseriesDescriptor tsd = make_timeseries_descriptor(
                                 row_count,
                                 std::move(*pipeline_context->desc_),
-                                std::move(*pipeline_context->norm_meta_),
+                                *pipeline_context->norm_meta_,
                                 pipeline_context->user_meta_
                                         ? std::make_optional(std::move(*pipeline_context->user_meta_))
                                         : std::nullopt,
-                                std::nullopt,
                                 std::nullopt,
                                 write_options.bucketize_dynamic
                         );

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -867,6 +867,45 @@ def test_staging_with_sorting(in_memory_store_factory, arrow_output_format):
     assert_arrow_equal(expected, received)
 
 
+def test_staging_with_sorting_secondary_column(in_memory_store_factory, arrow_output_format):
+    lib = in_memory_store_factory(segment_row_size=2, dynamic_schema=True)
+    lib.set_output_format("pyarrow")
+    lib._set_allow_arrow_input()
+    sym = "test_staging_with_sorting_secondary_column"
+    # ts has duplicate values so the non-index sort column col0 breaks ties.
+    table = pa.table(
+        {
+            "ts": pa.array([2, 2, 1, 1], pa.timestamp("ns")),
+            "col0": pa.array([40, 30, 20, 10], pa.uint16()),
+            "col1": pa.array(["d", "c", "b", "a"], pa.string()),
+        }
+    )
+    input_table = to_format(table, arrow_output_format)
+    with assert_inputs_not_modified(input_table):
+        lib.stage(sym, input_table, sort_on_index=True, sort_columns=["col0"], index_column=True)
+    lib.compact_incomplete(sym, False, False)
+    expected = table.sort_by([("ts", "ascending"), ("col0", "ascending")])
+    received = lib.read(
+        sym,
+        output_format=arrow_output_format,
+        **string_format_kwargs(arrow_output_format, default=ArrowOutputStringFormat.SMALL_STRING),
+    ).data
+    assert_arrow_equal(expected, received)
+
+
+def test_staging_with_sorting_empty(in_memory_store_factory, arrow_output_format):
+    lib = in_memory_store_factory(segment_row_size=2, dynamic_schema=True)
+    lib.set_output_format("pyarrow")
+    lib._set_allow_arrow_input()
+    sym = "test_staging_with_sorting_empty"
+    table = pa.table({"ts": pa.array([], pa.timestamp("ns")), "col0": pa.array([], pa.uint16())})
+    input_table = to_format(table, arrow_output_format)
+    lib.stage(sym, input_table, sort_on_index=True, index_column=True)
+    lib.compact_incomplete(sym, False, False)
+    received = lib.read(sym, output_format=arrow_output_format).data
+    assert received.shape[0] == 0
+
+
 def test_recursive_normalizers(in_memory_version_store_arrow, all_recursive_metastructure_versions):
     lib = in_memory_version_store_arrow
     sym = "test_recursive_normalizers"

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -7,6 +7,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import gc
+from contextlib import contextmanager
 from hypothesis import given, settings
 import hypothesis.strategies as st
 import numpy as np
@@ -27,8 +28,17 @@ from arcticdb.util.test import (
 from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked
 from arcticdb.version_store._normalization import ArrowTableNormalizer
 from arcticdb_ext.storage import KeyType
-from tests.util.arrow import assert_arrow_equal, string_format_kwargs, to_format, undictionarify_table
+from tests.util.arrow import assert_arrow_equal, deep_copy, string_format_kwargs, to_format, undictionarify_table
 from tests.util.naughty_strings import read_big_list_of_naughty_strings
+
+
+@contextmanager
+def assert_inputs_not_modified(*inputs):
+    """Staging must not modify the caller's data, e.g. by sorting the underlying buffers in place."""
+    originals = [deep_copy(inp) for inp in inputs]
+    yield
+    for inp, original in zip(inputs, originals):
+        assert_arrow_equal(original, inp)
 
 
 def test_record_batches_roundtrip():
@@ -828,6 +838,7 @@ def test_staging_with_sorting(in_memory_store_factory, arrow_output_format):
             "col0": pa.array([0, 1, 2], pa.uint16()),
             "col1": pa.array([10, 11, 12], pa.uint8()),
             "col2": pa.array([20, 21, 22], pa.uint32()),
+            "col3": pa.array(["three", "one", "two"], pa.string()),
         }
     )
     table_1 = pa.table(
@@ -836,46 +847,24 @@ def test_staging_with_sorting(in_memory_store_factory, arrow_output_format):
             "col0": pa.array([3, 4, 5], pa.uint16()),
             "col1": pa.array([13, 14, 15], pa.uint8()),
             "col2": pa.array([23, 24, 25], pa.uint32()),
+            "col3": pa.array(["four", "six", "five"], pa.string()),
         }
     )
-    lib.stage(sym, to_format(table_0, arrow_output_format), sort_on_index=True, index_column=True)
-    lib.stage(sym, to_format(table_1, arrow_output_format), sort_on_index=True, index_column=True)
+    input_0 = to_format(table_0, arrow_output_format)
+    input_1 = to_format(table_1, arrow_output_format)
+    with assert_inputs_not_modified(input_0, input_1):
+        lib.stage(sym, input_0, sort_on_index=True, index_column=True)
+        lib.stage(sym, input_1, sort_on_index=True, index_column=True)
 
     assert len(lib_tool.find_keys_for_symbol(KeyType.APPEND_DATA, sym)) == 4
     lib.compact_incomplete(sym, False, False)
     expected = pa.concat_tables([table_0, table_1]).sort_by("ts")
-    received = lib.read(sym, output_format=arrow_output_format).data
+    received = lib.read(
+        sym,
+        output_format=arrow_output_format,
+        **string_format_kwargs(arrow_output_format, default=ArrowOutputStringFormat.SMALL_STRING),
+    ).data
     assert_arrow_equal(expected, received)
-
-
-# Merge with test_staging_with_sorting when 18190648152 is done
-@pytest.mark.xfail(reason="Not implemented yet, see issue 18190648152")
-def test_staging_with_sorting_strings(in_memory_store_factory):
-    lib = in_memory_store_factory(segment_row_size=2, dynamic_schema=True)
-    lib_tool = lib.library_tool()
-    lib.set_output_format("pyarrow")
-    lib._set_allow_arrow_input()
-    sym = "test_staging_with_sorting_strings"
-    table_0 = pa.table(
-        {
-            "ts": pa.array([3, 1, 2], pa.timestamp("ns")),
-            "col": pa.array(["three", "one", "two"], pa.string()),
-        }
-    )
-    table_1 = pa.table(
-        {
-            "ts": pa.array([4, 6, 5], pa.timestamp("ns")),
-            "col": pa.array(["four", "six", "five"], pa.string()),
-        }
-    )
-    lib.stage(sym, table_0, sort_on_index=True, index_column=True)
-    lib.stage(sym, table_1, sort_on_index=True, index_column=True)
-
-    assert len(lib_tool.find_keys_for_symbol(KeyType.APPEND_DATA, sym)) == 4
-    lib.compact_incomplete(sym, False, False)
-    expected = pa.concat_tables([table_0, table_1]).sort_by("ts")
-    received = lib.read(sym, arrow_string_format_default=ArrowOutputStringFormat.SMALL_STRING).data
-    assert expected.equals(received)
 
 
 def test_recursive_normalizers(in_memory_version_store_arrow, all_recursive_metastructure_versions):

--- a/python/tests/unit/arcticdb/version_store/test_sort.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort.py
@@ -199,6 +199,15 @@ def test_stage_finalize_sort_index(arctic_library):
     pd.testing.assert_frame_equal(result, expected)
 
 
+@pytest.mark.storage
+def test_stage_finalize_empty_with_sort_on_index(arctic_library):
+    symbol = "sym"
+    df = pd.DataFrame({"col": []}, index=pd.DatetimeIndex([], name="timestamp"))
+    arctic_library.stage(symbol, df, validate_index=False, sort_on_index=True)
+    arctic_library.finalize_staged_data(symbol)
+    assert_frame_equal(arctic_library.read(symbol).data, df)
+
+
 def test_stage_with_sort_index_chunking(lmdb_version_store_tiny_segment):
     symbol = "AAPL"
     lib = lmdb_version_store_tiny_segment  # 2 rows per segment, 2 cols per segment

--- a/python/tests/unit/arcticdb/version_store/test_sort.py
+++ b/python/tests/unit/arcticdb/version_store/test_sort.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import pandas as pd
 import numpy as np
 import pytest
@@ -7,6 +9,15 @@ from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import SortedValue
 
 from arcticdb.util.test import random_strings_of_length
+
+
+@contextmanager
+def assert_inputs_not_modified(*dfs):
+    """Staging must not modify the caller's input in place, e.g. by sorting the underlying buffers."""
+    originals = [df.copy(deep=True) for df in dfs]
+    yield
+    for df, original in zip(dfs, originals):
+        assert_frame_equal(df, original)
 
 
 @pytest.mark.storage
@@ -33,8 +44,9 @@ def test_stage_finalize(arctic_library):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
-    arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
+        arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
     arctic_library.finalize_staged_data(symbol)
     result = arctic_library.read(symbol).data
 
@@ -69,8 +81,9 @@ def test_stage_finalize_dynamic(arctic_library_dynamic):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
-    arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
+        arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
     arctic_library.finalize_staged_data(symbol)
     result = arctic_library.read(symbol).data
 
@@ -104,8 +117,9 @@ def test_stage_finalize_strings(arctic_library):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
-    arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
+        arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
     arctic_library.finalize_staged_data(symbol)
     result = arctic_library.read(symbol).data
 
@@ -141,8 +155,9 @@ def test_stage_finalize_strings_dynamic(arctic_library_dynamic):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
-    arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        arctic_library.stage(symbol, df1_shuffled, False, False, sort_cols)
+        arctic_library.stage(symbol, df2_shuffled, False, False, sort_cols)
     arctic_library.finalize_staged_data(symbol)
     result = arctic_library.read(symbol).data
 
@@ -174,8 +189,9 @@ def test_stage_finalize_sort_index(arctic_library):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    arctic_library.stage(symbol, df1_shuffled, False, True, None)
-    arctic_library.stage(symbol, df2_shuffled, False, True, None)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        arctic_library.stage(symbol, df1_shuffled, False, True, None)
+        arctic_library.stage(symbol, df2_shuffled, False, True, None)
     arctic_library.finalize_staged_data(symbol)
     result = arctic_library.read(symbol).data
 
@@ -197,7 +213,8 @@ def test_stage_with_sort_index_chunking(lmdb_version_store_tiny_segment):
     ).set_index("timestamp")
     df1_shuffled = df1.sample(frac=1)
 
-    lib.stage(symbol, df1_shuffled, validate_index=False, sort_on_index=True, sort_columns=None)
+    with assert_inputs_not_modified(df1_shuffled):
+        lib.stage(symbol, df1_shuffled, validate_index=False, sort_on_index=True, sort_columns=None)
 
     lib_tool = lib.library_tool()
     data_keys = lib_tool.find_keys_for_symbol(KeyType.APPEND_DATA, symbol)
@@ -232,7 +249,8 @@ def test_stage_with_sort_columns_not_ts(lmdb_version_store_v1):
     ).set_index("idx")
     df1_shuffled = df1.sample(frac=1)
 
-    lib.stage(symbol, df1_shuffled, validate_index=False, sort_on_index=False, sort_columns=["idx"])
+    with assert_inputs_not_modified(df1_shuffled):
+        lib.stage(symbol, df1_shuffled, validate_index=False, sort_on_index=False, sort_columns=["idx"])
 
     lib_tool = lib.library_tool()
     data_keys = lib_tool.find_keys_for_symbol(KeyType.APPEND_DATA, symbol)
@@ -273,8 +291,9 @@ def test_stage_finalize_dynamic_with_chunking(arctic_client, lib_name):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    lib.stage(symbol, df1_shuffled, False, False, sort_cols)
-    lib.stage(symbol, df2_shuffled, False, False, sort_cols)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        lib.stage(symbol, df1_shuffled, False, False, sort_cols)
+        lib.stage(symbol, df2_shuffled, False, False, sort_cols)
 
     lib_tool = lib._dev_tools.library_tool()
     data_keys = lib_tool.find_keys_for_symbol(KeyType.APPEND_DATA, symbol)
@@ -317,8 +336,9 @@ def test_stage_finalize_index_and_additional(arctic_library):
     df1_shuffled = df1.sample(frac=1)
     df2_shuffled = df2.sample(frac=1)
 
-    arctic_library.stage(symbol, df1_shuffled, False, True, sort_cols)
-    arctic_library.stage(symbol, df2_shuffled, False, True, sort_cols)
+    with assert_inputs_not_modified(df1_shuffled, df2_shuffled):
+        arctic_library.stage(symbol, df1_shuffled, False, True, sort_cols)
+        arctic_library.stage(symbol, df2_shuffled, False, True, sort_cols)
     arctic_library.finalize_staged_data(symbol)
     result = arctic_library.read(symbol).data
 

--- a/python/tests/util/arrow.py
+++ b/python/tests/util/arrow.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Union
 
 import polars as pl
@@ -17,9 +18,9 @@ def to_format(table: Union[pa.Table, pl.DataFrame], arrow_output_format: OutputF
 def deep_copy(table: Union[pa.Table, pl.DataFrame]) -> Union[pa.Table, pl.DataFrame]:
     """Deep copy of an arrow or polars table"""
     if isinstance(table, pl.DataFrame):
-        return pl.from_arrow(deep_copy(table.to_arrow()))
-    # There is explicit no deep clone pyarrow api so we use `pyarrow.take(num_rows)`
-    return table.take(list(range(table.num_rows)))
+        # copy.deepcopy on a polars DataFrame shares the underlying Arrow buffers, so round-trip through pyarrow.
+        return pl.from_arrow(copy.deepcopy(table.to_arrow()))
+    return copy.deepcopy(table)
 
 
 def assert_arrow_equal(expected: Union[pa.Table, pl.DataFrame], received: Union[pa.Table, pl.DataFrame]):

--- a/python/tests/util/arrow.py
+++ b/python/tests/util/arrow.py
@@ -14,6 +14,14 @@ def to_format(table: Union[pa.Table, pl.DataFrame], arrow_output_format: OutputF
     return table
 
 
+def deep_copy(table: Union[pa.Table, pl.DataFrame]) -> Union[pa.Table, pl.DataFrame]:
+    """Deep copy of an arrow or polars table"""
+    if isinstance(table, pl.DataFrame):
+        return pl.from_arrow(deep_copy(table.to_arrow()))
+    # There is explicit no deep clone pyarrow api so we use `pyarrow.take(num_rows)`
+    return table.take(list(range(table.num_rows)))
+
+
 def assert_arrow_equal(expected: Union[pa.Table, pl.DataFrame], received: Union[pa.Table, pl.DataFrame]):
     # Convert expected to be the same type as received
     if isinstance(expected, pa.Table) and isinstance(received, pl.DataFrame):


### PR DESCRIPTION
#### Reference Issues/PRs
Monday ref: 18190648152

#### What does this implement or fix?
Adds support for `lib.stage(arrow_with_strings, sort_by_index=True)` and other sorting on arrow strings.

Fixes a bug where `lib.stage(numpy_buffer, sort_by_index=True)` modifies the `numpy_buffer` in place.

This is done by replacing the `incomplete_segment_from_tensor_frame` with a new `incomplete_segment_from_frame` which works for both arrow and numpy buffers by using `WriteToSegmentTask`. 
Also introduces a new `enum CopyMode{ALWAYS, IF_NEEDED}`:
- `IF_NEEDED` is the old behavior where numeric contiguous buffers can end up represented as a view of the source data. - `ALWAYS` is a new option that allows explicitly requesting owned data so that the inplace sort does not modify user's input data.

Also refactors a few confusing places of code around the required change - inline comments in PR explain each of these changes. But in short the changes are:
- better `make_timeseries_descriptor` API
- use correct `stream_id` in `InputFrame::desc_for_tsd`


#### Any other comments?
The change is split in three commits which can be reviewed separately (but the mostly touch different lines so fine to review together as well)

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
