### PR TITLE
Bugfixes 18103677039 & 9682041273: persist metadata when appending or updating empty frames, and skip writing unnecessary symbol list keys

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -728,26 +728,21 @@ VersionedItem LocalVersionedEngine::update_internal(
     py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
     if (update_info.previous_index_key_.has_value()) {
-        if (frame->empty()) {
-            ARCTICDB_RUNTIME_DEBUG(
-                    log::version(),
-                    "Updating existing data with an empty item has no effect. \n"
-                    "No new version is being created for symbol='{}', "
-                    "and the last version is returned",
-                    stream_id
-            );
-            return VersionedItem{*std::move(update_info.previous_index_key_)};
-        }
-
-        auto versioned_item = update_impl(
-                store(),
-                update_info,
-                query,
-                frame,
-                get_write_options(),
-                dynamic_schema,
-                cfg().write_options().empty_types()
-        );
+        const auto versioned_item =
+                frame->empty()
+                        ? VersionedItem{async::submit_io_task(
+                                                UpdateMetadataTask{store(), update_info, std::move(frame->user_meta)}
+                          )
+                                                .get()}
+                        : update_impl(
+                                  store(),
+                                  update_info,
+                                  query,
+                                  frame,
+                                  get_write_options(),
+                                  dynamic_schema,
+                                  cfg().write_options().empty_types()
+                          );
         write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
         return versioned_item;
     } else {
@@ -1867,19 +1862,20 @@ VersionedItem LocalVersionedEngine::append_internal(
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
 
     if (update_info.previous_index_key_.has_value()) {
-        if (frame->empty()) {
-            ARCTICDB_RUNTIME_DEBUG(
-                    log::version(),
-                    "Appending an empty item to existing data has no effect. \n"
-                    "No new version has been created for symbol='{}', "
-                    "and the last version is returned",
-                    stream_id
-            );
-            return VersionedItem(*std::move(update_info.previous_index_key_));
-        }
-        auto versioned_item = append_impl(
-                store(), update_info, frame, get_write_options(), validate_index, cfg().write_options().empty_types()
-        );
+        const auto versioned_item =
+                frame->empty()
+                        ? VersionedItem{async::submit_io_task(
+                                                UpdateMetadataTask{store(), update_info, std::move(frame->user_meta)}
+                          )
+                                                .get()}
+                        : append_impl(
+                                  store(),
+                                  update_info,
+                                  frame,
+                                  get_write_options(),
+                                  validate_index,
+                                  cfg().write_options().empty_types()
+                          );
         write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
         return versioned_item;
     } else {
@@ -1933,24 +1929,19 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                                     auto write_options = get_write_options();
                                     if (update_info.previous_index_key_.has_value()) {
-                                        if (frame->empty()) {
-                                            ARCTICDB_DEBUG(
-                                                    log::version(),
-                                                    "Appending an empty item to existing data has no effect. \n"
-                                                    "No new version has been created for symbol='{}', "
-                                                    "and the last version is returned",
-                                                    stream_id
-                                            );
-                                            return VersionedItem{*std::move(update_info.previous_index_key_)};
-                                        }
-                                        index_key_fut = async_append_impl(
-                                                store(),
-                                                update_info,
-                                                frame,
-                                                write_options,
-                                                validate_index,
-                                                cfg().write_options().empty_types()
-                                        );
+                                        index_key_fut =
+                                                frame->empty()
+                                                        ? async::submit_io_task(UpdateMetadataTask{
+                                                                  store(), update_info, std::move(frame->user_meta)
+                                                          })
+                                                        : async_append_impl(
+                                                                  store(),
+                                                                  update_info,
+                                                                  frame,
+                                                                  write_options,
+                                                                  validate_index,
+                                                                  cfg().write_options().empty_types()
+                                                          );
                                     } else {
                                         missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
                                                 upsert, "Cannot append to non-existent symbol {}", stream_id
@@ -2017,27 +2008,22 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                                     auto write_options = get_write_options();
                                     if (update_info.previous_index_key_.has_value()) {
-                                        if (frame->empty()) {
-                                            ARCTICDB_DEBUG(
-                                                    log::version(),
-                                                    "Updating existing data with an empty item has no effect. \n"
-                                                    "No new version is being created for symbol='{}', "
-                                                    "and the last version is returned",
-                                                    stream_id
-                                            );
-                                            return VersionedItem(*std::move(update_info.previous_index_key_));
-                                        }
                                         const bool dynamic_schema = cfg().write_options().dynamic_schema();
                                         const bool empty_types = cfg().write_options().empty_types();
-                                        index_key_fut = async_update_impl(
-                                                store(),
-                                                update_info,
-                                                update_query,
-                                                std::move(frame),
-                                                std::move(write_options),
-                                                dynamic_schema,
-                                                empty_types
-                                        );
+                                        index_key_fut =
+                                                frame->empty()
+                                                        ? async::submit_io_task(UpdateMetadataTask{
+                                                                  store(), update_info, std::move(frame->user_meta)
+                                                          })
+                                                        : async_update_impl(
+                                                                  store(),
+                                                                  update_info,
+                                                                  update_query,
+                                                                  std::move(frame),
+                                                                  std::move(write_options),
+                                                                  dynamic_schema,
+                                                                  empty_types
+                                                          );
                                     } else {
                                         missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
                                                 upsert,

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1928,6 +1928,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                  prune_previous_versions](auto&& update_info) -> folly::Future<VersionedItem> {
                                     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                                     auto write_options = get_write_options();
+                                    bool add_new_symbol_list_entry{!update_info.previous_index_key_.has_value()};
                                     if (update_info.previous_index_key_.has_value()) {
                                         index_key_fut =
                                                 frame->empty()
@@ -1960,13 +1961,15 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                             .thenValue(
                                                     [this,
                                                      prune_previous_versions,
+                                                     add_new_symbol_list_entry,
                                                      update_info = std::move(update_info)](AtomKey&& index_key
                                                     ) mutable -> folly::Future<VersionedItem> {
                                                         return write_index_key_to_version_map_async(
                                                                 version_map(),
                                                                 std::move(index_key),
                                                                 std::move(update_info),
-                                                                prune_previous_versions
+                                                                prune_previous_versions,
+                                                                add_new_symbol_list_entry
                                                         );
                                                     }
                                             );
@@ -2007,6 +2010,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                  prune_previous_versions](UpdateInfo&& update_info) -> folly::Future<VersionedItem> {
                                     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
                                     auto write_options = get_write_options();
+                                    bool add_new_symbol_list_entry{!update_info.previous_index_key_.has_value()};
                                     if (update_info.previous_index_key_.has_value()) {
                                         const bool dynamic_schema = cfg().write_options().dynamic_schema();
                                         const bool empty_types = cfg().write_options().empty_types();
@@ -2045,12 +2049,14 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
                                     return std::move(index_key_fut)
                                             .thenValue([this,
                                                         update_info = std::move(update_info),
-                                                        prune_previous_versions](auto&& index_key) mutable {
+                                                        prune_previous_versions,
+                                                        add_new_symbol_list_entry](auto&& index_key) mutable {
                                                 return write_index_key_to_version_map_async(
                                                         version_map(),
                                                         std::move(index_key),
                                                         std::move(update_info),
-                                                        prune_previous_versions
+                                                        prune_previous_versions,
+                                                        add_new_symbol_list_entry
                                                 );
                                             });
                                 }

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -732,7 +732,7 @@ def test_append_batch_missing_keys(arctic_library):
     assert_frame_equal(read_dataframe.data, pd.concat([df2_write, df2_append]))
 
 
-def test_append_batch_empty_dataframe_does_not_increase_version(lmdb_version_store_v1):
+def test_append_batch_empty_dataframe_increases_version(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     lib.batch_write(["sym1", "sym2"], [pd.DataFrame({"a": [1, 2, 3]}), pd.DataFrame({"b": [1, 2, 3, 4]})])
     lib_tool = lib.library_tool()
@@ -746,7 +746,7 @@ def test_append_batch_empty_dataframe_does_not_increase_version(lmdb_version_sto
 
     append_result = lib.batch_append(["sym1", "sym2"], [pd.DataFrame({"a": [5, 6, 7]}), pd.DataFrame({"b": []})])
     assert append_result[0].version == 1
-    assert append_result[1].version == 0
+    assert append_result[1].version == 1
 
     sym_1_vit, sym_2_vit = lib.read("sym1"), lib.read("sym2")
 
@@ -756,16 +756,15 @@ def test_append_batch_empty_dataframe_does_not_increase_version(lmdb_version_sto
     assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym1")) == 2
     assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "sym1")) == 2
 
-    assert sym_2_vit.version == 0
+    assert sym_2_vit.version == 1
     assert_frame_equal(sym_2_vit.data, pd.DataFrame({"b": [1, 2, 3, 4]}))
-    assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "sym2")) == 1
-    assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym2")) == 1
+    assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "sym2")) == 2
+    assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym2")) == 2
     assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "sym2")) == 1
 
     # This result is wrong. The correct value is 2. This is due to a bug Monday: 9682041273, append_batch and
-    # update_batch should not create symbol list keys for already existing symbols. Since append_batch is noop when
-    # the input is empty, there is no key for sym_2, but there is a new key for sym_1 and that is wrong.
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 3
+    # update_batch should not create symbol list keys for already existing symbols.
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 4
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -762,9 +762,8 @@ def test_append_batch_empty_dataframe_increases_version(lmdb_version_store_v1):
     assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym2")) == 2
     assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "sym2")) == 1
 
