### PR TITLE
Bugfix 18023146743: Correct Raises docstring for missing versions in concat and extend test coverage

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1664,7 +1664,7 @@ class NativeVersionStore:
             * If the first clause in `query_builder` is not a multi-symbol join
             * If any subsequent clauses in `query_builder` are not single-symbol clauses
             * If any of the specified symbols are recursively normalized
-        MissingDataException
+        NoSuchVersionException
             * If a symbol or the version of symbol specified in as_ofs does not exist or has been deleted
         SchemaException
             * If the schema of symbols to be joined are incompatible. Examples of incompatible schemas include:

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -2383,7 +2383,7 @@ class Library:
             * If the first clause in `query_builder` is not a multi-symbol join
             * If any subsequent clauses in `query_builder` are not single-symbol clauses
             * If any of the specified symbols are recursively normalized
-        MissingDataException
+        NoSuchVersionException
             * If a symbol or the version of symbol specified in as_ofs does not exist or has been deleted
         SchemaException
             * If the schema of symbols to be joined are incompatible. Examples of incompatible schemas include:

--- a/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
+++ b/python/tests/unit/arcticdb/version_store/test_symbol_concatenation.py
@@ -756,6 +756,33 @@ def test_symbol_concat_non_existent_symbol(lmdb_library, any_output_format):
         concat(lib.read_batch([sym, "non-existent symbol"], lazy=True)).collect()
 
 
+def test_symbol_concat_non_existent_version_of_symbol(lmdb_library, any_output_format):
+    lib = lmdb_library
+    lib._nvs._set_output_format_for_pipeline_tests(any_output_format)
+    sym_0 = "test_symbol_concat_non_existent_version_of_symbol"
+    lib.write(sym_0, pd.DataFrame({"col": [0]}))
+    lib.snapshot("snap")
+    sym_1 = "deleted"
+    lib.write(sym_1, pd.DataFrame({"col": [0]}))
+    lib.delete(sym_1)
+    # Reading latest version, no live versions
+    with pytest.raises(NoSuchVersionException):
+        concat(lib.read_batch([sym_0, sym_1], lazy=True)).collect()
+    lib.write(sym_1, pd.DataFrame({"col": [0]}))
+    # Reading specific deleted version
+    read_requests = [ReadRequest(sym_0), ReadRequest(sym_1, as_of=0)]
+    with pytest.raises(NoSuchVersionException):
+        concat(lib.read_batch(read_requests, lazy=True)).collect()
+    # Reading from a snapshot that exists, but does not contain this symbol
+    read_requests = [ReadRequest(sym_0), ReadRequest(sym_1, as_of="snap")]
+    with pytest.raises(NoSuchVersionException):
+        concat(lib.read_batch(read_requests, lazy=True)).collect()
+    # Reading from a snapshot that doesn't exist
+    read_requests = [ReadRequest(sym_0), ReadRequest(sym_1, as_of="non-existent-snap")]
+    with pytest.raises(NoSuchVersionException):
+        concat(lib.read_batch(read_requests, lazy=True)).collect()
+
+
 def test_symbol_concat_pickled_data(lmdb_library, any_output_format):
     lib = lmdb_library
     lib._nvs._set_output_format_for_pipeline_tests(any_output_format)


### PR DESCRIPTION
#### Reference Issues/PRs
[18023146743](https://man312219.monday.com/boards/7852509418/pulses/18023146743)

#### What does this implement or fix?
Corrects the docstring for `concat` methods on what exception is raised with missing symbols/versions, and extends test coverage of this.