### PR TITLE
Enhancement 12036593840: append inline defrag post refactors

### DIFF
--- a/cpp/arcticdb/column_store/column.hpp
+++ b/cpp/arcticdb/column_store/column.hpp
@@ -400,6 +400,8 @@ class Column {
         update_offsets(val.nbytes());
         data_.commit();
         shapes_.commit();
+        // This seems incorrect for when Fortran-ordered is being set this way. last_physical_row_ is also not updated
+        // at all
         ++last_logical_row_;
     }
 

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -25,8 +25,8 @@ struct FrameSliceMap {
     FrameSliceMap(std::shared_ptr<PipelineContext> context, bool dynamic_schema) : context_(std::move(context)) {
         const entity::StreamDescriptor& descriptor = context_->descriptor();
         const auto true_index_field_count = descriptor.index().field_count();
-        const auto required_fields_count = static_cast<bool>(context_->norm_meta_)
-                                                   ? index::required_fields_count(descriptor, *context_->norm_meta_)
+        const auto required_fields_count = context_->has_normalization()
+                                                   ? index::required_fields_count(descriptor, context_->normalization())
                                                    : index::required_fields_count(descriptor);
         std::optional<size_t> min_col_index;
         for (const auto& context_row : *context_) {

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -42,16 +42,6 @@ TimeseriesDescriptor make_timeseries_descriptor(
     };
 }
 
-TimeseriesDescriptor make_timeseries_descriptor(
-        size_t total_rows, StreamDescriptor&& desc, const proto::descriptors::NormalizationMetadata& norm_meta,
-        std::optional<proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& next_key,
-        bool bucketize_dynamic
-) {
-    return make_timeseries_descriptor(
-            total_rows, desc, norm_meta, std::move(um), std::move(next_key), bucketize_dynamic
-    );
-}
-
 TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
         const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, std::optional<AtomKey>&& next_key,
         bool bucketize_dynamic
@@ -59,11 +49,8 @@ TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
     return make_timeseries_descriptor(
             pipeline_context->total_rows_,
             pipeline_context->descriptor(),
-            *pipeline_context->norm_meta_,
-            pipeline_context->user_meta_ ? std::make_optional<arcticdb::proto::descriptors::UserDefinedMetadata>(
-                                                   std::move(*pipeline_context->user_meta_)
-                                           )
-                                         : std::nullopt,
+            pipeline_context->normalization(),
+            pipeline_context->release_opt_user_defined_metadata(),
             std::move(next_key),
             bucketize_dynamic
     );

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -65,7 +65,7 @@ TimeseriesDescriptor make_timeseries_descriptor(
 // The overload above returns a TSD that shares a std::shared_ptr<FieldCollection> with the input StreamDescriptor,
 // which is error-prone. However, it is sometimes the desired behaviour, so needs to still be available.
 TimeseriesDescriptor make_timeseries_descriptor(
-        size_t total_rows, StreamDescriptor&& desc,
+        size_t total_rows, const StreamDescriptor& desc,
         const arcticdb::proto::descriptors::NormalizationMetadata& norm_meta,
         std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>&& um, std::optional<AtomKey>&& next_key,
         bool bucketize_dynamic

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -45,8 +45,49 @@ bool PipelineContext::only_index_columns_selected() const {
     return overall_column_bitset_->count() == 1 && (*overall_column_bitset_)[0];
 }
 
+std::optional<proto::descriptors::UserDefinedMetadata> PipelineContext::release_opt_user_defined_metadata() {
+    if (tsd_.has_value()) {
+        return std::move(*tsd_->mutable_proto().mutable_user_meta());
+    } else {
+        return std::nullopt;
+    }
+}
+
 const std::optional<util::BitSet>& PipelineContextRow::get_selected_columns() const {
     return parent_->selected_columns_;
+}
+
+void PipelineContext::set_tsd(TimeseriesDescriptor&& tsd) { tsd_.emplace(std::move(tsd)); }
+
+const TimeseriesDescriptor& PipelineContext::tsd() const {
+    util::check(tsd_.has_value(), "No TSD defined");
+    return *tsd_;
+}
+
+bool PipelineContext::has_normalization() const { return tsd_.has_value(); }
+
+const arcticdb::proto::descriptors::NormalizationMetadata& PipelineContext::normalization() const {
+    util::check(tsd_.has_value(), "No normalization metadata defined");
+    return tsd_->proto().normalization();
+}
+
+arcticdb::proto::descriptors::NormalizationMetadata& PipelineContext::mutable_normalization() {
+    if (!tsd_.has_value()) {
+        tsd_.emplace();
+    }
+    return *tsd_->mutable_proto().mutable_normalization();
+}
+
+void PipelineContext::set_normalization(arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta) {
+    if (!tsd_.has_value()) {
+        tsd_.emplace();
+    }
+    *tsd_->mutable_proto().mutable_normalization() = std::move(norm_meta);
+}
+
+arcticdb::proto::descriptors::NormalizationMetadata PipelineContext::release_normalization() {
+    util::check(tsd_.has_value(), "No normalization metadata defined");
+    return std::move(*tsd_->mutable_proto().mutable_normalization());
 }
 
 const StringPool& PipelineContextRow::string_pool() const { return *parent_->string_pools_[index_]; }

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -9,6 +9,8 @@
 #pragma once
 
 #include <arcticdb/column_store/string_pool.hpp>
+#include <arcticdb/entity/index_range.hpp>
+#include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/bitset.hpp>
 #include <memory>
@@ -111,8 +113,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     VersionId version_id_ = 0;
     size_t total_rows_ = 0;
     size_t rows_ = 0;
-    std::shared_ptr<arcticdb::proto::descriptors::NormalizationMetadata> norm_meta_;
-    std::unique_ptr<arcticdb::proto::descriptors::UserDefinedMetadata> user_meta_;
+    // Used in appends with compact_data_inline to check the data can be appended
+    std::optional<IndexValue> last_existing_index_value_;
     std::vector<SliceAndKey> slice_and_keys_;
     util::BitSet fetch_index_;
     std::vector<std::shared_ptr<StringPool>> string_pools_;
@@ -182,7 +184,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
         swap(left.stream_id_, right.stream_id_);
         swap(left.version_id_, right.version_id_);
         swap(left.total_rows_, right.total_rows_);
-        swap(left.norm_meta_, right.norm_meta_);
+        swap(left.tsd_, right.tsd_);
+        swap(left.last_existing_index_value_, right.last_existing_index_value_);
         swap(left.fetch_index_, right.fetch_index_);
         swap(left.string_pools_, right.string_pools_);
         swap(left.selected_columns_, right.selected_columns_);
@@ -225,12 +228,35 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     }
 
     bool is_pickled() const {
-        util::check(static_cast<bool>(norm_meta_), "No normalization metadata defined");
-        return norm_meta_->input_type_case() ==
+        util::check(tsd_.has_value(), "No normalization metadata defined");
+        return tsd_->proto().normalization().input_type_case() ==
                arcticdb::proto::descriptors::NormalizationMetadata::InputTypeCase::kMsgPackFrame;
     }
 
+    void set_tsd(TimeseriesDescriptor&& tsd);
+
+    const TimeseriesDescriptor& tsd() const;
+
+    bool has_normalization() const;
+
+    const arcticdb::proto::descriptors::NormalizationMetadata& normalization() const;
+
+    arcticdb::proto::descriptors::NormalizationMetadata& mutable_normalization();
+
+    void set_normalization(arcticdb::proto::descriptors::NormalizationMetadata&& norm_meta);
+
+    arcticdb::proto::descriptors::NormalizationMetadata release_normalization();
+
     bool only_index_columns_selected() const;
+
+    std::optional<proto::descriptors::UserDefinedMetadata> release_opt_user_defined_metadata();
+
+  private:
+    // Carries the normalization metadata and user metadata for the pipeline. On indexed reads it is initialised from
+    // the existing on-disk version (the compact path additionally relies on its descriptor, total rows and sorted
+    // state being those of the existing version); on writes / incompletes / joins it is created solely to carry the
+    // working normalization metadata.
+    std::optional<TimeseriesDescriptor> tsd_;
 };
 
 } // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/test/test_rollback.cpp
+++ b/cpp/arcticdb/pipeline/test/test_rollback.cpp
@@ -10,7 +10,8 @@
 #include <optional>
 #include <type_traits>
 #include <util/test/generators.hpp>
-#include <pipeline/write_frame.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
+#include <arcticdb/version/versioned_engine.hpp>
 
 using namespace arcticdb;
 
@@ -96,7 +97,7 @@ TestTensorFrame append_with_three_segments(version_store::PythonVersionStore& st
     constexpr size_t update_val{1};
     auto append_frame =
             get_test_frame<TimeseriesIndex>(stream_id, get_test_timeseries_fields(), 30, start_index, update_val);
-    store.append_internal(stream_id, append_frame.frame_, false, false, false);
+    store.append_internal(stream_id, append_frame.frame_, version_store::AppendOptions{});
     start_index += 30; // To avoid sameappends
     return append_frame;
 }

--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -431,7 +431,7 @@ SegmentInMemory WriteToSegmentTask::slice() const {
         );
     }
 
-    seg.end_block_write(rows_to_write);
+    seg.set_row_data(rows_to_write - 1);
 
     if (ConfigsMap().instance()->get_int("Statistics.GenerateOnWrite", 0) == 1)
         seg.calculate_statistics();

--- a/cpp/arcticdb/pipeline/write_frame.hpp
+++ b/cpp/arcticdb/pipeline/write_frame.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/stream/index.hpp>
 #include <folly/futures/Future.h>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/index_segment_reader.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/storage/store.hpp>
@@ -37,7 +38,7 @@ struct WriteToSegmentTask : public async::BaseTask {
 
     WriteToSegmentTask(
             std::shared_ptr<InputFrame> frame, FrameSlice slice,
-            const std::optional<TypedStreamVersion>& typed_stream_version, bool sparsify_floats = false,
+            const std::optional<TypedStreamVersion>& typed_stream_version = std::nullopt, bool sparsify_floats = false,
             CopyMode copy_mode = CopyMode::IF_NEEDED
     );
 

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -939,10 +939,12 @@ struct CompactDataClause {
     ClauseInfo clause_info_;
     std::shared_ptr<ComponentManager> component_manager_;
     uint64_t rows_per_segment_;
+    std::shared_ptr<InputFrame> frame_;
     uint64_t min_rows_per_segment_;
     uint64_t max_rows_per_segment_;
+    bool dynamic_schema_;
 
-    explicit CompactDataClause(uint64_t rows_per_segment);
+    CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<InputFrame> frame = std::shared_ptr<InputFrame>());
     ARCTICDB_MOVE_COPY_DEFAULT(CompactDataClause)
 
     [[nodiscard]] std::vector<std::vector<size_t>> structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys);