-    # This result is wrong. The correct value is 2. This is due to a bug Monday: 9682041273, append_batch and
-    # update_batch should not create symbol list keys for already existing symbols.
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 4
+    # Appending already existing symbols (i.e. non-upsert path) does not add a symbol list key
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/test_update.py
+++ b/python/tests/integration/arcticdb/test_update.py
@@ -479,7 +479,7 @@ def test_update_batch_error_scenario1(arctic_library):
     lib.write_batch([WritePayload(symbol, df)])
     update = UpdatePayload(symbol, df_0col)
     update_result = lib.update_batch([update], prune_previous_versions=True)
-    assert update_result[0].version == 0
+    assert update_result[0].version == 1
 
 
 @pytest.mark.xfail(IS_PANDAS_ONE, reason="update_batch return unexpected exception (9589648728)")
@@ -500,7 +500,7 @@ def test_update_batch_error_scenario2(arctic_library):
         symbol, df[0:1], date_range=(pd.Timestamp("2030-12-11 00:00:00"), pd.Timestamp("2030-12-11 00:00:01"))
     )
     update_result = lib.update_batch([update], prune_previous_versions=True)
-    assert update_result[0].version == 0
+    assert update_result[0].version == 1
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
@@ -272,12 +272,6 @@ def test_append_scenario_with_errors_and_success(version_store_and_real_s3_basic
     df_different_index = pd.DataFrame({"value": [4, 5, 6]}, index=["a", "b", "c"])  # String index instead of datetime
     df_no_index = pd.DataFrame({"value": [4, 5, 6]})
 
-    # Test append to non-existent symbol
-    for sym in [symbol, None, ""]:
-        with pytest.raises(TypeError):
-            lib.append(sym)
-    assert len(lib.list_symbols()) == 0
-
     # Empty dataframe will create symbol with one version
     result = lib.append(symbol, df_empty)
     assert len(lib.list_symbols()) == 1
@@ -347,11 +341,10 @@ def test_append_scenario_with_errors_and_success(version_store_and_real_s3_basic
         with pytest.raises(StreamDescriptorMismatch):
             lib.append(symbol, df_different_schema)
 
-    # Append empty dataframe to symbol with content does not increase version
-    # but as we saw previously it will create symbol
+    # Append empty dataframe to symbol with content increases the version in case the metadata has changed
     result = lib.append(symbol, df_empty)
     assert len(lib.list_symbols()) == 1
-    assert len(lib.list_versions()) == 4 if dynamic_schema else 3
+    assert len(lib.list_versions()) == 5 if dynamic_schema else 4
 
     # Validate that validate_index works as expected
     with pytest.raises(UnsortedDataException):

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -697,6 +697,8 @@ def test_prune_previous_versions_append_batch(basic_store):
 
     # When
     lib.batch_write(syms, [df0, df0])
+    # One symbol list key for each symbol
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
     lib.batch_append(syms, [df1, df1])
 
     for sym in syms:
@@ -724,8 +726,8 @@ def test_prune_previous_versions_append_batch(basic_store):
         assert len(keys_for_sym) == 3
         latest_ver_key = max(keys_for_sym, key=lambda x: x.version_id)
         check_write_and_prune_previous_version_keys(lib_tool, sym, latest_ver_key)
-    # Then - we got 6 symbol keys: 1 for each of the writes
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 6
+    # Still only 2 symbol list keys [batch_]append only writes symbol list keys on upsert
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
 
 
 def test_batch_append_after_delete_upsert(lmdb_version_store_v1):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -250,15 +250,15 @@ def test_update_with_empty_series_or_dataframe(
 
     assert first_operation.version == 0
 
-    # Has no effect, but must not fail.
+    # Has no effect on data, but must not fail.
     second_operation = lib.append(symbol, empty)
 
-    # No new version is created.
-    assert second_operation.version == first_operation.version
+    # A new version is created.
+    assert second_operation.version == first_operation.version + 1
 
     third_operation = lib.update(symbol, one_row)
 
-    # A new version is created in this case.
+    # A new version is created.
     assert third_operation.version == second_operation.version + 1
 
     received = lib.read(symbol).data
@@ -268,17 +268,17 @@ def test_update_with_empty_series_or_dataframe(
 
     first_operation = lib.write(symbol, one_row)
 
-    # Has no effect, but must not fail.
+    # Has no effect on data, but must not fail.
     second_operation = lib.append(symbol, empty)
 
-    # No new version is created.
-    assert first_operation.version == second_operation.version
+    # A new version is created.
+    assert second_operation.version == first_operation.version + 1
 
-    # Has no effect, but must not fail.
+    # Has no effect on data, but must not fail.
     third_operation = lib.update(symbol, empty)
 
-    # No new version is created as well.
-    assert third_operation.version == first_operation.version
+    # A new version is created.
+    assert third_operation.version == second_operation.version + 1
 
     received = lib.read(symbol).data
     assert_pandas_container_equal(one_row, received)

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -798,3 +798,25 @@ def test_append_after_delete_range(sym, lmdb_version_store):
 
     sliced_data = lib.read("sym", date_range=(datetime(2025, 9, 1), datetime(2025, 9, 4))).data
     assert_frame_equal(sliced_data, expected_data)
+
+
+@pytest.mark.parametrize("batch", [True, False])
+def test_append_empty_frame_metadata(lmdb_version_store_v1, batch):
+    lib = lmdb_version_store_v1
+    sym = "test_append_empty_frame_metadata"
+    write_df = pd.DataFrame({"col": np.arange(1)})
+    metadata_v0 = "v0"
+    lib.write(sym, write_df, metadata=metadata_v0)
+    empty_df = pd.DataFrame({"col": np.arange(0)})  # Using arange guarantees the dtype matches the written df
+    metadata_v1 = "v1"
+    append_vit = (
+        lib.batch_append([sym], [empty_df], metadata_vector=[metadata_v1])[0]
+        if batch
+        else lib.append(sym, empty_df, metadata=metadata_v1)
+    )
+    assert append_vit.version == 1
+    assert append_vit.metadata == metadata_v1
+    read_vit = lib.read(sym)
+    assert read_vit.version == 1
+    assert read_vit.metadata == metadata_v1
+    assert_frame_equal(read_vit.data, write_df)

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -13,8 +13,9 @@ import arcticdb
 import arcticdb.exceptions
 from arcticdb.version_store import NativeVersionStore
 from arcticdb_ext.exceptions import InternalException, NormalizationException, UnsortedDataException, SchemaException
+from arcticdb_ext.storage import KeyType
 from arcticdb_ext import set_config_int
-from arcticdb.util.test import random_integers, assert_frame_equal
+from arcticdb.util.test import random_integers, assert_frame_equal, assert_series_equal
 from arcticdb.config import set_log_level
 from arcticdb.util.test_utils import generate_random_numpy_array, supported_types_list
 from arcticdb.util.logger import get_logger
@@ -800,23 +801,41 @@ def test_append_after_delete_range(sym, lmdb_version_store):
     assert_frame_equal(sliced_data, expected_data)
 
 
+@pytest.mark.parametrize("data_class", ["dataframe", "series"])
 @pytest.mark.parametrize("batch", [True, False])
-def test_append_empty_frame_metadata(lmdb_version_store_v1, batch):
+@pytest.mark.parametrize("metadata_v1", ["v1", None])
+def test_append_empty_frame_metadata(lmdb_version_store_v1, data_class, batch, metadata_v1):
     lib = lmdb_version_store_v1
     sym = "test_append_empty_frame_metadata"
-    write_df = pd.DataFrame({"col": np.arange(1)})
+    write_data = pd.DataFrame({"col": np.arange(1)}) if data_class == "dataframe" else pd.Series(np.arange(1))
     metadata_v0 = "v0"
-    lib.write(sym, write_df, metadata=metadata_v0)
-    empty_df = pd.DataFrame({"col": np.arange(0)})  # Using arange guarantees the dtype matches the written df
-    metadata_v1 = "v1"
+    lib.write(sym, write_data, metadata=metadata_v0)
+    # Using arange guarantees the dtype matches the written df
+    append_data = pd.DataFrame({"col": np.arange(0)}) if data_class == "dataframe" else pd.Series(np.arange(0))
     append_vit = (
-        lib.batch_append([sym], [empty_df], metadata_vector=[metadata_v1])[0]
+        lib.batch_append([sym], [append_data], metadata_vector=[metadata_v1])[0]
         if batch
-        else lib.append(sym, empty_df, metadata=metadata_v1)
+        else lib.append(sym, append_data, metadata=metadata_v1)
     )
     assert append_vit.version == 1
     assert append_vit.metadata == metadata_v1
     read_vit = lib.read(sym)
     assert read_vit.version == 1
     assert read_vit.metadata == metadata_v1
-    assert_frame_equal(read_vit.data, write_df)
+    assert_func = assert_frame_equal if data_class == "dataframe" else assert_series_equal
+    assert_func(read_vit.data, write_data)
+
+
+@pytest.mark.parametrize("batch", [True, False])
+def test_symbol_list_key_added_on_upsert(lmdb_version_store_v1, batch):
+    lib = lmdb_version_store_v1
+    sym = "test_symbol_list_key_added_on_upsert"
+    lib.write(sym, 0)
+    lib.delete(sym)
+    lib_tool = lib.library_tool()
+    assert not len(lib.list_symbols())
+    num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
+    append_df = pd.DataFrame({"col": np.arange(0)})
+    (lib.batch_append([sym], [append_df]) if batch else lib.append(sym, append_df))
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
+    assert lib.list_symbols() == [sym]

--- a/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
@@ -604,11 +604,11 @@ class TestCanAppendToEmptyColumn:
         assert_frame_equal(lmdb_version_store_static_and_dynamic.read("sym").data, df_to_append)
 
 
-class TestAppendAndUpdateWithEmptyToColumnDoesNothing:
+class TestAppendAndUpdateWithEmptyToColumnOnlyIncrementsVersionNumber:
     """
     Test if it is possible to append/update empty column to an already existing column. The append/update should not
-    change anything. If dynamic schema is used the append/update should not create new columns. The append/update
-    should not even reach the C++ layer and the version should not be changed.
+    change anything about the data, but will always create a new version in case the metadata has changed. If dynamic
+    schema is used the append/update should not create new columns.
     """
 
     @pytest.fixture(params=[pd.RangeIndex(0, 3), list(pd.date_range(start="1/1/2024", end="1/3/2024"))])
@@ -620,53 +620,73 @@ class TestAppendAndUpdateWithEmptyToColumnDoesNothing:
         yield pd.DataFrame({"col": []}, dtype=dtype, index=empty_index)
 
     @staticmethod
-    def assert_append_empty_does_nothing(initial_df, store, empty):
+    def assert_append_empty_only_increments_version_number(initial_df, store, empty):
+        # Use read_metadata over read to avoid some IO
+        version_before = store.read_metadata("sym").version
         store.append("sym", empty)
         read_result = store.read("sym")
         assert_frame_equal(read_result.data, initial_df)
-        assert read_result.version == 0
+        assert read_result.version == version_before + 1
 
     @staticmethod
-    def assert_update_empty_does_nothing(initial_df, store, empty):
+    def assert_update_empty_only_increments_version_number(initial_df, store, empty):
+        # Use read_metadata over read to avoid some IO
+        version_before = store.read_metadata("sym").version
         store.update("sym", empty)
         read_result = store.read("sym")
         assert_frame_equal(read_result.data, initial_df)
-        assert read_result.version == 0
+        assert read_result.version == version_before + 1
 
     def test_integer(self, lmdb_version_store_static_and_dynamic, index, int_dtype, empty_dataframe):
         df = pd.DataFrame({"col": [1, 2, 3]}, dtype=int_dtype, index=index)
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
-        self.assert_update_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
+        self.assert_append_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
+        self.assert_update_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
 
     def test_float(self, lmdb_version_store_static_and_dynamic, index, float_dtype, empty_dataframe):
         df = pd.DataFrame({"col": [1, 2, 3]}, dtype=float_dtype, index=index)
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
-        self.assert_update_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
+        self.assert_append_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
+        self.assert_update_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
 
     def test_bool(self, lmdb_version_store_static_and_dynamic, index, boolean_dtype, empty_dataframe):
         df = pd.DataFrame({"col": [False, True, None]}, dtype=boolean_dtype, index=index)
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
-        self.assert_update_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
+        self.assert_append_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
+        self.assert_update_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
 
     def test_nones(self, lmdb_version_store_static_and_dynamic, index, empty_dataframe):
         df = pd.DataFrame({"col": [None, None, None]}, index=index)
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
-        self.assert_update_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
+        self.assert_append_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
+        self.assert_update_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
 
     @pytest.mark.parametrize("initial_empty_index", [pd.RangeIndex(0, 0), pd.DatetimeIndex([])])
     def test_empty(self, lmdb_version_store_static_and_dynamic, initial_empty_index, empty_dataframe):
         df = pd.DataFrame({"col": []}, index=initial_empty_index)
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(
+        self.assert_append_empty_only_increments_version_number(
             lmdb_version_store_static_and_dynamic.read("sym").data,
             lmdb_version_store_static_and_dynamic,
             empty_dataframe,
         )
-        self.assert_update_empty_does_nothing(
+        self.assert_update_empty_only_increments_version_number(
             lmdb_version_store_static_and_dynamic.read("sym").data,
             lmdb_version_store_static_and_dynamic,
             empty_dataframe,
@@ -675,8 +695,12 @@ class TestAppendAndUpdateWithEmptyToColumnDoesNothing:
     def test_string(self, lmdb_version_store_static_and_dynamic, index, empty_dataframe):
         df = pd.DataFrame({"col": ["short", 20 * "long", None]}, index=index)
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
-        self.assert_update_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
+        self.assert_append_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
+        self.assert_update_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
 
     def test_date(self, lmdb_version_store_static_and_dynamic, date_dtype, index, empty_dataframe):
         df = pd.DataFrame(
@@ -685,8 +709,12 @@ class TestAppendAndUpdateWithEmptyToColumnDoesNothing:
             index=index,
         )
         lmdb_version_store_static_and_dynamic.write("sym", df)
-        self.assert_append_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
-        self.assert_update_empty_does_nothing(df, lmdb_version_store_static_and_dynamic, empty_dataframe)
+        self.assert_append_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
+        self.assert_update_empty_only_increments_version_number(
+            df, lmdb_version_store_static_and_dynamic, empty_dataframe
+        )
 
     def test_empty_df_does_not_create_new_columns_in_dynamic_schema(self, lmdb_version_store_dynamic_schema, index):
         df = pd.DataFrame({"col": [1, 2, 3]}, dtype="int32", index=index)
@@ -702,7 +730,7 @@ class TestAppendAndUpdateWithEmptyToColumnDoesNothing:
         lmdb_version_store_dynamic_schema.append("sym", to_append)
         read_result = lmdb_version_store_dynamic_schema.read("sym")
         assert_frame_equal(read_result.data, df)
-        assert read_result.version == 0
+        assert read_result.version == 1
 
 
 class TestCanUpdateEmptyColumn:

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -19,6 +19,7 @@ from arcticdb.util.test import (
     random_string,
     random_floats,
     assert_frame_equal,
+    assert_series_equal,
 )
 from arcticdb.exceptions import InternalException, UnsortedDataException, NormalizationException, SchemaException
 from arcticdb_ext.version_store import StreamDescriptorMismatch
@@ -1038,26 +1039,49 @@ def test_update_new_data_contains_old(version_store_factory):
     assert len(lib_tool.read_index("sym")) == 30
 
 
+@pytest.mark.parametrize("data_class", ["dataframe", "series"])
 @pytest.mark.parametrize("batch", [True, False])
-def test_update_empty_frame_metadata(lmdb_library, batch):
+@pytest.mark.parametrize("metadata_v1", ["v1", None])
+def test_update_empty_frame_metadata(lmdb_library, data_class, batch, metadata_v1):
     # Need to use a V2 API fixture as there is no batch_update on the V1 API
     lib = lmdb_library
     sym = "test_update_empty_frame_metadata"
-    write_df = pd.DataFrame({"col": np.arange(1)}, index=[pd.Timestamp("2026-01-01")])
+    write_data = pd.DataFrame({"col": np.arange(1)}) if data_class == "dataframe" else pd.Series(np.arange(1))
+    write_data.index = [pd.Timestamp("2026-01-01")]
     metadata_v0 = "v0"
-    lib.write(sym, write_df, metadata=metadata_v0)
-    empty_df = pd.DataFrame(
-        {"col": np.arange(0)}, index=pd.DatetimeIndex([])
-    )  # Using arange guarantees the dtype matches the written df
-    metadata_v1 = "v1"
+    lib.write(sym, write_data, metadata=metadata_v0)
+    # Using arange guarantees the dtype matches the written df
+    update_data = pd.DataFrame({"col": np.arange(0)}) if data_class == "dataframe" else pd.Series(np.arange(0))
+    update_data.index = pd.DatetimeIndex([])
     update_vit = (
-        lib.update_batch([UpdatePayload(sym, empty_df, metadata_v1)])[0]
+        lib.update_batch([UpdatePayload(sym, update_data, metadata_v1)])[0]
         if batch
-        else lib.update(sym, empty_df, metadata=metadata_v1)
+        else lib.update(sym, update_data, metadata=metadata_v1)
     )
     assert update_vit.version == 1
     assert update_vit.metadata == metadata_v1
     read_vit = lib.read(sym)
     assert read_vit.version == 1
     assert read_vit.metadata == metadata_v1
-    assert_frame_equal(read_vit.data, write_df)
+    assert_func = assert_frame_equal if data_class == "dataframe" else assert_series_equal
+    assert_func(read_vit.data, write_data)
+
+
+@pytest.mark.parametrize("batch", [True, False])
+def test_symbol_list_key_added_on_upsert(lmdb_library, batch):
+    # Need to use a V2 API fixture as there is no batch_update on the V1 API
+    lib = lmdb_library
+    sym = "test_symbol_list_key_added_on_upsert"
+    lib.write_pickle(sym, 0)
+    lib.delete(sym)
+    lib_tool = lib._dev_tools.library_tool()
+    assert not len(lib.list_symbols())
+    num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
+    update_df = pd.DataFrame({"col": np.arange(0)}, index=pd.DatetimeIndex([]))
+    (
+        lib.update_batch([UpdatePayload(sym, update_df)], upsert=True)
+        if batch
+        else lib.update(sym, update_df, upsert=True)
+    )
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
+    assert lib.list_symbols() == [sym]

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -872,53 +872,6 @@ class TestBatchUpdate:
         assert "symbol_1" in str(ex_info.value)
         assert "symbol_2" not in str(ex_info.value)
 
-    @pytest.mark.parametrize("upsert", [True, False])
-    def test_empty_dataframe_does_not_increase_version(self, lmdb_library, upsert):
-        lib = lmdb_library
-        lib_tool = lib._dev_tools.library_tool()
-        df1 = pd.DataFrame({"a": range(5)}, index=pd.date_range("2024-01-01", periods=5))
-        df2 = pd.DataFrame({"b": range(5)}, index=pd.date_range("2023-01-01", periods=5))
-        lib.write_batch([UpdatePayload("symbol_1", df1), UpdatePayload("symbol_2", df2)])
-        for symbol in ["symbol_1", "symbol_2"]:
-            assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, symbol)) == 1
-            assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, symbol)) == 1
-            assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, symbol)) == 1
-        # One symbol list entry for symbol_1 and one for symbol_2
-        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
-        update_1 = pd.DataFrame({"a": []}, index=pd.date_range("2024-01-01", periods=0))
-        update_2 = pd.DataFrame({"b": [10, 20]}, index=pd.date_range("2023-01-02", periods=2))
-        res = lib.update_batch(
-            [UpdatePayload("symbol_1", update_1), UpdatePayload("symbol_2", update_2)], upsert=upsert
-        )
-
-        assert res[0].version == 0
-        assert res[1].version == 1
-
-        sym_1_vit, sym_2_vit = lib.read("symbol_1"), lib.read("symbol_2")
-
-        assert sym_1_vit.version == 0
-        assert_frame_equal(sym_1_vit.data, df1)
-        assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "symbol_1")) == 1
-        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "symbol_1")) == 1
-        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "symbol_1")) == 1
-
-        assert sym_2_vit.version == 1
-        assert_frame_equal(
-            sym_2_vit.data, pd.DataFrame({"b": [0, 10, 20, 3, 4]}, index=pd.date_range("2023-01-01", periods=5))
-        )
-        assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "symbol_2")) == 2
-        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "symbol_2")) == 2
-        # Update happens in the middle of the dataframe. Data prior the update range (value 0) is in one segment, then
-        # there's one segment for the new data (values 10, 20) then there's one segment for the data that's pas the
-        # update range (values 3, 4). The fourth segment is the original data segment
-        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "symbol_2")) == 4
-        assert len(lib_tool.read_index("symbol_2")) == 3
-
-        # This result is wrong. The correct value is 2. This is due to a bug Monday: 9682041273, append_batch and
-        # update_batch should not create symbol list keys for already existing symbols. Since update_batch is noop when
-        # the input is empty, there is no key for symbol_1, but there is a new key for symbol_2 and that is wrong.
-        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 3
-
     def test_empty_dataframe_with_daterange_does_not_delete_data(self, lmdb_library):
         sym = "symbol_1"
         input_df = pd.DataFrame({"a": [1, 2]}, index=pd.date_range(start=pd.Timestamp("2024-01-02"), periods=2))
