### PR TITLE
Merge filter clauses in to one expression during query builder evaluation

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1082,6 +1082,7 @@ if(${TEST})
             pipeline/test/test_column_stats_dispatch.cpp
             pipeline/test/test_column_stats_dispatch_range_vs_range.cpp
             pipeline/test/test_column_stats_isin.cpp
+            pipeline/test/test_column_stats_query_metadata.cpp
             util/test/test_regex.cpp
             processing/test/ast_test_helpers.hpp
             processing/test/test_arithmetic_type_promotion.cpp

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -16,7 +16,6 @@
 #include <arcticdb/pipeline/value.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/stream/stream_utils.hpp>
-#include <arcticdb/processing/query_planner.hpp>
 
 #include <iterator>
 #include <unordered_set>
@@ -457,13 +456,16 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
 }
 
 ColumnStatsQueryMetadata::ColumnStatsQueryMetadata(const std::vector<std::shared_ptr<Clause>>& clauses) {
-    // The clauses eligible for column stats use:
+    // We apply column stats filtering to a "prefix" of clauses that are eligible based on the rules below.
+    // Column stats are not used for any clauses after this "prefix".
     // - FilterClauses contribute filter expressions and columns of interest
     // - DateRangeClauses contribute their range
-    // - RowRangeClauses are skipped
+    // - A RowRangeClause ends the prefix unless it is the first clause, because a leading RowRangeClause
+    //   selects absolute row positions. A RowRangeClause anywhere else is over a changed dataset,
+    //   so a filter after it must not drive pruning (that would change which rows are "first/last N").
     // - Anything else (Resample / GroupBy / Project) ends the prefix because those clauses
     // transform the data so stats computed on the original segments are no longer valid.
-    for (const auto& clause : clauses) {
+    for (auto&& [idx, clause] : folly::enumerate(clauses)) {
         auto& clause_type = folly::poly_type(*clause);
         if (clause_type == typeid(DateRangeClause)) {
             const auto& date_range_clause = folly::poly_cast<DateRangeClause>(*clause);
@@ -476,7 +478,10 @@ ColumnStatsQueryMetadata::ColumnStatsQueryMetadata(const std::vector<std::shared
             continue;
         }
         if (clause_type == typeid(RowRangeClause)) {
-            continue;
+            if (idx == 0) {
+                continue;
+            }
+            break;
         }
         if (clause_type != typeid(FilterClause)) {
             break;
@@ -546,10 +551,12 @@ namespace {
 FilterQuery<index::IndexSegmentReader> build_filter_from_column_stats_data(
         ColumnStatsData&& column_stats, std::vector<std::shared_ptr<ExpressionContext>>&& filter_expressions
 ) {
-    util::check(!filter_expressions.empty(), "Expected at least one filter expression");
-    ARCTICDB_DEBUG(log::version(), "AND-ing expression contexts from filters");
-    ExpressionContext overall_context = and_filter_expression_contexts(filter_expressions);
-    ARCTICDB_DEBUG(log::version(), "Creating column stats filter");
+    util::check(
+            filter_expressions.size() == 1,
+            "Expected exactly one filter expression for column stats (filters are merged in plan_query), got {}",
+            filter_expressions.size()
+    );
+    ExpressionContext overall_context = *filter_expressions.front();
     return create_column_stats_filter(std::move(column_stats), std::move(overall_context));
 }
 

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -25,7 +25,7 @@ namespace arcticdb {
 bool is_column_stats_enabled() { return ConfigsMap::instance()->get_int("ColumnStats.UseForQueries", 0) == 1; }
 
 bool ColumnStatsQueryMetadata::should_try_column_stats_read() const {
-    return is_column_stats_enabled() && !filter_expressions.empty();
+    return is_column_stats_enabled() && filter_expression.has_value();
 }
 
 StatsVariantData dispatch_unary_stats(const StatsVariantData& left, OperationType operation);
@@ -469,12 +469,12 @@ ColumnStatsQueryMetadata::ColumnStatsQueryMetadata(const std::vector<std::shared
         auto& clause_type = folly::poly_type(*clause);
         if (clause_type == typeid(DateRangeClause)) {
             const auto& date_range_clause = folly::poly_cast<DateRangeClause>(*clause);
-            if (date_range.has_value()) {
-                date_range->first = std::max(date_range->first, date_range_clause.start());
-                date_range->second = std::min(date_range->second, date_range_clause.end());
-            } else {
-                date_range = std::make_pair(date_range_clause.start(), date_range_clause.end());
-            }
+            util::check(
+                    !date_range.has_value(),
+                    "Expected at most one DateRangeClause in the column stats prefix (date ranges are merged in "
+                    "plan_query)"
+            );
+            date_range = std::make_pair(date_range_clause.start(), date_range_clause.end());
             continue;
         }
         if (clause_type == typeid(RowRangeClause)) {
@@ -487,12 +487,12 @@ ColumnStatsQueryMetadata::ColumnStatsQueryMetadata(const std::vector<std::shared
             break;
         }
         const auto& filter = folly::poly_cast<FilterClause>(*clause);
-        filter_expressions.emplace_back(filter.expression_context_);
         util::check(
-                filter.clause_info().input_columns_.has_value(),
-                "FilterClause is missing input_columns_ — Python bindings should always populate this"
+                !filter_expression.has_value(),
+                "Expected at most one FilterClause in the column stats prefix (filters are merged in plan_query)"
         );
-        for (const auto& col : *filter.clause_info().input_columns_) {
+        filter_expression = filter.expression_context_;
+        for (const auto& col : filter.clause_info().input_columns_) {
             columns_of_interest.insert(col);
         }
     }
@@ -546,22 +546,6 @@ SegmentInMemory partial_decode_column_stats_segment(
     return partial;
 }
 
-namespace {
-
-FilterQuery<index::IndexSegmentReader> build_filter_from_column_stats_data(
-        ColumnStatsData&& column_stats, std::vector<std::shared_ptr<ExpressionContext>>&& filter_expressions
-) {
-    util::check(
-            filter_expressions.size() == 1,
-            "Expected exactly one filter expression for column stats (filters are merged in plan_query), got {}",
-            filter_expressions.size()
-    );
-    ExpressionContext overall_context = *filter_expressions.front();
-    return create_column_stats_filter(std::move(column_stats), std::move(overall_context));
-}
-
-} // namespace
-
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         std::shared_ptr<Segment> column_stats_compressed, const TimeseriesDescriptor& tsd,
         ColumnStatsQueryMetadata&& query_metadata
@@ -573,7 +557,8 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
     SegmentInMemory partial_segment =
             partial_decode_column_stats_segment(*column_stats_compressed, tsd, query_metadata.columns_of_interest);
     ColumnStatsData column_stats{std::move(partial_segment), tsd, query_metadata.date_range};
-    return build_filter_from_column_stats_data(std::move(column_stats), std::move(query_metadata.filter_expressions));
+    ExpressionContext expression_context = *query_metadata.filter_expression.value();
+    return create_column_stats_filter(std::move(column_stats), std::move(expression_context));
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -25,7 +25,7 @@ namespace arcticdb {
 bool is_column_stats_enabled() { return ConfigsMap::instance()->get_int("ColumnStats.UseForQueries", 0) == 1; }
 
 bool ColumnStatsQueryMetadata::should_try_column_stats_read() const {
-    return is_column_stats_enabled() && filter_expression.has_value();
+    return is_column_stats_enabled() && filter_expression != nullptr;
 }
 
 StatsVariantData dispatch_unary_stats(const StatsVariantData& left, OperationType operation);
@@ -488,7 +488,7 @@ ColumnStatsQueryMetadata::ColumnStatsQueryMetadata(const std::vector<std::shared
         }
         const auto& filter = folly::poly_cast<FilterClause>(*clause);
         util::check(
-                !filter_expression.has_value(),
+                filter_expression == nullptr,
                 "Expected at most one FilterClause in the column stats prefix (filters are merged in plan_query)"
         );
         filter_expression = filter.expression_context_;
@@ -557,7 +557,7 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
     SegmentInMemory partial_segment =
             partial_decode_column_stats_segment(*column_stats_compressed, tsd, query_metadata.columns_of_interest);
     ColumnStatsData column_stats{std::move(partial_segment), tsd, query_metadata.date_range};
-    ExpressionContext expression_context = *query_metadata.filter_expression.value();
+    ExpressionContext expression_context = *query_metadata.filter_expression;
     return create_column_stats_filter(std::move(column_stats), std::move(expression_context));
 }
 

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -124,8 +124,8 @@ class ColumnStatsData {
 };
 
 struct ColumnStatsQueryMetadata {
-    // Filter expressions we can apply column stats to.
-    std::vector<std::shared_ptr<ExpressionContext>> filter_expressions;
+    // Filter expression we can apply column stats to.
+    std::optional<std::shared_ptr<ExpressionContext>> filter_expression;
     // Columns referenced in the user's query.
     std::unordered_set<std::string> columns_of_interest;
     std::optional<std::pair<timestamp, timestamp>> date_range;

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -125,7 +125,7 @@ class ColumnStatsData {
 
 struct ColumnStatsQueryMetadata {
     // Filter expression we can apply column stats to.
-    std::optional<std::shared_ptr<ExpressionContext>> filter_expression;
+    std::shared_ptr<ExpressionContext> filter_expression;
     // Columns referenced in the user's query.
     std::unordered_set<std::string> columns_of_interest;
     std::optional<std::pair<timestamp, timestamp>> date_range;

--- a/cpp/arcticdb/pipeline/read_pipeline.cpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.cpp
@@ -8,11 +8,8 @@ inline std::optional<util::BitSet> clause_column_bitset(
 ) {
     folly::F14FastSet<std::string_view> column_set;
     for (const auto& clause : clauses) {
-        auto opt_columns = clause->clause_info().input_columns_;
-        if (opt_columns.has_value()) {
-            for (const auto& column : *clause->clause_info().input_columns_) {
-                column_set.insert(std::string_view(column));
-            }
+        for (const auto& column : clause->clause_info().input_columns_) {
+            column_set.insert(std::string_view(column));
         }
     }
     if (!column_set.empty())

--- a/cpp/arcticdb/pipeline/test/test_column_stats_query_metadata.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_query_metadata.cpp
@@ -1,0 +1,56 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/pipeline/column_stats_filter.hpp>
+#include <arcticdb/processing/clause.hpp>
+#include <arcticdb/processing/expression_context.hpp>
+#include <arcticdb/processing/test/ast_test_helpers.hpp>
+
+using namespace arcticdb;
+
+namespace {
+
+std::shared_ptr<FilterClause> make_filter(const std::string& column) {
+    ExpressionContext ec;
+    ec.root_ = node(col(column), OperationType::IDENTITY);
+    return std::make_shared<FilterClause>(std::unordered_set<std::string>{column}, ec, std::nullopt);
+}
+
+std::shared_ptr<RowRangeClause> make_head(int64_t n) {
+    return std::make_shared<RowRangeClause>(RowRangeClause::RowRangeType::HEAD, n);
+}
+
+std::shared_ptr<DateRangeClause> make_date_range(timestamp start, timestamp end) {
+    return std::make_shared<DateRangeClause>(start, end);
+}
+
+template<typename T>
+std::shared_ptr<Clause> wrap(const std::shared_ptr<T>& clause) {
+    return std::make_shared<Clause>(*clause);
+}
+
+} // namespace
+
+TEST(ColumnStatsQueryMetadata, FilterThenHeadThenFilterOnlyUsesLeadingFilter) {
+    std::vector<std::shared_ptr<Clause>> clauses{wrap(make_filter("a")), wrap(make_head(2)), wrap(make_filter("b"))};
+
+    ColumnStatsQueryMetadata metadata(clauses);
+
+    ASSERT_TRUE(metadata.filter_expression.has_value());
+    EXPECT_EQ(metadata.columns_of_interest, (std::unordered_set<std::string>{"a"}));
+}
+
+TEST(ColumnStatsQueryMetadata, TwoDateRangeClausesViolatesMergedInvariant) {
+    // plan_query always merges consecutive DateRangeClauses into one before ColumnStatsQueryMetadata is
+    // constructed, so this shape is unreachable via the planner. Build it by hand to assert the guard fires.
+    std::vector<std::shared_ptr<Clause>> clauses{wrap(make_date_range(0, 100)), wrap(make_date_range(50, 200))};
+
+    EXPECT_THROW(ColumnStatsQueryMetadata metadata(clauses), InternalException);
+}

--- a/cpp/arcticdb/pipeline/test/test_column_stats_query_metadata.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_query_metadata.cpp
@@ -43,7 +43,7 @@ TEST(ColumnStatsQueryMetadata, FilterThenHeadThenFilterOnlyUsesLeadingFilter) {
 
     ColumnStatsQueryMetadata metadata(clauses);
 
-    ASSERT_TRUE(metadata.filter_expression.has_value());
+    ASSERT_TRUE(metadata.filter_expression != nullptr);
     EXPECT_EQ(metadata.columns_of_interest, (std::unordered_set<std::string>{"a"}));
 }
 

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -142,7 +142,7 @@ std::vector<EntityId> FilterClause::process(std::vector<EntityId>&& entity_ids) 
 }
 
 OutputSchema FilterClause::modify_schema(OutputSchema&& output_schema) const {
-    check_column_presence(output_schema, *clause_info_.input_columns_, "Filter");
+    check_column_presence(output_schema, clause_info_.input_columns_, "Filter");
     std::variant<BitSetTag, DataType> return_type = expression_context_->root_->compute(output_schema.column_types());
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             std::holds_alternative<BitSetTag>(return_type), "FilterClause AST would produce a column, not a bitset"
@@ -215,7 +215,7 @@ std::vector<EntityId> ProjectClause::process(std::vector<EntityId>&& entity_ids)
 }
 
 OutputSchema ProjectClause::modify_schema(OutputSchema&& output_schema) const {
-    check_column_presence(output_schema, *clause_info_.input_columns_, "Project");
+    check_column_presence(output_schema, clause_info_.input_columns_, "Project");
     const auto& root = *expression_context_->root_;
     if (root.is_value()) {
         const auto& value = std::get<std::shared_ptr<Value>>(std::get<ExpressionNode::Leaf>(root.kind_));
@@ -269,7 +269,7 @@ AggregationClause::AggregationClause(
     clause_info_.input_structure_ = ProcessingStructure::HASH_BUCKETED;
     clause_info_.can_combine_with_column_selection_ = false;
     clause_info_.index_ = NewIndex(grouping_column_);
-    clause_info_.input_columns_ = std::make_optional<std::unordered_set<std::string>>({grouping_column_});
+    clause_info_.input_columns_ = {grouping_column_};
     str_ = "AGGREGATE {";
     for (const auto& named_aggregator : named_aggregators) {
         str_.append(fmt::format(
@@ -278,7 +278,7 @@ AggregationClause::AggregationClause(
                 named_aggregator.input_column_name_,
                 named_aggregator.aggregation_operator_
         ));
-        clause_info_.input_columns_->insert(named_aggregator.input_column_name_);
+        clause_info_.input_columns_.insert(named_aggregator.input_column_name_);
         auto typed_input_column_name = ColumnName(named_aggregator.input_column_name_);
         auto typed_output_column_name = ColumnName(named_aggregator.output_column_name_);
         if (named_aggregator.aggregation_operator_ == "sum") {
@@ -529,7 +529,7 @@ std::vector<EntityId> AggregationClause::process(std::vector<EntityId>&& entity_
 }
 
 OutputSchema AggregationClause::modify_schema(OutputSchema&& output_schema) const {
-    check_column_presence(output_schema, *clause_info_.input_columns_, "Aggregation");
+    check_column_presence(output_schema, clause_info_.input_columns_, "Aggregation");
     output_schema.clear_default_values();
     const auto& input_stream_desc = output_schema.stream_descriptor();
     StreamDescriptor stream_desc(input_stream_desc.id());
@@ -1031,7 +1031,7 @@ std::vector<std::vector<size_t>> DateRangeClause::structure_for_processing(std::
 }
 
 std::vector<EntityId> DateRangeClause::process(std::vector<EntityId>&& entity_ids) const {
-    if (entity_ids.empty()) {
+    if (entity_ids.empty() || start_ > end_) {
         return {};
     }
     auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -310,7 +310,7 @@ struct PartitionClause {
     }
 
     OutputSchema modify_schema(OutputSchema&& output_schema) const {
-        check_column_presence(output_schema, *clause_info_.input_columns_, "GroupBy");
+        check_column_presence(output_schema, clause_info_.input_columns_, "GroupBy");
         return output_schema;
     }
 
@@ -432,6 +432,8 @@ struct ResampleClause {
     void set_aggregations(const std::vector<NamedAggregator>& named_aggregators);
 
     void set_date_range(timestamp date_range_start, timestamp date_range_end);
+
+    void check_origin_supported_with_date_range() const;
 
     std::vector<timestamp> generate_bucket_boundaries(
             timestamp first_ts, timestamp last_ts, bool responsible_for_first_overlapping_bucket

--- a/cpp/arcticdb/processing/clause_resample.cpp
+++ b/cpp/arcticdb/processing/clause_resample.cpp
@@ -44,7 +44,7 @@ template<ResampleBoundary closed_boundary>
 OutputSchema ResampleClause<closed_boundary>::modify_schema(OutputSchema&& output_schema) const {
     check_is_timeseries(output_schema.stream_descriptor(), "Resample");
     output_schema.clear_default_values();
-    check_column_presence(output_schema, *clause_info_.input_columns_, "Resample");
+    check_column_presence(output_schema, clause_info_.input_columns_, "Resample");
     const auto& input_stream_desc = output_schema.stream_descriptor();
     StreamDescriptor stream_desc(input_stream_desc.id());
     stream_desc.add_field(input_stream_desc.field(0));
@@ -91,6 +91,11 @@ std::string ResampleClause<closed_boundary>::rule() const {
 
 template<ResampleBoundary closed_boundary>
 void ResampleClause<closed_boundary>::set_date_range(timestamp date_range_start, timestamp date_range_end) {
+    date_range_.emplace(date_range_start, date_range_end);
+}
+
+template<ResampleBoundary closed_boundary>
+void ResampleClause<closed_boundary>::check_origin_supported_with_date_range() const {
     // Start and end need to read the first and last segments of the date range. At the moment buckets are set up
     // before reading and processing the data.
     constexpr static std::array unsupported_origin{"start", "end", "start_day", "end_day"};
@@ -105,12 +110,11 @@ void ResampleClause<closed_boundary>::set_date_range(timestamp date_range_start,
             "Resampling origins {} are not supported in conjunction with date range",
             unsupported_origin
     );
-    date_range_.emplace(date_range_start, date_range_end);
 }
 
 template<ResampleBoundary closed_boundary>
 void ResampleClause<closed_boundary>::set_aggregations(const std::vector<NamedAggregator>& named_aggregators) {
-    clause_info_.input_columns_ = std::make_optional<std::unordered_set<std::string>>();
+    clause_info_.input_columns_.clear();
     str_ = fmt::format("RESAMPLE({}) | AGGREGATE {{", rule());
     for (const auto& named_aggregator : named_aggregators) {
         str_.append(fmt::format(
@@ -119,7 +123,7 @@ void ResampleClause<closed_boundary>::set_aggregations(const std::vector<NamedAg
                 named_aggregator.input_column_name_,
                 named_aggregator.aggregation_operator_
         ));
-        clause_info_.input_columns_->insert(named_aggregator.input_column_name_);
+        clause_info_.input_columns_.insert(named_aggregator.input_column_name_);
         auto typed_input_column_name = ColumnName(named_aggregator.input_column_name_);
         auto typed_output_column_name = ColumnName(named_aggregator.output_column_name_);
         if (named_aggregator.aggregation_operator_ == "sum") {
@@ -189,6 +193,7 @@ std::vector<std::vector<size_t>> ResampleClause<closed_boundary>::structure_for_
     );
 
     if (date_range_.has_value()) {
+        check_origin_supported_with_date_range();
         date_range_->first = std::max(date_range_->first, index_range.first);
         date_range_->second = std::min(date_range_->second, index_range.second);
     } else {

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -49,7 +49,8 @@ struct ClauseInfo {
     bool can_combine_with_column_selection_{true};
     // The names of the columns that are needed for this clause to make sense
     // Could either be on disk, or columns created by earlier clauses in the processing pipeline
-    std::optional<std::unordered_set<std::string>> input_columns_{std::nullopt};
+    // Empty if this clause does not have specific input columns (e.g. it operates on all columns)
+    std::unordered_set<std::string> input_columns_;
     // KeepCurrentIndex if this clause does not modify the index in any way
     // KeepCurrentTopLevelIndex if this clause requires multi-index levels>0 to be dropped, but otherwise does not
     // modify it NewIndex if this clause has changed the index to a new (supplied) name

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 
 namespace arcticdb {
@@ -26,23 +27,43 @@ bool is_date_range(const ClauseVariant& clause) {
 
 bool date_range_can_move_to_left_of(const ClauseVariant& clause) { return is_filter(clause) || is_project(clause); }
 
-// Move each DateRangeClause as far left as it can go, so that filters that were only separated by a
-// date range end up next to each other and can be merged. Each date range ends up at the front of the
-// run of clauses it is allowed to move past, keeping the original order, eg
-// [F1, F2, DR1, F3, F4, DR2] -> [DR1, DR2, F1, F2, F3, F4]
-void move_date_ranges_left(std::vector<ClauseVariant>& clauses) {
-    size_t insert_pos = 0; // location of the clause we can move a date range left to
-    // Move each date range we see left to insert_pos. If we have [F1, F2, DR1, F3] then we hit rotate(start=0,
-    // middle=2, last=3). This rotates within [0, 3) and makes index 2 the new start, that is it rotates [F1, F2, DR1]
-    // until DR1 is the new start. This results in [DR1, F1, F2, F3].
-    for (size_t i = 0; i < clauses.size(); ++i) {
-        if (is_date_range(clauses.at(i))) {
-            std::rotate(clauses.begin() + insert_pos, clauses.begin() + i, clauses.begin() + i + 1);
-            ++insert_pos;
-        } else if (!date_range_can_move_to_left_of(clauses.at(i))) {
-            insert_pos = i + 1;
+// Move each DateRangeClause as far left as it can go and merge any that end up adjacent into a single
+// DateRangeClause, so that filters that were only separated by a date range end up next to
+// each other (and can then be merged by merge_consecutive_filter_clauses), eg
+// [F1, F2, DR1, F3, F4, DR2] -> [DR_12, F1, F2, F3, F4]
+std::vector<ClauseVariant> move_and_merge_date_ranges_left(std::vector<ClauseVariant>&& clauses) {
+    std::vector<ClauseVariant> result;
+    result.reserve(clauses.size());
+    // The date ranges merged so far for the run currently being built, and the filters/projects seen since the
+    // last one, both still pending output until the run ends (so the merged date range can be emitted first).
+    std::shared_ptr<DateRangeClause> merged_date_range;
+    std::vector<ClauseVariant> run;
+    auto flush_run = [&]() {
+        if (merged_date_range) {
+            result.emplace_back(std::move(merged_date_range));
+        }
+        for (auto& clause : run) {
+            result.push_back(std::move(clause));
+        }
+        run.clear();
+    };
+    for (auto& clause : clauses) {
+        if (is_date_range(clause)) {
+            auto& date_range = std::get<std::shared_ptr<DateRangeClause>>(clause);
+            merged_date_range = merged_date_range ? std::make_shared<DateRangeClause>(
+                                                            std::max(merged_date_range->start_, date_range->start_),
+                                                            std::min(merged_date_range->end_, date_range->end_)
+                                                    )
+                                                  : date_range;
+        } else {
+            run.push_back(std::move(clause));
+            if (!date_range_can_move_to_left_of(clause)) {
+                flush_run();
+            }
         }
     }
+    flush_run();
+    return result;
 }
 
 std::shared_ptr<FilterClause> merge_filter_run(const std::vector<std::shared_ptr<FilterClause>>& filters) {
@@ -54,11 +75,7 @@ std::shared_ptr<FilterClause> merge_filter_run(const std::vector<std::shared_ptr
     bool any_memory = false;
     for (const auto& filter : filters) {
         expression_contexts.push_back(filter->expression_context_);
-        if (filter->clause_info_.input_columns_.has_value()) {
-            input_columns.insert(
-                    filter->clause_info_.input_columns_->begin(), filter->clause_info_.input_columns_->end()
-            );
-        }
+        input_columns.insert(filter->clause_info_.input_columns_.begin(), filter->clause_info_.input_columns_.end());
         any_memory = any_memory || filter->optimisation_ == PipelineOptimisation::MEMORY;
     }
     // Respect the (opt-in) memory request if any clause in the run asked for it (speed is the default if the user
@@ -70,6 +87,9 @@ std::shared_ptr<FilterClause> merge_filter_run(const std::vector<std::shared_ptr
 }
 
 std::vector<ClauseVariant> merge_consecutive_filter_clauses(std::vector<ClauseVariant>&& clauses) {
+    // Merge runs of consecutive filters together so [f1, f2, p1, f3, f4] becomes [F_12, p1, F_34].
+    // A projection between two filters stops them from being merged together (the second filter might reference the
+    // projected column, so it cannot be merged with the first).
     std::vector<ClauseVariant> result;
     std::vector<std::shared_ptr<FilterClause>> run;
     auto flush_run = [&]() {
@@ -93,6 +113,7 @@ std::vector<ClauseVariant> merge_consecutive_filter_clauses(std::vector<ClauseVa
 } // namespace
 
 std::vector<ClauseVariant> plan_query(std::vector<ClauseVariant>&& clauses) {
+    clauses = move_and_merge_date_ranges_left(std::move(clauses));
     if (clauses.size() >= 2 && std::holds_alternative<std::shared_ptr<DateRangeClause>>(clauses[0])) {
         util::variant_match(clauses[1], [&clauses](auto&& clause) {
             if constexpr (is_resample<typename std::remove_cvref_t<decltype(clause)>::element_type>::value) {
@@ -104,7 +125,6 @@ std::vector<ClauseVariant> plan_query(std::vector<ClauseVariant>&& clauses) {
             }
         });
     }
-    move_date_ranges_left(clauses);
     return merge_consecutive_filter_clauses(std::move(clauses));
 }
 

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -8,7 +8,89 @@
 
 #include <arcticdb/processing/query_planner.hpp>
 
+#include <algorithm>
+#include <string>
+#include <unordered_set>
+
 namespace arcticdb {
+
+namespace {
+
+bool is_filter(const ClauseVariant& clause) { return std::holds_alternative<std::shared_ptr<FilterClause>>(clause); }
+
+bool is_project(const ClauseVariant& clause) { return std::holds_alternative<std::shared_ptr<ProjectClause>>(clause); }
+
+bool is_date_range(const ClauseVariant& clause) {
+    return std::holds_alternative<std::shared_ptr<DateRangeClause>>(clause);
+}
+
+bool date_range_can_move_to_left_of(const ClauseVariant& clause) { return is_filter(clause) || is_project(clause); }
+
+// Move each DateRangeClause as far left as it can go, so that filters that were only separated by a
+// date range end up next to each other and can be merged. Each date range ends up at the front of the
+// run of clauses it is allowed to move past, keeping the original order, eg
+// [F1, F2, DR1, F3, F4, DR2] -> [DR1, DR2, F1, F2, F3, F4]
+void move_date_ranges_left(std::vector<ClauseVariant>& clauses) {
+    size_t insert_pos = 0; // location of the clause we can move a date range left to
+    // Move each date range we see left to insert_pos. If we have [F1, F2, DR1, F3] then we hit rotate(start=0,
+    // middle=2, last=3). This rotates within [0, 3) and makes index 2 the new start, that is it rotates [F1, F2, DR1]
+    // until DR1 is the new start. This results in [DR1, F1, F2, F3].
+    for (size_t i = 0; i < clauses.size(); ++i) {
+        if (is_date_range(clauses.at(i))) {
+            std::rotate(clauses.begin() + insert_pos, clauses.begin() + i, clauses.begin() + i + 1);
+            ++insert_pos;
+        } else if (!date_range_can_move_to_left_of(clauses.at(i))) {
+            insert_pos = i + 1;
+        }
+    }
+}
+
+std::shared_ptr<FilterClause> merge_filter_run(const std::vector<std::shared_ptr<FilterClause>>& filters) {
+    if (filters.size() == 1) {
+        return filters.front();
+    }
+    std::vector<std::shared_ptr<ExpressionContext>> expression_contexts;
+    std::unordered_set<std::string> input_columns;
+    bool any_memory = false;
+    for (const auto& filter : filters) {
+        expression_contexts.push_back(filter->expression_context_);
+        if (filter->clause_info_.input_columns_.has_value()) {
+            input_columns.insert(
+                    filter->clause_info_.input_columns_->begin(), filter->clause_info_.input_columns_->end()
+            );
+        }
+        any_memory = any_memory || filter->optimisation_ == PipelineOptimisation::MEMORY;
+    }
+    // Respect the (opt-in) memory request if any clause in the run asked for it (speed is the default if the user
+    // doesn't specify).
+    auto optimisation = any_memory ? PipelineOptimisation::MEMORY : PipelineOptimisation::SPEED;
+    return std::make_shared<FilterClause>(
+            std::move(input_columns), and_filter_expression_contexts(expression_contexts), optimisation
+    );
+}
+
+std::vector<ClauseVariant> merge_consecutive_filter_clauses(std::vector<ClauseVariant>&& clauses) {
+    std::vector<ClauseVariant> result;
+    std::vector<std::shared_ptr<FilterClause>> run;
+    auto flush_run = [&]() {
+        if (!run.empty()) {
+            result.emplace_back(merge_filter_run(run));
+        }
+        run.clear();
+    };
+    for (auto& clause : clauses) {
+        if (is_filter(clause)) {
+            run.push_back(std::get<std::shared_ptr<FilterClause>>(clause));
+        } else {
+            flush_run();
+            result.push_back(std::move(clause));
+        }
+    }
+    flush_run();
+    return result;
+}
+
+} // namespace
 
 std::vector<ClauseVariant> plan_query(std::vector<ClauseVariant>&& clauses) {
     if (clauses.size() >= 2 && std::holds_alternative<std::shared_ptr<DateRangeClause>>(clauses[0])) {
@@ -22,7 +104,8 @@ std::vector<ClauseVariant> plan_query(std::vector<ClauseVariant>&& clauses) {
             }
         });
     }
-    return clauses;
+    move_date_ranges_left(clauses);
+    return merge_consecutive_filter_clauses(std::move(clauses));
 }
 
 /**

--- a/cpp/arcticdb/processing/query_planner.cpp
+++ b/cpp/arcticdb/processing/query_planner.cpp
@@ -8,6 +8,8 @@
 
 #include <arcticdb/processing/query_planner.hpp>
 
+#include <arcticdb/util/collection_utils.hpp>
+
 #include <algorithm>
 #include <string>
 #include <type_traits>
@@ -32,8 +34,7 @@ bool date_range_can_move_to_left_of(const ClauseVariant& clause) { return is_fil
 // each other (and can then be merged by merge_consecutive_filter_clauses), eg
 // [F1, F2, DR1, F3, F4, DR2] -> [DR_12, F1, F2, F3, F4]
 std::vector<ClauseVariant> move_and_merge_date_ranges_left(std::vector<ClauseVariant>&& clauses) {
-    std::vector<ClauseVariant> result;
-    result.reserve(clauses.size());
+    auto result = util::reserve_vector<ClauseVariant>(clauses.size());
     // The date ranges merged so far for the run currently being built, and the filters/projects seen since the
     // last one, both still pending output until the run ends (so the merged date range can be emitted first).
     std::shared_ptr<DateRangeClause> merged_date_range;

--- a/cpp/arcticdb/processing/test/test_query_planner.cpp
+++ b/cpp/arcticdb/processing/test/test_query_planner.cpp
@@ -47,6 +47,18 @@ std::shared_ptr<RowRangeClause> make_row_range() {
     return std::make_shared<RowRangeClause>(RowRangeClause::RowRangeType::HEAD, int64_t{10});
 }
 
+std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>> make_resample(
+        ResampleOrigin origin = ResampleOrigin{std::string{"epoch"}}
+) {
+    ResampleClause<ResampleBoundary::LEFT>::BucketGeneratorT generate_bucket_boundaries =
+            [](timestamp, timestamp, std::string_view, ResampleBoundary, timestamp, const ResampleOrigin&) {
+                return std::vector<timestamp>{};
+            };
+    return std::make_shared<ResampleClause<ResampleBoundary::LEFT>>(
+            "dummy", ResampleBoundary::LEFT, std::move(generate_bucket_boundaries), timestamp{0}, std::move(origin)
+    );
+}
+
 const FilterClause& as_filter(const ClauseVariant& clause) { return *std::get<std::shared_ptr<FilterClause>>(clause); }
 
 OperationType root_operation(const FilterClause& filter) {
@@ -86,7 +98,7 @@ TEST(QueryPlanner, MergeThreeFilters) {
     ASSERT_EQ(result.size(), 1);
     const auto& merged = as_filter(result[0]);
     EXPECT_EQ(root_operation(merged), OperationType::AND);
-    EXPECT_EQ(*merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b", "c"}));
+    EXPECT_EQ(merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b", "c"}));
 }
 
 TEST(QueryPlanner, SingleFilterUnchanged) {
@@ -107,7 +119,7 @@ TEST(QueryPlanner, DateRangeMovedLeftBetweenFiltersEnablesMerge) {
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[1]));
     const auto& merged = as_filter(result[1]);
     EXPECT_EQ(root_operation(merged), OperationType::AND);
-    EXPECT_EQ(*merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+    EXPECT_EQ(merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
 }
 
 TEST(QueryPlanner, ProjectBlocksMergingFilters) {
@@ -130,11 +142,11 @@ TEST(QueryPlanner, RowRangeBlocksMergingFilters) {
     ASSERT_EQ(result.size(), 3);
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
     EXPECT_EQ(root_operation(as_filter(result[0])), OperationType::AND);
-    EXPECT_EQ(*as_filter(result[0]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+    EXPECT_EQ(as_filter(result[0]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
     EXPECT_TRUE(std::holds_alternative<std::shared_ptr<RowRangeClause>>(result[1]));
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
     EXPECT_EQ(root_operation(as_filter(result[2])), OperationType::AND);
-    EXPECT_EQ(*as_filter(result[2]).clause_info_.input_columns_, (std::unordered_set<std::string>{"c", "d"}));
+    EXPECT_EQ(as_filter(result[2]).clause_info_.input_columns_, (std::unordered_set<std::string>{"c", "d"}));
 }
 
 TEST(QueryPlanner, DateRangeNotMovedLeftPastGroupBy) {
@@ -178,9 +190,28 @@ TEST(QueryPlanner, DateRangeMovedLeftPastProjectButStopsAtRowRange) {
     EXPECT_TRUE(std::holds_alternative<std::shared_ptr<ProjectClause>>(result[3]));
 }
 
+TEST(QueryPlanner, DateRangesMergedAroundFilterAndProject) {
+    // Mirrors test_querybuilder_filter_then_date_range_then_project_then_date_range: a filter and a
+    // project both sit between the two date ranges, and both are movable, so the ranges slide to the
+    // front and merge into one intersected range, leaving the filter and project behind it in order.
+    std::vector<ClauseVariant> clauses{
+            make_filter("a"), make_date_range(0, 60), make_project("b"), make_date_range(40, 100)
+    };
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 3);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[0]));
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->start_, 40);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->end_, 60);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[1]));
+    EXPECT_EQ(root_operation(as_filter(result[1])), OperationType::IDENTITY);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<ProjectClause>>(result[2]));
+}
+
 TEST(QueryPlanner, MultipleDateRangesMovedToFrontInOrder) {
-    // Matches the move_date_ranges_left doc example: both date ranges move to the front in order,
-    // leaving the four filters next to each other so they merge into one.
+    // Matches the move_date_ranges_left doc example: both date ranges move to the front, where they
+    // are then merged into one intersected DateRangeClause, leaving the four filters next to each
+    // other so they merge into one.
     std::vector<ClauseVariant> clauses{
             make_filter("a"),
             make_filter("b"),
@@ -191,15 +222,83 @@ TEST(QueryPlanner, MultipleDateRangesMovedToFrontInOrder) {
     };
     auto result = plan_query(std::move(clauses));
 
-    ASSERT_EQ(result.size(), 3);
+    ASSERT_EQ(result.size(), 2);
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[0]));
-    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[1]));
-    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->start_, 0);
-    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[1])->start_, 50);
-    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
-    const auto& merged = as_filter(result[2]);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->start_, 50);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->end_, 100);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[1]));
+    const auto& merged = as_filter(result[1]);
     EXPECT_EQ(root_operation(merged), OperationType::AND);
-    EXPECT_EQ(*merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b", "c", "d"}));
+    EXPECT_EQ(merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b", "c", "d"}));
+}
+
+TEST(QueryPlanner, MergeConsecutiveDateRangesIntersectsBounds) {
+    std::vector<ClauseVariant> clauses{make_date_range(0, 100), make_date_range(50, 200)};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[0]));
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->start_, 50);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->end_, 100);
+}
+
+TEST(QueryPlanner, DisjointDateRangesMergeToInvertedRange) {
+    // The planner just intersects bounds, it is DateRangeClause::process's job to treat start_ >
+    // end_ as an empty result.
+    std::vector<ClauseVariant> clauses{make_date_range(0, 10), make_date_range(20, 30)};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[0]));
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->start_, 20);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->end_, 10);
+}
+
+TEST(QueryPlanner, MultipleLeadingDateRangesFoldIntoResample) {
+    auto resample = make_resample();
+    std::vector<ClauseVariant> clauses{make_date_range(0, 100), make_date_range(50, 200), resample};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>>>(result[0]));
+    const auto& folded = *std::get<std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>>>(result[0]);
+    ASSERT_TRUE(folded.date_range_.has_value());
+    EXPECT_EQ(folded.date_range_->first, 50);
+    EXPECT_EQ(folded.date_range_->second, 100);
+}
+
+TEST(QueryPlanner, MultipleDisjointLeadingDateRangesFoldIntoResample) {
+    auto resample = make_resample();
+    std::vector<ClauseVariant> clauses{make_date_range(0, 10), make_date_range(20, 30), resample};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>>>(result[0]));
+    const auto& folded = *std::get<std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>>>(result[0]);
+    ASSERT_TRUE(folded.date_range_.has_value());
+    EXPECT_EQ(folded.date_range_->first, 20);
+    EXPECT_EQ(folded.date_range_->second, 10);
+}
+
+TEST(QueryPlanner, DateRangesBeforeAndAfterResample) {
+    std::vector<ClauseVariant> clauses{
+            make_date_range(0, 100),
+            make_date_range(50, 200),
+            make_resample(),
+            make_date_range(60, 120),
+            make_date_range(70, 300)
+    };
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 2);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>>>(result[0]));
+    const auto& folded = *std::get<std::shared_ptr<ResampleClause<ResampleBoundary::LEFT>>>(result[0]);
+    ASSERT_TRUE(folded.date_range_.has_value());
+    EXPECT_EQ(folded.date_range_->first, 50);
+    EXPECT_EQ(folded.date_range_->second, 100);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[1]));
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[1])->start_, 70);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[1])->end_, 120);
 }
 
 TEST(QueryPlanner, TwoSeparateMergeRunsAroundABarrier) {
@@ -211,11 +310,11 @@ TEST(QueryPlanner, TwoSeparateMergeRunsAroundABarrier) {
     ASSERT_EQ(result.size(), 3);
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
     EXPECT_EQ(root_operation(as_filter(result[0])), OperationType::AND);
-    EXPECT_EQ(*as_filter(result[0]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+    EXPECT_EQ(as_filter(result[0]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
     EXPECT_TRUE(std::holds_alternative<std::shared_ptr<ProjectClause>>(result[1]));
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
     EXPECT_EQ(root_operation(as_filter(result[2])), OperationType::AND);
-    EXPECT_EQ(*as_filter(result[2]).clause_info_.input_columns_, (std::unordered_set<std::string>{"c", "d"}));
+    EXPECT_EQ(as_filter(result[2]).clause_info_.input_columns_, (std::unordered_set<std::string>{"c", "d"}));
 }
 
 TEST(QueryPlanner, RunMergedWhenItIsTheFinalClausesAfterABarrier) {
@@ -226,7 +325,7 @@ TEST(QueryPlanner, RunMergedWhenItIsTheFinalClausesAfterABarrier) {
     EXPECT_TRUE(std::holds_alternative<std::shared_ptr<GroupByClause>>(result[0]));
     ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[1]));
     EXPECT_EQ(root_operation(as_filter(result[1])), OperationType::AND);
-    EXPECT_EQ(*as_filter(result[1]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+    EXPECT_EQ(as_filter(result[1]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
 }
 
 TEST(QueryPlanner, EmptyAndSingleNonFilter) {

--- a/cpp/arcticdb/processing/test/test_query_planner.cpp
+++ b/cpp/arcticdb/processing/test/test_query_planner.cpp
@@ -7,6 +7,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/query_planner.hpp>
 #include <arcticdb/processing/expression_context.hpp>
 #include <arcticdb/processing/test/ast_test_helpers.hpp>
@@ -21,6 +23,34 @@ std::shared_ptr<ExpressionContext> make_filter_context(bool dynamic_schema) {
     context->root_ = node(col("a"), val(int64_t{0}, DataType::INT64), OperationType::GT);
     context->dynamic_schema_ = dynamic_schema;
     return context;
+}
+
+std::shared_ptr<FilterClause> make_filter(
+        const std::string& column, std::optional<PipelineOptimisation> optimisation = std::nullopt
+) {
+    ExpressionContext ec;
+    ec.root_ = node(col(column), OperationType::IDENTITY);
+    return std::make_shared<FilterClause>(std::unordered_set<std::string>{column}, ec, optimisation);
+}
+
+std::shared_ptr<ProjectClause> make_project(const std::string& column) {
+    ExpressionContext ec;
+    ec.root_ = node(col(column), OperationType::IDENTITY);
+    return std::make_shared<ProjectClause>(std::unordered_set<std::string>{column}, "projected", ec);
+}
+
+std::shared_ptr<DateRangeClause> make_date_range(timestamp start = 0, timestamp end = 100) {
+    return std::make_shared<DateRangeClause>(start, end);
+}
+
+std::shared_ptr<RowRangeClause> make_row_range() {
+    return std::make_shared<RowRangeClause>(RowRangeClause::RowRangeType::HEAD, int64_t{10});
+}
+
+const FilterClause& as_filter(const ClauseVariant& clause) { return *std::get<std::shared_ptr<FilterClause>>(clause); }
+
+OperationType root_operation(const FilterClause& filter) {
+    return std::get<ExpressionNode::Operation>(filter.expression_context_->root_->kind_).operation_type_;
 }
 
 } // namespace
@@ -47,4 +77,163 @@ TEST(QueryPlanner, AndFilterExpressionContextsSingleInheritsDynamicSchema) {
 TEST(QueryPlanner, AndFilterExpressionContextsRejectsInconsistentDynamicSchema) {
     std::vector<std::shared_ptr<ExpressionContext>> contexts{make_filter_context(true), make_filter_context(false)};
     ASSERT_THROW(and_filter_expression_contexts(contexts), InternalException);
+}
+
+TEST(QueryPlanner, MergeThreeFilters) {
+    std::vector<ClauseVariant> clauses{make_filter("a"), make_filter("b"), make_filter("c")};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 1);
+    const auto& merged = as_filter(result[0]);
+    EXPECT_EQ(root_operation(merged), OperationType::AND);
+    EXPECT_EQ(*merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b", "c"}));
+}
+
+TEST(QueryPlanner, SingleFilterUnchanged) {
+    std::vector<ClauseVariant> clauses{make_filter("a")};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 1);
+    // Not merged, so we keep the original IDENTITY root
+    EXPECT_EQ(root_operation(as_filter(result[0])), OperationType::IDENTITY);
+}
+
+TEST(QueryPlanner, DateRangeMovedLeftBetweenFiltersEnablesMerge) {
+    std::vector<ClauseVariant> clauses{make_filter("a"), make_date_range(), make_filter("b")};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[0]));
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[1]));
+    const auto& merged = as_filter(result[1]);
+    EXPECT_EQ(root_operation(merged), OperationType::AND);
+    EXPECT_EQ(*merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+}
+
+TEST(QueryPlanner, ProjectBlocksMergingFilters) {
+    std::vector<ClauseVariant> clauses{make_filter("a"), make_project("a"), make_filter("b")};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<ProjectClause>>(result[1]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
+}
+
+TEST(QueryPlanner, RowRangeBlocksMergingFilters) {
+    // Filters on each side of the RowRange merge within their side, but not across it.
+    std::vector<ClauseVariant> clauses{
+            make_filter("a"), make_filter("b"), make_row_range(), make_filter("c"), make_filter("d")
+    };
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 3);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
+    EXPECT_EQ(root_operation(as_filter(result[0])), OperationType::AND);
+    EXPECT_EQ(*as_filter(result[0]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<RowRangeClause>>(result[1]));
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
+    EXPECT_EQ(root_operation(as_filter(result[2])), OperationType::AND);
+    EXPECT_EQ(*as_filter(result[2]).clause_info_.input_columns_, (std::unordered_set<std::string>{"c", "d"}));
+}
+
+TEST(QueryPlanner, DateRangeNotMovedLeftPastGroupBy) {
+    std::vector<ClauseVariant> clauses{make_filter("a"), std::make_shared<GroupByClause>("g"), make_date_range()};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 3);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<GroupByClause>>(result[1]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[2]));
+}
+
+TEST(QueryPlanner, MergedOptimisationIsMemoryIfAnyMember) {
+    {
+        std::vector<ClauseVariant> clauses{
+                make_filter("a", PipelineOptimisation::MEMORY), make_filter("b", PipelineOptimisation::SPEED)
+        };
+        auto result = plan_query(std::move(clauses));
+        ASSERT_EQ(result.size(), 1);
+        EXPECT_EQ(as_filter(result[0]).optimisation_, PipelineOptimisation::MEMORY);
+    }
+    {
+        std::vector<ClauseVariant> clauses{
+                make_filter("a", PipelineOptimisation::SPEED), make_filter("b", PipelineOptimisation::SPEED)
+        };
+        auto result = plan_query(std::move(clauses));
+        ASSERT_EQ(result.size(), 1);
+        EXPECT_EQ(as_filter(result[0]).optimisation_, PipelineOptimisation::SPEED);
+    }
+}
+
+TEST(QueryPlanner, DateRangeMovedLeftPastProjectButStopsAtRowRange) {
+    // The date range moves left past the Project but not past the RowRange.
+    std::vector<ClauseVariant> clauses{make_filter("a"), make_row_range(), make_project("a"), make_date_range()};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 4);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<RowRangeClause>>(result[1]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[2]));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<ProjectClause>>(result[3]));
+}
+
+TEST(QueryPlanner, MultipleDateRangesMovedToFrontInOrder) {
+    // Matches the move_date_ranges_left doc example: both date ranges move to the front in order,
+    // leaving the four filters next to each other so they merge into one.
+    std::vector<ClauseVariant> clauses{
+            make_filter("a"),
+            make_filter("b"),
+            make_date_range(0, 100),
+            make_filter("c"),
+            make_filter("d"),
+            make_date_range(50, 200)
+    };
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 3);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[0]));
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<DateRangeClause>>(result[1]));
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[0])->start_, 0);
+    EXPECT_EQ(std::get<std::shared_ptr<DateRangeClause>>(result[1])->start_, 50);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
+    const auto& merged = as_filter(result[2]);
+    EXPECT_EQ(root_operation(merged), OperationType::AND);
+    EXPECT_EQ(*merged.clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b", "c", "d"}));
+}
+
+TEST(QueryPlanner, TwoSeparateMergeRunsAroundABarrier) {
+    std::vector<ClauseVariant> clauses{
+            make_filter("a"), make_filter("b"), make_project("a"), make_filter("c"), make_filter("d")
+    };
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 3);
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[0]));
+    EXPECT_EQ(root_operation(as_filter(result[0])), OperationType::AND);
+    EXPECT_EQ(*as_filter(result[0]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<ProjectClause>>(result[1]));
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[2]));
+    EXPECT_EQ(root_operation(as_filter(result[2])), OperationType::AND);
+    EXPECT_EQ(*as_filter(result[2]).clause_info_.input_columns_, (std::unordered_set<std::string>{"c", "d"}));
+}
+
+TEST(QueryPlanner, RunMergedWhenItIsTheFinalClausesAfterABarrier) {
+    std::vector<ClauseVariant> clauses{std::make_shared<GroupByClause>("g"), make_filter("a"), make_filter("b")};
+    auto result = plan_query(std::move(clauses));
+
+    ASSERT_EQ(result.size(), 2);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<GroupByClause>>(result[0]));
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<FilterClause>>(result[1]));
+    EXPECT_EQ(root_operation(as_filter(result[1])), OperationType::AND);
+    EXPECT_EQ(*as_filter(result[1]).clause_info_.input_columns_, (std::unordered_set<std::string>{"a", "b"}));
+}
+
+TEST(QueryPlanner, EmptyAndSingleNonFilter) {
+    EXPECT_TRUE(plan_query({}).empty());
+
+    std::vector<ClauseVariant> clauses{std::make_shared<GroupByClause>("g")};
+    auto result = plan_query(std::move(clauses));
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_TRUE(std::holds_alternative<std::shared_ptr<GroupByClause>>(result[0]));
 }

--- a/cpp/arcticdb/processing/test/test_resample.cpp
+++ b/cpp/arcticdb/processing/test/test_resample.cpp
@@ -11,6 +11,7 @@
 #include <arcticdb/entity/atom_key.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/clause.hpp>
+#include <arcticdb/util/error_code.hpp>
 #include <arcticdb/util/test/test_utils.hpp>
 
 using namespace arcticdb;
@@ -23,10 +24,11 @@ auto generate_bucket_boundaries(std::vector<timestamp>&& bucket_boundaries) {
 
 template<ResampleBoundary resample_boundary>
 ResampleClause<resample_boundary> generate_resample_clause(
-        ResampleBoundary label_boundary, std::vector<timestamp>&& bucket_boundaries
+        ResampleBoundary label_boundary, std::vector<timestamp>&& bucket_boundaries,
+        ResampleOrigin origin = timestamp{0}
 ) {
     ResampleClause<resample_boundary> res{
-            "dummy", label_boundary, generate_bucket_boundaries(std::move(bucket_boundaries)), 0, 0
+            "dummy", label_boundary, generate_bucket_boundaries(std::move(bucket_boundaries)), 0, std::move(origin)
     };
     ProcessingConfig processing_config{false, 0, IndexDescriptor::Type::TIMESTAMP};
     res.set_processing_config(processing_config);
@@ -172,6 +174,38 @@ TEST(Resample, StructureForProcessingExactBoundary) {
     ASSERT_EQ(ranges_and_keys[1], bottom);
     std::vector<std::vector<size_t>> expected_proc_unit_ids_right{{0, 1}, {1}};
     ASSERT_EQ(expected_proc_unit_ids_right, proc_unit_ids);
+}
+
+TEST(Resample, StructureForProcessingRaisesForUnsupportedOriginWithFoldedDateRange) {
+    // A leading DateRangeClause sets date_range_ before this function uses
+    // it to compute bucket boundaries, without having read any row data yet - so start/end/start_day/end_day
+    // origins are unsafe in that case. See ResampleClause::check_origin_supported_with_date_range.
+    StreamId sym{"sym"};
+    ColRange col_range{1, 2};
+    RowRange row_range{0, 100};
+    auto key = AtomKeyBuilder().start_index(0).end_index(1000).build<KeyType::TABLE_DATA>(sym);
+    std::vector<RangesAndKey> ranges_and_keys{RangesAndKey(row_range, col_range, key)};
+
+    auto resample_clause = generate_resample_clause<ResampleBoundary::LEFT>(
+            ResampleBoundary::LEFT, {1, 500}, ResampleOrigin{std::string{"start"}}
+    );
+    resample_clause.date_range_ = {50, 200};
+    EXPECT_THROW(resample_clause.structure_for_processing(ranges_and_keys), UserInputException);
+}
+
+TEST(Resample, StructureForProcessingAllowsUnsupportedOriginWithoutFoldedDateRange) {
+    // With no date range clause, date_range_ is derived from the real index in ranges_and_keys, so
+    // all origins are OK.
+    StreamId sym{"sym"};
+    ColRange col_range{1, 2};
+    RowRange row_range{0, 100};
+    auto key = AtomKeyBuilder().start_index(0).end_index(1000).build<KeyType::TABLE_DATA>(sym);
+    std::vector<RangesAndKey> ranges_and_keys{RangesAndKey(row_range, col_range, key)};
+
+    auto resample_clause = generate_resample_clause<ResampleBoundary::LEFT>(
+            ResampleBoundary::LEFT, {1, 500}, ResampleOrigin{std::string{"start"}}
+    );
+    EXPECT_NO_THROW(resample_clause.structure_for_processing(ranges_and_keys));
 }
 
 TEST(Resample, FindBuckets) {

--- a/cpp/arcticdb/processing/test/test_resample.cpp
+++ b/cpp/arcticdb/processing/test/test_resample.cpp
@@ -190,7 +190,7 @@ TEST(Resample, StructureForProcessingRaisesForUnsupportedOriginWithFoldedDateRan
             ResampleBoundary::LEFT, {1, 500}, ResampleOrigin{std::string{"start"}}
     );
     resample_clause.date_range_ = {50, 200};
-    EXPECT_THROW(resample_clause.structure_for_processing(ranges_and_keys), UserInputException);
+    EXPECT_THROW((void)resample_clause.structure_for_processing(ranges_and_keys), UserInputException);
 }
 
 TEST(Resample, StructureForProcessingAllowsUnsupportedOriginWithoutFoldedDateRange) {
@@ -205,7 +205,7 @@ TEST(Resample, StructureForProcessingAllowsUnsupportedOriginWithoutFoldedDateRan
     auto resample_clause = generate_resample_clause<ResampleBoundary::LEFT>(
             ResampleBoundary::LEFT, {1, 500}, ResampleOrigin{std::string{"start"}}
     );
-    EXPECT_NO_THROW(resample_clause.structure_for_processing(ranges_and_keys));
+    EXPECT_NO_THROW((void)resample_clause.structure_for_processing(ranges_and_keys));
 }
 
 TEST(Resample, FindBuckets) {

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2987,6 +2987,29 @@
         "version": "54d190c55702975510edf47cdb800becc58916ede08d29d59d38870213dabcae",
         "warmup_time": 0.2
     },
+    "query_builder.QueryBuilderFunctions.peakmem_filtering_chained": {
+        "code": "class QueryBuilderFunctions:\n    def peakmem_filtering_chained(self, *args):\n        self._filtering_chained()\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n        self.null_symbol = _null_symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n    \n            df_with_nulls = df.copy()\n    \n            # Null out 90% of the id1 column, but make sure the first row has non-null id001 so the\n            # equality benchmark does return something\n            df_with_nulls.iloc[0, df_with_nulls.columns.get_loc(\"id1\")] = \"id001\"\n            null_mask = np.random.random(len(df_with_nulls)) < 0.9\n            null_mask[0] = False\n            df_with_nulls.loc[null_mask, \"id1\"] = None\n            null_sym = _null_symbol_name(rows)\n    \n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n                self.logger.info(f\"writing {df_with_nulls.shape} under {null_sym}\")\n                lib.write(null_sym, df_with_nulls)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "name": "query_builder.QueryBuilderFunctions.peakmem_filtering_chained",
+        "param_names": [
+            "num_rows",
+            "storages"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "setup_cache_key": "query_builder:48",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "407d5303b6d2042312fe4aeecb7e00e50b13da757d62ada727903703327b9369"
+    },
     "query_builder.QueryBuilderFunctions.peakmem_filtering_numeric": {
         "code": "class QueryBuilderFunctions:\n    def peakmem_filtering_numeric(self, *args):\n        self._filtering_numeric()\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n        self.null_symbol = _null_symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n    \n            df_with_nulls = df.copy()\n    \n            # Null out 90% of the id1 column, but make sure the first row has non-null id001 so the\n            # equality benchmark does return something\n            df_with_nulls.iloc[0, df_with_nulls.columns.get_loc(\"id1\")] = \"id001\"\n            null_mask = np.random.random(len(df_with_nulls)) < 0.9\n            null_mask[0] = False\n            df_with_nulls.loc[null_mask, \"id1\"] = None\n            null_sym = _null_symbol_name(rows)\n    \n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n                self.logger.info(f\"writing {df_with_nulls.shape} under {null_sym}\")\n                lib.write(null_sym, df_with_nulls)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
         "name": "query_builder.QueryBuilderFunctions.peakmem_filtering_numeric",
@@ -3239,6 +3262,34 @@
         "type": "peakmemory",
         "unit": "bytes",
         "version": "7da53a3b5fd2e393d8e4f06497727b84b2e42ed202dccfe52fd96fbabfee743b"
+    },
+    "query_builder.QueryBuilderFunctions.time_filtering_chained": {
+        "code": "class QueryBuilderFunctions:\n    def time_filtering_chained(self, *args):\n        self._filtering_chained()\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n        self.null_symbol = _null_symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n    \n            df_with_nulls = df.copy()\n    \n            # Null out 90% of the id1 column, but make sure the first row has non-null id001 so the\n            # equality benchmark does return something\n            df_with_nulls.iloc[0, df_with_nulls.columns.get_loc(\"id1\")] = \"id001\"\n            null_mask = np.random.random(len(df_with_nulls)) < 0.9\n            null_mask[0] = False\n            df_with_nulls.loc[null_mask, \"id1\"] = None\n            null_sym = _null_symbol_name(rows)\n    \n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n                self.logger.info(f\"writing {df_with_nulls.shape} under {null_sym}\")\n                lib.write(null_sym, df_with_nulls)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",
+        "min_run_count": 2,
+        "name": "query_builder.QueryBuilderFunctions.time_filtering_chained",
+        "number": 0,
+        "param_names": [
+            "num_rows",
+            "storages"
+        ],
+        "params": [
+            [
+                "1000000",
+                "10000000"
+            ],
+            [
+                "<Storage.LMDB: 2>",
+                "<Storage.AMAZON: 1>"
+            ]
+        ],
+        "rounds": 3,
+        "sample_time": 2,
+        "setup_cache_key": "query_builder:48",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "1b4a4c488d40afc9ee1d6c716ddcad1b937ec1de1b565c1b89da8e8e622e78f9",
+        "warmup_time": 1.0
     },
     "query_builder.QueryBuilderFunctions.time_filtering_numeric": {
         "code": "class QueryBuilderFunctions:\n    def time_filtering_numeric(self, *args):\n        self._filtering_numeric()\n\n    def setup(self, lib_for_storage, num_rows, storage):\n        self.lib = lib_for_storage[storage]\n        if self.lib is None:\n            raise SkipNotImplemented\n        self.symbol = _symbol_name(num_rows)\n        self.null_symbol = _null_symbol_name(num_rows)\n\n    def setup_cache(self):\n        start = time.time()\n        lib_for_storage = create_libraries_across_storages(self.storages)\n    \n        for rows in QueryBuilderFunctions.num_rows:\n            df = generate_benchmark_df(rows)\n            sym = _symbol_name(rows)\n    \n            df_with_nulls = df.copy()\n    \n            # Null out 90% of the id1 column, but make sure the first row has non-null id001 so the\n            # equality benchmark does return something\n            df_with_nulls.iloc[0, df_with_nulls.columns.get_loc(\"id1\")] = \"id001\"\n            null_mask = np.random.random(len(df_with_nulls)) < 0.9\n            null_mask[0] = False\n            df_with_nulls.loc[null_mask, \"id1\"] = None\n            null_sym = _null_symbol_name(rows)\n    \n            for storage in QueryBuilderFunctions.storages:\n                if not is_storage_enabled(storage):\n                    continue\n                lib = lib_for_storage[storage]\n                self.logger.info(f\"writing {df.shape} under {sym}\")\n                lib.write(sym, df)\n                self.logger.info(f\"writing {df_with_nulls.shape} under {null_sym}\")\n                lib.write(null_sym, df_with_nulls)\n    \n        self.logger.info(f\"setup_cache time: {time.time() - start}\")\n        return lib_for_storage",

--- a/python/benchmarks/query_builder.py
+++ b/python/benchmarks/query_builder.py
@@ -111,6 +111,22 @@ class QueryBuilderFunctions:
         result = self.lib.read(self.symbol, columns=["v3"], query_builder=q)
         assert not result.data.empty
 
+    def _filtering_chained(self):
+        # A long chain of separate filter clauses (q[a][b][c]...), which the query planner folds into a
+        # single FilterClause. The early filters are deliberately low-selectivity (each keeps almost
+        # all rows), so without merging each clause would materialise a large intermediate filtered
+        # segment.
+        q = QueryBuilder()
+        q = q[q["v3"] > 0.0]  # keeps ~all rows
+        q = q[q["v3"] < 99.0]  # keeps ~99%
+        q = q[q["v2"] > 1]  # keeps ~93%
+        q = q[q["v2"] < 15]  # keeps ~93%
+        q = q[q["v1"] > 1]  # keeps ~80%
+        q = q[q["v1"] < 5]  # keeps ~80%
+        q = q[q["v3"] < 50.0]  # narrows to ~50%
+        result = self.lib.read(self.symbol, columns=["v1", "v2", "v3"], query_builder=q)
+        assert not result.data.empty
+
     def _projection(self):
         q = QueryBuilder()
         q = q.apply("new_col", q["v2"] * q["v3"])
@@ -150,6 +166,12 @@ class QueryBuilderFunctions:
 
     def peakmem_filtering_numeric(self, *args):
         self._filtering_numeric()
+
+    def time_filtering_chained(self, *args):
+        self._filtering_chained()
+
+    def peakmem_filtering_chained(self, *args):
+        self._filtering_chained()
 
     def time_filtering_string_isin(self, lib_for_storage, num_rows, storage):
         # Selects about 1% of the rows

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -842,6 +842,42 @@ def test_column_stats_with_date_range(in_memory_version_store, clear_query_stats
     assert_frame_equal(result, df1)
 
 
+def test_column_stats_filter_after_head_clause_not_pruned(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
+):
+    """A filter after a head() clause must not contribute to pruning, because this
+    would change which rows are 'first N'."""
+    lib = in_memory_version_store
+
+    df0 = pd.DataFrame({"col_1": [1, 2], "col_2": [1, 2]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"col_1": [3, 4], "col_2": [3, 4]}, index=pd.date_range("2000-01-03", periods=2))
+    df2 = pd.DataFrame({"col_1": [5, 6], "col_2": [5, 6]}, index=pd.date_range("2000-01-05", periods=2))
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.append(sym, df2)
+
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[q["col_1"] >= 3]
+    q = q.head(2)
+    q = q[q["col_2"] > 4]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    # col_1 >= 3 keeps seg1 and seg2 (seg0 pruned); head(2) of those is [3, 4]; col_2 > 4 yields
+    # nothing. If col_2 > 4 were used to prune, only seg2 would survive and the result would wrongly
+    # be [5, 6]. The first filter still prunes seg0, so two segments are read.
+    expected = pd.concat([df0, df1, df2])
+    expected = expected[expected["col_1"] >= 3].head(2)
+    expected = expected[expected["col_2"] > 4]
+    assert expected.empty
+    assert_frame_equal(result, expected)
+    assert table_data_reads == 2, f"Expected 2 TABLE_DATA reads (seg0 pruned), got {table_data_reads}"
+
+
 @pytest.mark.parametrize("negated", (True, False))
 def test_column_stats_bool_column_filters(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, negated

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1970,9 +1970,8 @@ def test_filter_clause_merging_not_across_row_range(
 def test_filter_merge_date_range_between(
     lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
-    """We move DateRangeClauses between two filters left in the query plan so we can merge the filters,
-    and in future restrict the data that the filter needs to evaluate against. This test just checks
-    that we give correct results.
+    """We move DateRangeClauses between two filters left in the query plan so we can merge the filters.
+    This test just checks that we give correct results.
     """
     lib = lmdb_version_store_tiny_segment
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -2001,8 +2000,8 @@ def test_filter_merge_dynamic_schema_missing_column(lmdb_version_store_dynamic_s
     lib = lmdb_version_store_dynamic_schema
     lib._set_output_format_for_pipeline_tests(any_output_format)
     symbol = "test_filter_merge_dynamic_schema_missing_column"
-    df0 = pd.DataFrame({"a": [1, 2], "b": [10, 20]}, index=pd.date_range("2000-01-01", periods=2))
-    df1 = pd.DataFrame({"a": [3, 4]}, index=pd.date_range("2000-01-03", periods=2))
+    df0 = pd.DataFrame({"a": [1, 2, 3], "b": [10, 20, 200]}, index=pd.date_range("2000-01-01", periods=3))
+    df1 = pd.DataFrame({"a": [4, 5]}, index=pd.date_range("2000-01-04", periods=2))
     lib.write(symbol, df0)
     lib.append(symbol, df1)
 

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1912,3 +1912,264 @@ def test_filter_regex_comma_separated_strings(lmdb_version_store_v1, sym, dynami
     received = lib.read(sym, query_builder=q).data
     assert_frame_equal(expected, received)
     assert not expected.empty
+
+
+def test_filter_clause_merging(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    """Consecutive filters are merged into one in the query planner, the result must match both the
+    equivalent ANDed filter and Pandas."""
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_clause_merging"
+    df = pd.DataFrame(
+        {"a": np.arange(20), "b": np.arange(20)[::-1], "c": np.arange(20) % 4},
+        index=pd.date_range("2000-01-01", periods=20),
+    )
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    expected = df[(df["a"] > 5) & (df["b"] > 5) & (df["c"] == 1)]
+    assert not expected.empty
+
+    q_chained = QueryBuilder()
+    q_chained = q_chained[q_chained["a"] > 5]
+    q_chained = q_chained[q_chained["b"] > 5]
+    q_chained = q_chained[q_chained["c"] == 1]
+    assert_frame_equal(expected, lib.read(symbol, query_builder=q_chained).data)
+
+    q_single = QueryBuilder()
+    q_single = q_single[(q_single["a"] > 5) & (q_single["b"] > 5) & (q_single["c"] == 1)]
+    assert_frame_equal(expected, lib.read(symbol, query_builder=q_single).data)
+
+
+def test_filter_clause_merging_not_across_row_range(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    """A RowRangeClause between two filters must not be moved left, because it affects the data that
+    the filter to its right should act on but not what the filter on its left should act on."""
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_clause_merging_not_across_row_range"
+    df = pd.DataFrame({"a": np.arange(20), "b": 19 - np.arange(20)}, index=pd.date_range("2000-01-01", periods=20))
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    q = QueryBuilder()
+    q = q[q["a"] >= 5]
+    q = q.head(8)
+    q = q[q["b"] < 10]
+    received = lib.read(symbol, query_builder=q).data
+
+    expected = df[df["a"] >= 5].head(8)
+    expected = expected[expected["b"] < 10]
+    assert not expected.empty
+    assert_frame_equal(expected, received)
+
+
+def test_filter_merge_date_range_between(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    """We move DateRangeClauses between two filters left in the query plan so we can merge the filters,
+    and in future restrict the data that the filter needs to evaluate against. This test just checks
+    that we give correct results.
+    """
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_date_range_between"
+    df = pd.DataFrame({"a": np.arange(20), "b": np.arange(20)}, index=pd.date_range("2000-01-01", periods=20))
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    start = pd.Timestamp("2000-01-05")
+    end = pd.Timestamp("2000-01-15")
+    q = QueryBuilder()
+    q = q[q["a"] > 3]
+    q = q.date_range((start, end))
+    q = q[q["b"] < 17]
+    received = lib.read(symbol, query_builder=q).data
+
+    expected = df[df["a"] > 3]
+    expected = expected[(expected.index >= start) & (expected.index <= end)]
+    expected = expected[expected["b"] < 17]
+    assert not expected.empty
+    assert_frame_equal(expected, received)
+
+
+def test_filter_merge_dynamic_schema_missing_column(lmdb_version_store_dynamic_schema, any_output_format):
+    """Merged filter referencing a column absent from some segments must still work."""
+    lib = lmdb_version_store_dynamic_schema
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_dynamic_schema_missing_column"
+    df0 = pd.DataFrame({"a": [1, 2], "b": [10, 20]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"a": [3, 4]}, index=pd.date_range("2000-01-03", periods=2))
+    lib.write(symbol, df0)
+    lib.append(symbol, df1)
+
+    q = QueryBuilder()
+    q = q[q["a"] > 1]
+    q = q[q["b"] < 100]
+    received = lib.read(symbol, query_builder=q).data
+
+    full_df = pd.concat([df0, df1])
+    expected = full_df[(full_df["a"] > 1) & (full_df["b"] < 100)]
+    assert_frame_equal(expected, received, check_dtype=False)
+
+
+def test_filter_merge_optimise_for_memory(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    """Merging filters under MEMORY optimisation returns correct rows."""
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_optimise_for_memory"
+    df = pd.DataFrame(
+        {"a": np.arange(20), "s": [f"str_{i}" for i in range(20)]}, index=pd.date_range("2000-01-01", periods=20)
+    )
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    q = QueryBuilder()
+    q = q[q["a"] > 3]
+    q = q[q["a"] < 15]
+    q.optimise_for_memory()
+    received = lib.read(symbol, query_builder=q).data
+
+    expected = df[(df["a"] > 3) & (df["a"] < 15)]
+    assert not expected.empty
+    assert_frame_equal(expected, received)
+
+
+def test_filter_merge_date_range_moved_left_past_projection(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    """A date range moved left past a projection is safe. A projection does not change the index, and
+    a date range filters on the index, so applying the date range before the projection gives the same
+    rows."""
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_date_range_moved_left_past_projection"
+    df = pd.DataFrame({"a": np.arange(20)}, index=pd.date_range("2000-01-01", periods=20))
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    start = pd.Timestamp("2000-01-05")
+    end = pd.Timestamp("2000-01-15")
+    q = QueryBuilder()
+    q = q[q["a"] >= 2]
+    q = q.apply("doubled", q["a"] * 2)
+    q = q.date_range((start, end))
+    received = lib.read(symbol, query_builder=q).data
+
+    expected = df[df["a"] >= 2].copy()
+    expected["doubled"] = expected["a"] * 2
+    expected = expected[(expected.index >= start) & (expected.index <= end)]
+    assert not expected.empty
+    assert_frame_equal(expected, received)
+
+
+def compare_chained_filters_vs_single_and(lib, symbol, build):
+    chained = lib.read(symbol, query_builder=build(combined=False)).data
+    combined = lib.read(symbol, query_builder=build(combined=True)).data
+    assert not chained.empty
+    assert_frame_equal(chained.sort_index(), combined.sort_index())
+
+
+def test_filter_merge_then_groupby(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_then_groupby"
+    n = 30
+    df = pd.DataFrame(
+        {"g": np.arange(n) % 4, "a": np.arange(n), "b": n - np.arange(n)},
+        index=pd.date_range("2000-01-01", periods=n),
+    )
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    def build(combined):
+        q = QueryBuilder()
+        if combined:
+            q = q[(q["a"] > 5) & (q["b"] > 5)]
+        else:
+            q = q[q["a"] > 5]
+            q = q[q["b"] > 5]
+        return q.groupby("g").agg({"a": "sum", "b": "mean"})
+
+    compare_chained_filters_vs_single_and(lib, symbol, build)
+
+
+def test_filter_merge_then_resample(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_then_resample"
+    n = 30
+    df = pd.DataFrame({"a": np.arange(n), "b": n - np.arange(n)}, index=pd.date_range("2000-01-01", periods=n))
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    def build(combined):
+        q = QueryBuilder()
+        if combined:
+            q = q[(q["a"] > 3) & (q["b"] > 3)]
+        else:
+            q = q[q["a"] > 3]
+            q = q[q["b"] > 3]
+        return q.resample("2D").agg({"a": "sum"})
+
+    compare_chained_filters_vs_single_and(lib, symbol, build)
+
+
+def test_filter_merge_projection_between_filters(
+    lmdb_version_store_tiny_segment, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    """A projection between two filters stops them from being merged together (the second filter references the projected
+    column, so it cannot be merged with the first)."""
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_filter_merge_projection_between_filters"
+    df = pd.DataFrame({"a": np.arange(20), "b": np.arange(20, 40)}, index=pd.date_range("2000-01-01", periods=20))
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    q = QueryBuilder()
+    q = q[q["a"] > 2]
+    q = q.apply("c", q["a"] + q["b"])
+    q = q[q["c"] < 50]
+    received = lib.read(symbol, query_builder=q).data
+
+    expected = df[df["a"] > 2].copy()
+    expected["c"] = expected["a"] + expected["b"]
+    expected = expected[expected["c"] < 50]
+    assert not expected.empty
+    assert_frame_equal(expected, received)
+
+
+def test_filter_merge_after_concat(lmdb_version_store_tiny_segment, any_output_format):
+    """Filters chained after a concat are merged and applied to the joined
+    result. The merged form must match the equivalent single ANDed filter."""
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    df0 = pd.DataFrame({"a": np.arange(10), "b": np.arange(10, 20)}, index=pd.date_range("2000-01-01", periods=10))
+    df1 = pd.DataFrame({"a": np.arange(20, 30), "b": np.arange(30, 40)}, index=pd.date_range("2000-01-20", periods=10))
+    lib.write("test_filter_merge_after_concat_0", df0)
+    lib.write("test_filter_merge_after_concat_1", df1)
+    symbols = ["test_filter_merge_after_concat_0", "test_filter_merge_after_concat_1"]
+
+    def build(combined):
+        q = QueryBuilder().concat("outer")
+        if combined:
+            q = q[(q["a"] > 5) & (q["b"] < 38)]
+        else:
+            q = q[q["a"] > 5]
+            q = q[q["b"] < 38]
+        return q
+
+    chained = lib.batch_read_and_join(symbols, query_builder=build(False)).data
+    combined = lib.batch_read_and_join(symbols, query_builder=build(True)).data
+    assert not chained.empty
+    assert_frame_equal(chained, combined)

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -16,6 +16,7 @@ import datetime
 import dateutil
 
 from arcticdb import OutputFormat
+from arcticdb.exceptions import SchemaException
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal, query_stats_operation_count
 import arcticdb.toolbox.query_stats as qs
@@ -243,8 +244,9 @@ def test_querybuilder_filter_datetime_with_timezone(lmdb_version_store_tiny_segm
 
 @pytest.mark.parametrize("batch", [True, False])
 @pytest.mark.parametrize("use_date_range_clause", [True, False])
+@pytest.mark.parametrize("disjoint", [True, False])
 def test_querybuilder_date_range_then_date_range(
-    lmdb_version_store_tiny_segment, batch, use_date_range_clause, any_output_format
+    lmdb_version_store_tiny_segment, batch, use_date_range_clause, disjoint, any_output_format
 ):
     lib = lmdb_version_store_tiny_segment
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -252,8 +254,12 @@ def test_querybuilder_date_range_then_date_range(
     df = pd.DataFrame({"col": np.arange(1, 11)}, index=pd.date_range("2000-01-01", periods=10))
     lib.write(symbol, df)
 
-    first_date_range = (pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-09"))
-    second_date_range = (pd.Timestamp("2000-01-07"), pd.Timestamp("2000-01-08"))
+    if disjoint:
+        first_date_range = (pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-04"))
+        second_date_range = (pd.Timestamp("2000-01-07"), pd.Timestamp("2000-01-09"))
+    else:
+        first_date_range = (pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-09"))
+        second_date_range = (pd.Timestamp("2000-01-07"), pd.Timestamp("2000-01-08"))
 
     q = QueryBuilder()
     if use_date_range_clause:
@@ -270,6 +276,31 @@ def test_querybuilder_date_range_then_date_range(
             received = lib.batch_read([symbol], date_ranges=[first_date_range], query_builder=q)[symbol].data
         else:
             received = lib.read(symbol, date_range=first_date_range, query_builder=q).data
+
+    if disjoint:
+        assert len(received) == 0
+        assert list(received.columns) == list(df.columns)
+    else:
+        expected = df.query("col in [7, 8]")
+        assert_frame_equal(expected, received)
+
+
+def test_querybuilder_date_range_kwarg_and_clause_intersect_with_filter(
+    lmdb_version_store_tiny_segment, column_stats_filtering_enabled_and_disabled, any_output_format
+):
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_querybuilder_date_range_kwarg_and_clause_intersect_with_filter"
+    df = pd.DataFrame({"col": np.arange(1, 11)}, index=pd.date_range("2000-01-01", periods=10))
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+
+    kwarg_date_range = (pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-09"))
+    clause_date_range = (pd.Timestamp("2000-01-07"), pd.Timestamp("2000-01-08"))
+
+    q = QueryBuilder().date_range(clause_date_range)
+    q = q[q["col"] >= 7]
+    received = lib.read(symbol, date_range=kwarg_date_range, query_builder=q).data
     expected = df.query("col in [7, 8]")
     assert_frame_equal(expected, received)
 
@@ -475,6 +506,26 @@ def test_querybuilder_empty_date_range_then_groupby(lmdb_version_store_v1, any_o
     assert received.index.name == "col1"
     assert len(received.columns) == 1
     assert "col2" in received.columns
+
+
+def test_querybuilder_date_range_then_groupby_then_date_range_raises(lmdb_version_store_v1, any_output_format):
+    # Once GroupBy is followed by Agg, the index is no longer a timeseries (it becomes the grouping
+    # column), so a DateRangeClause after it must be rejected.
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_querybuilder_date_range_then_groupby_then_date_range_raises"
+    df = pd.DataFrame(
+        {"col1": ["a", "b", "c", "a", "b", "c", "a", "b", "c", "d"], "col2": np.arange(1, 11)},
+        index=pd.date_range("2000-01-01", periods=10),
+    )
+    lib.write(symbol, df)
+
+    q = QueryBuilder()
+    q = q.date_range((pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-09")))
+    q = q.groupby("col1").agg({"col2": "sum"})
+    q = q.date_range((pd.Timestamp("2000-01-04"), pd.Timestamp("2000-01-06")))
+    with pytest.raises(SchemaException):
+        lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("batch", [True, False])
@@ -893,6 +944,31 @@ def test_querybuilder_project_then_date_range(lmdb_version_store_tiny_segment, a
     expected = df
     expected["new_col"] = expected["col"] * 3
     expected = expected.query("col in [3, 4, 5, 6, 7, 8]")
+    assert_frame_equal(expected, received, check_dtype=False)
+
+
+def test_querybuilder_filter_then_date_range_then_project_then_date_range(
+    lmdb_version_store_tiny_segment, any_output_format
+):
+    # The two DateRangeClauses should be moved to the front of the pipeline and merged into a single
+    # intersected range (query_planner.cpp's move_and_merge_date_ranges_left), leaving the filter and
+    # projection alone. Here we just check that we give correct results.
+    lib = lmdb_version_store_tiny_segment
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_querybuilder_filter_then_date_range_then_project_then_date_range"
+    df = pd.DataFrame({"col": np.arange(1, 11)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(symbol, df)
+
+    q = QueryBuilder()
+    q = q[q["col"] != 5]
+    q = q.date_range((pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-06")))
+    q = q.apply("new_col", q["col"] * 10)
+    q = q.date_range((pd.Timestamp("2024-01-04"), pd.Timestamp("2024-01-09")))
+    received = lib.read(symbol, query_builder=q).data
+
+    expected = df.query("col != 5").copy()
+    expected["new_col"] = expected["col"] * 10
+    expected = expected.loc["2024-01-04":"2024-01-06"]
     assert_frame_equal(expected, received, check_dtype=False)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -528,6 +528,46 @@ def test_querybuilder_date_range_then_groupby_then_date_range_raises(lmdb_versio
         lib.read(symbol, query_builder=q)
 
 
+def test_querybuilder_date_range_then_groupby_then_date_range_raises_with_timestamp_grouping_column(
+    lmdb_version_store_v1, any_output_format
+):
+    # The grouping column becomes an ordinary data column with the real index replaced by a plain
+    # rowcount index (see AggregationClause::modify_schema), regardless of the grouping column's own
+    # dtype. So a DateRangeClause after GroupBy+Agg must still be rejected even when the grouping
+    # column itself holds timestamps.
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_querybuilder_date_range_then_groupby_then_date_range_raises_with_timestamp_grouping_column"
+    df = pd.DataFrame(
+        {
+            "col1": pd.to_datetime(
+                [
+                    "2000-06-01",
+                    "2000-06-02",
+                    "2000-06-03",
+                    "2000-06-01",
+                    "2000-06-02",
+                    "2000-06-03",
+                    "2000-06-01",
+                    "2000-06-02",
+                    "2000-06-03",
+                    "2000-06-04",
+                ]
+            ),
+            "col2": np.arange(1, 11),
+        },
+        index=pd.date_range("2000-01-01", periods=10),
+    )
+    lib.write(symbol, df)
+
+    q = QueryBuilder()
+    q = q.date_range((pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-09")))
+    q = q.groupby("col1").agg({"col2": "sum"})
+    q = q.date_range((pd.Timestamp("2000-01-04"), pd.Timestamp("2000-01-06")))
+    with pytest.raises(SchemaException):
+        lib.read(symbol, query_builder=q)
+
+
 @pytest.mark.parametrize("batch", [True, False])
 @pytest.mark.parametrize("use_row_range_clause", [True, False])
 def test_querybuilder_row_range(lmdb_version_store_tiny_segment, batch, use_row_range_clause, any_output_format):

--- a/python/tests/unit/arcticdb/version_store/test_resample.py
+++ b/python/tests/unit/arcticdb/version_store/test_resample.py
@@ -861,6 +861,129 @@ class TestResamplingOrigin:
             date_range=(pd.Timestamp("2025-01-02 00:00:00"), pd.Timestamp("2025-01-03 00:00:00")),
         )
 
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "start_day",
+            "start",
+            pytest.param("end", marks=pytest.mark.skipif(PANDAS_VERSION < Version("1.3.0"), reason="Not supported")),
+            pytest.param(
+                "end_day", marks=pytest.mark.skipif(PANDAS_VERSION < Version("1.3.0"), reason="Not supported")
+            ),
+        ],
+    )
+    def test_multiple_date_range_clauses_then_unsupported_origin_resample_raises(
+        self, lmdb_version_store_v1, origin, closed, any_output_format
+    ):
+        lib = lmdb_version_store_v1
+        lib._set_output_format_for_pipeline_tests(any_output_format)
+        sym = "test_multiple_date_range_clauses_then_unsupported_origin_resample_raises"
+
+        lib.write(
+            sym,
+            pd.DataFrame(
+                {"col": [1, 2, 3, 4, 5]},
+                index=pd.date_range("2024-01-01", periods=5),
+            ),
+        )
+        q = (
+            QueryBuilder()
+            .date_range((pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-04")))
+            .date_range((pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-05")))
+            .resample("1min", origin=origin, closed=closed)
+            .agg({"col_min": ("col", "min")})
+        )
+        with pytest.raises(UserInputException) as exception_info:
+            lib.read(sym, query_builder=q)
+        assert all(w in str(exception_info.value) for w in [origin, "origin"])
+
+    @pytest.mark.parametrize(
+        "origin",
+        [
+            "start_day",
+            "start",
+            pytest.param("end", marks=pytest.mark.skipif(PANDAS_VERSION < Version("1.3.0"), reason="Not supported")),
+            pytest.param(
+                "end_day", marks=pytest.mark.skipif(PANDAS_VERSION < Version("1.3.0"), reason="Not supported")
+            ),
+        ],
+    )
+    def test_date_range_then_filter_then_any_origin_resample_allowed(
+        self, lmdb_version_store_v1, origin, closed, any_output_format
+    ):
+        # Unlike leading date ranges folding straight into the resample, a filter in between stops the fold, so
+        # the resample computes its bucket boundaries from the real, already-filtered data it receives rather than
+        # the raw requested date range - so start/end/start_day/end_day origins work correctly here. Filter out the
+        # row at the start of the date range, so the filtered data's true first timestamp (which "start"/"start_day"
+        # origins anchor on) differs from the date range's own boundary.
+        lib = lmdb_version_store_v1
+        lib._set_output_format_for_pipeline_tests(any_output_format)
+        sym = "test_date_range_then_filter_then_any_origin_resample_allowed"
+
+        idx = pd.date_range("2024-01-01", periods=10, freq="D")
+        df = pd.DataFrame({"col": np.arange(10)}, index=idx)
+        lib.write(sym, df)
+
+        date_range = (pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-09"))
+        q = QueryBuilder().date_range(date_range)
+        q = q[q["col"] != 1]
+        q = q.resample("2D", origin=origin, closed=closed).agg({"col": "sum"})
+        received = lib.read(sym, query_builder=q).data
+
+        filtered = df.loc[date_range[0] : date_range[1]]
+        filtered = filtered[filtered["col"] != 1]
+        resampler = filtered.resample("2D", origin=origin, closed=closed)
+        # ArcticDB never emits empty buckets, but pandas can, eg for origin="end"/"end_day" with closed="left".
+        expected = resampler.agg({"col": "sum"})[resampler["col"].count() > 0]
+
+        assert_frame_equal(expected, received)
+
+    def test_date_range_after_any_origin_resample_allowed(self, lmdb_version_store_v1, closed, any_output_format):
+        lib = lmdb_version_store_v1
+        lib._set_output_format_for_pipeline_tests(any_output_format)
+        sym = "test_date_range_after_any_origin_resample_allowed"
+        idx = pd.date_range("2024-01-01", periods=10, freq="min")
+        df = pd.DataFrame({"col": np.arange(10)}, index=idx)
+        lib.write(sym, df)
+
+        reference = QueryBuilder().resample("2min", origin="start", closed=closed).agg({"col": "sum"})
+        reference_full = lib.read(sym, query_builder=reference).data
+        post_range = (pd.Timestamp("2024-01-01 00:02:00"), pd.Timestamp("2024-01-01 00:06:00"))
+        expected = reference_full.loc[post_range[0] : post_range[1]]
+
+        q = QueryBuilder().resample("2min", origin="start", closed=closed).agg({"col": "sum"}).date_range(post_range)
+        received = lib.read(sym, query_builder=q).data
+
+        assert_frame_equal(expected, received)
+
+    def test_epoch_origin_resample_with_multiple_leading_date_ranges_allowed(
+        self, lmdb_version_store_v1, closed, any_output_format
+    ):
+        lib = lmdb_version_store_v1
+        lib._set_output_format_for_pipeline_tests(any_output_format)
+        sym = "test_epoch_origin_resample_with_multiple_leading_date_ranges_allowed"
+        idx = pd.date_range("2024-01-01", periods=10, freq="min")
+        df = pd.DataFrame({"col": np.arange(10)}, index=idx)
+        lib.write(sym, df)
+
+        pre_range_a = (pd.Timestamp("2024-01-01 00:00:00"), pd.Timestamp("2024-01-01 00:07:00"))
+        pre_range_b = (pd.Timestamp("2024-01-01 00:02:00"), pd.Timestamp("2024-01-01 00:09:00"))
+        merged_pre = (max(pre_range_a[0], pre_range_b[0]), min(pre_range_a[1], pre_range_b[1]))
+
+        reference = QueryBuilder().resample("2min", origin="epoch", closed=closed).agg({"col": "sum"})
+        expected = lib.read(sym, date_range=merged_pre, query_builder=reference).data
+
+        q = (
+            QueryBuilder()
+            .date_range(pre_range_a)
+            .date_range(pre_range_b)
+            .resample("2min", origin="epoch", closed=closed)
+            .agg({"col": "sum"})
+        )
+        received = lib.read(sym, query_builder=q).data
+
+        assert_frame_equal(expected, received)
+
 
 @pytest.mark.skipif(PANDAS_VERSION < Version("1.1.0"), reason="Pandas < 1.1.0 do not have offset param")
 @pytest.mark.parametrize("closed", ["left", "right"])
@@ -942,6 +1065,56 @@ def test_date_range_outside_symbol_timerange(lmdb_version_store_v1, any_output_f
     received_df = lib.read(sym, query_builder=q).data
     assert not len(received_df)
     assert received_df.columns == df.columns
+
+
+def test_disjoint_date_ranges_fold_into_resample_produce_empty_result(lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_disjoint_date_ranges_fold_into_resample_produce_empty_result"
+    df = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2025-01-01", periods=10))
+    lib.write(sym, df)
+    q = (
+        QueryBuilder()
+        .date_range((pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-04")))
+        .date_range((pd.Timestamp("2025-01-07"), pd.Timestamp("2025-01-09")))
+        .resample("1min")
+        .agg({"col": "sum"})
+    )
+    received_df = lib.read(sym, query_builder=q).data
+    assert not len(received_df)
+    assert list(received_df.columns) == list(df.columns)
+
+
+def test_date_ranges_both_sides_of_resample_intersect_independently(lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_date_ranges_both_sides_of_resample_intersect_independently"
+    df = pd.DataFrame({"col": np.arange(20)}, index=pd.date_range("2025-01-01", periods=20, freq="D"))
+    lib.write(sym, df)
+
+    pre_range_a = (pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-12"))
+    pre_range_b = (pd.Timestamp("2025-01-04"), pd.Timestamp("2025-01-15"))
+    merged_pre = (max(pre_range_a[0], pre_range_b[0]), min(pre_range_a[1], pre_range_b[1]))
+    post_range_c = (pd.Timestamp("2025-01-01"), pd.Timestamp("2025-01-10"))
+    post_range_d = (pd.Timestamp("2025-01-03"), pd.Timestamp("2025-01-20"))
+    merged_post = (max(post_range_c[0], post_range_d[0]), min(post_range_c[1], post_range_d[1]))
+
+    reference_q = QueryBuilder().resample("2D").agg({"col": "sum"})
+    reference_resampled = lib.read(sym, date_range=merged_pre, query_builder=reference_q).data
+    expected = reference_resampled.loc[merged_post[0] : merged_post[1]]
+
+    q = (
+        QueryBuilder()
+        .date_range(pre_range_a)
+        .date_range(pre_range_b)
+        .resample("2D")
+        .agg({"col": "sum"})
+        .date_range(post_range_c)
+        .date_range(post_range_d)
+    )
+    received = lib.read(sym, query_builder=q).data
+
+    assert_frame_equal(expected, received)
 
 
 class TestResampleDynamicSchema:


### PR DESCRIPTION
11643672444

Only review https://github.com/man-group/ArcticDB/pull/3204/changes/412ee424d92e1a1aa334e0dc807a5500c35715ca - the rest of this diff is already in PR #3201 

- Merge filter clauses in to one to prevent materializing intermediate segments, and to unify with column stats evaluation which already does this. This improves performance and memory use for query builders with long chains of filters like:

```
        q = QueryBuilder()
        q = q[q["v3"] > 0.0]  # keeps ~all rows
        q = q[q["v3"] < 99.0]  # keeps ~99%
        q = q[q["v2"] > 1]  # keeps ~93%
        q = q[q["v2"] < 15]  # keeps ~93%
        q = q[q["v1"] > 1]  # keeps ~80%
        q = q[q["v1"] < 5]  # keeps ~80%
        q = q[q["v3"] < 50.0]  # narrows to ~50%
```

Benchmark results:

```
| Change   | Before [5077a00b] <master>   | After [b2bb249c] <aseaton/column-stats/11643672444/and-clauses-pipeline>   |   Ratio | Benchmark (Parameter)                                                                      |
|----------|------------------------------|----------------------------------------------------------------------------|---------|--------------------------------------------------------------------------------------------|
| -        | 258M                         | 208M                                                                       |    0.81 | query_builder.QueryBuilderFunctions.peakmem_filtering_chained(1000000, <Storage.LMDB: 2>)  |
| -        | 1.68G                        | 1.14G                                                                      |    0.68 | query_builder.QueryBuilderFunctions.peakmem_filtering_chained(10000000, <Storage.LMDB: 2>) |
| -        | 55.5±4ms                     | 35.4±2ms                                                                   |    0.64 | query_builder.QueryBuilderFunctions.time_filtering_chained(10000000, <Storage.LMDB: 2>)    |
| -        | 21.8±0.4ms                   | 12.6±0.08ms                                                                |    0.58 | query_builder.QueryBuilderFunctions.time_filtering_chained(1000000, <Storage.LMDB: 2>)     |
```

- Fix a bug with column stats evaluation where it was incorrectly evaluating filters that came after a RowRange filter (exclude from release notes)