@@ -955,7 +957,7 @@ struct CompactDataClause {
 
     [[nodiscard]] const ClauseInfo& clause_info() const;
 
-    void set_processing_config(const ProcessingConfig&);
+    void set_processing_config(const ProcessingConfig& processing_config);
 
     void set_component_manager(std::shared_ptr<ComponentManager> component_manager);
 
@@ -968,5 +970,10 @@ struct CompactDataClause {
     [[nodiscard]] bool row_ranges_all_acceptable_lengths(const std::set<RowRange>& row_ranges) const;
 
     [[nodiscard]] std::set<RowRange> structure_row_ranges(const std::set<RowRange>& row_ranges) const;
+
+  private:
+    void add_segment_from_frame(
+            const ProcessingUnit& proc, size_t col_range_start, std::vector<SegmentInMemory>& segments
+    ) const;
 };
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/clause_compact_data.cpp
+++ b/cpp/arcticdb/processing/clause_compact_data.cpp
@@ -11,14 +11,21 @@
 #include <cstdint>
 #include <set>
 
+#include <arcticdb/column_store/column_reslicer.hpp>
 #include <arcticdb/column_store/segment_reslicer.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/input_frame.hpp>
+#include <arcticdb/pipeline/write_frame.hpp>
 #include <arcticdb/processing/clause_utils.hpp>
 #include <arcticdb/util/collection_utils.hpp>
 
 namespace arcticdb {
 
-CompactDataClause::CompactDataClause(uint64_t rows_per_segment) : rows_per_segment_(rows_per_segment) {
+CompactDataClause::CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<InputFrame> frame) :
+    rows_per_segment_(rows_per_segment) {
+    if (frame && frame->num_rows > 0) {
+        frame_ = std::move(frame);
+    }
     // Magic range of +-33% chosen so that:
     // - 2 row slices with < min_rows_per_segment_ cannot be combined into one row slice with > max_rows_per_segment_
     // - 1 row slice with a little more than max_rows_per_segment_ when split in half will still have
@@ -102,10 +109,22 @@ std::vector<std::vector<size_t>> CompactDataClause::structure_for_processing(std
     for (const auto& range_and_key : ranges_and_keys) {
         row_ranges.insert(range_and_key.row_range());
     }
+    if (frame_) {
+        // frame_ is non null when we have arrived here via the compact_data_inline argument to append[_batch]
+        // In this case, we treat the frame being appended as if it is ONE row-slice (even if it is larger than the
+        // library's default slicing policy). A consequence of this is that the resulting structure on-disk may not be
+        // identical to calling append with compact_data_inline=false, followed by an explicit compact_data call.
+        // However, the invariant that all row-slices will have rows_per_segments+-33% will be maintained in both cases
+        util::check(
+                frame_->offset == (row_ranges.empty() ? 0 : row_ranges.rbegin()->second),
+                "CompactDataClause expects the input frame offset to match the end of the existing data"
+        );
+        row_ranges.emplace(frame_->offset, frame_->offset + frame_->num_rows);
+    }
     // The greedy algorithm in structure_row_ranges can reslice data where all segments have an acceptable number of
     // rows, which is not desirable, so short-circuit out if this is the case
     if (row_ranges_all_acceptable_lengths(row_ranges)) {
-        log::version().info("No work to do in CompactDataClause, data is already compacted");
+        log::version().debug("No work to do in CompactDataClause, existing data is already compacted");
         ranges_and_keys.clear();
         return {};
     }
@@ -126,7 +145,7 @@ std::vector<std::vector<size_t>> CompactDataClause::structure_for_processing(std
             }
     );
     if (ranges_and_keys.empty()) {
-        log::version().info("No work to do in CompactDataClause, data is already compacted");
+        log::version().debug("No work to do in CompactDataClause, existing data is already compacted");
         return {};
     }
     // Order by column slice (i.e. all segments in first column slice from top to bottom, then second column slice, etc)
@@ -184,6 +203,12 @@ std::vector<EntityId> CompactDataClause::process(std::vector<EntityId>&& entity_
             proc.row_ranges_->back()->second
     );
     std::vector<SegmentInMemory> segments = util::extract_from_pointers(std::move(*proc.segments_));
+    // Presence of frame implies we are doing inline compaction in append. The second condition means we are processing
+    // the last row-slice of the existing data, and so it must be combined with the frame
+    if (frame_ && frame_->offset == proc.row_ranges_->back()->second) {
+        add_segment_from_frame(proc, col_range_start, segments);
+    }
+
     SegmentReslicer reslicer{max_rows_per_segment_};
     segments = reslicer.reslice_segments(std::move(segments));
 
@@ -214,9 +239,48 @@ std::vector<EntityId> CompactDataClause::process(std::vector<EntityId>&& entity_
     return push_entities(*component_manager_, std::move(proc));
 }
 
+void CompactDataClause::add_segment_from_frame(
+        const ProcessingUnit& proc, size_t col_range_start, std::vector<SegmentInMemory>& segments
+) const {
+    uint64_t total_rows_without_frame = std::accumulate(
+            segments.cbegin(),
+            segments.cend(),
+            uint64_t(0),
+            [](uint64_t n, const SegmentInMemory& segment) { return n + segment.row_count(); }
+    );
+    auto total_rows = total_rows_without_frame + frame_->num_rows;
+    ReslicingInfo reslicing_info{total_rows, max_rows_per_segment_};
+    // Work out how many rows of the frame we need to combine with segments from disk
+    uint64_t row_count{0};
+    for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+        row_count += reslicing_info.rows_in_slice(idx);
+        if (row_count > total_rows_without_frame) {
+            break;
+        }
+    }
+    // Note that this RowRange does not automatically include all of the rows in the frame. This is for 3 reasons:
+    // - WriteToSegmentTask can be parallelised in the post-processing step that writes the remainder of the frame
+    // - At time of writing, WriteClause compresses all of the segments it receives in 1 thread, which can also be
+    //   parallelised if we do it later
+    // - If no compaction of existing data is needed, there is no obvious set of entity ids to call
+    //   CompactDataClause::process with to slice+write the frame
+    const SpecificSlicer slicer{
+            {RowRange{frame_->offset, frame_->offset + (row_count - total_rows_without_frame)}},
+            {ColRange{
+                    col_range_start, dynamic_schema_ ? frame_->desc().field_count() : proc.col_ranges_->front()->second
+            }}
+    };
+    // There is a check in SpecificSlicer that exactly 1 slice will be produced in this case
+    auto frame_slice = slicer(*frame_)[0];
+    WriteToSegmentTask write_to_segment_task{frame_, std::move(frame_slice)};
+    segments.emplace_back(std::get<SegmentInMemory>(write_to_segment_task()));
+}
+
 const ClauseInfo& CompactDataClause::clause_info() const { return clause_info_; }
 
-void CompactDataClause::set_processing_config(const ProcessingConfig&) {}
+void CompactDataClause::set_processing_config(const ProcessingConfig& processing_config) {
+    dynamic_schema_ = processing_config.dynamic_schema_;
+}
 
 void CompactDataClause::set_component_manager(std::shared_ptr<ComponentManager> component_manager) {
     component_manager_ = std::move(component_manager);

--- a/cpp/arcticdb/python/normalization_utils.cpp
+++ b/cpp/arcticdb/python/normalization_utils.cpp
@@ -226,10 +226,10 @@ void check_arrow_column_metadata(
 }
 
 void fix_normalization_or_throw(
-        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr,
-        const pipelines::InputFrame& new_frame, bool dynamic_schema
+        bool is_append, const TimeseriesDescriptor& existing_tsd, const pipelines::InputFrame& new_frame,
+        bool dynamic_schema
 ) {
-    auto& old_norm = existing_isr.tsd().proto().normalization();
+    auto& old_norm = existing_tsd.proto().normalization();
     auto& new_norm = new_frame.norm_meta;
     normalization::check<ErrorCode::E_INCOMPATIBLE_OBJECTS>(
             old_norm.input_type_case() == new_frame.norm_meta.input_type_case(),
@@ -239,10 +239,10 @@ void fix_normalization_or_throw(
             new_frame.norm_meta.input_type_case()
     );
     if (check_pandas_like(old_norm, new_norm)) {
-        const IndexDescriptor::Type old_index_type = existing_isr.tsd().index().type();
+        const IndexDescriptor::Type old_index_type = existing_tsd.index().type();
         const IndexDescriptor::Type new_index_type = new_frame.desc().index().type();
         if (old_index_type == new_index_type && old_index_type == IndexDescriptor::Type::ROWCOUNT) {
-            update_rowcount_normalization_data(old_norm, new_norm, existing_isr.tsd().total_rows());
+            update_rowcount_normalization_data(old_norm, new_norm, existing_tsd.total_rows());
         }
         return;
     }

--- a/cpp/arcticdb/python/normalization_utils.hpp
+++ b/cpp/arcticdb/python/normalization_utils.hpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <unordered_set>
 #include <arcticdb/entity/descriptors.hpp>
+#include <arcticdb/entity/timeseries_descriptor.hpp>
 
 namespace arcticdb {
 
@@ -20,17 +21,14 @@ struct OutputSchema;
 
 namespace pipelines {
 struct InputFrame;
-namespace index {
-struct IndexSegmentReader;
-} // namespace index
 } // namespace pipelines
 
 /**
  * The new frame for append/update is compatible with the existing index. Throws various exceptions if not.
  */
 void fix_normalization_or_throw(
-        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr,
-        const pipelines::InputFrame& new_frame, bool dynamic_schema
+        bool is_append, const TimeseriesDescriptor& existing_tsd, const pipelines::InputFrame& new_frame,
+        bool dynamic_schema
 );
 
 proto::descriptors::NormalizationMetadata generate_norm_meta(

--- a/cpp/arcticdb/util/collection_utils.hpp
+++ b/cpp/arcticdb/util/collection_utils.hpp
@@ -58,6 +58,13 @@ std::vector<std::shared_ptr<T>> extract_to_pointers(std::vector<T>&& input) {
     return res;
 }
 
+template<typename T>
+std::vector<T> reserve_vector(size_t size) {
+    std::vector<T> res;
+    res.reserve(size);
+    return res;
+}
+
 } // namespace util
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1358,20 +1358,12 @@ CompactDataInfo LocalVersionedEngine::compact_data_explain_plan_internal(
             .get();
 }
 
-VersionedItem LocalVersionedEngine::compact_data_internal(
-        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
+VersionedItem LocalVersionedEngine::maybe_compact_data_and_write_version(
+        const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
+        std::optional<CompactDataFrame> compact_data_frame
 ) {
-    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
-    py::gil_scoped_release release_gil;
-    UpdateInfo update_info = compact_data_preamble(stream_id);
-    auto versioned_item = compact_data_impl(
-                                  store(),
-                                  VersionedItem{*update_info.previous_index_key_},
-                                  get_write_options(),
-                                  IndexPartialKey{stream_id, update_info.next_version_id_},
-                                  rows_per_segment.value_or(get_write_options().segment_row_size)
-    )
-                                  .get();
+    auto versioned_item =
+            compact_data_impl(store(), update_info, get_write_options(), rows_per_segment, compact_data_frame).get();
     if (versioned_item.has_value()) {
         write_version_and_prune_previous(
                 prune_previous_versions, versioned_item->key_, update_info.previous_index_key_
@@ -1382,6 +1374,17 @@ VersionedItem LocalVersionedEngine::compact_data_internal(
         // return is for the existing version
         return {std::move(*update_info.previous_index_key_)};
     }
+}
+
+VersionedItem LocalVersionedEngine::compact_data_internal(
+        const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
+) {
+    ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
+    py::gil_scoped_release release_gil;
+    UpdateInfo update_info = compact_data_preamble(stream_id);
+    return maybe_compact_data_and_write_version(
+            update_info, rows_per_segment.value_or(get_write_options().segment_row_size), prune_previous_versions
+    );
 }
 
 bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) {
@@ -1540,9 +1543,7 @@ std::shared_ptr<PipelineContext> setup_join_pipeline_context(
     auto output_schema = modify_schema(clauses.front()->join_schemas(std::move(input_schemas)), clauses);
     auto pipeline_context = std::make_shared<PipelineContext>();
     pipeline_context->set_descriptor(output_schema.stream_descriptor());
-    pipeline_context->norm_meta_ =
-            std::make_shared<arcticdb::proto::descriptors::NormalizationMetadata>(std::move(output_schema.norm_metadata_
-            ));
+    pipeline_context->set_normalization(std::move(output_schema.norm_metadata_));
     return pipeline_context;
 }
 
@@ -1851,31 +1852,49 @@ std::vector<std::variant<folly::Unit, DataError>> LocalVersionedEngine::batch_de
 }
 
 VersionedItem LocalVersionedEngine::append_internal(
-        const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool upsert, bool prune_previous_versions,
-        bool validate_index
+        const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, const AppendOptions& append_options
 ) {
     py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
 
+    // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data_inline is true,
+    // but also when it isn't. However, the read-modify-write pipeline is all built around the PipelineContext class
+    // which assumes an existing version. Better if we just make the FixedSlicer smarter so that its logic is more like
+    // ReslicingInfo
     if (update_info.previous_index_key_.has_value()) {
-        const auto versioned_item =
-                frame->empty()
-                        ? VersionedItem{async::submit_io_task(
-                                                UpdateMetadataTask{store(), update_info, std::move(frame->user_meta)}
-                          )
-                                                .get()}
-                        : append_impl(
-                                  store(),
-                                  update_info,
-                                  frame,
-                                  get_write_options(),
-                                  validate_index,
-                                  cfg().write_options().empty_types()
-                          );
-        write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
-        return versioned_item;
+        if (append_options.compact_data_inline) {
+            auto compact_data_frame = std::make_optional<CompactDataFrame>(
+                    frame, append_options.validate_index, cfg().write_options().empty_types()
+            );
+            return maybe_compact_data_and_write_version(
+                    update_info,
+                    get_write_options().segment_row_size,
+                    append_options.prune_previous_versions,
+                    compact_data_frame
+            );
+        } else {
+            const auto versioned_item =
+                    frame->empty() ? VersionedItem{async::submit_io_task(
+                                                           UpdateMetadataTask{
+                                                                   store(), update_info, std::move(frame->user_meta)
+                                                           }
+                                     )
+                                                           .get()}
+                                   : append_impl(
+                                             store(),
+                                             update_info,
+                                             frame,
+                                             get_write_options(),
+                                             append_options.validate_index,
+                                             cfg().write_options().empty_types()
+                                     );
+            write_version_and_prune_previous(
+                    append_options.prune_previous_versions, versioned_item.key_, update_info.previous_index_key_
+            );
+            return versioned_item;
+        }
     } else {
-        if (upsert) {
+        if (append_options.upsert) {
             auto write_options = get_write_options();
             auto versioned_item = write_dataframe_impl(
                     store_,
@@ -1884,7 +1903,7 @@ VersionedItem LocalVersionedEngine::append_internal(
                     write_options,
                     std::make_shared<DeDupMap>(),
                     false,
-                    validate_index
+                    append_options.validate_index
             );
 
             if (cfg_.symbol_list())
@@ -1900,7 +1919,7 @@ VersionedItem LocalVersionedEngine::append_internal(
 
 std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_append_internal(
         const std::vector<StreamId>& stream_ids, std::vector<std::shared_ptr<pipelines::InputFrame>>&& frames,
-        bool prune_previous_versions, bool validate_index, bool upsert, bool throw_on_error
+        const AppendOptions& append_options, bool throw_on_error
 ) {
     py::gil_scoped_release release_gil;
 
@@ -1916,12 +1935,9 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                 std::move(stream_update_info_fut)
                         .via(&async::cpu_executor())
                         .thenValue(
-                                [this,
-                                 frame = std::move(frames[idx]),
-                                 validate_index,
-                                 stream_id = stream_ids[idx],
-                                 upsert,
-                                 prune_previous_versions](auto&& update_info) -> folly::Future<VersionedItem> {
+                                [this, frame = std::move(frames[idx]), append_options, stream_id = stream_ids[idx]](
+                                        auto&& update_info
+                                ) -> folly::Future<VersionedItem> {
                                     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                                     auto write_options = get_write_options();
                                     bool add_new_symbol_list_entry{!update_info.previous_index_key_.has_value()};
@@ -1936,12 +1952,14 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                                                   update_info,
                                                                   frame,
                                                                   write_options,
-                                                                  validate_index,
+                                                                  append_options.validate_index,
                                                                   cfg().write_options().empty_types()
                                                           );
                                     } else {
                                         missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
-                                                upsert, "Cannot append to non-existent symbol {}", stream_id
+                                                append_options.upsert,
+                                                "Cannot append to non-existent symbol {}",
+                                                stream_id
                                         );
                                         index_key_fut = async_write_dataframe_impl(
                                                 store(),
@@ -1950,13 +1968,13 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                                 write_options,
                                                 std::make_shared<DeDupMap>(),
                                                 false,
-                                                validate_index
+                                                append_options.validate_index
                                         );
                                     }
                                     return std::move(index_key_fut)
                                             .thenValue(
                                                     [this,
-                                                     prune_previous_versions,
+                                                     append_options,
                                                      add_new_symbol_list_entry,
                                                      update_info = std::move(update_info)](AtomKey&& index_key
                                                     ) mutable -> folly::Future<VersionedItem> {
@@ -1964,7 +1982,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                                                 version_map(),
                                                                 std::move(index_key),
                                                                 std::move(update_info),
-                                                                prune_previous_versions,
+                                                                append_options.prune_previous_versions,
                                                                 add_new_symbol_list_entry
                                                         );
                                                     }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -131,8 +131,7 @@ class LocalVersionedEngine : public VersionedEngine {
     ) override;
 
     VersionedItem append_internal(
-            const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool upsert,
-            bool prune_previous_versions, bool validate_index
+            const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, const AppendOptions& append_options
     ) override;
 
     VersionedItem delete_range_internal(
@@ -289,7 +288,7 @@ class LocalVersionedEngine : public VersionedEngine {
 
     std::vector<std::variant<VersionedItem, DataError>> batch_append_internal(
             const std::vector<StreamId>& stream_ids, std::vector<std::shared_ptr<pipelines::InputFrame>>&& frames,
-            bool prune_previous_versions, bool validate_index, bool upsert, bool throw_on_error
+            const AppendOptions& append_options, bool throw_on_error
     );
 
     std::vector<std::variant<VersionedItem, DataError>> batch_update_internal(
@@ -338,6 +337,11 @@ class LocalVersionedEngine : public VersionedEngine {
     CompactDataInfo compact_data_explain_plan_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
     ) override;
+
+    VersionedItem maybe_compact_data_and_write_version(
+            const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
+            std::optional<CompactDataFrame> compact_data_frame = std::nullopt
+    );
 
     VersionedItem compact_data_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions

--- a/cpp/arcticdb/version/schema_checks.cpp
+++ b/cpp/arcticdb/version/schema_checks.cpp
@@ -66,20 +66,18 @@ void check_multiindex_matches(
     }
 }
 
-void check_multiindex_matches(
-        const pipelines::index::IndexSegmentReader& existing_isr, const pipelines::InputFrame& frame
-) {
-    if (existing_isr.tsd().normalization().has_df()) {
+void check_multiindex_matches(const TimeseriesDescriptor& existing_tsd, const pipelines::InputFrame& frame) {
+    if (existing_tsd.normalization().has_df()) {
         check_multiindex_matches(
-                existing_isr.tsd().normalization().df().common(),
-                existing_isr.tsd().as_stream_descriptor(),
+                existing_tsd.normalization().df().common(),
+                existing_tsd.as_stream_descriptor(),
                 frame.norm_meta.df().common(),
                 frame.desc()
         );
-    } else if (existing_isr.tsd().normalization().has_series()) {
+    } else if (existing_tsd.normalization().has_series()) {
         check_multiindex_matches(
-                existing_isr.tsd().normalization().series().common(),
-                existing_isr.tsd().as_stream_descriptor(),
+                existing_tsd.normalization().series().common(),
+                existing_tsd.as_stream_descriptor(),
                 frame.norm_meta.series().common(),
                 frame.desc()
         );
@@ -87,15 +85,15 @@ void check_multiindex_matches(
 }
 
 void check_normalization_index_match(
-        NormalizationOperation operation, const pipelines::index::IndexSegmentReader& existing_isr,
-        const pipelines::InputFrame& frame, bool empty_types
+        NormalizationOperation operation, const TimeseriesDescriptor& existing_tsd, const pipelines::InputFrame& frame,
+        bool empty_types
 ) {
-    const IndexDescriptor::Type old_idx_kind = existing_isr.tsd().as_stream_descriptor().index().type();
+    const IndexDescriptor::Type old_idx_kind = existing_tsd.as_stream_descriptor().index().type();
     const IndexDescriptor::Type new_idx_kind = frame.desc().index().type();
 
     // In case of multiindex we require the multiindex fields in the input to match the mutliindex fields on disk even
     // when dynamic schema is used. This is because it's too hard to keep the normalization metadata in sync.
-    check_multiindex_matches(existing_isr, frame);
+    check_multiindex_matches(existing_tsd, frame);
 
     if (operation == UPDATE) {
         const bool new_is_timeseries = std::holds_alternative<stream::TimeseriesIndex>(frame.index);
@@ -225,14 +223,14 @@ bool columns_match(
 }
 
 void fix_descriptor_mismatch_or_throw(
-        NormalizationOperation operation, bool dynamic_schema, const pipelines::index::IndexSegmentReader& existing_isr,
+        NormalizationOperation operation, bool dynamic_schema, const TimeseriesDescriptor& existing_tsd,
         const pipelines::InputFrame& new_frame, bool empty_types
 ) {
 
-    fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame, dynamic_schema);
-    check_normalization_index_match(operation, existing_isr, new_frame, empty_types);
+    fix_normalization_or_throw(operation == APPEND, existing_tsd, new_frame, dynamic_schema);
+    check_normalization_index_match(operation, existing_tsd, new_frame, empty_types);
 
-    const auto& old_sd = existing_isr.tsd().as_stream_descriptor();
+    const auto& old_sd = existing_tsd.as_stream_descriptor();
     // We need to check that the index names match regardless of the dynamic schema setting
     if (!index_names_match(old_sd, new_frame.desc())) {
         throw StreamDescriptorMismatch(
@@ -254,21 +252,20 @@ void fix_descriptor_mismatch_or_throw(
         );
     }
 
-    if (dynamic_schema && new_frame.norm_meta.has_series() && existing_isr.tsd().normalization().has_series()) {
+    if (dynamic_schema && new_frame.norm_meta.has_series() && existing_tsd.normalization().has_series()) {
         const bool both_dont_have_name = !new_frame.norm_meta.series().common().has_name() &&
-                                         !existing_isr.tsd().normalization().series().common().has_name();
+                                         !existing_tsd.normalization().series().common().has_name();
         const bool both_have_name = new_frame.norm_meta.series().common().has_name() &&
-                                    existing_isr.tsd().normalization().series().common().has_name();
+                                    existing_tsd.normalization().series().common().has_name();
         const auto name_or_default = [](const proto::descriptors::NormalizationMetadata& meta) {
             return meta.series().common().has_name() ? meta.series().common().name() : "<series_name_not_set>";
         };
         schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                both_dont_have_name ||
-                        (both_have_name && new_frame.norm_meta.series().common().name() ==
-                                                   existing_isr.tsd().normalization().series().common().name()),
+                both_dont_have_name || (both_have_name && new_frame.norm_meta.series().common().name(
+                                                          ) == existing_tsd.normalization().series().common().name()),
                 "Series are not allowed to have different names for append and update even for dynamic schema. "
                 "Existing name: {}, new name: {}",
-                name_or_default(existing_isr.tsd().normalization()),
+                name_or_default(existing_tsd.normalization()),
                 name_or_default(new_frame.norm_meta)
         );
     }

--- a/cpp/arcticdb/version/schema_checks.hpp
+++ b/cpp/arcticdb/version/schema_checks.hpp
@@ -2,6 +2,7 @@
 
 #include <arcticdb/pipeline/input_frame.hpp>
 #include <arcticdb/python/normalization_utils.hpp>
+#include <arcticdb/entity/timeseries_descriptor.hpp>
 
 namespace arcticdb {
 
@@ -25,7 +26,7 @@ bool columns_match(
 );
 
 void fix_descriptor_mismatch_or_throw(
-        NormalizationOperation operation, bool dynamic_schema, const pipelines::index::IndexSegmentReader& existing_isr,
+        NormalizationOperation operation, bool dynamic_schema, const TimeseriesDescriptor& existing_tsd,
         const pipelines::InputFrame& new_frame, bool empty_types
 );
 } // namespace arcticdb

--- a/cpp/arcticdb/version/test/test_version_store.cpp
+++ b/cpp/arcticdb/version/test/test_version_store.cpp
@@ -641,12 +641,14 @@ TEST(VersionStore, AppendRefKeyOptimisation) {
 
     // Append v0
     auto test_frame_0 = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.append_internal(symbol, std::move(test_frame_0.frame_), true, false, false);
+    version_store::AppendOptions append_options{.upsert = true};
+    version_store.append_internal(symbol, std::move(test_frame_0.frame_), append_options);
+    append_options.upsert = false;
 
     // Append v1
     start_val += num_rows;
     auto test_frame_1 = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.append_internal(symbol, std::move(test_frame_1.frame_), false, false, false);
+    version_store.append_internal(symbol, std::move(test_frame_1.frame_), append_options);
 
     // Snapshot and delete
     std::cout << "Snap" << std::endl;
@@ -659,7 +661,7 @@ TEST(VersionStore, AppendRefKeyOptimisation) {
     // Append v2
     start_val += num_rows;
     auto test_frame_2 = get_test_frame<stream::TimeseriesIndex>(symbol, fields, num_rows, start_val);
-    version_store.append_internal(symbol, std::move(test_frame_2.frame_), false, false, false);
+    version_store.append_internal(symbol, std::move(test_frame_2.frame_), append_options);
 
     uint64_t version_id = 1;
     // Test that v1 is visible when deleted versions are included

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -135,7 +135,7 @@ folly::Future<entity::AtomKey> async_write_dataframe_impl(
     return write_frame(std::move(partial_key), frame, slicing_policy, store, de_dup_map, sparsify_floats);
 }
 
-void sorted_data_check_append(const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader) {
+void sorted_data_check_append(const InputFrame& frame, const TimeseriesDescriptor& existing_tsd) {
     if (!index_is_not_timeseries_or_is_sorted_ascending(frame)) {
         sorting::raise<ErrorCode::E_UNSORTED_DATA>(
                 "When calling append with validate_index enabled, input data must be sorted"
@@ -143,7 +143,7 @@ void sorted_data_check_append(const InputFrame& frame, const index::IndexSegment
     }
     sorting::check<ErrorCode::E_UNSORTED_DATA>(
             !std::holds_alternative<stream::TimeseriesIndex>(frame.index) ||
-                    index_segment_reader.tsd().sorted() == SortedValue::ASCENDING,
+                    existing_tsd.sorted() == SortedValue::ASCENDING,
             "When calling append with validate_index enabled, the existing data must be sorted"
     );
 }
@@ -181,21 +181,28 @@ void check_update_data_is_sorted(const InputFrame& frame, const index::IndexSegm
 }
 
 static void check_can_append(
-        const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader,
-        const WriteOptions& write_options, bool validate_index, bool empty_types
+        const InputFrame& frame, const TimeseriesDescriptor& existing_tsd,
+        const std::optional<IndexValue>& last_existing_index_value, const WriteOptions& write_options,
+        bool validate_index, bool empty_types
 ) {
-    util::check_rte(!index_segment_reader.is_pickled(), "Cannot append to pickled data");
-    fix_descriptor_mismatch_or_throw(APPEND, write_options.dynamic_schema, index_segment_reader, frame, empty_types);
+    const bool is_pickled = existing_tsd.proto().normalization().input_type_case() ==
+                            arcticdb::proto::descriptors::NormalizationMetadata::InputTypeCase::kMsgPackFrame;
+    util::check_rte(!is_pickled, "Cannot append to pickled data");
+    fix_descriptor_mismatch_or_throw(APPEND, write_options.dynamic_schema, existing_tsd, frame, empty_types);
     if (validate_index) {
-        sorted_data_check_append(frame, index_segment_reader);
+        sorted_data_check_append(frame, existing_tsd);
     }
     util::variant_match(
             frame.index,
-            [&index_segment_reader, &frame, &write_options](const TimeseriesIndex&) {
+            [&existing_tsd, &last_existing_index_value, &frame, &write_options](const TimeseriesIndex&) {
                 util::check(frame.has_index(), "Cannot append timeseries without index");
-                if (index_segment_reader.tsd().total_rows() != 0 && frame.num_rows != 0) {
+                if (existing_tsd.total_rows() != 0 && frame.num_rows != 0) {
+                    util::check(
+                            last_existing_index_value.has_value(),
+                            "Cannot append timeseries: last index value of existing data is unknown"
+                    );
                     auto first_index = NumericIndex{frame.index_value_at(0)};
-                    auto prev = std::get<NumericIndex>(index_segment_reader.last()->key().end_index());
+                    auto prev = std::get<NumericIndex>(*last_existing_index_value);
                     util::check(
                             write_options.ignore_sort_order || prev - 1 <= first_index,
                             "Can't append dataframe with start index {} to existing sequence "
@@ -221,7 +228,7 @@ static void check_can_update(
     util::check(index::is_timeseries_index(index_desc), "Update not supported for non-timeseries indexes");
     check_update_data_is_sorted(frame, index_segment_reader);
     (void)check_and_mark_slices(index_segment_reader, false, std::nullopt);
-    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader, frame, empty_types);
+    fix_descriptor_mismatch_or_throw(UPDATE, dynamic_schema, index_segment_reader.tsd(), frame, empty_types);
 }
 
 folly::Future<AtomKey> async_append_impl(
@@ -239,7 +246,17 @@ folly::Future<AtomKey> async_append_impl(
             .thenValueInline([store, update_info, frame, options, validate_index, empty_types](
                                      index::IndexSegmentReader&& index_segment_reader
                              ) {
-                check_can_append(*frame, index_segment_reader, options, validate_index, empty_types);
+                const std::optional<IndexValue> last_existing_index_value =
+                        index_segment_reader.tsd().total_rows() == 0 ? std::optional<IndexValue>()
+                                                                     : index_segment_reader.last()->key().end_index();
+                check_can_append(
+                        *frame,
+                        index_segment_reader.tsd(),
+                        last_existing_index_value,
+                        options,
+                        validate_index,
+                        empty_types
+                );
                 bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
                 auto row_offset = index_segment_reader.tsd().total_rows();
                 frame->set_offset(static_cast<ssize_t>(row_offset));
@@ -951,9 +968,8 @@ void set_output_descriptors(
                 (*clause)->clause_info().index_,
                 [](const KeepCurrentIndex&) { return false; },
                 [&](const KeepCurrentTopLevelIndex&) {
-                    if (pipeline_context->norm_meta_->mutable_df()->mutable_common()->has_multi_index()) {
-                        const auto& multi_index =
-                                pipeline_context->norm_meta_->mutable_df()->mutable_common()->multi_index();
+                    if (pipeline_context->normalization().df().common().has_multi_index()) {
+                        const auto& multi_index = pipeline_context->normalization().df().common().multi_index();
                         auto name = multi_index.name();
                         auto tz = multi_index.tz();
                         bool fake_name{false};
@@ -964,7 +980,8 @@ void set_output_descriptors(
                             }
                         }
                         auto mutable_index =
-                                pipeline_context->norm_meta_->mutable_df()->mutable_common()->mutable_index();
+                                pipeline_context->mutable_normalization().mutable_df()->mutable_common()->mutable_index(
+                                );
                         mutable_index->set_tz(tz);
                         mutable_index->set_is_physically_stored(true);
                         mutable_index->set_name(name);
@@ -974,7 +991,8 @@ void set_output_descriptors(
                 },
                 [&](const NewIndex& new_index) {
                     index_column = new_index;
-                    auto mutable_index = pipeline_context->norm_meta_->mutable_df()->mutable_common()->mutable_index();
+                    auto mutable_index =
+                            pipeline_context->mutable_normalization().mutable_df()->mutable_common()->mutable_index();
                     mutable_index->set_name(new_index);
                     mutable_index->clear_fake_name();
                     mutable_index->set_is_physically_stored(true);
@@ -1157,9 +1175,9 @@ static StreamDescriptor generate_initial_output_schema_descriptor(const Pipeline
 
 static OutputSchema create_initial_output_schema(PipelineContext& pipeline_context) {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            pipeline_context.norm_meta_, "Normalization metadata should not be missing during read_and_process"
+            pipeline_context.has_normalization(), "Normalization metadata should not be missing during read_and_process"
     );
-    return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), *pipeline_context.norm_meta_};
+    return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), pipeline_context.normalization()};
 }
 
 static OutputSchema generate_output_schema(PipelineContext& pipeline_context, const ReadQuery& read_query) {
@@ -1193,9 +1211,7 @@ static void generate_output_schema_and_save_to_pipeline(
     OutputSchema schema = generate_output_schema(pipeline_context, read_query);
     auto&& [descriptor, norm_meta, default_values] = schema.release();
     pipeline_context.set_descriptor(std::forward<StreamDescriptor>(descriptor));
-    pipeline_context.norm_meta_ = std::make_shared<proto::descriptors::NormalizationMetadata>(
-            std::forward<proto::descriptors::NormalizationMetadata>(norm_meta)
-    );
+    pipeline_context.set_normalization(std::forward<proto::descriptors::NormalizationMetadata>(norm_meta));
     pipeline_context.default_values_ = std::forward<decltype(default_values)>(default_values);
 }
 
@@ -1328,7 +1344,7 @@ void check_can_perform_processing(
 ) {
     // To remain backward compatibility, pending new major release to merge into below section
     // Ticket: 18038782559
-    const bool is_pickled = pipeline_context->norm_meta_ && pipeline_context->is_pickled();
+    const bool is_pickled = pipeline_context->has_normalization() && pipeline_context->is_pickled();
     util::check(
             !is_pickled ||
                     (!read_query.columns.has_value() && std::holds_alternative<std::monostate>(read_query.row_filter)),
@@ -1357,9 +1373,9 @@ void check_can_perform_processing(
     const bool is_query_empty =
             (!read_query.columns && !read_query.row_range &&
              std::holds_alternative<std::monostate>(read_query.row_filter) && read_query.clauses_.empty());
-    const bool is_numpy_array = pipeline_context->norm_meta_ && pipeline_context->norm_meta_->has_np();
+    const bool is_numpy_array = pipeline_context->has_normalization() && pipeline_context->normalization().has_np();
     // We do not support processing over numpy arrays in general, but compact_data (either directly, or via the
-    // compact_data_inline argument to append[_batch]) must work with numpy arrays as well as Series/DataFrames
+    // compact_data_inline argument to append) must work with numpy arrays as well as Series/DataFrames
     const bool is_compaction =
             !read_query.clauses_.empty() && folly::poly_type(*read_query.clauses_.front()) == typeid(CompactDataClause);
     if (!is_query_empty) {
@@ -1409,13 +1425,15 @@ static void read_indexed_keys_to_pipeline(
     pipeline_context->slice_and_keys_ = filter_index(index_segment_reader, combine_filter_functions(queries));
     pipeline_context->total_rows_ = pipeline_context->calc_rows();
     pipeline_context->rows_ = index_segment_reader.tsd().total_rows();
-    pipeline_context->norm_meta_ = std::make_unique<arcticdb::proto::descriptors::NormalizationMetadata>(
-            std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_normalization())
-    );
-    pipeline_context->user_meta_ = std::make_unique<arcticdb::proto::descriptors::UserDefinedMetadata>(
-            std::move(*index_segment_reader.mutable_tsd().mutable_proto().mutable_user_meta())
-    );
     pipeline_context->bucketize_dynamic_ = bucketize_dynamic;
+    // Capture the end index of the last existing row-slice before discarding the reader. This is needed by
+    // check_can_append on the inline-compaction path, and avoids retaining the whole index segment in the context.
+    if (!index_segment_reader.empty()) {
+        pipeline_context->last_existing_index_value_ = index_segment_reader.last()->key().end_index();
+    }
+    // tsd_ carries the existing version's normalization and user metadata (and, for the compact path, its descriptor,
+    // total rows and sorted state). The normalization metadata is read back via pipeline_context->normalization().
+    pipeline_context->set_tsd(std::move(index_segment_reader.mutable_tsd()));
     check_can_perform_processing(pipeline_context, read_query);
     ARCTICDB_DEBUG(
             log::version(),
@@ -1503,10 +1521,11 @@ static std::variant<bool, CompactionError> read_incompletes_to_pipeline(
     }
     ranges::copy(incomplete_segments, std::back_inserter(pipeline_context->slice_and_keys_));
 
-    if (!pipeline_context->norm_meta_) {
-        pipeline_context->norm_meta_ = std::make_unique<arcticdb::proto::descriptors::NormalizationMetadata>();
-        pipeline_context->norm_meta_->CopyFrom(seg.index_descriptor().proto().normalization());
-        ensure_timeseries_norm_meta(*pipeline_context->norm_meta_, pipeline_context->stream_id_, flags.sparsify);
+    if (!pipeline_context->has_normalization()) {
+        arcticdb::proto::descriptors::NormalizationMetadata norm_meta;
+        norm_meta.CopyFrom(seg.index_descriptor().proto().normalization());
+        ensure_timeseries_norm_meta(norm_meta, pipeline_context->stream_id_, flags.sparsify);
+        pipeline_context->set_normalization(std::move(norm_meta));
     }
 
     const StreamDescriptor& staged_desc = incomplete_segments[0].segment(store).descriptor();
@@ -1920,7 +1939,7 @@ folly::Future<folly::Unit> copy_segments_to_frame(
         SegmentInMemory frame, std::shared_ptr<std::any> handler_data, const ReadOptions& read_options
 ) {
     const auto required_fields_count =
-            pipelines::index::required_fields_count(pipeline_context->descriptor(), *pipeline_context->norm_meta_);
+            pipelines::index::required_fields_count(pipeline_context->descriptor(), pipeline_context->normalization());
     std::vector<folly::Future<folly::Unit>> copy_tasks;
     DecodePathData shared_data;
     for (auto context_row : folly::enumerate(*pipeline_context)) {
@@ -2218,7 +2237,7 @@ VersionedItem collate_and_write(
     tsd.set_stream_descriptor(pipeline_context->descriptor());
     tsd.set_total_rows(pipeline_context->total_rows_);
     auto& tsd_proto = tsd.mutable_proto();
-    tsd_proto.mutable_normalization()->CopyFrom(*pipeline_context->norm_meta_);
+    tsd_proto.mutable_normalization()->CopyFrom(pipeline_context->normalization());
     if (user_meta)
         tsd_proto.mutable_user_meta()->CopyFrom(*user_meta);
 
@@ -3019,7 +3038,7 @@ folly::Future<VersionedItem> read_modify_write_impl(
                 const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                         row_count,
                         pipeline_context->descriptor(),
-                        *pipeline_context->norm_meta_,
+                        pipeline_context->normalization(),
                         std::move(user_meta_proto),
                         std::nullopt,
                         write_options.bucketize_dynamic
@@ -3069,7 +3088,7 @@ folly::Future<VersionedItem> merge_update_impl(
             "Merge update supports only ascending indexed data and row count indexed data"
     );
     folly::poly_cast<MergeUpdateClause>(*merge_update_clause).fake_index_name_ =
-            index_type == IndexDescriptor::Type::TIMESTAMP && is_fake_index_name(*pipeline_context->norm_meta_);
+            index_type == IndexDescriptor::Type::TIMESTAMP && is_fake_index_name(pipeline_context->normalization());
     return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
             .thenValue([pipeline_context = std::move(pipeline_context),
                         store,
@@ -3097,8 +3116,8 @@ folly::Future<VersionedItem> merge_update_impl(
                 const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                         row_count,
                         pipeline_context->descriptor(),
-                        *pipeline_context->norm_meta_,
-                        pipeline_context->user_meta_ ? std::make_optional(std::move(source->user_meta)) : std::nullopt,
+                        pipeline_context->normalization(),
+                        std::make_optional(std::move(source->user_meta)),
                         std::nullopt,
                         write_options.bucketize_dynamic
                 );
@@ -3178,96 +3197,252 @@ folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
     });
 }
 
+static folly::Future<std::vector<SliceAndKey>> slice_and_write_frame_remainder(
+        const std::shared_ptr<Store>& store, std::shared_ptr<InputFrame> frame, size_t start_row,
+        uint64_t max_rows_per_segment, const WriteOptions& write_options, IndexPartialKey target_partial_index_key
+) {
+    auto remaining_rows_to_write = (frame->offset + frame->num_rows) - start_row;
+    ReslicingInfo reslicing_info{remaining_rows_to_write, max_rows_per_segment};
+    auto row_ranges = util::reserve_vector<RowRange>(reslicing_info.num_segments);
+    for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+        row_ranges.emplace_back(start_row, start_row + reslicing_info.rows_in_slice(idx));
+        start_row += reslicing_info.rows_in_slice(idx);
+    }
+    std::vector<ColRange> col_ranges;
+    if (write_options.dynamic_schema) {
+        col_ranges.emplace_back(frame->desc().index().field_count(), frame->desc().field_count());
+    } else {
+        ColRange col_range{
+                frame->desc().index().field_count(),
+                frame->desc().index().field_count() + write_options.column_group_size
+        };
+        col_ranges.emplace_back(col_range);
+        while (col_range.second < frame->desc().field_count()) {
+            col_range.first += write_options.column_group_size;
+            // The slicing implementation gracefully handles column ranges that are wider than the number of columns in
+            // the input frame
+            col_range.second += write_options.column_group_size;
+            col_ranges.emplace_back(col_range);
+        }
+    }
+    const SpecificSlicer slicer{std::move(row_ranges), std::move(col_ranges)};
+    return folly::via(
+            &async::io_executor(),
+            [store, frame, slicer = std::move(slicer), key = std::move(target_partial_index_key)]() mutable {
+                // These rows are being appended, so dedup isn't possible
+                auto de_dup_map = std::make_shared<DeDupMap>();
+                return slice_and_write(frame, slicer, std::move(key), store, de_dup_map, false);
+            }
+    );
+}
+
+static std::vector<RowRange> find_sorted_unique_row_ranges(const std::vector<SliceAndKey>& slices_and_keys) {
+    // Use an ordered set so we can binary search afterwards
+    std::set<RowRange> row_ranges;
+    for (const auto& slice_and_key : slices_and_keys) {
+        row_ranges.insert(slice_and_key.slice().row_range);
+    }
+    return std::vector<RowRange>(
+            std::make_move_iterator(row_ranges.begin()), std::make_move_iterator(row_ranges.end())
+    );
+}
+
+static std::vector<SliceAndKey> prev_version_unchanged_slices(
+        const std::vector<RowRange>& new_row_ranges, std::vector<SliceAndKey>&& prev_slice_and_keys,
+        size_t& last_row_on_disk
+) {
+    std::vector<SliceAndKey> prev_version_unchanged_slices;
+    // When there is column slicing, this means we only binary search for the
+    // first_row once per row slice in the original data
+    std::unordered_set<size_t> first_rows_to_keep;
+    std::unordered_set<size_t> first_rows_to_discard;
+    for (SliceAndKey& slice_and_key : prev_slice_and_keys) {
+        // We are looking for slices from prev_slice_and_keys that are not covered by any of the new_row_ranges written
+        // to disk as part of the compaction. It is sufficient to look for slices where the first row is not in any of
+        // the new_row_ranges, as all slices from the previous version will either have been completely rewritten to
+        // disk, or entirely ignored by CompactDataClause::structure_for_processing, there is nothing inbetween.
+        auto first_row = slice_and_key.slice().row_range.first;
+        if (first_rows_to_keep.contains(first_row)) {
+            last_row_on_disk = std::max(last_row_on_disk, slice_and_key.slice().rows().second);
+            prev_version_unchanged_slices.emplace_back(std::move(slice_and_key));
+        } else if (!first_rows_to_discard.contains(first_row)) {
+            auto begin = new_row_ranges.cbegin();
+            auto end = new_row_ranges.cend();
+            auto mid = begin + std::distance(begin, end) / 2;
+            while (begin != end) {
+                if (mid->contains(first_row)) {
+                    break;
+                } else if (first_row < mid->first) {
+                    end = mid;
+                    mid = begin + std::distance(begin, end) / 2;
+                } else { // first_row >= mid->second
+                    begin = std::next(mid);
+                    mid = begin + std::distance(begin, end) / 2;
+                }
+            }
+            if (begin == end) {
+                last_row_on_disk = std::max(last_row_on_disk, slice_and_key.slice().rows().second);
+                prev_version_unchanged_slices.emplace_back(std::move(slice_and_key));
+                first_rows_to_keep.emplace(first_row);
+            } else {
+                first_rows_to_discard.emplace(first_row);
+            }
+        }
+    }
+    return prev_version_unchanged_slices;
+}
+
+static std::shared_ptr<TimeseriesDescriptor> compact_data_tsd(
+        std::optional<CompactDataFrame>& compact_data_frame, PipelineContext& pipeline_context,
+        const WriteOptions& write_options
+) {
+    const auto& existing_tsd = pipeline_context.tsd();
+    if (compact_data_frame.has_value()) {
+        auto& frame = compact_data_frame->frame_;
+        if (frame->num_rows > 0) {
+            check_can_append(
+                    *frame,
+                    existing_tsd,
+                    pipeline_context.last_existing_index_value_,
+                    write_options,
+                    compact_data_frame->validate_index_,
+                    compact_data_frame->empty_types_
+            );
+            frame->set_offset(existing_tsd.total_rows());
+            frame->set_bucketize_dynamic(existing_tsd.column_groups());
+            return std::make_shared<TimeseriesDescriptor>(index::get_merged_tsd(
+                    frame->offset + frame->num_rows, write_options.dynamic_schema, existing_tsd, frame
+            ));
+        } else {
+            frame->set_offset(existing_tsd.total_rows());
+            frame->set_bucketize_dynamic(existing_tsd.column_groups());
+            auto merged_tsd = std::make_shared<TimeseriesDescriptor>(existing_tsd);
+            *merged_tsd->mutable_proto().mutable_user_meta() = std::move(frame->user_meta);
+            return merged_tsd;
+        }
+    } else {
+        return std::make_shared<TimeseriesDescriptor>(make_timeseries_descriptor(
+                existing_tsd.total_rows(),
+                *pipeline_context.desc_,
+                pipeline_context.normalization(),
+                pipeline_context.release_opt_user_defined_metadata(),
+                std::nullopt,
+                write_options.bucketize_dynamic
+        ));
+    }
+}
+
 folly::Future<std::optional<VersionedItem>> compact_data_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const WriteOptions& write_options,
-        const IndexPartialKey& target_partial_index_key, uint64_t rows_per_segment
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const WriteOptions& write_options,
+        uint64_t rows_per_segment, std::optional<CompactDataFrame> compact_data_frame
 ) {
     auto read_query = std::make_shared<ReadQuery>();
-    read_query->clauses_.push_back(std::make_shared<Clause>(CompactDataClause(rows_per_segment)));
-    VersionIdentifier resolved =
-            std::make_shared<IndexInformation>(read_index_key_without_column_stats(store, versioned_item.key_));
-    std::shared_ptr<PipelineContext> pipeline_context =
-            setup_pipeline_context(store, std::move(resolved), *read_query, {});
-    return read_modify_write_data_keys(store, read_query, ReadOptions{}, target_partial_index_key, pipeline_context)
-            .thenValue(
-                    [pipeline_context = std::move(pipeline_context),
-                     store,
-                     write_options,
-                     target_partial_index_key,
-                     read_query](std::vector<SliceAndKey>&& slices_and_keys
-                    ) -> folly::Future<std::optional<VersionedItem>> {
-                        if (slices_and_keys.empty()) {
-                            return folly::makeFuture(std::optional<VersionedItem>());
-                        }
-                        // Use an ordered set so we can binary search afterwards
-                        std::set<RowRange> new_row_ranges_set;
-                        for (const auto& slice_and_key : slices_and_keys) {
-                            new_row_ranges_set.insert(slice_and_key.slice().row_range);
-                        }
-                        std::vector<RowRange> new_row_ranges(
-                                std::make_move_iterator(new_row_ranges_set.begin()),
-                                std::make_move_iterator(new_row_ranges_set.end())
-                        );
-                        // When there is column slicing, this means we only binary search for the first_row once per
-                        // row slice in the original data
-                        std::unordered_set<size_t> first_rows_to_keep;
-                        std::unordered_set<size_t> first_rows_to_discard;
-                        for (SliceAndKey& slice_and_key : pipeline_context->slice_and_keys_) {
-                            auto first_row = slice_and_key.slice().row_range.first;
-                            if (first_rows_to_keep.contains(first_row)) {
-                                slices_and_keys.emplace_back(std::move(slice_and_key));
-                            } else if (!first_rows_to_discard.contains(first_row)) {
-                                auto begin = new_row_ranges.cbegin();
-                                auto end = new_row_ranges.cend();
-                                auto mid = begin + std::distance(begin, end) / 2;
-                                while (begin != end) {
-                                    if (mid->contains(first_row)) {
-                                        break;
-                                    } else if (first_row < mid->first) {
-                                        end = mid;
-                                        mid = begin + std::distance(begin, end) / 2;
-                                    } else { // first_row >= mid->second
-                                        begin = std::next(mid);
-                                        mid = begin + std::distance(begin, end) / 2;
+    if (compact_data_frame.has_value()) {
+        read_query->clauses_.push_back(
+                std::make_shared<Clause>(CompactDataClause(rows_per_segment, compact_data_frame->frame_))
+        );
+    } else {
+        read_query->clauses_.push_back(std::make_shared<Clause>(CompactDataClause(rows_per_segment)));
+    }
+
+    return folly::via(
+                   &async::io_executor(),
+                   [store, read_query, update_info]() {
+                       VersionIdentifier resolved = std::make_shared<IndexInformation>(
+                               read_index_key_without_column_stats(store, *update_info.previous_index_key_)
+                       );
+                       return setup_pipeline_context(store, std::move(resolved), *read_query, {});
+                   }
+    )
+            .via(&async::cpu_executor())
+            .thenValue([store,
+                        update_info,
+                        write_options,
+                        compact_data_frame = std::move(compact_data_frame),
+                        read_query](std::shared_ptr<PipelineContext>&& pipeline_context) mutable {
+                const auto& stream_id = update_info.previous_index_key_->id();
+                const auto dynamic_schema = write_options.dynamic_schema;
+                auto tsd = compact_data_tsd(compact_data_frame, *pipeline_context, write_options);
+                auto frame =
+                        compact_data_frame.has_value() ? compact_data_frame->frame_ : std::shared_ptr<InputFrame>();
+                IndexPartialKey target_partial_index_key{stream_id, update_info.next_version_id_};
+                ReadOptions read_options;
+                read_options.set_dynamic_schema(dynamic_schema);
+                return read_modify_write_data_keys(
+                               store, read_query, read_options, target_partial_index_key, pipeline_context
+                )
+                        .thenValue(
+                                [pipeline_context = std::move(pipeline_context),
+                                 store,
+                                 write_options,
+                                 target_partial_index_key,
+                                 read_query,
+                                 tsd,
+                                 frame](std::vector<SliceAndKey>&& slices_and_keys
+                                ) -> folly::Future<std::optional<VersionedItem>> {
+                                    if (slices_and_keys.empty() && !frame) {
+                                        return folly::makeFuture(std::optional<VersionedItem>());
                                     }
+                                    const std::vector<RowRange> new_row_ranges =
+                                            find_sorted_unique_row_ranges(slices_and_keys);
+                                    size_t last_row_on_disk = new_row_ranges.empty() ? 0 : new_row_ranges.back().second;
+                                    auto unchanged_slices = prev_version_unchanged_slices(
+                                            new_row_ranges,
+                                            std::move(pipeline_context->slice_and_keys_),
+                                            last_row_on_disk
+                                    );
+                                    slices_and_keys.insert(
+                                            slices_and_keys.end(),
+                                            std::make_move_iterator(unchanged_slices.begin()),
+                                            std::make_move_iterator(unchanged_slices.end())
+                                    );
+                                    // This implies there are more rows in frame that have not yet been written to disk
+                                    auto remaining_slice_and_keys_fut =
+                                            frame && last_row_on_disk < frame->offset + frame->num_rows
+                                                    ? slice_and_write_frame_remainder(
+                                                              store,
+                                                              frame,
+                                                              last_row_on_disk,
+                                                              folly::poly_cast<CompactDataClause>(
+                                                                      *read_query->clauses_.front()
+                                                              )
+                                                                      .max_rows_per_segment_,
+                                                              write_options,
+                                                              target_partial_index_key
+                                                      )
+                                                    : folly::makeFuture(std::vector<SliceAndKey>{});
+                                    return (std::move(remaining_slice_and_keys_fut))
+                                            .via(&async::cpu_executor())
+                                            .thenValue([store,
+                                                        slices_and_keys = std::move(slices_and_keys),
+                                                        pipeline_context,
+                                                        tsd,
+                                                        target_partial_index_key](
+                                                               std::vector<SliceAndKey>&& remaining_slice_and_keys
+                                                       ) mutable {
+                                                slices_and_keys.insert(
+                                                        slices_and_keys.end(),
+                                                        std::make_move_iterator(remaining_slice_and_keys.begin()),
+                                                        std::make_move_iterator(remaining_slice_and_keys.end())
+                                                );
+                                                ranges::sort(slices_and_keys);
+                                                // String columns always compacted to dynamic UTF-8
+                                                for (auto& field : tsd->mutable_fields()) {
+                                                    if (is_sequence_type(field.type().data_type())) {
+                                                        field.type_.data_type_ = DataType::UTF_DYNAMIC64;
+                                                    }
+                                                }
+                                                return index::write_index(
+                                                        index_type_from_descriptor(pipeline_context->descriptor()),
+                                                        *tsd,
+                                                        std::move(slices_and_keys),
+                                                        target_partial_index_key,
+                                                        store
+                                                );
+                                            });
                                 }
-                                if (begin == end) {
-                                    slices_and_keys.emplace_back(std::move(slice_and_key));
-                                    first_rows_to_keep.emplace(first_row);
-                                } else {
-                                    first_rows_to_discard.emplace(first_row);
-                                }
-                            }
-                        }
-                        ranges::sort(slices_and_keys);
-                        pipeline_context->slice_and_keys_.clear();
-                        const size_t row_count = slices_and_keys.back().slice().row_range.second -
-                                                 slices_and_keys.front().slice().row_range.first;
-                        TimeseriesDescriptor tsd = make_timeseries_descriptor(
-                                row_count,
-                                std::move(*pipeline_context->desc_),
-                                *pipeline_context->norm_meta_,
-                                pipeline_context->user_meta_
-                                        ? std::make_optional(std::move(*pipeline_context->user_meta_))
-                                        : std::nullopt,
-                                std::nullopt,
-                                write_options.bucketize_dynamic
                         );
-                        // String columns always compacted to dynamic UTF-8
-                        for (auto& field : tsd.mutable_fields()) {
-                            if (is_sequence_type(field.type().data_type())) {
-                                field.type_.data_type_ = DataType::UTF_DYNAMIC64;
-                            }
-                        }
-                        return index::write_index(
-                                index_type_from_descriptor(pipeline_context->descriptor()),
-                                tsd,
-                                std::move(slices_and_keys),
-                                target_partial_index_key,
-                                store
-                        );
-                    }
-            );
+            });
 }
 
 folly::Future<SymbolProcessingResult> read_and_process(
@@ -3305,8 +3480,9 @@ folly::Future<SymbolProcessingResult> read_and_process(
                 // for a symbol, no indexed versions
                 return SymbolProcessingResult{
                         std::move(res_versioned_item),
-                        pipeline_context->user_meta_ ? std::move(*pipeline_context->user_meta_)
-                                                     : proto::descriptors::UserDefinedMetadata{},
+                        pipeline_context->release_opt_user_defined_metadata().value_or(
+                                proto::descriptors::UserDefinedMetadata{}
+                        ),
                         std::move(output_schema),
                         std::move(entity_ids)
                 };

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -203,9 +203,15 @@ folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, uint64_t rows_per_segment
 );
 
+struct CompactDataFrame {
+    std::shared_ptr<InputFrame> frame_;
+    bool validate_index_;
+    bool empty_types_;
+};
+
 folly::Future<std::optional<VersionedItem>> compact_data_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const WriteOptions& write_options,
-        const IndexPartialKey& target_partial_index_key, uint64_t rows_per_segment
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const WriteOptions& write_options,
+        uint64_t rows_per_segment, std::optional<CompactDataFrame> compact_data_frame = std::nullopt
 );
 
 std::shared_ptr<PipelineContext> setup_pipeline_context(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -119,6 +119,9 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_ap
         const std::vector<py::object>& norms, const std::vector<py::object>& user_metas, bool prune_previous_versions,
         bool validate_index, bool upsert, bool throw_on_error
 ) {
+    AppendOptions append_options{
+            .upsert = upsert, .prune_previous_versions = prune_previous_versions, .validate_index = validate_index
+    };
     auto frames = create_input_tensor_frames(
             stream_ids,
             items,
@@ -127,9 +130,7 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_ap
             cfg().write_options().empty_types(),
             sortedness_scan_for(validate_index)
     );
-    return batch_append_internal(
-            stream_ids, std::move(frames), prune_previous_versions, validate_index, upsert, throw_on_error
-    );
+    return batch_append_internal(stream_ids, std::move(frames), append_options, throw_on_error);
 }
 
 void PythonVersionStore::_clear_symbol_list_keys() { symbol_list().clear(store()); }
@@ -828,8 +829,14 @@ VersionedItem PythonVersionStore::test_write_versioned_segment(
 
 VersionedItem PythonVersionStore::append(
         const StreamId& stream_id, const convert::InputItem& item, const py::object& norm, const py::object& user_meta,
-        bool upsert, bool prune_previous_versions, bool validate_index
+        bool upsert, bool prune_previous_versions, bool validate_index, bool compact_data_inline
 ) {
+    AppendOptions append_options{
+            .upsert = upsert,
+            .prune_previous_versions = prune_previous_versions,
+            .validate_index = validate_index,
+            .compact_data_inline = compact_data_inline
+    };
     return append_internal(
             stream_id,
             convert::py_input_item_to_frame(
@@ -840,9 +847,7 @@ VersionedItem PythonVersionStore::append(
                     cfg().write_options().empty_types(),
                     sortedness_scan_for(validate_index)
             ),
-            upsert,
-            prune_previous_versions,
-            validate_index
+            append_options
     );
 }
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -72,7 +72,8 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     VersionedItem append(
             const StreamId& stream_id, const convert::InputItem& item, const py::object& norm,
-            const py::object& user_meta, bool upsert, bool prune_previous_versions, bool validate_index
+            const py::object& user_meta, bool upsert, bool prune_previous_versions, bool validate_index,
+            bool compact_data_inline
     );
 
     VersionedItem update(

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -32,6 +32,13 @@ struct DeleteRangeOptions {
     bool prune_previous_versions_;
 };
 
+struct AppendOptions {
+    bool upsert = false;
+    bool prune_previous_versions = false;
+    bool validate_index = false;
+    bool compact_data_inline = false;
+};
+
 enum class Slicing { NoSlicing, RowSlicing };
 
 /**
@@ -51,8 +58,7 @@ class VersionedEngine {
     ) = 0;
 
     virtual VersionedItem append_internal(
-            const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool upsert,
-            bool prune_previous_versions, bool validate_index
+            const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, const AppendOptions& append_options
     ) = 0;
 
     virtual VersionedItem delete_range_internal(

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -955,6 +955,7 @@ class NativeVersionStore:
         prune_previous_version: Optional[bool] = None,
         validate_index: bool = False,
         index_column: bool = False,
+        compact_data_inline: bool = False,
         **kwargs,
     ) -> Optional[VersionedItem]:
         # FUTURE: use @overload and Literal for the existence of the return value once we ditch Python 3.6
@@ -984,6 +985,13 @@ class NativeVersionStore:
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
+        compact_data_inline: bool, default=False
+            If False, the data being appended will be sliced and written to disk without consideration for how
+            fragmented this may make the data.
+            If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
+            Note that this will usually involve reading some data segments from disk and doing some in-memory
+            processing, and so will generally be slower than when this argument is False. However, subsequent reads of
+            the data will generally be faster.
         kwargs :
             passed through to the write handler
 
@@ -1073,7 +1081,14 @@ class NativeVersionStore:
                 else:
                     call_time = time.time_ns()
                     vit = self.version_store.append(
-                        symbol, item, norm_meta, udm, write_if_missing, prune_previous_version, validate_index
+                        symbol,
+                        item,
+                        norm_meta,
+                        udm,
+                        write_if_missing,
+                        prune_previous_version,
+                        validate_index,
+                        compact_data_inline,
                     )
                     # This is a heuristic to check for the case of using append call to write an empty dataframe in that
                     # case we want to warn users that the processing pipeline might not work as expected. There are two

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1366,6 +1366,7 @@ class Library:
         prune_previous_versions: bool = False,
         validate_index: bool = True,
         index_column: bool = False,
+        compact_data_inline: bool = False,
     ) -> VersionedItem:
         """
         Appends the given data to the existing, stored data. Append always appends along the index. A new version will
@@ -1399,6 +1400,13 @@ class Library:
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
+        compact_data_inline: bool, default=False
+            If False, the data being appended will be sliced and written to disk without consideration for how
+            fragmented this may make the data.
+            If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
+            Note that this will usually involve reading some data segments from disk and doing some in-memory
+            processing, and so will generally be slower than when this argument is False. However, subsequent reads of
+            the data will generally be faster.
 
         Returns
         -------
@@ -1455,6 +1463,7 @@ class Library:
             prune_previous_version=prune_previous_versions,
             validate_index=validate_index,
             index_column=index_column,
+            compact_data_inline=compact_data_inline,
         )
 
     def append_batch(

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -63,29 +63,6 @@ def gen_params_append_single():
 
 
 @pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
-def test_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
-    tz = "America/New_York"
-    version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
-    dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
-    a = np.arange(dtidx.shape[0])
-    tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
-    c1 = dtidx[append_point]
-    c2 = dtidx[append_point + 1]
-    tf1 = tf.tsloc[:c1]
-    sid = "XXX"
-    version_store.write(sid, tf1)
-    tf2 = tf.tsloc[c2:]
-    version_store.append(sid, tf2)
-
-    dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
-    vit = version_store.read(sid, date_range=dtr, columns=list(cols))
-    rtf = tf.tsloc[dtr[0] : dtr[1]]
-    col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
-    rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
-    assert rtf == vit.data
-
-
-@pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
 def test_incomplete_append_partial_read(version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point):
     tz = "America/New_York"
     version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
@@ -107,42 +84,6 @@ def test_incomplete_append_partial_read(version_store_factory, colnum, periods, 
     col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
     rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
     assert rtf == vit.data
-
-
-# test_hypothesis_version_store.py covers the appends that are allowed.
-# Only need to check the forbidden ones have useful error messages:
-@pytest.mark.parametrize(
-    "initial, append, match",
-    [
-        # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
-        (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "DataFrame"),
-        (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "E_INCOMPATIBLE_INDEX"),
-        (
-            InputFactories.DF_RC,
-            InputFactories.DF_RC_NON_RANGE,
-            "range",
-        ),
-        (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "step"),
-    ],
-)
-@pytest.mark.parametrize("swap", ["swap", ""])
-def test_(
-    initial: InputFactories,
-    append: InputFactories,
-    match,
-    swap,
-    lmdb_version_store: NativeVersionStore,
-):
-    lib = lmdb_version_store
-    if swap:
-        initial, append = append, initial
-    init_data, next_start = initial.make(1, 3)
-    lib.write("s", init_data)
-
-    to_append, _ = append.make(abs(next_start), 1)
-    with pytest.raises(NormalizationException) as e:
-        lib.append("s", to_append)
-    assert match in str(e.value)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
@@ -280,34 +221,96 @@ def test_append_with_defragmentation(
         )
 
 
-def test_regular_append_dynamic_schema_named_index(
-    lmdb_version_store_tiny_segment_dynamic,
-):
-    lib = lmdb_version_store_tiny_segment_dynamic
-    sym = "test_parallel_append_dynamic_schema_named_index"
-    df_0 = pd.DataFrame({"col_0": [0], "col_1": [0.5]}, index=pd.date_range("2024-01-01", periods=1))
-    df_0.index.name = "date"
-    df_1 = pd.DataFrame({"col_0": [1]}, index=pd.date_range("2024-01-02", periods=1))
-    lib.write(sym, df_0)
-    with pytest.raises(StreamDescriptorMismatch) as exception_info:
-        lib.append(sym, df_1)
+@pytest.mark.parametrize("compact_data_inline", [True, False])
+class TestAppendHypothesis:
+    @pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
+    def test_append_partial_read(
+        self, version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point, compact_data_inline
+    ):
+        tz = "America/New_York"
+        version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
+        dtidx = pd.date_range("2019-02-06 11:43", periods=6).tz_localize(tz)
+        a = np.arange(dtidx.shape[0])
+        tf = TimeFrame(dtidx.values, columns_names=["a", "b", "c"], columns_values=[a, a + a, a * 10])
+        c1 = dtidx[append_point]
+        c2 = dtidx[append_point + 1]
+        tf1 = tf.tsloc[:c1]
+        sid = "XXX"
+        version_store.write(sid, tf1)
+        tf2 = tf.tsloc[c2:]
+        version_store.append(sid, tf2, compact_data_inline=compact_data_inline)
 
-    assert "date" in str(exception_info.value)
+        dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
+        vit = version_store.read(sid, date_range=dtr, columns=list(cols))
+        rtf = tf.tsloc[dtr[0] : dtr[1]]
+        col_names, col_values = zip(*[(c, v) for c, v in zip(rtf.columns_names, rtf.columns_values) if c in cols])
+        rtf = TimeFrame(rtf.times, list(col_names), list(col_values))
+        assert rtf == vit.data
 
+    # test_hypothesis_version_store.py covers the appends that are allowed.
+    # Only need to check the forbidden ones have useful error messages:
+    @pytest.mark.parametrize(
+        "initial, append, match",
+        [
+            # (InputFactories.DF_RC_NON_RANGE, InputFactories.DF_DTI, "TODO(AN-722)"),
+            (InputFactories.DF_RC, InputFactories.ND_ARRAY_1D, "DataFrame"),
+            (InputFactories.DF_RC, InputFactories.DF_MULTI_RC, "E_INCOMPATIBLE_INDEX"),
+            (
+                InputFactories.DF_RC,
+                InputFactories.DF_RC_NON_RANGE,
+                "range",
+            ),
+            (InputFactories.DF_RC, InputFactories.DF_RC_STEP, "step"),
+        ],
+    )
+    @pytest.mark.parametrize("swap", ["swap", ""])
+    def test_(
+        self,
+        initial: InputFactories,
+        append: InputFactories,
+        match,
+        swap,
+        lmdb_version_store: NativeVersionStore,
+        compact_data_inline,
+    ):
+        lib = lmdb_version_store
+        if swap:
+            initial, append = append, initial
+        init_data, next_start = initial.make(1, 3)
+        lib.write("s", init_data)
 
-@pytest.mark.parametrize(
-    "idx", [pd.date_range(pd.Timestamp("2020-01-01"), periods=3), pd.RangeIndex(start=0, stop=3, step=1)]
-)
-def test_append_bool_named_col(lmdb_version_store_dynamic_schema, idx):
-    symbol = "bad_append"
+        to_append, _ = append.make(abs(next_start), 1)
+        with pytest.raises(NormalizationException) as e:
+            lib.append("s", to_append, compact_data_inline=compact_data_inline)
+        assert match in str(e.value)
 
-    initial = pd.DataFrame({"col": [1, 2, 3]}, index=idx)
-    lmdb_version_store_dynamic_schema.write(symbol, initial)
+    def test_regular_append_dynamic_schema_named_index(
+        self, lmdb_version_store_tiny_segment_dynamic, compact_data_inline
+    ):
+        lib = lmdb_version_store_tiny_segment_dynamic
+        sym = "test_parallel_append_dynamic_schema_named_index"
+        df_0 = pd.DataFrame({"col_0": [0], "col_1": [0.5]}, index=pd.date_range("2024-01-01", periods=1))
+        df_0.index.name = "date"
+        df_1 = pd.DataFrame({"col_0": [1]}, index=pd.date_range("2024-01-02", periods=1))
+        lib.write(sym, df_0)
+        with pytest.raises(StreamDescriptorMismatch) as exception_info:
+            lib.append(sym, df_1, compact_data_inline=compact_data_inline)
 
-    bad_df = pd.DataFrame({True: [4, 5, 6]}, index=idx)
+        assert "date" in str(exception_info.value)
 
-    # The normalization exception is getting reraised as an ArcticNativeException so we check for that
-    with pytest.raises(ArcticNativeException):
-        lmdb_version_store_dynamic_schema.append(symbol, bad_df)
+    @pytest.mark.parametrize(
+        "idx", [pd.date_range(pd.Timestamp("2020-01-01"), periods=3), pd.RangeIndex(start=0, stop=3, step=1)]
+    )
+    def test_append_bool_named_col(self, lmdb_version_store_dynamic_schema, idx, compact_data_inline):
+        symbol = "bad_append"
 
-    assert_frame_equal(lmdb_version_store_dynamic_schema.read(symbol).data, initial)
+        initial = pd.DataFrame({"col": [1, 2, 3]}, index=idx)
+        lmdb_version_store_dynamic_schema.write(symbol, initial)
+
+        bad_df = pd.DataFrame({True: [4, 5, 6]}, index=idx)
+
+        # The normalization exception is getting reraised as an ArcticNativeException so we check for that
+        with pytest.raises(ArcticNativeException):
+            lmdb_version_store_dynamic_schema.append(symbol, bad_df, compact_data_inline=compact_data_inline)
+
+        assert_frame_equal(lmdb_version_store_dynamic_schema.read(symbol).data, initial)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -438,6 +438,29 @@ def test_prune_previous_defragment_symbol_data(version_store_factory, monkeypatc
     assert len(lt.find_keys(KeyType.TABLE_INDEX)) == 1 if should_be_pruned else 3
 
 
+@pytest.mark.parametrize("lib_config", (True, False))
+@pytest.mark.parametrize("env_var", (True, False))
+@pytest.mark.parametrize("arg", (True, False, None))
+def test_prune_previous_append_compact_data_inline(version_store_factory, monkeypatch, lib_config, env_var, arg):
+    lib = version_store_factory(prune_previous_version=lib_config, use_tombstones=True)
+    should_be_pruned = lib_config
+    if env_var:
+        monkeypatch.setenv("PRUNE_PREVIOUS_VERSION", "true")
+        should_be_pruned = True
+    if arg is not None:
+        should_be_pruned = arg
+
+    lt = lib.library_tool()
+    sym = f"test_prune_previous_append_compact_data_inline"
+    df_0 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
+    lib.write(sym, df_0)
+
+    df_1 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-11", periods=10))
+    lib.append(sym, df_1, prune_previous_version=arg, compact_data_inline=True)
+
+    assert len(lt.find_keys(KeyType.TABLE_INDEX)) == (1 if should_be_pruned else 2)
+
+
 @pytest.mark.parametrize("index_start", range(9))
 def test_update_index_overlap_corner_cases(lmdb_version_store_tiny_segment, index_start):
     lib = lmdb_version_store_tiny_segment

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -22,147 +22,69 @@ from arcticdb.util.logger import get_logger
 from tests.util.mark import WINDOWS
 
 
-def test_append_simple(lmdb_version_store):
-    symbol = "test_append_simple"
-    df1 = pd.DataFrame({"x": np.arange(1, 10, dtype=np.int64)})
-    lmdb_version_store.write(symbol, df1)
-    vit = lmdb_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
+def get_next_business_date(d: datetime) -> datetime:
+    """Returns next business date from datetime 'd' (uses pandas BDay)."""
 
-    df2 = pd.DataFrame({"x": np.arange(11, 20, dtype=np.int64)})
-    lmdb_version_store.append(symbol, df2)
-    vit = lmdb_version_store.read(symbol)
-    expected = pd.concat([df1, df2], ignore_index=True)
-    assert_frame_equal(vit.data, expected)
+    return (d + BDay(1)).to_pydatetime()
 
 
-@pytest.mark.parametrize("empty_types", (True, False))
-@pytest.mark.parametrize("dynamic_schema", (True, False))
-def test_append_range_index(version_store_factory, empty_types, dynamic_schema):
-    lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
-    sym = "test_append_range_index"
-    df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(0, 4, 2))
-    lib.write(sym, df_0)
-
-    # Appending another range index following on from what is there should work
-    df_1 = pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(4, 8, 2))
-    lib.append(sym, df_1)
-    expected = pd.concat([df_0, df_1])
-    received = lib.read(sym).data
-    assert_frame_equal(expected, received)
-
-    # Appending a range starting earlier or later, or with a different step size, should fail
-    for idx in [
-        pd.RangeIndex(6, 10, 2),
-        pd.RangeIndex(10, 14, 2),
-        pd.RangeIndex(8, 14, 3),
-    ]:
-        with pytest.raises(NormalizationException):
-            lib.append(sym, pd.DataFrame({"col": [4, 5]}, index=idx))
-
-
-@pytest.mark.parametrize("empty_types", (True, False))
-@pytest.mark.parametrize("dynamic_schema", (True, False))
-def test_append_range_index_from_zero(version_store_factory, empty_types, dynamic_schema):
-    lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
-    sym = "test_append_range_index_from_zero"
-    df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(-6, -2, 2))
-    lib.write(sym, df_0)
-
-    with pytest.raises(NormalizationException):
-        lib.append(sym, pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(0, 4, 2)))
-
-
-def test_append_indexed(s3_version_store):
-    symbol = "test_append_simple"
-    idx1 = np.arange(0, 10)
-    d1 = {"x": np.arange(10, 20, dtype=np.int64)}
-    df1 = pd.DataFrame(data=d1, index=idx1)
-    s3_version_store.write(symbol, df1)
-    vit = s3_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
-
-    idx2 = np.arange(10, 20)
-    d2 = {"x": np.arange(20, 30, dtype=np.int64)}
-    df2 = pd.DataFrame(data=d2, index=idx2)
-    s3_version_store.append(symbol, df2)
-    vit = s3_version_store.read(symbol)
-    expected = pd.concat([df1, df2])
-    assert_frame_equal(vit.data, expected)
-
-
-def test_append_string_of_different_sizes(lmdb_version_store):
-    symbol = "test_append_simple"
-    df1 = pd.DataFrame(data={"x": ["cat", "dog"]}, index=np.arange(0, 2))
-    lmdb_version_store.write(symbol, df1)
-    vit = lmdb_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
-
-    df2 = pd.DataFrame(
-        data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]},
-        index=np.arange(2, 4),
+def create_random_data(at_date: datetime, num_cols: int = 5) -> pd.DataFrame:
+    date_range = pd.date_range(
+        start=at_date.replace(hour=0, minute=0, second=0, microsecond=0),
+        end=at_date.replace(hour=18, minute=0, second=0, microsecond=0),
+        freq="s",
     )
-    lmdb_version_store.append(symbol, df2)
-    vit = lmdb_version_store.read(symbol)
-    expected = pd.concat([df1, df2])
-    assert_frame_equal(vit.data, expected)
+    data = np.round(np.random.random(size=(len(date_range), num_cols)) * 100, 2)
+
+    return pd.DataFrame(data=data, index=date_range, columns=[f"c{i + 1}" for i in range(num_cols)])
 
 
-def test_append_dynamic_schema_add_column(lmdb_version_store_dynamic_schema):
-    symbol = "symbol"
-    lib = lmdb_version_store_dynamic_schema
-    df_1 = pd.DataFrame(data={"a": [1.0, 2.0]}, index=pd.date_range("2018-01-01", periods=2))
-    df_2 = pd.DataFrame(data={"b": [3.0, 4.0]}, index=pd.date_range("2018-01-03", periods=2))
+@pytest.mark.xfail(reason="Needs to be fixed with issue #496")
+def test_append_with_cont_mem_problem(sym, lmdb_version_store_tiny_segment_dynamic):
+    set_config_int("SymbolDataCompact.SegmentCount", 1)
+    df0 = pd.DataFrame({"0": ["01234567890123456"]}, index=[pd.Timestamp(0)])
+    df1 = pd.DataFrame({"0": ["012345678901234567"]}, index=[pd.Timestamp(1)])
+    df2 = pd.DataFrame({"0": ["0123456789012345678"]}, index=[pd.Timestamp(2)])
+    df3 = pd.DataFrame({"0": ["01234567890123456789"]}, index=[pd.Timestamp(3)])
+    df = pd.concat([df0, df1, df2, df3])
 
-    lib.write(symbol, df_1)
-    lib.append(symbol, df_2)
-
-    expected_df = pd.concat([df_1, df_2])
-    result_df = lib.read(symbol).data
-    assert_frame_equal(result_df, expected_df)
-
-
-def test_append_snapshot_delete(lmdb_version_store):
-    symbol = "test_append_snapshot_delete"
-    if sys.platform == "win32":
-        # Keep it smaller on Windows due to restricted LMDB size
-        row_count = 1000
-    else:
-        row_count = 1000000
-    idx1 = np.arange(0, row_count)
-    d1 = {"x": np.arange(row_count, 2 * row_count, dtype=np.int64)}
-    df1 = pd.DataFrame(data=d1, index=idx1)
-    lmdb_version_store.write(symbol, df1)
-    vit = lmdb_version_store.read(symbol)
-    assert_frame_equal(vit.data, df1)
-
-    lmdb_version_store.snapshot("my_snap")
-
-    idx2 = np.arange(row_count, 2 * row_count)
-    d2 = {"x": np.arange(2 * row_count, 3 * row_count, dtype=np.int64)}
-    df2 = pd.DataFrame(data=d2, index=idx2)
-    lmdb_version_store.append(symbol, df2)
-    vit = lmdb_version_store.read(symbol)
-    expected = pd.concat([df1, df2])
-    assert_frame_equal(vit.data, expected)
-
-    lmdb_version_store.delete(symbol)
-    versions = lmdb_version_store.list_versions()
-    assert len(versions) == 1
-    version = versions[0]
-    version.pop("date")
-    assert version == {"deleted": True, "snapshots": ["my_snap"], "symbol": symbol, "version": 0}
-
-    assert_frame_equal(lmdb_version_store.read(symbol, as_of="my_snap").data, df1)
+    for _ in range(100):
+        lib = lmdb_version_store_tiny_segment_dynamic
+        lib.write(sym, df0).version
+        lib.append(sym, df1).version
+        lib.append(sym, df2).version
+        lib.append(sym, df3).version
+        assert lib.get_info(sym)["sorted"] == "ASCENDING"
+        lib.version_store.defragment_symbol_data(sym, None)
+        assert lib.get_info(sym)["sorted"] == "ASCENDING"
+        res = lib.read(sym).data
+        assert_frame_equal(df, res)
 
 
-def test_append_out_of_order_throws(lmdb_version_store):
-    lib: NativeVersionStore = lmdb_version_store
-    lib.write("a", pd.DataFrame({"c": [1, 2, 3]}, index=pd.date_range(0, periods=3)))
-    with pytest.raises(Exception, match="1970-01-03"):
-        lib.append("a", pd.DataFrame({"c": [4]}, index=pd.date_range(1, periods=1)))
+def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
+    pytest.skip("This test is flaky due to trying to retrieve the log messages")
+    lib = s3_store_factory(dynamic_strings=True, incomplete=True)
+    lib_tool = lib.library_tool()
+    symbol = sym
+
+    write_df = pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([1, 2, 3]))
+    lib_tool.append_incomplete(symbol, write_df)
+    # Need to compact so that the APPEND_REF points to a non-existent APPEND_DATA (intentionally)
+    lib.compact_incomplete(symbol, True, False, False, True)
+    set_log_level("DEBUG")
+
+    try:
+        read_df = lib.read(symbol, date_range=(pd.to_datetime(0), pd.to_datetime(10))).data
+        assert_frame_equal(read_df, write_df.tz_localize("UTC"))
+
+        err = get_stderr()
+        assert err.count("W arcticdb.storage | Failed to find segment for key") == 0
+        assert err.count("D arcticdb.storage | Failed to find segment for key") == 1
+    finally:
+        set_log_level()
 
 
+# sort_index assumes segments are internally sorted, which is not the case when appending with compact_data_inline=True
 @pytest.mark.parametrize("prune_previous_versions", [True, False])
 def test_append_out_of_order_and_sort(lmdb_version_store_ignore_order, prune_previous_versions):
     symbol = "out_of_order"
@@ -233,406 +155,6 @@ def test_sort_index(version_store_factory, dynamic_schema, prune_previous_versio
     assert_frame_equal(lib.read(symbol).data, sorted_df)
 
 
-def test_upsert_with_delete(lmdb_version_store_big_map):
-    lib = lmdb_version_store_big_map
-    symbol = "upsert_with_delete"
-    lib.version_store.remove_incomplete(symbol)
-    lib.version_store._set_validate_version_map()
-
-    num_rows = 1111
-    dtidx = pd.date_range("1970-01-01", periods=num_rows)
-    test = pd.DataFrame(
-        {
-            "uint8": random_integers(num_rows, np.uint8),
-            "uint32": random_integers(num_rows, np.uint32),
-        },
-        index=dtidx,
-    )
-    chunk_size = 100
-    list_df = [test[i : i + chunk_size] for i in range(0, test.shape[0], chunk_size)]
-
-    for idx, df in enumerate(list_df):
-        if idx % 3 == 0:
-            lib.delete(symbol)
-
-        lib.append(symbol, df, write_if_missing=True)
-
-    first = list_df[len(list_df) - 3]
-    second = list_df[len(list_df) - 2]
-    third = list_df[len(list_df) - 1]
-
-    expected = pd.concat([first, second, third])
-    vit = lib.read(symbol)
-    assert_frame_equal(vit.data, expected)
-
-
-@pytest.mark.xfail(
-    condition=WINDOWS, raises=arcticdb.exceptions.ArcticDbNotYetImplemented, reason="Not implemented on Windows"
-)
-@pytest.mark.parametrize("dtype", supported_types_list)
-def test_append_numpy_array(lmdb_version_store, dtype):
-    """Tests append with all supported by arctic data types"""
-    sym = f"test_append_numpy_array"
-    np1 = generate_random_numpy_array(10, dtype)
-    lmdb_version_store.write(sym, np1)
-    np2 = generate_random_numpy_array(10, dtype)
-    lmdb_version_store.append(sym, np2)
-    expected = np.concatenate((np1, np2))
-    assert_array_equal(lmdb_version_store.read(sym).data, expected)
-
-
-def test_append_pickled_symbol(lmdb_version_store):
-    symbol = "test_append_pickled_symbol"
-    lmdb_version_store.write(symbol, np.arange(100).tolist())
-    assert lmdb_version_store.is_symbol_pickled(symbol)
-    with pytest.raises(InternalException):
-        _ = lmdb_version_store.append(symbol, np.arange(100).tolist())
-
-
-def test_append_not_sorted_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-
-    with pytest.raises(UnsortedDataException):
-        lmdb_version_store.append(symbol, df2, validate_index=True)
-
-
-@pytest.mark.parametrize("validate_index", (True, False))
-def test_append_same_index_value(lmdb_version_store_v1, validate_index):
-    lib = lmdb_version_store_v1
-    sym = "test_append_same_index_value"
-    df_0 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
-    lib.write(sym, df_0)
-
-    df_1 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range(df_0.index[-1], periods=2))
-    lib.append(sym, df_1, validate_index=validate_index)
-    expected = pd.concat([df_0, df_1])
-    received = lib.read(sym).data
-    assert_frame_equal(expected, received)
-    assert lib.get_info(sym)["sorted"] == "ASCENDING"
-
-
-def test_append_existing_not_sorted_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_initial_rows), 3)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == False
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-
-    with pytest.raises(UnsortedDataException):
-        lmdb_version_store.append(symbol, df2, validate_index=True)
-
-
-def test_append_not_sorted_non_validate_index(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-    lmdb_version_store.append(symbol, df2)
-
-
-def test_append_not_sorted_multi_index_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx1 = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    dtidx2 = np.roll(np.arange(0, num_initial_rows), 3)
-    df = pd.DataFrame(
-        {"c": np.arange(0, num_initial_rows, dtype=np.int64)},
-        index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
-    )
-    assert isinstance(df.index, MultiIndex) == True
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx1 = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    dtidx2 = np.arange(0, num_rows)
-    df2 = pd.DataFrame(
-        {"c": np.arange(0, num_rows, dtype=np.int64)},
-        index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
-    )
-    assert df2.index.is_monotonic_increasing == False
-    assert isinstance(df.index, MultiIndex) == True
-
-    with pytest.raises(UnsortedDataException):
-        lmdb_version_store.append(symbol, df2, validate_index=True)
-
-
-def test_append_not_sorted_range_index_non_exception(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    dtidx = pd.RangeIndex(0, num_initial_rows, 1)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNKNOWN"
-
-    num_rows = 20
-    dtidx = pd.RangeIndex(num_initial_rows, num_initial_rows + num_rows, 1)
-    dtidx = np.roll(dtidx, 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-    with pytest.raises(NormalizationException):
-        lmdb_version_store.append(symbol, df2)
-
-
-def test_append_mix_ascending_not_sorted(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
-    assert df.index.is_monotonic_increasing == True
-
-    lmdb_version_store.write(symbol, df, validate_index=True)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-    lmdb_version_store.append(symbol, df2, validate_index=True)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "ASCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2021-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == False
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2022-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-
-def test_append_mix_descending_not_sorted(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df.index.is_monotonic_decreasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "DESCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df2.index.is_monotonic_decreasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "DESCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2021-01-01")
-    dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_decreasing == False
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2022-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df2.index.is_monotonic_decreasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-
-def test_append_mix_ascending_descending(lmdb_version_store):
-    symbol = "bad_append"
-
-    num_initial_rows = 20
-    initial_timestamp = pd.Timestamp("2019-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
-    df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df.index.is_monotonic_decreasing == True
-
-    lmdb_version_store.write(symbol, df)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "DESCENDING"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2020-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
-    assert df2.index.is_monotonic_increasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-    num_rows = 20
-    initial_timestamp = pd.Timestamp("2022-01-01")
-    dtidx = pd.date_range(initial_timestamp, periods=num_rows)
-    df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
-    assert df2.index.is_monotonic_decreasing == True
-    lmdb_version_store.append(symbol, df2)
-    info = lmdb_version_store.get_info(symbol)
-    assert info["sorted"] == "UNSORTED"
-
-
-@pytest.mark.xfail(reason="Needs to be fixed with issue #496")
-def test_append_with_cont_mem_problem(sym, lmdb_version_store_tiny_segment_dynamic):
-    set_config_int("SymbolDataCompact.SegmentCount", 1)
-    df0 = pd.DataFrame({"0": ["01234567890123456"]}, index=[pd.Timestamp(0)])
-    df1 = pd.DataFrame({"0": ["012345678901234567"]}, index=[pd.Timestamp(1)])
-    df2 = pd.DataFrame({"0": ["0123456789012345678"]}, index=[pd.Timestamp(2)])
-    df3 = pd.DataFrame({"0": ["01234567890123456789"]}, index=[pd.Timestamp(3)])
-    df = pd.concat([df0, df1, df2, df3])
-
-    for _ in range(100):
-        lib = lmdb_version_store_tiny_segment_dynamic
-        lib.write(sym, df0).version
-        lib.append(sym, df1).version
-        lib.append(sym, df2).version
-        lib.append(sym, df3).version
-        assert lib.get_info(sym)["sorted"] == "ASCENDING"
-        lib.version_store.defragment_symbol_data(sym, None)
-        assert lib.get_info(sym)["sorted"] == "ASCENDING"
-        res = lib.read(sym).data
-        assert_frame_equal(df, res)
-
-
-def test_append_docs_example(lmdb_version_store):
-    # This test is really just the append example from the docs.
-    # Other examples are included so that outputs can be easily re-generated.
-    lib = lmdb_version_store
-
-    # Write example
-    cols = ["COL_%d" % i for i in range(50)]
-    df = pd.DataFrame(np.random.randint(0, 50, size=(25, 50)), columns=cols)
-    df.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
-    print(df.head(2))
-    lib.write("test_frame", df)
-
-    # Read it back
-    from_storage_df = lib.read("test_frame").data
-    print(from_storage_df.head(2))
-
-    # Slicing and filtering examples
-    print(lib.read("test_frame", date_range=(df.index[5], df.index[8])).data)
-    _range = (df.index[5], df.index[8])
-    _cols = ["COL_30", "COL_31"]
-    print(lib.read("test_frame", date_range=_range, columns=_cols).data)
-    from arcticdb import QueryBuilder
-
-    q = QueryBuilder()
-    q = q[(q["COL_30"] > 30) & (q["COL_31"] < 50)]
-    print(lib.read("test_frame", date_range=_range, columns=_cols, query_builder=q).data)
-
-    # Update example
-    random_data = np.random.randint(0, 50, size=(25, 50))
-    df2 = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
-    df2.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
-    df2 = df2.iloc[[0, 2]]
-    print(df2)
-    lib.update("test_frame", df2)
-    print(lib.head("test_frame", 2))
-
-    # Append example
-    random_data = np.random.randint(0, 50, size=(5, 50))
-    df_append = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
-    print(df_append)
-    df_append.index = pd.date_range(datetime(2000, 1, 2, 7), periods=5, freq="H")
-
-    lib.append("test_frame", df_append)
-    print(lib.tail("test_frame", 7).data)
-    expected = pd.concat([df2, df.drop(df.index[:3]), df_append])
-    assert_frame_equal(lib.read("test_frame").data, expected)
-
-    print(lib.tail("test_frame", 7, as_of=0).data)
-
-
-def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
-    pytest.skip("This test is flaky due to trying to retrieve the log messages")
-    lib = s3_store_factory(dynamic_strings=True, incomplete=True)
-    lib_tool = lib.library_tool()
-    symbol = sym
-
-    write_df = pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([1, 2, 3]))
-    lib_tool.append_incomplete(symbol, write_df)
-    # Need to compact so that the APPEND_REF points to a non-existent APPEND_DATA (intentionally)
-    lib.compact_incomplete(symbol, True, False, False, True)
-    set_log_level("DEBUG")
-
-    try:
-        read_df = lib.read(symbol, date_range=(pd.to_datetime(0), pd.to_datetime(10))).data
-        assert_frame_equal(read_df, write_df.tz_localize("UTC"))
-
-        err = get_stderr()
-        assert err.count("W arcticdb.storage | Failed to find segment for key") == 0
-        assert err.count("D arcticdb.storage | Failed to find segment for key") == 1
-    finally:
-        set_log_level()
-
-
 @pytest.mark.parametrize("prune_previous_versions", [True, False])
 def test_defragment_read_prev_versions(sym, lmdb_version_store, prune_previous_versions):
     start_time, end_time = pd.to_datetime(("1990-1-1", "1995-1-1"))
@@ -688,154 +210,637 @@ def test_defragment_no_work_to_do(sym, lmdb_version_store):
         lmdb_version_store.defragment_symbol_data(sym)
 
 
-@pytest.mark.parametrize(
-    "to_write, to_append",
-    [
-        (pd.DataFrame({"a": [1]}), pd.Series([2])),
-        (pd.DataFrame({"a": [1]}), np.array([2])),
-        (pd.Series([1]), pd.DataFrame({"a": [2]})),
-        (pd.Series([1]), np.array([2])),
-        (np.array([1]), pd.DataFrame({"a": [2]})),
-        (np.array([1]), pd.Series([2])),
-        (pd.DataFrame({"a": [1], "b": [2]}), pd.Series([2])),
-        (pd.DataFrame({"a": [1], "b": [2]}), np.array([2])),
-        (pd.Series([1]), pd.DataFrame({"a": [2], "b": [2]})),
-        (np.array([1]), pd.DataFrame({"a": [2], "b": [2]})),
-    ],
-)
-def test_append_mismatched_object_kind(to_write, to_append, lmdb_version_store_dynamic_schema_v1):
-    lib = lmdb_version_store_dynamic_schema_v1
-    lib.write("sym", to_write)
-    with pytest.raises(NormalizationException) as e:
-        lib.append("sym", to_append)
-    assert "Append" in str(e.value)
+@pytest.mark.parametrize("compact_data_inline", [True, False])
+class TestAppend:
+    def test_append_simple(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_simple"
+        df1 = pd.DataFrame({"x": np.arange(1, 10, dtype=np.int64)})
+        lmdb_version_store.write(symbol, df1)
+        vit = lmdb_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
 
+        df2 = pd.DataFrame({"x": np.arange(11, 20, dtype=np.int64)})
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = lmdb_version_store.read(symbol)
+        expected = pd.concat([df1, df2], ignore_index=True)
+        assert_frame_equal(vit.data, expected)
 
-@pytest.mark.parametrize(
-    "to_write, to_append",
-    [
-        (pd.Series([1, 2, 3], name="name_1"), pd.Series([4, 5, 6], name="name_2")),
+    @pytest.mark.parametrize("empty_types", (True, False))
+    @pytest.mark.parametrize("dynamic_schema", (True, False))
+    def test_append_range_index(self, version_store_factory, empty_types, dynamic_schema, compact_data_inline):
+        lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
+        sym = "test_append_range_index"
+        df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(0, 4, 2))
+        lib.write(sym, df_0)
+
+        # Appending another range index following on from what is there should work
+        df_1 = pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(4, 8, 2))
+        lib.append(sym, df_1, compact_data_inline=compact_data_inline)
+        expected = pd.concat([df_0, df_1])
+        received = lib.read(sym).data
+        assert_frame_equal(expected, received)
+
+        # Appending a range starting earlier or later, or with a different step size, should fail
+        for idx in [
+            pd.RangeIndex(6, 10, 2),
+            pd.RangeIndex(10, 14, 2),
+            pd.RangeIndex(8, 14, 3),
+        ]:
+            with pytest.raises(NormalizationException):
+                lib.append(sym, pd.DataFrame({"col": [4, 5]}, index=idx), compact_data_inline=compact_data_inline)
+
+    @pytest.mark.parametrize("empty_types", (True, False))
+    @pytest.mark.parametrize("dynamic_schema", (True, False))
+    def test_append_range_index_from_zero(
+        self, version_store_factory, empty_types, dynamic_schema, compact_data_inline
+    ):
+        lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
+        sym = "test_append_range_index_from_zero"
+        df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(-6, -2, 2))
+        lib.write(sym, df_0)
+
+        with pytest.raises(NormalizationException):
+            lib.append(
+                sym,
+                pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(0, 4, 2)),
+                compact_data_inline=compact_data_inline,
+            )
+
+    def test_append_indexed(self, s3_version_store, compact_data_inline):
+        symbol = "test_append_simple"
+        idx1 = np.arange(0, 10)
+        d1 = {"x": np.arange(10, 20, dtype=np.int64)}
+        df1 = pd.DataFrame(data=d1, index=idx1)
+        s3_version_store.write(symbol, df1)
+        vit = s3_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
+
+        idx2 = np.arange(10, 20)
+        d2 = {"x": np.arange(20, 30, dtype=np.int64)}
+        df2 = pd.DataFrame(data=d2, index=idx2)
+        s3_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = s3_version_store.read(symbol)
+        expected = pd.concat([df1, df2])
+        assert_frame_equal(vit.data, expected)
+
+    def test_append_string_of_different_sizes(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_simple"
+        df1 = pd.DataFrame(data={"x": ["cat", "dog"]}, index=np.arange(0, 2))
+        lmdb_version_store.write(symbol, df1)
+        vit = lmdb_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
+
+        df2 = pd.DataFrame(
+            data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]},
+            index=np.arange(2, 4),
+        )
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = lmdb_version_store.read(symbol)
+        expected = pd.concat([df1, df2])
+        assert_frame_equal(vit.data, expected)
+
+    def test_append_dynamic_schema_add_column(self, lmdb_version_store_dynamic_schema, compact_data_inline):
+        symbol = "symbol"
+        lib = lmdb_version_store_dynamic_schema
+        df_1 = pd.DataFrame(data={"a": [1.0, 2.0]}, index=pd.date_range("2018-01-01", periods=2))
+        df_2 = pd.DataFrame(data={"b": [3.0, 4.0]}, index=pd.date_range("2018-01-03", periods=2))
+
+        lib.write(symbol, df_1)
+        lib.append(symbol, df_2, compact_data_inline=compact_data_inline)
+
+        expected_df = pd.concat([df_1, df_2])
+        result_df = lib.read(symbol).data
+        assert_frame_equal(result_df, expected_df)
+
+    def test_append_snapshot_delete(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_snapshot_delete"
+        if sys.platform == "win32":
+            # Keep it smaller on Windows due to restricted LMDB size
+            row_count = 1000
+        else:
+            row_count = 1000000
+        idx1 = np.arange(0, row_count)
+        d1 = {"x": np.arange(row_count, 2 * row_count, dtype=np.int64)}
+        df1 = pd.DataFrame(data=d1, index=idx1)
+        lmdb_version_store.write(symbol, df1)
+        vit = lmdb_version_store.read(symbol)
+        assert_frame_equal(vit.data, df1)
+
+        lmdb_version_store.snapshot("my_snap")
+
+        idx2 = np.arange(row_count, 2 * row_count)
+        d2 = {"x": np.arange(2 * row_count, 3 * row_count, dtype=np.int64)}
+        df2 = pd.DataFrame(data=d2, index=idx2)
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        vit = lmdb_version_store.read(symbol)
+        expected = pd.concat([df1, df2])
+        assert_frame_equal(vit.data, expected)
+
+        lmdb_version_store.delete(symbol)
+        versions = lmdb_version_store.list_versions()
+        assert len(versions) == 1
+        version = versions[0]
+        version.pop("date")
+        assert version == {"deleted": True, "snapshots": ["my_snap"], "symbol": symbol, "version": 0}
+
+        assert_frame_equal(lmdb_version_store.read(symbol, as_of="my_snap").data, df1)
+
+    def test_append_out_of_order_throws(self, lmdb_version_store, compact_data_inline):
+        lib: NativeVersionStore = lmdb_version_store
+        lib.write("a", pd.DataFrame({"c": [1, 2, 3]}, index=pd.date_range(0, periods=3)))
+        with pytest.raises(Exception, match="1970-01-03"):
+            lib.append(
+                "a",
+                pd.DataFrame({"c": [4]}, index=pd.date_range(1, periods=1)),
+                compact_data_inline=compact_data_inline,
+            )
+
+    def test_upsert_with_delete(self, lmdb_version_store_big_map, compact_data_inline):
+        lib = lmdb_version_store_big_map
+        symbol = "upsert_with_delete"
+        lib.version_store.remove_incomplete(symbol)
+        lib.version_store._set_validate_version_map()
+
+        num_rows = 1111
+        dtidx = pd.date_range("1970-01-01", periods=num_rows)
+        test = pd.DataFrame(
+            {
+                "uint8": random_integers(num_rows, np.uint8),
+                "uint32": random_integers(num_rows, np.uint32),
+            },
+            index=dtidx,
+        )
+        chunk_size = 100
+        list_df = [test[i : i + chunk_size] for i in range(0, test.shape[0], chunk_size)]
+
+        for idx, df in enumerate(list_df):
+            if idx % 3 == 0:
+                lib.delete(symbol)
+
+            lib.append(symbol, df, write_if_missing=True, compact_data_inline=compact_data_inline)
+
+        first = list_df[len(list_df) - 3]
+        second = list_df[len(list_df) - 2]
+        third = list_df[len(list_df) - 1]
+
+        expected = pd.concat([first, second, third])
+        vit = lib.read(symbol)
+        assert_frame_equal(vit.data, expected)
+
+    @pytest.mark.xfail(
+        condition=WINDOWS, raises=arcticdb.exceptions.ArcticDbNotYetImplemented, reason="Not implemented on Windows"
+    )
+    @pytest.mark.parametrize("dtype", supported_types_list)
+    def test_append_numpy_array(self, lmdb_version_store, dtype, compact_data_inline):
+        """Tests append with all supported by arctic data types"""
+        sym = f"test_append_numpy_array"
+        np1 = generate_random_numpy_array(10, dtype)
+        lmdb_version_store.write(sym, np1)
+        np2 = generate_random_numpy_array(10, dtype)
+        lmdb_version_store.append(sym, np2, compact_data_inline=compact_data_inline)
+        expected = np.concatenate((np1, np2))
+        assert_array_equal(lmdb_version_store.read(sym).data, expected)
+
+    def test_append_pickled_symbol(self, lmdb_version_store, compact_data_inline):
+        symbol = "test_append_pickled_symbol"
+        lmdb_version_store.write(symbol, np.arange(100).tolist())
+        assert lmdb_version_store.is_symbol_pickled(symbol)
+        with pytest.raises(InternalException):
+            _ = lmdb_version_store.append(symbol, np.arange(100).tolist(), compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+
+        with pytest.raises(UnsortedDataException):
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+
+    @pytest.mark.parametrize("validate_index", (True, False))
+    def test_append_same_index_value(self, lmdb_version_store_v1, validate_index, compact_data_inline):
+        lib = lmdb_version_store_v1
+        sym = "test_append_same_index_value"
+        df_0 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
+        lib.write(sym, df_0)
+
+        df_1 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range(df_0.index[-1], periods=2))
+        lib.append(sym, df_1, validate_index=validate_index, compact_data_inline=compact_data_inline)
+        expected = pd.concat([df_0, df_1])
+        received = lib.read(sym).data
+        assert_frame_equal(expected, received)
+        assert lib.get_info(sym)["sorted"] == "ASCENDING"
+
+    def test_append_existing_not_sorted_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_initial_rows), 3)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == False
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+
+        with pytest.raises(UnsortedDataException):
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_non_validate_index(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_multi_index_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx1 = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        dtidx2 = np.roll(np.arange(0, num_initial_rows), 3)
+        df = pd.DataFrame(
+            {"c": np.arange(0, num_initial_rows, dtype=np.int64)},
+            index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
+        )
+        assert isinstance(df.index, MultiIndex) == True
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx1 = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        dtidx2 = np.arange(0, num_rows)
+        df2 = pd.DataFrame(
+            {"c": np.arange(0, num_rows, dtype=np.int64)},
+            index=pd.MultiIndex.from_arrays([dtidx1, dtidx2], names=["datetime", "level"]),
+        )
+        assert df2.index.is_monotonic_increasing == False
+        assert isinstance(df.index, MultiIndex) == True
+
+        with pytest.raises(UnsortedDataException):
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+
+    def test_append_not_sorted_range_index_non_exception(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        dtidx = pd.RangeIndex(0, num_initial_rows, 1)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNKNOWN"
+
+        num_rows = 20
+        dtidx = pd.RangeIndex(num_initial_rows, num_initial_rows + num_rows, 1)
+        dtidx = np.roll(dtidx, 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+        with pytest.raises(NormalizationException):
+            lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+
+    def test_append_mix_ascending_not_sorted(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=dtidx)
+        assert df.index.is_monotonic_increasing == True
+
+        lmdb_version_store.write(symbol, df, validate_index=True)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+        lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "ASCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2021-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == False
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2022-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+    def test_append_mix_descending_not_sorted(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df.index.is_monotonic_decreasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "DESCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df2.index.is_monotonic_decreasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "DESCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2021-01-01")
+        dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_decreasing == False
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2022-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df2.index.is_monotonic_decreasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+    def test_append_mix_ascending_descending(self, lmdb_version_store, compact_data_inline):
+        symbol = "bad_append"
+
+        num_initial_rows = 20
+        initial_timestamp = pd.Timestamp("2019-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_initial_rows)
+        df = pd.DataFrame({"c": np.arange(0, num_initial_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df.index.is_monotonic_decreasing == True
+
+        lmdb_version_store.write(symbol, df)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "DESCENDING"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2020-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
+        assert df2.index.is_monotonic_increasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+        num_rows = 20
+        initial_timestamp = pd.Timestamp("2022-01-01")
+        dtidx = pd.date_range(initial_timestamp, periods=num_rows)
+        df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
+        assert df2.index.is_monotonic_decreasing == True
+        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        info = lmdb_version_store.get_info(symbol)
+        assert info["sorted"] == "UNSORTED"
+
+    def test_append_docs_example(self, lmdb_version_store, compact_data_inline):
+        # This test is really just the append example from the docs.
+        # Other examples are included so that outputs can be easily re-generated.
+        lib = lmdb_version_store
+
+        # Write example
+        cols = ["COL_%d" % i for i in range(50)]
+        df = pd.DataFrame(np.random.randint(0, 50, size=(25, 50)), columns=cols)
+        df.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
+        print(df.head(2))
+        lib.write("test_frame", df)
+
+        # Read it back
+        from_storage_df = lib.read("test_frame").data
+        print(from_storage_df.head(2))
+
+        # Slicing and filtering examples
+        print(lib.read("test_frame", date_range=(df.index[5], df.index[8])).data)
+        _range = (df.index[5], df.index[8])
+        _cols = ["COL_30", "COL_31"]
+        print(lib.read("test_frame", date_range=_range, columns=_cols).data)
+        from arcticdb import QueryBuilder
+
+        q = QueryBuilder()
+        q = q[(q["COL_30"] > 30) & (q["COL_31"] < 50)]
+        print(lib.read("test_frame", date_range=_range, columns=_cols, query_builder=q).data)
+
+        # Update example
+        random_data = np.random.randint(0, 50, size=(25, 50))
+        df2 = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
+        df2.index = pd.date_range(datetime(2000, 1, 1, 5), periods=25, freq="H")
+        df2 = df2.iloc[[0, 2]]
+        print(df2)
+        lib.update("test_frame", df2)
+        print(lib.head("test_frame", 2))
+
+        # Append example
+        random_data = np.random.randint(0, 50, size=(5, 50))
+        df_append = pd.DataFrame(random_data, columns=["COL_%d" % i for i in range(50)])
+        print(df_append)
+        df_append.index = pd.date_range(datetime(2000, 1, 2, 7), periods=5, freq="H")
+
+        lib.append("test_frame", df_append, compact_data_inline=compact_data_inline)
+        print(lib.tail("test_frame", 7).data)
+        expected = pd.concat([df2, df.drop(df.index[:3]), df_append])
+        assert_frame_equal(lib.read("test_frame").data, expected)
+
+        print(lib.tail("test_frame", 7, as_of=0).data)
+
+    @pytest.mark.parametrize(
+        "to_write, to_append",
+        [
+            (pd.DataFrame({"a": [1]}), pd.Series([2])),
+            (pd.DataFrame({"a": [1]}), np.array([2])),
+            (pd.Series([1]), pd.DataFrame({"a": [2]})),
+            (pd.Series([1]), np.array([2])),
+            (np.array([1]), pd.DataFrame({"a": [2]})),
+            (np.array([1]), pd.Series([2])),
+            (pd.DataFrame({"a": [1], "b": [2]}), pd.Series([2])),
+            (pd.DataFrame({"a": [1], "b": [2]}), np.array([2])),
+            (pd.Series([1]), pd.DataFrame({"a": [2], "b": [2]})),
+            (np.array([1]), pd.DataFrame({"a": [2], "b": [2]})),
+        ],
+    )
+    def test_append_mismatched_object_kind(
+        self, to_write, to_append, lmdb_version_store_dynamic_schema_v1, compact_data_inline
+    ):
+        lib = lmdb_version_store_dynamic_schema_v1
+        lib.write("sym", to_write)
+        with pytest.raises(NormalizationException) as e:
+            lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        assert "Append" in str(e.value)
+
+    @pytest.mark.parametrize(
+        "to_write, to_append",
+        [
+            (pd.Series([1, 2, 3], name="name_1"), pd.Series([4, 5, 6], name="name_2")),
+            (
+                pd.Series(
+                    [1, 2, 3],
+                    name="name_1",
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(1), pd.Timestamp(2)]),
+                ),
+                pd.Series(
+                    [4, 5, 6],
+                    name="name_2",
+                    index=pd.DatetimeIndex([pd.Timestamp(3), pd.Timestamp(4), pd.Timestamp(5)]),
+                ),
+            ),
+        ],
+    )
+    def test_append_series_with_different_column_name_throws(
+        self, lmdb_version_store_dynamic_schema_v1, to_write, to_append, compact_data_inline
+    ):
+        # It makes sense to create a new column and turn the whole thing into a dataframe. This would require changes in the
+        # logic for storing normalization metadata which is tricky. Noone has requested this, so we just throw.
+        lib = lmdb_version_store_dynamic_schema_v1
+        lib.write("sym", to_write)
+        with pytest.raises(SchemaException) as e:
+            lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        assert "name_1" in str(e.value) and "name_2" in str(e.value)
+
+    def test_append_series_with_different_row_range_index_name(
+        self, lmdb_version_store_dynamic_schema_v1, compact_data_inline
+    ):
+        lib = lmdb_version_store_dynamic_schema_v1
+        to_write = pd.Series([1, 2, 3])
+        to_write.index.name = "index_name_1"
+        to_append = pd.Series([4, 5, 6])
+        to_append.index.name = "index_name_2"
+        lib.write("sym", to_write)
+        lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        # The current behavior is the last modification operation is setting the index name.
+        # See Monday 9797097831, it would be best to require that index names are always matching. This is the case for
+        # datetime index because it's a physical column. It's a potentially breaking change.
+        assert lib.read("sym").data.index.name == "index_name_2"
+
+    def test_append_after_delete_range(self, sym, lmdb_version_store, compact_data_inline):
+        lib = lmdb_version_store
+
+        start_date = datetime(2025, 9, 1)
+        end_date = datetime(2025, 9, 2)
+        cur_date = start_date
+
+        # create data
+        while cur_date <= end_date:
+            df = create_random_data(at_date=cur_date)
+            lib.append("sym", df, compact_data_inline=compact_data_inline)
+            cur_date = get_next_business_date(cur_date)
+
+        # remove date
+        lib.delete("sym", date_range=(datetime(2025, 9, 2), datetime(2025, 9, 3)))
+
+        # re-insert data
+        start_date = datetime(2025, 9, 2)
+        end_date = datetime(2025, 9, 3)
+        cur_date = start_date
+
+        expected_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 2))).data
+
+        while cur_date <= end_date:
+            df = create_random_data(at_date=cur_date)
+            expected_data = pd.concat([expected_data, df])
+            lib.append("sym", df, compact_data_inline=compact_data_inline)
+            cur_date = get_next_business_date(cur_date)
+
+        assert_frame_equal(lib.read("sym").data, expected_data)
+
+        sliced_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 4))).data
+        assert_frame_equal(sliced_data, expected_data)
+
+    @pytest.mark.parametrize("data_class", ["dataframe", "series"])
+    @pytest.mark.parametrize("batch", [True, False])
+    @pytest.mark.parametrize("metadata_v1", ["v1", None])
+    def test_append_empty_frame_metadata(
+        self, lmdb_version_store_v1, data_class, batch, metadata_v1, compact_data_inline
+    ):
+        lib = lmdb_version_store_v1
+        sym = "test_append_empty_frame_metadata"
+        write_data = pd.DataFrame({"col": np.arange(1)}) if data_class == "dataframe" else pd.Series(np.arange(1))
+        metadata_v0 = "v0"
+        lib.write(sym, write_data, metadata=metadata_v0)
+        # Using arange guarantees the dtype matches the written df
+        append_data = pd.DataFrame({"col": np.arange(0)}) if data_class == "dataframe" else pd.Series(np.arange(0))
+        append_vit = (
+            # TODO: 12033601732 test with batch and compact_data_inline=True as well
+            lib.batch_append([sym], [append_data], metadata_vector=[metadata_v1])[0]
+            if batch
+            else lib.append(sym, append_data, metadata=metadata_v1, compact_data_inline=compact_data_inline)
+        )
+        assert append_vit.version == 1
+        assert append_vit.metadata == metadata_v1
+        read_vit = lib.read(sym)
+        assert read_vit.version == 1
+        assert read_vit.metadata == metadata_v1
+        assert_func = assert_frame_equal if data_class == "dataframe" else assert_series_equal
+        assert_func(read_vit.data, write_data)
+
+    @pytest.mark.parametrize("batch", [True, False])
+    def test_symbol_list_key_added_on_upsert(self, lmdb_version_store_v1, batch, compact_data_inline):
+        lib = lmdb_version_store_v1
+        sym = "test_symbol_list_key_added_on_upsert"
+        lib.write(sym, 0)
+        lib.delete(sym)
+        lib_tool = lib.library_tool()
+        assert not len(lib.list_symbols())
+        num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
+        append_df = pd.DataFrame({"col": np.arange(0)})
+        # TODO: 12033601732 test with batch and compact_data_inline=True as well
         (
-            pd.Series(
-                [1, 2, 3], name="name_1", index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(1), pd.Timestamp(2)])
-            ),
-            pd.Series(
-                [4, 5, 6], name="name_2", index=pd.DatetimeIndex([pd.Timestamp(3), pd.Timestamp(4), pd.Timestamp(5)])
-            ),
-        ),
-    ],
-)
-def test_append_series_with_different_column_name_throws(lmdb_version_store_dynamic_schema_v1, to_write, to_append):
-    # It makes sense to create a new column and turn the whole thing into a dataframe. This would require changes in the
-    # logic for storing normalization metadata which is tricky. Noone has requested this, so we just throw.
-    lib = lmdb_version_store_dynamic_schema_v1
-    lib.write("sym", to_write)
-    with pytest.raises(SchemaException) as e:
-        lib.append("sym", to_append)
-    assert "name_1" in str(e.value) and "name_2" in str(e.value)
-
-
-def test_append_series_with_different_row_range_index_name(lmdb_version_store_dynamic_schema_v1):
-    lib = lmdb_version_store_dynamic_schema_v1
-    to_write = pd.Series([1, 2, 3])
-    to_write.index.name = "index_name_1"
-    to_append = pd.Series([4, 5, 6])
-    to_append.index.name = "index_name_2"
-    lib.write("sym", to_write)
-    lib.append("sym", to_append)
-    # The current behavior is the last modification operation is setting the index name.
-    # See Monday 9797097831, it would be best to require that index names are always matching. This is the case for
-    # datetime index because it's a physical column. It's a potentially breaking change.
-    assert lib.read("sym").data.index.name == "index_name_2"
-
-
-def get_next_business_date(d: datetime) -> datetime:
-    """Returns next business date from datetime 'd' (uses pandas BDay)."""
-
-    return (d + BDay(1)).to_pydatetime()
-
-
-def create_random_data(at_date: datetime, num_cols: int = 5) -> pd.DataFrame:
-    date_range = pd.date_range(
-        start=at_date.replace(hour=0, minute=0, second=0, microsecond=0),
-        end=at_date.replace(hour=18, minute=0, second=0, microsecond=0),
-        freq="s",
-    )
-    data = np.round(np.random.random(size=(len(date_range), num_cols)) * 100, 2)
-
-    return pd.DataFrame(data=data, index=date_range, columns=[f"c{i + 1}" for i in range(num_cols)])
-
-
-def test_append_after_delete_range(sym, lmdb_version_store):
-    lib = lmdb_version_store
-
-    start_date = datetime(2025, 9, 1)
-    end_date = datetime(2025, 9, 2)
-    cur_date = start_date
-
-    # create data
-    while cur_date <= end_date:
-        df = create_random_data(at_date=cur_date)
-        lib.append("sym", df)
-        cur_date = get_next_business_date(cur_date)
-
-    # remove date
-    lib.delete("sym", date_range=(datetime(2025, 9, 2), datetime(2025, 9, 3)))
-
-    # re-insert data
-    start_date = datetime(2025, 9, 2)
-    end_date = datetime(2025, 9, 3)
-    cur_date = start_date
-
-    expected_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 2))).data
-
-    while cur_date <= end_date:
-        df = create_random_data(at_date=cur_date)
-        expected_data = pd.concat([expected_data, df])
-        lib.append("sym", df)
-        cur_date = get_next_business_date(cur_date)
-
-    assert_frame_equal(lib.read("sym").data, expected_data)
-
-    sliced_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 4))).data
-    assert_frame_equal(sliced_data, expected_data)
-
-
-@pytest.mark.parametrize("data_class", ["dataframe", "series"])
-@pytest.mark.parametrize("batch", [True, False])
-@pytest.mark.parametrize("metadata_v1", ["v1", None])
-def test_append_empty_frame_metadata(lmdb_version_store_v1, data_class, batch, metadata_v1):
-    lib = lmdb_version_store_v1
-    sym = "test_append_empty_frame_metadata"
-    write_data = pd.DataFrame({"col": np.arange(1)}) if data_class == "dataframe" else pd.Series(np.arange(1))
-    metadata_v0 = "v0"
-    lib.write(sym, write_data, metadata=metadata_v0)
-    # Using arange guarantees the dtype matches the written df
-    append_data = pd.DataFrame({"col": np.arange(0)}) if data_class == "dataframe" else pd.Series(np.arange(0))
-    append_vit = (
-        lib.batch_append([sym], [append_data], metadata_vector=[metadata_v1])[0]
-        if batch
-        else lib.append(sym, append_data, metadata=metadata_v1)
-    )
-    assert append_vit.version == 1
-    assert append_vit.metadata == metadata_v1
-    read_vit = lib.read(sym)
-    assert read_vit.version == 1
-    assert read_vit.metadata == metadata_v1
-    assert_func = assert_frame_equal if data_class == "dataframe" else assert_series_equal
-    assert_func(read_vit.data, write_data)
-
-
-@pytest.mark.parametrize("batch", [True, False])
-def test_symbol_list_key_added_on_upsert(lmdb_version_store_v1, batch):
-    lib = lmdb_version_store_v1
-    sym = "test_symbol_list_key_added_on_upsert"
-    lib.write(sym, 0)
-    lib.delete(sym)
-    lib_tool = lib.library_tool()
-    assert not len(lib.list_symbols())
-    num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
-    append_df = pd.DataFrame({"col": np.arange(0)})
-    (lib.batch_append([sym], [append_df]) if batch else lib.append(sym, append_df))
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
-    assert lib.list_symbols() == [sym]
+            lib.batch_append([sym], [append_df])
+            if batch
+            else lib.append(sym, append_df, compact_data_inline=compact_data_inline)
+        )
+        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
+        assert lib.list_symbols() == [sym]

--- a/python/tests/unit/arcticdb/version_store/test_append_compact_data_inline.py
+++ b/python/tests/unit/arcticdb/version_store/test_append_compact_data_inline.py
@@ -1,0 +1,678 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+from hypothesis import given, settings
+import hypothesis.strategies as st
+import numpy as np
+import pandas as pd
+from polars.testing import assert_frame_equal as assert_frame_equal_pl
+import pyarrow as pa
+import pytest
+
+from arcticdb_ext.exceptions import InternalException
+import arcticdb.toolbox.query_stats as qs
+from arcticdb.util.hypothesis import (
+    use_of_function_scoped_fixtures_in_hypothesis_checked,
+)
+from arcticdb.util.test import (
+    assert_frame_equal,
+    assert_series_equal,
+    query_stats_operation_count,
+    random_strings_of_length,
+)
+from tests.util.mark import MACOS, WINDOWS
+from tests.util.naughty_strings import read_big_list_of_naughty_strings
+
+pytestmark = pytest.mark.pipeline
+
+
+def generic_compact_data_inline_test(lib, sym, df, **append_kwargs):
+    qs.reset_stats()  # Clear any leftover stats from a previous failed run
+    vit_before_compaction = lib.read(sym, output_format="PANDAS" if isinstance(df, pd.DataFrame) else "POLARS")
+    oracle_sym = sym + "_oracle"
+    lib.write(oracle_sym, vit_before_compaction.data)
+    lib.append(oracle_sym, df, compact_data_inline=False, **append_kwargs)
+    # Use Polars so that sparse data checking is proper
+    expected = lib.read(oracle_sym, output_format="POLARS").data
+    pre_compaction_index = lib.read_index(sym)
+    pre_compaction_data_keys = len(pre_compaction_index)
+
+    with qs.query_stats():
+        lib.append(sym, df, compact_data_inline=True, **append_kwargs)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    rows_per_segment = lib.lib_cfg().lib_desc.version.write_options.segment_row_size
+    if rows_per_segment == 0:
+        rows_per_segment = 100_000
+    vit_after_compaction = lib.read(sym, output_format="POLARS")
+    received = vit_after_compaction.data
+    assert_frame_equal_pl(expected, received)
+    post_compaction_index = lib.read_index(sym)
+    row_counts = post_compaction_index["end_row"] - post_compaction_index["start_row"]
+    # Definitions taken from CompactDataClause constructor
+    min_rows_per_segment = max((2 * rows_per_segment) // 3, 1)
+    max_rows_per_segment = max((4 * rows_per_segment) // 3, rows_per_segment + 1)
+    # There might be fewer rows in total than min_rows_per_segment
+    min_rows_per_segment = min(min_rows_per_segment, len(expected))
+    assert row_counts.min() >= min_rows_per_segment
+    assert row_counts.max() <= max_rows_per_segment
+
+    post_compaction_data_keys = len(post_compaction_index)
+    new_data_keys = len(post_compaction_index[post_compaction_index["version_id"] > vit_before_compaction.version])
+    compacted_data_keys = pre_compaction_data_keys - (post_compaction_data_keys - new_data_keys)
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == compacted_data_keys
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == new_data_keys
+    # Doing a compaction would now have no impact
+    compact_data_info = lib.compact_data_explain_plan(sym)
+    assert not compact_data_info.will_do_work
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_basic(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory()
+    sym = "test_basic"
+    df_0 = pd.DataFrame(
+        {"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20)
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {"col": np.arange(20, 30)}, index=None if index is None else pd.date_range("2026-01-21", periods=10)
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+def test_frequent_append_io_counts_compact_once(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_frequent_append_io_counts_compact_once"
+    df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
+    for idx in range(99):
+        lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000])
+    with qs.query_stats():
+        lib.append(sym, df[99 * 2_000 :], compact_data_inline=True)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    received = lib.read(sym).data
+    assert_frame_equal(df, received)
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 99
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+    assert len(lib.read_index(sym)) == 2
+
+
+def test_frequent_append_io_counts_compact_every_time(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_frequent_append_io_counts_compact_every_time"
+    df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
+    for idx in range(100):
+        with qs.query_stats():
+            lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000], compact_data_inline=True)
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        received = lib.read(sym).data
+        assert_frame_equal(df[: (idx + 1) * 2_000], received)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == (0 if idx == 0 else 1)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") <= 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") <= 2
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        assert len(lib.read_index(sym)) <= 2
+
+
+def test_pyarrow_tables(in_memory_version_store_arrow, clear_query_stats):
+    lib = in_memory_version_store_arrow
+    sym = "test_pyarrow_tables"
+    table_0 = pa.table({"col": pa.array(np.arange(20))})
+    lib.write(sym, table_0)
+    table_1 = pa.table({"col": pa.array(np.arange(20, 30))})
+    with qs.query_stats():
+        lib.append(sym, table_1, compact_data_inline=True)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    vit = lib.read(sym)
+    assert vit.version == 1
+    expected = pa.concat_tables([table_0, table_1])
+    assert expected.equals(vit.data)
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+    assert len(lib.read_index(sym)) == 1
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_series(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory()
+    sym = "test_series"
+    series_0 = pd.Series(np.arange(20), index=None if index is None else pd.date_range("2026-01-01", periods=20))
+    lib.write(sym, series_0)
+    series_1 = pd.Series(np.arange(20, 30), index=None if index is None else pd.date_range("2026-01-21", periods=10))
+    with qs.query_stats():
+        lib.append(sym, series_1, compact_data_inline=True)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    vit = lib.read(sym)
+    assert vit.version == 1
+    expected = pd.concat([series_0, series_1])
+    if index is None:
+        expected.reset_index(drop=True, inplace=True)
+    assert_series_equal(expected, vit.data)
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+    assert len(lib.read_index(sym)) == 1
+
+
+def test_numpy_arrays(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_numpy_arrays"
+    array_0 = np.arange(20)
+    lib.write(sym, array_0)
+    array_1 = np.arange(20, 30)
+    with qs.query_stats():
+        lib.append(sym, array_1, compact_data_inline=True)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    vit = lib.read(sym)
+    assert vit.version == 1
+    expected = np.concatenate([array_0, array_1])
+    assert (vit.data == expected).all()
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+    assert len(lib.read_index(sym)) == 1
+
+
+def test_existing_zero_rows(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_existing_zero_rows"
+    # Zero-rowed data gets stored with a datetime index
+    df_0 = pd.DataFrame({"col": np.arange(0)})
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame({"col": np.arange(15)}, index=pd.date_range("2026-01-21", periods=15))
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("write_if_missing", [True, False])
+@pytest.mark.parametrize("compact_data_inline", [True, False])
+def test_write_if_missing(in_memory_store_factory, write_if_missing, compact_data_inline):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_write_if_missing"
+    df = pd.DataFrame({"col": np.arange(15)})
+    if write_if_missing:
+        lib.append(sym, df, compact_data_inline=compact_data_inline, write_if_missing=write_if_missing)
+        assert_frame_equal(df, lib.read(sym).data)
+        index = lib.read_index(sym)
+        row_counts = (index["end_row"] - index["start_row"]).to_list()
+        # See comment in LocalVersionedEngine::append_internal as to why this isn't [8, 7] when compact_data_inline is
+        # True
+        assert row_counts == [10, 5]
+    else:
+        with pytest.raises(InternalException):
+            lib.append(sym, df, compact_data_inline=compact_data_inline, write_if_missing=write_if_missing)
+
+
+def test_metadata(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    sym = "test_metadata"
+    lib.write(sym, pd.DataFrame({"col": [0]}), metadata="0")
+    lib.append(sym, pd.DataFrame({"col": [1]}), metadata="1", compact_data_inline=True)
+    vit = lib.read(sym)
+    assert vit.metadata == "1"
+    assert_frame_equal(vit.data, pd.DataFrame({"col": [0, 1]}))
+    assert len(lib.read_index(sym)) == 1
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_compact_whole_symbol(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_compact_whole_symbol"
+    df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
+    lib.write(sym, df[:5])
+    lib.append(sym, df[5:10])
+    lib.append(sym, df[10:15])
+    generic_compact_data_inline_test(lib, sym, df[15:])
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_compact_leftover_slices(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_compact_leftover_slices"
+    df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
+    lib.write(sym, df[:5])
+    generic_compact_data_inline_test(lib, sym, df[5:])
+
+
+def test_existing_data_compacted(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_existing_data_compacted"
+    df = pd.DataFrame({"col": np.arange(20)})
+    lib.write(sym, df[:10])
+    generic_compact_data_inline_test(lib, sym, df[10:])
+
+
+@pytest.mark.parametrize("total_rows", [25, 30, 35])
+def test_tail_of_existing_data_already_compacted(in_memory_store_factory, clear_query_stats, total_rows):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_tail_of_existing_data_already_compacted"
+    df = pd.DataFrame({"col": np.arange(total_rows)})
+    lib.write(sym, df[:5])
+    lib.append(sym, df[5:10])
+    lib.append(sym, df[10:20])
+    assert len(lib.read_index(sym)) == 3
+    generic_compact_data_inline_test(lib, sym, df[20:])
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
+def test_dynamic_schema_col_ordering(in_memory_store_factory, clear_query_stats, index, segment_row_size):
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
+    sym = "test_dynamic_schema_col_ordering"
+    df_0 = pd.DataFrame(
+        {
+            "col_0": np.arange(20, dtype=np.float64),
+            "col_1": np.arange(20, 40, dtype=np.float64),
+            "col_2": np.arange(40, 60, dtype=np.float64),
+        },
+        index=None if index is None else pd.date_range("2026-01-01", periods=20),
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {
+            "col_3": np.arange(100, 110, dtype=np.float64),
+            "col_2": np.arange(60, 70, dtype=np.float64),
+            "col_1": np.arange(40, 50, dtype=np.float64),
+        },
+        index=None if index is None else pd.date_range("2026-01-21", periods=10),
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
+def test_dynamic_schema_type_promotion(in_memory_store_factory, clear_query_stats, segment_row_size):
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
+    sym = "test_dynamic_schema_type_promotion"
+    df_0 = pd.DataFrame(
+        {
+            "col_0": np.arange(20, dtype=np.float64),
+            "col_1": np.arange(20, 40, dtype=np.uint8),
+            "col_2": np.arange(40, 60, dtype=np.int16),
+        },
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {
+            "col_0": np.arange(100, 110, dtype=np.int32),
+            "col_1": np.arange(60, 70, dtype=np.uint16),
+            "col_2": np.arange(40, 50, dtype=np.uint16),
+        },
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5])
+def test_column_slicing(in_memory_store_factory, clear_query_stats, index, segment_row_size):
+    lib = in_memory_store_factory(segment_row_size=segment_row_size, column_group_size=2)
+    sym = "test_column_slicing"
+    df_0 = pd.DataFrame(
+        {f"col_{idx}": np.arange(20) for idx in range(5)},
+        index=None if index is None else pd.date_range("2026-01-01", periods=20),
+    )
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(
+        {f"col_{idx}": np.arange(20, 30) for idx in range(5)},
+        index=None if index is None else pd.date_range("2026-01-21", periods=10),
+    )
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("names", [None, ["ts", None], [None, "level 2"], ["ts", "level 2"]])
+def test_multiindex(in_memory_store_factory, clear_query_stats, names):
+    lib = in_memory_store_factory(segment_row_size=10, dynamic_strings=True)
+    sym = "test_multiindex"
+    num_rows = 20
+    df = pd.DataFrame(
+        {"col": np.arange(num_rows)},
+        index=pd.MultiIndex.from_product(
+            [pd.date_range("2026-01-01", periods=num_rows // 2), ["GOOG", "AAPL"]], names=names
+        ),
+    )
+    lib.write(sym, df[:5])
+    with qs.query_stats():
+        lib.append(sym, df[5:], compact_data_inline=True)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    vit = lib.read(sym)
+    assert vit.version == 1
+    assert_frame_equal(df, vit.data)
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+    assert len(lib.read_index(sym)) == 2
+
+
+def test_string_none_nan_handling(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory(dynamic_strings=True)
+    sym = "test_string_none_nan_handling"
+    df = pd.DataFrame({"col": ["hello", np.nan, np.nan, None, None, None, np.nan, np.nan, None, None]})
+    lib.write(sym, df[:5], coerce_columns={"col": object})
+    generic_compact_data_inline_test(lib, sym, df[5:], coerce_columns={"col": object})
+
+
+@pytest.mark.parametrize("dynamic_strings_first", [True, False])
+def test_fixed_width_and_dynamic_strings(in_memory_store_factory, clear_query_stats, dynamic_strings_first):
+    lib = in_memory_store_factory()
+    sym = "test_fixed_width_and_dynamic_strings"
+    # Include two segments with different widths of strings
+    df = pd.DataFrame({"col": ["a", "bb", "ccc", "dddd", "eeeee", "f", "gg", "hhhhhhhhhhhhhh", "i"]})
+    lib.write(sym, df[:3], dynamic_strings=dynamic_strings_first)
+    lib.append(sym, df[3:5], dynamic_strings=dynamic_strings_first)
+    lib.append(sym, df[5:7], dynamic_strings=not dynamic_strings_first)
+    generic_compact_data_inline_test(lib, sym, df[7:], dynamic_strings=not dynamic_strings_first)
+
+
+@pytest.mark.parametrize("dynamic_strings_first", [True, False])
+def test_blns(in_memory_store_factory, clear_query_stats, dynamic_strings_first):
+    lib = in_memory_store_factory()
+    sym = "test_blns"
+    df = pd.DataFrame({"col": read_big_list_of_naughty_strings()})
+    lib.write(sym, df[: len(df) // 2], dynamic_strings=dynamic_strings_first)
+    generic_compact_data_inline_test(lib, sym, df[len(df) // 2 :], dynamic_strings=not dynamic_strings_first)
+
+
+def test_append_empty_frame_compacts_existing_data(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_append_empty_frame_compacts_existing_data"
+    lib.write(sym, pd.DataFrame({"col": np.arange(5)}))
+    lib.append(sym, pd.DataFrame({"col": np.arange(5, 10)}))
+    # Schema checks happen after empty input frame checks, so we don't need the same column set
+    with qs.query_stats():
+        lib.append(sym, pd.DataFrame())
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    assert lib.read(sym).version == 2
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 0
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+    with qs.query_stats():
+        lib.append(sym, pd.DataFrame(), compact_data_inline=True)
+        stats = qs.get_query_stats()
+    qs.reset_stats()
+    assert lib.read(sym).version == 3
+    assert len(lib.read_index(sym)) == 1
+    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 2
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+
+
+@pytest.mark.parametrize("rows_to_append", [5, 10, 15, 20])
+def test_fortran_ordered_data(in_memory_store_factory, clear_query_stats, rows_to_append):
+    lib = in_memory_store_factory(segment_row_size=10)
+    sym = "test_fortran_ordered_data"
+    cols = ["col_0", "col_1"]
+    df_0 = pd.DataFrame(np.random.randint(0, 100, size=(5, 2)), columns=cols)
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame(np.random.randint(0, 100, size=(rows_to_append, 2)), columns=cols)
+    generic_compact_data_inline_test(lib, sym, df_1)
+
+
+@pytest.mark.parametrize("index", [None, "ts"])
+def test_column_filtered_read(in_memory_store_factory, clear_query_stats, index):
+    lib = in_memory_store_factory(column_group_size=2, segment_row_size=10)
+    sym = "test_column_filtered_read"
+    num_rows = 20
+    df = pd.DataFrame(
+        {
+            "col_a": np.arange(num_rows),
+            "col_b": np.arange(num_rows, 2 * num_rows),
+            "col_c": np.arange(2 * num_rows, 3 * num_rows),
+        },
+        index=None if index is None else pd.date_range("2026-01-01", periods=num_rows),
+    )
+    lib.write(sym, df[:5])
+    for i in range(1, 4):
+        generic_compact_data_inline_test(lib, sym, df[i * 5 : (i + 1) * 5])
+    expected_col_a = df[["col_a"]]
+    expected_col_bc = df[["col_b", "col_c"]]
+    assert_frame_equal(expected_col_a, lib.read(sym, columns=["col_a"]).data)
+    assert_frame_equal(expected_col_bc, lib.read(sym, columns=["col_b", "col_c"]).data)
+
+
+@pytest.mark.parametrize("rows_per_segment", [3, 7, 10])
+def test_date_range_read(in_memory_store_factory, clear_query_stats, rows_per_segment):
+    lib = in_memory_store_factory(segment_row_size=rows_per_segment, dynamic_strings=True)
+    sym = "test_date_range_read"
+    num_rows = 100
+    index = pd.date_range("2026-01-01", periods=num_rows)
+    df = pd.DataFrame(
+        {"ints": np.arange(num_rows), "strings": 20 * ["hello", None, "gutentag", np.nan, "konichiwa"]}, index=index
+    )
+    lib.write(sym, df[:5])
+    for i in range(1, 20):
+        generic_compact_data_inline_test(lib, sym, df[i * 5 : (i + 1) * 5])
+    mid = index[num_rows // 2]
+    expected_first_half = df[:mid]
+    expected_second_half = df[mid:]
+    assert_frame_equal(expected_first_half, lib.read(sym, date_range=(index[0], mid)).data)
+    assert_frame_equal(expected_second_half, lib.read(sym, date_range=(mid, index[-1])).data)
+
+
+def test_read_previous_version(in_memory_store_factory, clear_query_stats):
+    lib = in_memory_store_factory()
+    sym = "test_read_previous_version"
+    df = pd.DataFrame({"col": np.arange(10)})
+    lib.write(sym, df[:5])
+    generic_compact_data_inline_test(lib, sym, df[5:])
+    assert_frame_equal(df[:5], lib.read(sym, as_of=0).data)
+    assert_frame_equal(df, lib.read(sym, as_of=1).data)
+    assert_frame_equal(df, lib.read(sym).data)
+
+
+def test_schema_mismatch_static(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    sym = "test_schema_mismatch_static"
+    df_0 = pd.DataFrame({"col_0": [0]})
+    lib.write(sym, df_0)
+    # Different column sets
+    df_1 = pd.DataFrame({"col_1": [0]})
+    with pytest.raises(Exception) as e_without_arg:
+        lib.append(sym, df_1)
+    with pytest.raises(Exception) as e_with_arg:
+        lib.append(sym, df_1, compact_data_inline=True)
+    assert e_with_arg.type == e_without_arg.type
+    assert e_with_arg.typename == e_without_arg.typename
+    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+    # Different column type
+    df_1 = pd.DataFrame({"col_0": ["hello"]})
+    with pytest.raises(Exception) as e_without_arg:
+        lib.append(sym, df_1)
+    with pytest.raises(Exception) as e_with_arg:
+        lib.append(sym, df_1, compact_data_inline=True)
+    assert e_with_arg.type == e_without_arg.type
+    assert e_with_arg.typename == e_without_arg.typename
+    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+
+
+def test_schema_mismatch_dynamic(in_memory_store_factory):
+    lib = in_memory_store_factory(dynamic_schema=True)
+    sym = "test_schema_mismatch_dynamic"
+    df_0 = pd.DataFrame({"col_0": [0]})
+    lib.write(sym, df_0)
+    df_1 = pd.DataFrame({"col_0": ["hello"]})
+    with pytest.raises(Exception) as e_without_arg:
+        lib.append(sym, df_1)
+    with pytest.raises(Exception) as e_with_arg:
+        lib.append(sym, df_1, compact_data_inline=True)
+    assert e_with_arg.type == e_without_arg.type
+    assert e_with_arg.typename == e_without_arg.typename
+    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+
+
+# We are more interested in the slicing than the data, so the parameters are for:
+# - number of rows and columns
+# - library slicing settings
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(
+    # Making these parameters too large results in all the time being spent in numpy generating random numbers
+    num_rows=st.integers(1, 1_000),
+    num_cols=st.integers(1, 20),
+    # The more interesting cases are when num_rows > rows_per_segment
+    rows_per_segment=st.integers(10, 100),
+    cols_per_segment=st.integers(1, 20),
+    # Shrinks towards False, which is the simpler case
+    sparse=st.booleans(),
+)
+@pytest.mark.skipif(
+    WINDOWS or MACOS,
+    reason="""
+        On macOS/Windows the low timestamp resolution can cause duplicate keys when
+        successive operations land within the same clock tick.
+        TODO: Fix the underlying issue and remove this workaround (monday ticket ref 11777175142)
+""",
+)
+def test_hypothesis_static_schema(
+    in_memory_store_factory, clear_query_stats, num_rows, num_cols, rows_per_segment, cols_per_segment, sparse
+):
+    rng = np.random.default_rng(42)
+    lib = in_memory_store_factory(
+        column_group_size=cols_per_segment, segment_row_size=rows_per_segment, dynamic_strings=True, name="_unique_"
+    )
+    lib._set_allow_arrow_input()
+    sym = "test_hypothesis_static_schema"
+    supported_types = [
+        np.uint8,
+        np.uint16,
+        np.uint32,
+        np.uint64,
+        np.int8,
+        np.int16,
+        np.int32,
+        np.int64,
+        np.float32,
+        np.float64,
+        bool,
+        str,
+        np.datetime64,
+    ]
+    col_types = rng.choice(supported_types, num_cols)
+    data = {}
+    string_values = random_strings_of_length(10, 5, True)
+    for idx in range(num_cols):
+        col_name = f"col_{idx}"
+        col_type = col_types[idx]
+        if np.issubdtype(col_type, np.integer):
+            arr = rng.integers(np.iinfo(col_type).min, np.iinfo(col_type).max, num_rows, col_type, True)
+        elif np.issubdtype(col_type, np.floating):
+            arr = rng.random(num_rows, col_type)
+        elif col_type == bool:
+            arr = rng.random(num_rows) > 0.5
+        elif col_type == str:
+            arr = rng.choice(string_values, num_rows)
+        else:
+            # datetime
+            arr = pd.date_range("2026-01-01", freq="s", periods=num_rows).values
+            rng.shuffle(arr)
+        if sparse:
+            null_mask = rng.random(num_rows) < 0.5
+            arr = pa.array(arr, mask=null_mask)
+        else:
+            arr = pa.array(arr)
+        data[col_name] = arr
+    table = pa.table(data)
+    # Append random numbers of rows between 1 and 2 * rows_per_segment
+    remaining_rows = num_rows
+    first_iteration = True
+    while remaining_rows > 0:
+        rows_to_take = rng.integers(1, 2 * rows_per_segment)
+        if first_iteration:
+            lib.write(sym, table.slice(length=rows_to_take))
+            first_iteration = False
+        else:
+            # This basically does lib.append(sym, table.slice(length=rows_to_take), compact_data_inline=True), plus some
+            # read-only checks
+            generic_compact_data_inline_test(lib, sym, table.slice(length=rows_to_take))
+        table = table.slice(offset=rows_to_take)
+        remaining_rows -= rows_to_take
+
+
+# We are more interested in the slicing than the data, so the parameters are for:
+# - number of rows
+# - library slicing settings
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@settings(deadline=None)
+@given(
+    # Making these parameters too large results in all the time being spent in numpy generating random numbers
+    num_rows=st.integers(1, 1_000),
+    # The more interesting cases are when num_rows > rows_per_segment
+    rows_per_segment=st.integers(10, 100),
+    # Shrinks towards False, which is the simpler case
+    sparse=st.booleans(),
+)
+@pytest.mark.skipif(
+    WINDOWS or MACOS,
+    reason="""
+        On macOS/Windows the low timestamp resolution can cause duplicate keys when
+        successive operations land within the same clock tick.
+        TODO: Fix the underlying issue and remove this workaround (monday ticket ref 11777175142)
+""",
+)
+def test_hypothesis_dynamic_schema(in_memory_store_factory, clear_query_stats, num_rows, rows_per_segment, sparse):
+    rng = np.random.default_rng(42)
+    lib = in_memory_store_factory(dynamic_schema=True, dynamic_strings=True, name="_unique_")
+    lib._set_allow_arrow_input()
+    sym = "test_hypothesis_dynamic_schema"
+    unsigned_int_types = [np.uint8, np.uint16, np.uint32, np.uint64]
+    signed_int_types = [np.int8, np.int16, np.int32, np.int64]
+    float_types = [np.float32, np.float64]
+    # Two string columns as stringpool dedup make them more complicated
+    cols = {
+        "unsigned_ints": unsigned_int_types,
+        "signed_ints": signed_int_types,
+        "floats": float_types,
+        # Exclude uint64 as it cannot be combined with signed int types at write time
+        "numeric": unsigned_int_types[:3] + signed_int_types + float_types,
+        "bools": [bool],
+        "timestamps": [np.datetime64],
+        "strings_1": [str],
+        "strings_2": [str],
+    }
+    all_col_names = list(cols.keys())
+    string_values = random_strings_of_length(10, 5, True)
+    # Append random numbers of rows between 1 and 2 * rows_per_segment
+    remaining_rows = num_rows
+    first_iteration = True
+    while remaining_rows > 0:
+        rows_to_take = rng.integers(1, 2 * rows_per_segment)
+        # Pick a subset of columns
+        num_columns = rng.integers(1, len(cols) + 1)
+        col_names = rng.choice(all_col_names, num_columns, False)
+        data = {}
+        for col_name in col_names:
+            col_type = rng.choice(cols[col_name])
+            if np.issubdtype(col_type, np.integer):
+                arr = rng.integers(np.iinfo(col_type).min, np.iinfo(col_type).max, rows_to_take, col_type, True)
+            elif np.issubdtype(col_type, np.floating):
+                arr = rng.random(rows_to_take, col_type)
+            elif col_type == bool:
+                arr = rng.random(rows_to_take) > 0.5
+            elif col_type == str:
+                arr = rng.choice(string_values, rows_to_take)
+            else:
+                # datetime
+                arr = pd.date_range("2026-01-01", freq="s", periods=rows_to_take).values
+                rng.shuffle(arr)
+            if sparse:
+                null_mask = rng.random(rows_to_take) < 0.5
+                arr = pa.array(arr, mask=null_mask)
+            else:
+                arr = pa.array(arr)
+            data[col_name] = arr
+        table = pa.table(data)
+        if first_iteration:
+            lib.write(sym, table)
+            first_iteration = False
+        else:
+            # This basically does lib.append(sym, table, compact_data_inline=True), plus some read-only checks
+            generic_compact_data_inline_test(lib, sym, table)
+        remaining_rows -= rows_to_take


### PR DESCRIPTION
#### Reference Issues/PRs
[12036593840](https://man312219.monday.com/boards/7852509418/pulses/12036593840)

#### What does this implement or fix?

Adds a new `compact_data_inline` argument to `append` (defaulting to `False`). When set to `True`, the `compact_data` invariant that all row-slices must have the lib config `rows_per_segment` rows ±33% will hold. This is similar to calling `append` with `compact_data_inline=False`, followed by `compact_data`, but creating only one new version. Due to implementation details, the on-disk structure may be different than calling the two methods separately.

Manually benchmarked - performance when no data needs to be read from disk is the same whether `compact_data_inline` is set or not. When compaction is needed, the pathological case of appending a single row to a 100k row symbol results in a x3 slowdown with 10 columns of numeric or string data. This decreases to x2 slower when appending 50k rows.