@@ -930,7 +883,7 @@ class TestBatchUpdate:
         )
         lmdb_library.update_batch([payload])
         vit = lmdb_library.read(sym)
-        assert vit.version == 0
+        assert vit.version == 1
         assert_frame_equal(vit.data, input_df)
 
 
@@ -1038,3 +991,28 @@ def test_update_new_data_contains_old(version_store_factory):
     lib_tool = lib.library_tool()
     assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 55
     assert len(lib_tool.read_index("sym")) == 30
+
+
+@pytest.mark.parametrize("batch", [True, False])
+def test_update_empty_frame_metadata(lmdb_library, batch):
+    # Need to use a V2 API fixture as there is no batch_update on the V1 API
+    lib = lmdb_library
+    sym = "test_update_empty_frame_metadata"
+    write_df = pd.DataFrame({"col": np.arange(1)}, index=[pd.Timestamp("2026-01-01")])
+    metadata_v0 = "v0"
+    lib.write(sym, write_df, metadata=metadata_v0)
+    empty_df = pd.DataFrame(
+        {"col": np.arange(0)}, index=pd.DatetimeIndex([])
+    )  # Using arange guarantees the dtype matches the written df
+    metadata_v1 = "v1"
+    update_vit = (
+        lib.update_batch([UpdatePayload(sym, empty_df, metadata_v1)])[0]
+        if batch
+        else lib.update(sym, empty_df, metadata=metadata_v1)
+    )
+    assert update_vit.version == 1
+    assert update_vit.metadata == metadata_v1
+    read_vit = lib.read(sym)
+    assert read_vit.version == 1
+    assert read_vit.metadata == metadata_v1
+    assert_frame_equal(read_vit.data, write_df)

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -872,6 +872,51 @@ class TestBatchUpdate:
         assert "symbol_1" in str(ex_info.value)
         assert "symbol_2" not in str(ex_info.value)
 
