### PR TITLE
Bugfix 8428733242: Throw appropriate exceptions on mixed object column types

### DIFF
--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -21,14 +21,15 @@ constexpr const char none_char[8] = {'\300', '\000', '\000', '\000', '\000', '\0
 using namespace arcticdb::pipelines;
 using namespace arcticdb::stream;
 
-[[nodiscard]] static inline bool is_unicode(PyObject* obj) { return PyUnicode_Check(obj); }
+[[nodiscard]] static inline bool is_unicode(PyObject* obj) { return PyUnicode_CheckExact(obj); }
+
+[[nodiscard]] static inline bool is_bytes(PyObject* obj) { return PyBytes_CheckExact(obj); }
 
 [[nodiscard]] static inline bool is_py_boolean(PyObject* obj) { return PyBool_Check(obj); }
 
 std::variant<StringEncodingError, PyStringWrapper> pystring_to_buffer(PyObject* obj, bool is_owned) {
-    if (is_unicode(obj)) {
-        return StringEncodingError(
-                fmt::format("Unexpected unicode in Python object with type {}", obj->ob_type->tp_name)
+    if (!is_bytes(obj)) {
+        return StringEncodingError(fmt::format("Unexpected non-bytes Python object with type {}", obj->ob_type->tp_name)
         );
     }
     char* buffer;
@@ -215,7 +216,7 @@ NativeTensor obj_to_tensor(PyObject* ptr, bool empty_types, std::optional<std::s
                 desc.val_type_ = empty_types ? ValueType::EMPTY : ValueType::UTF_DYNAMIC;
             } else if (is_unicode(sample)) {
                 desc.val_type_ = ValueType::UTF_DYNAMIC;
-            } else if (PYBIND11_BYTES_CHECK(sample)) {
+            } else if (is_bytes(sample)) {
                 desc.val_type_ = ValueType::ASCII_DYNAMIC;
             } else if (is_py_array(sample)) {
                 normalization::raise<ErrorCode::E_UNIMPLEMENTED_INPUT_TYPE>(

--- a/python/tests/unit/arcticdb/test_string.py
+++ b/python/tests/unit/arcticdb/test_string.py
@@ -12,6 +12,7 @@ import platform
 import pandas as pd
 import pytest
 
+from arcticdb.exceptions import ArcticDbNotYetImplemented
 from arcticdb_ext.exceptions import UserInputException
 from arcticdb_ext.types import (
     TypeDescriptor,
@@ -211,3 +212,41 @@ def test_write_dynamic_simple(lmdb_version_store_v2):
     lmdb_version_store_v2.write("strings", df, dynamic_strings=True)
     vit = lmdb_version_store_v2.read("strings")
     assert_frame_equal(df, vit.data)
+
+
+class ArbitraryClass:
+    def __init__(self):
+        self.x = "blah"
+
+
+class StringInheritingClass(str):
+    def __init__(self):
+        super().__init__()
+
+
+class BytesInheritingClass(bytes):
+    def __init__(self):
+        super().__init__()
+
+
+@pytest.mark.parametrize(
+    "first_value", [b"blah", "blah", ArbitraryClass(), StringInheritingClass(), BytesInheritingClass()]
+)
+@pytest.mark.parametrize(
+    "second_value", [b"blah", "blah", ArbitraryClass(), StringInheritingClass(), BytesInheritingClass()]
+)
+def test_mixed_types_errors(lmdb_version_store_v1, first_value, second_value):
+    lib = lmdb_version_store_v1
+    sym = "test_mixed_types_errors"
+    df = pd.DataFrame({"col": [first_value, second_value]})
+    if first_value == second_value:
+        pytest.skip()
+    # The first value is used to determine the dtype, so we get a different exception when the first value is of a
+    # non-normalizable type
+    exception_type = (
+        ArcticDbNotYetImplemented
+        if isinstance(first_value, (ArbitraryClass, StringInheritingClass, BytesInheritingClass))
+        else UserInputException
+    )
+    with pytest.raises(exception_type):
+        lib.write(sym, df)


### PR DESCRIPTION
#### Reference Issues/PRs
[8428733242](https://man312219.monday.com/boards/7852509418/pulses/8428733242)

#### What does this implement or fix?
When writing `object` columns, the first (non-null) value in the column is used to determine the type, and all subsequent values are expected to be of the same type (`bytes` or `str`).
If the first value is not **exactly** one of these types, then an `ArcticDbNotYetImplemented` exception is raised. In particular, values that inherit from these classes (e.g. `StrEnum`) are not allowed, as the underlying conversion in the C++ layer [will not then work](https://github.com/man-group/ArcticDB/issues/703). This fixes two issues:

1. Objects that inherit from `str` are now correctly rejected when they are not the first value in the column
2. In `pystring_to_buffer` we check that the object **is** `bytes`, rather than it is **not** `unicode`. This fixes the case from the linked Monday issue, where a dataframe like `pd.DataFrame({"col": [b"blah", [0, 1]]})` would segfault in `PYBIND11_BYTES_AS_STRING_AND_SIZE` as the `[0, 1]` list is not a valid `bytes` object.

While 2 is uncontroversial (segfaults are bad), 1 _could_, in theory, break some workflows. e.g.

```
class A(str):
    def __init__(self):
        super().__init__()
lib.write(sym, pd.DataFrame({"col": ["hello", A()]}))
```

However, what is being serialised to disk in such a case would be garbage, and so throwing at write-time would be an improvement in behaviour.