### PR TITLE
Refactor passing pandas dataframe into c++ to use a struct

### DIFF
--- a/cpp/arcticdb/arrow/arrow_c_interface.hpp
+++ b/cpp/arcticdb/arrow/arrow_c_interface.hpp
@@ -20,7 +20,7 @@ namespace arcticdb {
 // Write path (Python -> C++):
 //   1. Python calls _export_to_c into array_/schema_, setting release callbacks that decref
 //      the underlying PyArrow buffers.
-//   2. py_ndf_to_frame moves array_/schema_ into owning sparrow::record_batches via
+//   2. py_input_item_to_frame moves array_/schema_ into owning sparrow::record_batches via
 //      record_batch(ArrowArray&&, ArrowSchema&&). Sparrow takes ownership and will call
 //      release (decref) on destruction.
 //   3. The sparrow record batches are used to construct a SegmentInMemory whose external blocks

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -240,7 +240,7 @@ NativeTensor obj_to_tensor(PyObject* ptr, bool empty_types, std::optional<std::s
     return {nbytes, desc.arr_->nd, strides.data(), shapes.data(), dt, desc.elsize_, data, desc.ndim_};
 }
 
-void tensors_to_frame(const PandasData& pandas_data, const bool empty_types, InputFrame& frame) {
+void pandas_data_to_frame(const PandasData& pandas_data, const bool empty_types, InputFrame& frame) {
     frame.num_rows = 0u;
     // Fill index
     const auto& idx_names = pandas_data.index_names;
@@ -357,7 +357,7 @@ void record_batches_to_frame(
     );
 }
 
-std::shared_ptr<InputFrame> py_ndf_to_frame(
+std::shared_ptr<InputFrame> py_input_item_to_frame(
         const StreamId& stream_name, const InputItem& item, const py::object& norm_meta, const py::object& user_meta,
         bool empty_types, pipelines::SortednessScan sortedness_scan
 ) {
@@ -370,7 +370,7 @@ std::shared_ptr<InputFrame> py_ndf_to_frame(
 
     util::variant_match(
             item,
-            [&](const std::shared_ptr<PandasData>& pandas_data) { tensors_to_frame(*pandas_data, empty_types, *res); },
+            [&](const std::shared_ptr<PandasData>& pandas_data) { pandas_data_to_frame(*pandas_data, empty_types, *res); },
             [&](const std::vector<std::shared_ptr<RecordBatchData>>& record_batches) {
                 record_batches_to_frame(record_batches, *res, sortedness_scan);
             }

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -370,7 +370,12 @@ std::shared_ptr<InputFrame> py_input_item_to_frame(
 
     util::variant_match(
             item,
-            [&](const std::shared_ptr<PandasData>& pandas_data) { pandas_data_to_frame(*pandas_data, empty_types, *res); },
+            [&](const std::shared_ptr<PandasData>& pandas_data) {
+                user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                        pandas_data, "Expected pandas input data but received nullptr"
+                );
+                pandas_data_to_frame(*pandas_data, empty_types, *res);
+            },
             [&](const std::vector<std::shared_ptr<RecordBatchData>>& record_batches) {
                 record_batches_to_frame(record_batches, *res, sortedness_scan);
             }

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -240,11 +240,11 @@ NativeTensor obj_to_tensor(PyObject* ptr, bool empty_types, std::optional<std::s
     return {nbytes, desc.arr_->nd, strides.data(), shapes.data(), dt, desc.elsize_, data, desc.ndim_};
 }
 
-void tensors_to_frame(const py::tuple& tuple, const bool empty_types, InputFrame& frame) {
+void tensors_to_frame(const PandasData& pandas_data, const bool empty_types, InputFrame& frame) {
     frame.num_rows = 0u;
     // Fill index
-    auto idx_names = tuple[0].cast<std::vector<std::string>>();
-    auto idx_vals = tuple[2].cast<std::vector<py::object>>();
+    const auto& idx_names = pandas_data.index_names;
+    const auto& idx_vals = pandas_data.index_values;
     util::check(
             idx_names.size() == idx_vals.size(),
             "Number idx names {} and values {} do not match",
@@ -279,9 +279,9 @@ void tensors_to_frame(const py::tuple& tuple, const bool empty_types, InputFrame
     }
 
     // Fill tensors
-    auto col_names = tuple[1].cast<std::vector<std::string>>();
-    auto col_vals = tuple[3].cast<std::vector<py::object>>();
-    auto sorted = tuple[4].cast<SortedValue>();
+    const auto& col_names = pandas_data.column_names;
+    const auto& col_vals = pandas_data.columns_values;
+    const auto sorted = pandas_data.sorted;
 
     for (auto i = 0u; i < col_vals.size(); ++i) {
         auto tensor = [&] {
@@ -370,7 +370,7 @@ std::shared_ptr<InputFrame> py_ndf_to_frame(
 
     util::variant_match(
             item,
-            [&](const py::tuple& tensors) { tensors_to_frame(tensors, empty_types, *res); },
+            [&](const std::shared_ptr<PandasData>& pandas_data) { tensors_to_frame(*pandas_data, empty_types, *res); },
             [&](const std::vector<std::shared_ptr<RecordBatchData>>& record_batches) {
                 record_batches_to_frame(record_batches, *res, sortedness_scan);
             }

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -22,16 +22,17 @@ namespace py = pybind11;
 using namespace arcticdb::entity;
 
 struct ARCTICDB_VISIBILITY_HIDDEN PandasData {
-    PandasData() = default;
     PandasData(
-            std::vector<std::string> index_names, std::vector<std::string> column_names,
-            std::vector<py::object> index_values, std::vector<py::object> columns_values, SortedValue sorted
+            std::vector<std::string>&& index_names, std::vector<std::string>&& column_names,
+            std::vector<py::object>&& index_values, std::vector<py::object>&& columns_values, SortedValue sorted
     ) :
         index_names(std::move(index_names)),
         column_names(std::move(column_names)),
         index_values(std::move(index_values)),
         columns_values(std::move(columns_values)),
         sorted(sorted) {}
+
+    ARCTICDB_MOVE_ONLY_DEFAULT(PandasData)
 
     std::vector<std::string> index_names;
     std::vector<std::string> column_names;

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -103,7 +103,7 @@ void record_batches_to_frame(
         pipelines::SortednessScan sortedness_scan
 );
 
-std::shared_ptr<pipelines::InputFrame> py_ndf_to_frame(
+std::shared_ptr<pipelines::InputFrame> py_input_item_to_frame(
         const StreamId& stream_name, const InputItem& item, const py::object& norm_meta, const py::object& user_meta,
         bool empty_types, pipelines::SortednessScan sortedness_scan
 );

--- a/cpp/arcticdb/python/python_to_tensor_frame.hpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.hpp
@@ -12,15 +12,36 @@
 #include <arcticdb/python/gil_lock.hpp>
 #include <arcticdb/pipeline/input_frame.hpp>
 #include <arcticdb/entity/native_tensor.hpp>
+#include <memory>
 #include <string>
+#include <vector>
 
 namespace arcticdb::convert {
 
 namespace py = pybind11;
 using namespace arcticdb::entity;
 
-// py::tuple for Pandas data, record batches for Arrow data
-using InputItem = std::variant<py::tuple, std::vector<std::shared_ptr<RecordBatchData>>>;
+struct ARCTICDB_VISIBILITY_HIDDEN PandasData {
+    PandasData() = default;
+    PandasData(
+            std::vector<std::string> index_names, std::vector<std::string> column_names,
+            std::vector<py::object> index_values, std::vector<py::object> columns_values, SortedValue sorted
+    ) :
+        index_names(std::move(index_names)),
+        column_names(std::move(column_names)),
+        index_values(std::move(index_values)),
+        columns_values(std::move(columns_values)),
+        sorted(sorted) {}
+
+    std::vector<std::string> index_names;
+    std::vector<std::string> column_names;
+    std::vector<py::object> index_values;
+    std::vector<py::object> columns_values;
+    SortedValue sorted{SortedValue::UNKNOWN};
+};
+
+// PandasData for Pandas data, record batches for Arrow data
+using InputItem = std::variant<std::shared_ptr<PandasData>, std::vector<std::shared_ptr<RecordBatchData>>>;
 
 struct ARCTICDB_VISIBILITY_HIDDEN PyStringWrapper {
     char* buffer_;

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -85,7 +85,7 @@ SegmentInMemory LibraryTool::item_to_segment_in_memory(
         const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
         const py::object& user_meta, std::optional<AtomKey> next_key
 ) {
-    auto frame = convert::py_ndf_to_frame(
+    auto frame = convert::py_input_item_to_frame(
             stream_id,
             item,
             norm,

--- a/cpp/arcticdb/toolbox/library_tool.cpp
+++ b/cpp/arcticdb/toolbox/library_tool.cpp
@@ -82,8 +82,8 @@ void LibraryTool::overwrite_segment_in_memory(VariantKey key, const SegmentInMem
 }
 
 SegmentInMemory LibraryTool::item_to_segment_in_memory(
-        const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
-        std::optional<AtomKey> next_key
+        const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+        const py::object& user_meta, std::optional<AtomKey> next_key
 ) {
     auto frame = convert::py_ndf_to_frame(
             stream_id,
@@ -100,7 +100,8 @@ SegmentInMemory LibraryTool::item_to_segment_in_memory(
 }
 
 SegmentInMemory LibraryTool::overwrite_append_data(
-        VariantKey key, const py::tuple& item, const py::object& norm, const py::object& user_meta
+        VariantKey key, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+        const py::object& user_meta
 ) {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             std::holds_alternative<AtomKey>(key) && std::get<AtomKey>(key).type() == KeyType::APPEND_DATA,

--- a/cpp/arcticdb/toolbox/library_tool.hpp
+++ b/cpp/arcticdb/toolbox/library_tool.hpp
@@ -15,6 +15,7 @@
 #include <arcticdb/async/async_store.hpp>
 #include <arcticdb/entity/read_result.hpp>
 #include <arcticdb/version/local_versioned_engine.hpp>
+#include <arcticdb/python/python_to_tensor_frame.hpp>
 #include <memory>
 
 namespace arcticdb::toolbox::apy {
@@ -43,12 +44,13 @@ class LibraryTool {
     void overwrite_segment_in_memory(VariantKey key, const SegmentInMemory& segment_in_memory);
 
     SegmentInMemory item_to_segment_in_memory(
-            const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
-            std::optional<AtomKey> next_key = std::nullopt
+            const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+            const py::object& user_meta, std::optional<AtomKey> next_key = std::nullopt
     );
 
     SegmentInMemory overwrite_append_data(
-            VariantKey key, const py::tuple& item, const py::object& norm, const py::object& user_meta
+            VariantKey key, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+            const py::object& user_meta
     );
 
     void remove(VariantKey key);

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -12,6 +12,7 @@
 #include <pybind11/operators.h>
 #include <arcticdb/entity/data_error.hpp>
 #include <arcticdb/entity/protobuf_mappings.hpp>
+#include <arcticdb/python/python_to_tensor_frame.hpp>
 #include <arcticdb/version/version_store_api.hpp>
 #include <arcticdb/version/version_constants.hpp>
 #include <arcticdb/version/python_bindings_common.hpp>
@@ -272,6 +273,24 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             .def(py::init<>())
             .def("array", &RecordBatchData::array)
             .def("schema", &RecordBatchData::schema);
+
+    py::class_<convert::PandasData, std::shared_ptr<convert::PandasData>>(version, "PandasData")
+            .def(py::init<
+                         std::vector<std::string>,
+                         std::vector<std::string>,
+                         std::vector<py::object>,
+                         std::vector<py::object>,
+                         SortedValue>(),
+                 py::arg("index_names"),
+                 py::arg("column_names"),
+                 py::arg("index_values"),
+                 py::arg("columns_values"),
+                 py::arg("sorted"))
+            .def_readonly("index_names", &convert::PandasData::index_names)
+            .def_readonly("column_names", &convert::PandasData::column_names)
+            .def_readonly("index_values", &convert::PandasData::index_values)
+            .def_readonly("columns_values", &convert::PandasData::columns_values)
+            .def_readonly("sorted", &convert::PandasData::sorted);
 
     py::enum_<VersionRequestType>(version, "VersionRequestType", R"pbdoc(
         Enum of possible version request types passed to as_of.

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -276,10 +276,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
 
     py::class_<convert::PandasData, std::shared_ptr<convert::PandasData>>(version, "PandasData")
             .def(py::init<
-                         std::vector<std::string>,
-                         std::vector<std::string>,
-                         std::vector<py::object>,
-                         std::vector<py::object>,
+                         std::vector<std::string>&&,
+                         std::vector<std::string>&&,
+                         std::vector<py::object>&&,
+                         std::vector<py::object>&&,
                          SortedValue>(),
                  py::arg("index_names"),
                  py::arg("column_names"),

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -62,7 +62,7 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
     auto versioned_item = write_dataframe_impl(
             store(),
             VersionId(version_id),
-            convert::py_ndf_to_frame(
+            convert::py_input_item_to_frame(
                     stream_id,
                     item,
                     norm,
@@ -88,7 +88,7 @@ std::vector<std::shared_ptr<InputFrame>> create_input_tensor_frames(
     std::vector<std::shared_ptr<InputFrame>> output;
     output.reserve(stream_ids.size());
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
-        output.emplace_back(convert::py_ndf_to_frame(
+        output.emplace_back(convert::py_input_item_to_frame(
                 stream_ids[idx], items[idx], norms[idx], user_metas[idx], empty_types, sortedness_scan
         ));
     }
@@ -708,7 +708,7 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
         auto versioned_item = write_dataframe_impl(
                 store(),
                 version_id,
-                convert::py_ndf_to_frame(
+                convert::py_input_item_to_frame(
                         subkeyname,
                         partitioned_dfs[idx],
                         norm_meta,
@@ -806,7 +806,7 @@ VersionedItem PythonVersionStore::write_versioned_dataframe(
         bool prune_previous_versions, bool sparsify_floats, bool validate_index
 ) {
     ARCTICDB_SAMPLE(WriteVersionedDataframe, 0)
-    auto frame = convert::py_ndf_to_frame(
+    auto frame = convert::py_input_item_to_frame(
             stream_id, item, norm, user_meta, cfg().write_options().empty_types(), sortedness_scan_for(validate_index)
     );
     auto versioned_item = write_versioned_dataframe_internal(
@@ -832,7 +832,7 @@ VersionedItem PythonVersionStore::append(
 ) {
     return append_internal(
             stream_id,
-            convert::py_ndf_to_frame(
+            convert::py_input_item_to_frame(
                     stream_id,
                     item,
                     norm,
@@ -855,7 +855,7 @@ VersionedItem PythonVersionStore::update(
             query,
             // update always requires a sorted index (both the upsert-to-write path and updating existing data),
             // so always determine the Arrow index sort order.
-            convert::py_ndf_to_frame(
+            convert::py_input_item_to_frame(
                     stream_id,
                     item,
                     norm,
@@ -885,7 +885,7 @@ void PythonVersionStore::append_incomplete(
     using namespace arcticdb::pipelines;
 
     // Turn the input into a standardised frame object
-    auto frame = convert::py_ndf_to_frame(
+    auto frame = convert::py_input_item_to_frame(
             stream_id, item, norm, user_meta, cfg().write_options().empty_types(), SortednessScan::SKIP
     );
     append_incomplete_frame(stream_id, frame, validate_index);
@@ -1012,7 +1012,7 @@ StageResult PythonVersionStore::write_parallel(
     // When the data will be sorted for us (sort_on_index or sort_columns) the input order is irrelevant, so only
     // determine the Arrow index sort order when the unsorted input itself must be validated.
     const bool verify = validate_index && !sort_on_index && (!sort_columns || sort_columns->empty());
-    auto frame = convert::py_ndf_to_frame(
+    auto frame = convert::py_input_item_to_frame(
             stream_id, item, norm, py::none(), cfg().write_options().empty_types(), sortedness_scan_for(verify)
     );
     return write_parallel_frame(stream_id, frame, validate_index, sort_on_index, sort_columns);
@@ -1535,7 +1535,7 @@ void write_dataframe_to_file(
         const py::object& norm, const py::object& user_meta
 ) {
     ARCTICDB_SAMPLE(WriteDataframeToFile, 0)
-    auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, false, pipelines::SortednessScan::SKIP);
+    auto frame = convert::py_input_item_to_frame(stream_id, item, norm, user_meta, false, pipelines::SortednessScan::SKIP);
     write_dataframe_to_file_internal(
             stream_id, frame, path, WriteOptions{}, codec::default_lz4_codec(), EncodingVersion::V2
     );
@@ -1574,7 +1574,7 @@ VersionedItem PythonVersionStore::merge(
     };
     return merge_internal(
             stream_id,
-            convert::py_ndf_to_frame(
+            convert::py_input_item_to_frame(
                     stream_id,
                     source,
                     norm,

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -45,8 +45,8 @@ template PythonVersionStore::PythonVersionStore(
 );
 
 VersionedItem PythonVersionStore::write_dataframe_specific_version(
-        const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
-        VersionId version_id
+        const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+        const py::object& user_meta, VersionId version_id
 ) {
     ARCTICDB_SAMPLE(WriteDataFrame, 0)
 
@@ -689,7 +689,7 @@ std::unordered_set<StreamId> PythonVersionStore::list_streams_unordered(
 size_t PythonVersionStore::compact_symbol_list() { return compact_symbol_list_internal(); }
 
 VersionedItem PythonVersionStore::write_partitioned_dataframe(
-        const StreamId& stream_id, const py::tuple& item, const py::object& norm_meta,
+        const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm_meta,
         const std::vector<std::string>& partition_value
 ) {
     ARCTICDB_SAMPLE(WritePartitionedDataFrame, 0)
@@ -697,7 +697,7 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     auto version_id = get_next_version_from_key(maybe_prev);
 
     //    TODO: We are not actually partitioning stuff atm, just assuming a single partition is passed for now.
-    std::array<py::object, 1> partitioned_dfs{item};
+    std::array<std::shared_ptr<convert::PandasData>, 1> partitioned_dfs{item};
 
     auto write_options = get_write_options();
     auto de_dup_map = std::make_shared<DeDupMap>();
@@ -876,8 +876,8 @@ VersionedItem PythonVersionStore::delete_range(
 }
 
 void PythonVersionStore::append_incomplete(
-        const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
-        bool validate_index
+        const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+        const py::object& user_meta, bool validate_index
 ) const {
 
     using namespace arcticdb::entity;
@@ -1531,8 +1531,8 @@ bool PythonVersionStore::is_empty_excluding_key_types(const std::vector<KeyType>
 }
 
 void write_dataframe_to_file(
-        const StreamId& stream_id, const std::string& path, const py::tuple& item, const py::object& norm,
-        const py::object& user_meta
+        const StreamId& stream_id, const std::string& path, const std::shared_ptr<convert::PandasData>& item,
+        const py::object& norm, const py::object& user_meta
 ) {
     ARCTICDB_SAMPLE(WriteDataframeToFile, 0)
     auto frame = convert::py_ndf_to_frame(stream_id, item, norm, user_meta, false, pipelines::SortednessScan::SKIP);
@@ -1565,8 +1565,9 @@ void PythonVersionStore::force_delete_symbol(const StreamId& stream_id) {
 }
 
 VersionedItem PythonVersionStore::merge(
-        const StreamId& stream_id, const py::tuple& source, const py::object& norm, const py::object& user_meta,
-        const bool prune_previous_versions, const bool upsert, const py::tuple& py_strategy, std::vector<std::string> on
+        const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& source, const py::object& norm,
+        const py::object& user_meta, const bool prune_previous_versions, const bool upsert,
+        const py::tuple& py_strategy, std::vector<std::string> on
 ) {
     const MergeStrategy strategy{
             .matched = py_strategy[0].cast<MergeAction>(), .not_matched_by_target = py_strategy[1].cast<MergeAction>()

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1535,7 +1535,8 @@ void write_dataframe_to_file(
         const py::object& norm, const py::object& user_meta
 ) {
     ARCTICDB_SAMPLE(WriteDataframeToFile, 0)
-    auto frame = convert::py_input_item_to_frame(stream_id, item, norm, user_meta, false, pipelines::SortednessScan::SKIP);
+    auto frame =
+            convert::py_input_item_to_frame(stream_id, item, norm, user_meta, false, pipelines::SortednessScan::SKIP);
     write_dataframe_to_file_internal(
             stream_id, frame, path, WriteOptions{}, codec::default_lz4_codec(), EncodingVersion::V2
     );

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -42,8 +42,8 @@ class PythonVersionStore : public LocalVersionedEngine {
         LocalVersionedEngine(store, ct) {}
 
     VersionedItem write_dataframe_specific_version(
-            const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
-            VersionId version_id
+            const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+            const py::object& user_meta, VersionId version_id
     );
 
     VersionedItem write_versioned_dataframe(
@@ -62,7 +62,7 @@ class PythonVersionStore : public LocalVersionedEngine {
     );
 
     VersionedItem write_partitioned_dataframe(
-            const StreamId& stream_id, const py::tuple& item, const py::object& norm_meta,
+            const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm_meta,
             const std::vector<std::string>& partition_cols
     );
 
@@ -85,8 +85,8 @@ class PythonVersionStore : public LocalVersionedEngine {
     );
 
     void append_incomplete(
-            const StreamId& stream_id, const py::tuple& item, const py::object& norm, const py::object& user_meta,
-            bool validate_index
+            const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& item, const py::object& norm,
+            const py::object& user_meta, bool validate_index
     ) const;
 
     std::variant<VersionedItem, CompactionError> compact_incomplete(
@@ -292,9 +292,9 @@ class PythonVersionStore : public LocalVersionedEngine {
     std::vector<AtomKey> get_version_history(const StreamId& stream_id);
 
     VersionedItem merge(
-            const StreamId& stream_id, const py::tuple& source, const py::object& norm, const py::object& user_meta,
-            const bool prune_previous_versions, const bool upsert, const py::tuple& py_strategy,
-            std::vector<std::string> on
+            const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& source, const py::object& norm,
+            const py::object& user_meta, const bool prune_previous_versions, const bool upsert,
+            const py::tuple& py_strategy, std::vector<std::string> on
     );
 
     CompactDataInfo compact_data_explain_plan(const StreamId& stream_id, std::optional<uint64_t> rows_per_segment);
@@ -308,8 +308,8 @@ class PythonVersionStore : public LocalVersionedEngine {
 };
 
 void write_dataframe_to_file(
-        const StreamId& stream_id, const std::string& path, const py::tuple& item, const py::object& norm,
-        const py::object& user_meta
+        const StreamId& stream_id, const std::string& path, const std::shared_ptr<convert::PandasData>& item,
+        const py::object& norm, const py::object& user_meta
 );
 
 ReadResult read_dataframe_from_file(

--- a/docs/claude/python/NORMALIZATION.md
+++ b/docs/claude/python/NORMALIZATION.md
@@ -29,7 +29,8 @@ DatetimeIndex variations    →                 Nanosecond timestamps
 ## NormalizedInput
 
 `NormalizedInput` is a named tuple with:
-- `item` - NPDDataFrame ready for C++ (numpy arrays in structured format)
+- `item` - `PandasData` ready for C++ (a pybind-bound struct holding the column/index names and
+  references to the numpy arrays)
 - `metadata` - NormalizationMetadata protobuf containing df/ts/np/msg_pack_frame metadata
 
 ### Conversion Flow
@@ -38,7 +39,7 @@ DatetimeIndex variations    →                 Nanosecond timestamps
 pandas.DataFrame / pa.Table / pl.DataFrame
         │
         ▼ normalize()
-NormalizedInput (NPDDataFrame or RecordBatches + NormalizationMetadata)
+NormalizedInput (PandasData or RecordBatches + NormalizationMetadata)
         │
         ▼ to C++
 InputFrame
@@ -58,7 +59,7 @@ pandas.DataFrame / pa.Table / pl.DataFrame (based on OutputFormat)
 
 ### Input Normalization
 
-`normalize(data, string_max_len)` converts input data to the internal format. For pandas DataFrames this produces an NPDDataFrame (numpy arrays). For PyArrow Tables and polars DataFrames this produces a vector of record batches.
+`normalize(data, string_max_len)` converts input data to the internal format. For pandas DataFrames this produces a `PandasData` (column/index names plus references to the numpy arrays). For PyArrow Tables and polars DataFrames this produces a vector of record batches.
 
 ### Type Conversion
 

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -41,7 +41,7 @@ from arcticdb.exceptions import (
 )
 from arcticdb.supported_types import DateRangeInput, time_types as supported_time_types
 from arcticdb.util._versions import IS_PANDAS_TWO, IS_PANDAS_ZERO
-from arcticdb_ext.version_store import RecordBatchData, SortedValue as _SortedValue
+from arcticdb_ext.version_store import PandasData, RecordBatchData, SortedValue as _SortedValue
 from pandas.core.internals import make_block
 
 from pandas import DataFrame, MultiIndex, Series, DatetimeIndex, Index, RangeIndex
@@ -93,19 +93,7 @@ def _tz_error_context():
         ) from e
 
 
-NPDDataFrame = NamedTuple(
-    "NPDDataFrame",
-    [
-        # DO NOT REORDER, positional access used in c++
-        ("index_names", List[str]),
-        ("column_names", List[str]),
-        ("index_values", List[np.ndarray]),
-        ("columns_values", List[np.ndarray]),
-        ("sorted", _SortedValue),
-    ],
-)
-
-NormalizedInput = NamedTuple("NormalizedInput", [("item", NPDDataFrame), ("metadata", NormalizationMetadata)])
+NormalizedInput = NamedTuple("NormalizedInput", [("item", PandasData), ("metadata", NormalizationMetadata)])
 
 
 _PICKLED_METADATA_LOGLEVEL = None  # set lazily with function below
@@ -146,8 +134,8 @@ class FrameData(
     )
 ):
     @staticmethod
-    def from_npd_df(df):
-        # type: (NPDDataFrame)->FrameData
+    def from_pandas_data(df):
+        # type: (PandasData)->FrameData
         return FrameData(
             data=df.index_values + df.columns_values,
             names=df.column_names,
@@ -1047,7 +1035,7 @@ class NdArrayNormalizer(Normalizer):
         # the protobuf which is used during denorm. This can be problematic as this might lead to a lot of
         # (MAX_ROWS x 1) segments instead of an even distribution for now.
         return NormalizedInput(
-            item=NPDDataFrame(
+            item=PandasData(
                 index_names=[],
                 index_values=[],
                 column_names=["ndarray"],
@@ -1357,7 +1345,7 @@ class DataFrameNormalizer(_PandasNormalizer):
                 sort_status = _SortedValue.UNSORTED
 
         return NormalizedInput(
-            item=NPDDataFrame(
+            item=PandasData(
                 index_names=index_names,
                 index_values=ix_vals,
                 column_names=columns,
@@ -1388,7 +1376,7 @@ class MsgPackNormalizer(Normalizer):
         column_val = np.array(memoryview(packed), np.uint8).view(np.uint64)
 
         return NormalizedInput(
-            item=NPDDataFrame(
+            item=PandasData(
                 index_names=[],
                 index_values=[],
                 column_names=["bytes"],
@@ -1510,7 +1498,7 @@ class TimeFrameNormalizer(Normalizer):
         )
 
         return NormalizedInput(
-            item=NPDDataFrame(
+            item=PandasData(
                 index_names=index_names,
                 index_values=ix_vals,
                 column_names=columns_names,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -87,7 +87,7 @@ from arcticdb.flattener import Flattener
 from arcticdb.log import version as log
 from arcticdb.version_store._custom_normalizers import get_custom_normalizer, CompositeCustomNormalizer
 from arcticdb.version_store._normalization import (
-    NPDDataFrame,
+    PandasData,
     normalize_metadata,
     normalize_recursive_metastruct,
     denormalize_user_metadata,
@@ -677,7 +677,7 @@ class NativeVersionStore:
 
     @staticmethod
     def _valid_item_type(item):
-        return isinstance(item, NPDDataFrame) or (
+        return isinstance(item, PandasData) or (
             isinstance(item, list) and all(isinstance(el, RecordBatchData) for el in item)
         )
 

--- a/python/tests/unit/arcticdb/version_store/test_deletion.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion.py
@@ -21,7 +21,7 @@ from arcticdb.util.tasks import (
 from arcticdb_ext.exceptions import InternalException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb_ext.version_store import ManualClockVersionStore
-from arcticdb.version_store._normalization import NPDDataFrame
+from arcticdb.version_store._normalization import PandasData
 from arcticdb.util.test import sample_dataframe
 from arcticdb.version_store._store import resolve_defaults
 
@@ -451,7 +451,7 @@ def test_tombstone_of_non_existing_version(lmdb_version_store_tombstone, sym):
         dynamic_strings = resolve_defaults("dynamic_strings", proto_cfg, False)
         pickle_on_failure = resolve_defaults("pickle_on_failure", proto_cfg, False)
         udm, item, norm_meta = lib._try_normalize(sym, data, None, pickle_on_failure, dynamic_strings, None)
-        if isinstance(item, NPDDataFrame):
+        if isinstance(item, PandasData):
             lib.version_store.write_dataframe_specific_version(sym, item, norm_meta, udm, version)
 
     lib = lmdb_version_store_tombstone
@@ -490,7 +490,7 @@ def test_tombstone_of_non_existing_version(lmdb_version_store_tombstone, sym):
 def test_tombstone_of_non_existing_version_multiple_deletes(lmdb_version_store_tombstone, sym):
     def write_specific_version(data, version):
         udm, item, norm_meta = lib._try_normalize(sym, data, None, False, False, None)
-        if isinstance(item, NPDDataFrame):
+        if isinstance(item, PandasData):
             lib.version_store.write_dataframe_specific_version(sym, item, norm_meta, udm, version)
 
     lib = lmdb_version_store_tombstone

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -50,7 +50,7 @@ from arcticdb.version_store._normalization import (
     _from_tz_timestamp,
     DataFrameNormalizer,
     NdArrayNormalizer,
-    NPDDataFrame,
+    PandasData,
 )
 from arcticdb.version_store._common import TimeFrame
 from arcticdb.util.test import (
@@ -77,7 +77,7 @@ def test_msg_pack(d):
     norm = test_msgpack_normalizer
 
     df, norm_meta = norm.normalize(d)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     D = norm.denormalize(fd, norm_meta)
 
     assert d == D
@@ -246,7 +246,7 @@ def test_empty_df():
 
     norm = CompositeNormalizer()
     df, norm_meta = norm.normalize(d)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     D = norm.denormalize(fd, norm_meta)
     if not IS_PANDAS_ZERO:
         assert_equal(d.index.to_numpy(), D.index.to_numpy())
@@ -391,7 +391,7 @@ def test_multiindex_with_tz(tz):
     d = get_multiindex_df_with_tz(tz)
     norm = CompositeNormalizer(use_norm_failure_handler_known_types=True, fallback_normalizer=test_msgpack_normalizer)
     df, norm_meta = norm.normalize(d)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     denorm = norm.denormalize(fd, norm_meta)
     if pd.__version__.startswith("0"):
         assert_equal(d.index.get_values(), denorm.index.get_values())
@@ -408,7 +408,7 @@ def test_empty_df_with_multiindex_with_tz(tz):
     norm_df, norm_meta = norm.normalize(orig_df)
 
     # Slice the normalized df to an empty df (this can happen after date range slicing)
-    sliced_norm_df = NPDDataFrame(
+    sliced_norm_df = PandasData(
         index_names=norm_df.index_names,
         column_names=norm_df.column_names,
         index_values=[norm_df.index_values[0][0:0]],
@@ -416,7 +416,7 @@ def test_empty_df_with_multiindex_with_tz(tz):
         sorted=_SortedValue.UNKNOWN,
     )
 
-    fd = FrameData.from_npd_df(sliced_norm_df)
+    fd = FrameData.from_pandas_data(sliced_norm_df)
     sliced_denorm_df = norm.denormalize(fd, norm_meta)
 
     for index_level_num in [0, 1, 2]:
@@ -505,7 +505,7 @@ def test_namedtuple_inside_df():
     d = pd.DataFrame({"A": [NT(1, "b"), NT(2, "a")]})
     norm = CompositeNormalizer(use_norm_failure_handler_known_types=True, fallback_normalizer=test_msgpack_normalizer)
     df, norm_meta = norm.normalize(d)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     denorm = norm.denormalize(fd, norm_meta)
     if pd.__version__.startswith("0"):
         assert_equal(d.index.get_values(), denorm.index.get_values())
@@ -576,7 +576,7 @@ def test_numpy_array_normalization_composite():
     norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
     arr = np.random.rand(10, 10, 10)
     df, norm_meta = norm.normalize(arr)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     d = norm.denormalize(fd, norm_meta)
     assert np.array_equal(d, arr)
 
@@ -585,7 +585,7 @@ def test_numpy_array_normalizer():
     norm = NdArrayNormalizer()
     arr = np.random.rand(10, 10)
     df, norm_meta = norm.normalize(arr)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     d = norm.denormalize(fd, norm_meta.np)
     assert np.array_equal(d, arr)
 
@@ -595,7 +595,7 @@ def test_ndarray_arbitrary_shape():
     shape = np.random.randint(1, 5, 5)
     arr = np.random.rand(*shape)
     df, norm_meta = norm.normalize(arr)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     d = norm.denormalize(fd, norm_meta.np)
     assert np.array_equal(d, arr)
 
@@ -605,7 +605,7 @@ def test_dict_with_tuples():
     data = {(1, 2): [1, 24, 55]}
     norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
     df, norm_meta = norm.normalize(data)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     denormalized_data = norm.denormalize(fd, norm_meta)
     assert denormalized_data == data
     assert isinstance(denormalized_data, dict)
@@ -654,7 +654,7 @@ def test_numpy_ts_col_with_none(lmdb_version_store):
     df.loc[0, "a"] = pd.Timestamp(0)
     norm = CompositeNormalizer(use_norm_failure_handler_known_types=False, fallback_normalizer=test_msgpack_normalizer)
     df, norm_meta = norm.normalize(df)
-    fd = FrameData.from_npd_df(df)
+    fd = FrameData.from_pandas_data(df)
     df_denormed = norm.denormalize(fd, norm_meta)
     assert df_denormed["a"][0] == pd.Timestamp(0)
     # None's should be converted to NaT's now.


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
Main change:
- Added PandasData - a pybind struct that carries a pandas df (the column/index names + refs to the numpy arrays) replaces the old `py::tuple` that carried the same things as positional args.

Other changes I did around that:
- Renamed `py_ndf_to_frame` to `py_input_item_to_frame` to signify it accepts both pandas and Arrow input 
- Renamed `tensors_to_frame` to `pandas_data_to_frame` as it takes a PandasData now.
- Renamed `FrameData.from_npd_df` to `from_pandas_data` (Python) as it now takes a PandasData, not the old NPDDataFrame.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