+    @pytest.mark.parametrize("upsert", [True, False])
+    def test_empty_dataframe_increases_version(self, lmdb_library, upsert):
+        lib = lmdb_library
+        lib_tool = lib._dev_tools.library_tool()
+        df1 = pd.DataFrame({"a": range(5)}, index=pd.date_range("2024-01-01", periods=5))
+        df2 = pd.DataFrame({"b": range(5)}, index=pd.date_range("2023-01-01", periods=5))
+        lib.write_batch([UpdatePayload("symbol_1", df1), UpdatePayload("symbol_2", df2)])
+        for symbol in ["symbol_1", "symbol_2"]:
+            assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, symbol)) == 1
+            assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, symbol)) == 1
+            assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, symbol)) == 1
+        # One symbol list entry for symbol_1 and one for symbol_2
+        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
+        update_1 = pd.DataFrame({"a": []}, index=pd.date_range("2024-01-01", periods=0))
+        update_2 = pd.DataFrame({"b": [10, 20]}, index=pd.date_range("2023-01-02", periods=2))
+        res = lib.update_batch(
+            [UpdatePayload("symbol_1", update_1), UpdatePayload("symbol_2", update_2)], upsert=upsert
+        )
+
+        assert res[0].version == 1
+        assert res[1].version == 1
+
+        sym_1_vit, sym_2_vit = lib.read("symbol_1"), lib.read("symbol_2")
+
+        assert sym_1_vit.version == 1
+        assert_frame_equal(sym_1_vit.data, df1)
+        assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "symbol_1")) == 2
+        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "symbol_1")) == 2
+        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "symbol_1")) == 1
+
+        assert sym_2_vit.version == 1
+        assert_frame_equal(
+            sym_2_vit.data, pd.DataFrame({"b": [0, 10, 20, 3, 4]}, index=pd.date_range("2023-01-01", periods=5))
+        )
+        assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, "symbol_2")) == 2
+        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, "symbol_2")) == 2
+        # Update happens in the middle of the dataframe. Data prior the update range (value 0) is in one segment, then
+        # there's one segment for the new data (values 10, 20) then there's one segment for the data that's pas the
+        # update range (values 3, 4). The fourth segment is the original data segment
+        assert len(lib_tool.find_keys_for_symbol(KeyType.TABLE_DATA, "symbol_2")) == 4
+        assert len(lib_tool.read_index("symbol_2")) == 3
+
+        # Updating already existing symbols (i.e. non-upsert path) does not add a symbol list key
+        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
+
     def test_empty_dataframe_with_daterange_does_not_delete_data(self, lmdb_library):
         sym = "symbol_1"
         input_df = pd.DataFrame({"a": [1, 2]}, index=pd.date_range(start=pd.Timestamp("2024-01-02"), periods=2))


### PR DESCRIPTION
#### Reference Issues/PRs
[18103677039](https://man312219.monday.com/boards/7852509418/pulses/18103677039)
[9682041273](https://man312219.monday.com/boards/7852509418/pulses/9682041273)

#### What does this implement or fix?
First commit:
Previously, when an empty dataframe was provided to `append` or `update` (or batch variations thereof), a warning would be logged and no new version was created. In particular, this meant that the provided metadata was not persisted.

Second commit:
Reinstated a test removed as part of the first commit, and then fix the bug where symbol list keys were added on batch append/update even if a live version of the symbol already existed