### PR TITLE
Fix flaky compaction benchmark

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2136,7 +2136,7 @@
                 "10000"
             ]
         ],
-        "setup_cache_key": "compact_data:217",
+        "setup_cache_key": "compact_data:220",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "310049835bc1f2bbaa094caa69c3d1a21e1858b58ef43a2e878480bf72785195"
@@ -2163,7 +2163,7 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:217",
+        "setup_cache_key": "compact_data:220",
         "type": "time",
         "unit": "seconds",
         "version": "2d0282bafa3f8ae8121eb1529f89761519c7b9509a7a8a5b341a807aedc2197d",
@@ -2192,7 +2192,7 @@
                 "True"
             ]
         ],
-        "setup_cache_key": "compact_data:106",
+        "setup_cache_key": "compact_data:110",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "7ddde650100a4d862d7f8695176b37976f15d863d33961be34678a636d14286f"
@@ -2225,7 +2225,7 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:106",
+        "setup_cache_key": "compact_data:110",
         "type": "time",
         "unit": "seconds",
         "version": "22560f846d485befae82958fd482315fb72e650d867e9ffc509eace6a2b93f03",
@@ -2259,7 +2259,7 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "compact_data:162",
+        "setup_cache_key": "compact_data:166",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "a99039af2df70f85781dd519ac84c641eef72187661d78c10a7db379f500b5c7"
@@ -2297,7 +2297,7 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:162",
+        "setup_cache_key": "compact_data:166",
         "type": "time",
         "unit": "seconds",
         "version": "dd92a93207202dec280ad9849eeb15da6c3ebc0bea0dc490759473feb42ee3a5",

--- a/python/benchmarks/compact_data.py
+++ b/python/benchmarks/compact_data.py
@@ -12,13 +12,15 @@ import time
 
 import numpy as np
 import pandas as pd
+import random
 
 from arcticdb import Arctic, LibraryOptions
 from arcticdb.options import ModifiableLibraryOption
 from arcticdb.util.logger import get_logger
 from arcticdb.util.test import random_strings_of_length
 
-rng = np.random.default_rng()
+random.seed(42)
+rng = np.random.default_rng(42)
 
 
 class CompactDataBase:
@@ -77,6 +79,8 @@ class CompactDataBase:
         self.lib = self.ac.get_library(lib_name)
         # Check the compaction will actually do something!
         assert self.lib.compact_data_explain_plan(self.SYM, rows_per_segment=target_rows_per_segment).will_do_work
+        # read the symbol to warm up the cache
+        self.lib.read(self.SYM)
 
     def _teardown(self):
         shutil.rmtree(self.LMDB_DIR)
@@ -174,9 +178,8 @@ class CompactDataStringsStaticSchema(CompactDataBase):
                     for num_unique_strings in self.params[3]:
                         # Create one library per combination of benchmark parameters, as they don't all use the same
                         # slicing
-                        df = pd.DataFrame(
-                            {f"col_{i}": rng.choice(num_unique_strings, num_rows) for i in range(num_columns)}
-                        )
+                        strings = self.unique_strings[:num_unique_strings]
+                        df = pd.DataFrame({f"col_{i}": rng.choice(strings, num_rows) for i in range(num_columns)})
                         self._setup_cache_base(
                             ac,
                             self.lib_name(row_params, num_columns, column_slicing, num_unique_strings),


### PR DESCRIPTION
#### Reference Issues/PRs
Monday: 12428766378

#### What does this implement or fix?
The main issue with the benchmark was that it did not actually create string columns. It created numerical columns. Now it will be reported significantly slower than the base but that's expected.

Random generators are set up with constant seed for better reproducibility and the library is deliberately read from storage at the end of the setup to warm up the caches.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
