### PR TITLE
Add logging and a visualization for our task queues

### DIFF
--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -15,6 +15,8 @@
 #include <folly/executors/FutureExecutor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/ThreadPoolExecutor.h>
+#include <folly/system/ThreadName.h>
 #include <fmt/format.h>
 #include <thread>
 #include <algorithm>
@@ -61,6 +63,38 @@ class InstrumentedNamedFactory : public folly::ThreadFactory {
   private:
     std::mutex mutex_;
     folly::NamedThreadFactory named_factory_;
+};
+
+inline std::string format_task_stats_line(
+        std::string_view pool, std::string_view thread, const folly::ThreadPoolExecutor::ProcessedTaskInfo& info
+) {
+    return fmt::format(
+            "task_stats pool={} thread={} task_id={} enqueue_ns={} wait_ns={} run_ns={} expired={} priority={}",
+            pool,
+            thread,
+            info.taskId,
+            std::chrono::duration_cast<std::chrono::nanoseconds>(info.enqueueTime.time_since_epoch()).count(),
+            info.waitTime.count(),
+            info.runTime.count(),
+            info.expired,
+            static_cast<int>(info.priority)
+    );
+}
+
+class TaskStatsLoggingObserver : public folly::ThreadPoolExecutor::TaskObserver {
+  public:
+    explicit TaskStatsLoggingObserver(std::string pool) : pool_(std::move(pool)) {}
+
+    void taskProcessed(const folly::ThreadPoolExecutor::ProcessedTaskInfo& info) noexcept override {
+        ARCTICDB_RUNTIME_DEBUG(
+                log::schedule(),
+                "{}",
+                format_task_stats_line(pool_, folly::getCurrentThreadName().value_or("unknown"), info)
+        );
+    }
+
+  private:
+    std::string pool_;
 };
 
 template<typename SchedulerType>
@@ -209,6 +243,11 @@ class TaskScheduler {
         ARCTICDB_RUNTIME_DEBUG(
                 log::schedule(), "Task scheduler created with {:d} {:d}", cpu_thread_count_, io_thread_count_
         );
+        if (ConfigsMap::instance()->get_int("TaskScheduler.LogTaskStats", 0) != 0) {
+            cpu_exec_.addTaskObserver(std::make_unique<TaskStatsLoggingObserver>("CPU"));
+            io_exec_.addTaskObserver(std::make_unique<TaskStatsLoggingObserver>("IO"));
+            ARCTICDB_RUNTIME_DEBUG(log::schedule(), "Task stats logging enabled");
+        }
     }
 
     template<class Task>

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -16,7 +16,15 @@
 #include <arcticdb/util/test/config_common.hpp>
 #include <arcticdb/toolbox/query_stats.hpp>
 
+#include <folly/executors/ThreadPoolExecutor.h>
+#include <folly/system/ThreadName.h>
+#include <arcticdb/log/log.hpp>
+#include <spdlog/sinks/base_sink.h>
+
+#include <algorithm>
+#include <chrono>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <arcticdb/storage/s3/s3_storage.hpp>
@@ -813,4 +821,102 @@ TEST(KeyUtilsDeleteBatching, FlushesPendingBufferAtThreshold) {
     );
 
     ASSERT_EQ(storage->recorded_call_sizes(), std::vector<size_t>({3, 3, 3, 2}));
+}
+
+namespace task_observer_test {
+
+class CapturingSink : public spdlog::sinks::base_sink<std::mutex> {
+  public:
+    std::vector<std::string> snapshot() {
+        std::lock_guard lock(cap_mutex_);
+        return messages_;
+    }
+
+  protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        std::lock_guard lock(cap_mutex_);
+        messages_.emplace_back(msg.payload.data(), msg.payload.size());
+    }
+
+    void flush_() override {}
+
+  private:
+    std::mutex cap_mutex_;
+    std::vector<std::string> messages_;
+};
+
+struct SleepTask : arcticdb::async::BaseTask {
+    folly::Unit operator()() const {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        return folly::Unit{};
+    }
+};
+
+} // namespace task_observer_test
+
+TEST(Async, TaskStatsLoggingObserverLogsBothPools) {
+    using namespace task_observer_test;
+
+    auto& logger = arcticdb::log::schedule();
+    auto sink = std::make_shared<CapturingSink>();
+    const auto saved_level = logger.level();
+    logger.sinks().push_back(sink);
+    logger.set_level(spdlog::level::debug);
+
+    auto find_line = [&](const std::string& prefix) {
+        for (const auto& m : sink->snapshot()) {
+            if (m.rfind(prefix, 0) == 0) {
+                return m;
+            }
+        }
+        return std::string{};
+    };
+
+    {
+        arcticdb::async::TaskScheduler sched{1, 1};
+        sched.cpu_exec().addTaskObserver(std::make_unique<arcticdb::async::TaskStatsLoggingObserver>("CPU"));
+        sched.io_exec().addTaskObserver(std::make_unique<arcticdb::async::TaskStatsLoggingObserver>("IO"));
+
+        sched.submit_cpu_task(SleepTask{}).get();
+        sched.submit_io_task(SleepTask{}).get();
+
+        for (auto i = 0;
+             i < 500 && (find_line("task_stats pool=CPU").empty() || find_line("task_stats pool=IO").empty());
+             ++i) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+    logger.set_level(saved_level);
+    auto& sinks = logger.sinks();
+    sinks.erase(std::remove(sinks.begin(), sinks.end(), sink), sinks.end());
+
+    const auto cpu_line = find_line("task_stats pool=CPU");
+    const auto io_line = find_line("task_stats pool=IO");
+
+    ASSERT_FALSE(cpu_line.empty()) << "no CPU task_stats record logged";
+    ASSERT_FALSE(io_line.empty()) << "no IO task_stats record logged";
+#ifndef _WIN32
+    // folly::getCurrentThreadName() is unimplemented on Windows, so the thread field reads "unknown" there.
+    EXPECT_NE(cpu_line.find("thread=CPUPool"), std::string::npos) << cpu_line;
+    EXPECT_NE(io_line.find("thread=IOPool"), std::string::npos) << io_line;
+#endif
+    EXPECT_NE(cpu_line.find("run_ns="), std::string::npos) << cpu_line;
+    EXPECT_NE(io_line.find("run_ns="), std::string::npos) << io_line;
+}
+
+TEST(Async, FormatTaskStatsLine) {
+    folly::ThreadPoolExecutor::ProcessedTaskInfo info;
+    info.taskId = 42;
+    info.priority = 3;
+    info.enqueueTime = std::chrono::steady_clock::time_point{std::chrono::nanoseconds{1000}};
+    info.waitTime = std::chrono::nanoseconds{250};
+    info.runTime = std::chrono::nanoseconds{9000};
+    info.expired = false;
+
+    ASSERT_EQ(
+            arcticdb::async::format_task_stats_line("IO", "IOPool7", info),
+            "task_stats pool=IO thread=IOPool7 task_id=42 enqueue_ns=1000 wait_ns=250 run_ns=9000 expired=false "
+            "priority=3"
+    );
 }

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -95,6 +95,29 @@ If only `NumCPUThreads` is set, `NumIOThreads` will still default to x1.5 `NumCP
 
 <sup>\*</sup>On Linux machines, this core count takes cgroups into account. In particular, this means that CPU limits are respected in processes running in Kubernetes.
 
+### TaskScheduler.LogTaskStats
+
+Enable per-task diagnostics for the CPU and IO threadpools. When set to `1`, ArcticDB logs one record per completed task to the `schedule` log stream, recording which pool and worker thread ran the task, how long it waited in the queue, and how long it ran:
+
+```
+task_stats pool=IO thread=IOPool7 task_id=42 enqueue_ns=... wait_ns=... run_ns=... expired=false priority=0
+```
+
+Values:
+* 0: Disable (Default)
+* 1: Enable
+
+The records are logged at the `DEBUG` level, so you must also raise the `schedule` stream to `DEBUG` (see [Logging configuration](#logging-configuration) below). For example, to capture the records to a file:
+
+```
+ARCTICDB_TaskScheduler_LogTaskStats_int=1 ARCTICDB_schedule_loglevel=DEBUG \
+    python your_app.py 2> task_stats.log
+```
+
+The `thread` field is not supported on Windows and reads `unknown` there.
+
+The [`scripts/analyze_task_scheduler_queues.py`](https://github.com/man-group/ArcticDB/blob/master/scripts/analyze_task_scheduler_queues.py) script parses the captured log and provides a visualization.
+
 ### VersionStore.WillItemBePickledWarningMsg
 
 Control whether a detailed message explaining how the item is normalized is logged when calling the `will_item_be_pickled` function.

--- a/scripts/analyze_task_scheduler_queues.example_output.txt
+++ b/scripts/analyze_task_scheduler_queues.example_output.txt
@@ -1,0 +1,52 @@
+
+=== CPU pool ===
+  tasks:        107
+  peak depth:   4  (tasks waiting, not yet started)
+  wait:         p50 29.44us  p90 215.42us  p99 337.90us  max 343.25us
+  run:          p50 2.67ms  p90 8.58ms  p99 8.80ms  max 8.82ms
+  depth over time: ▁▁▃▁▁▁▃▃▃▃▃▃▃▁▃▃▃▃▃▃▃▃▃▃▁▃▃▁▃▃▁▁▃▃▁▁▅▁▁▁▃▃▃▁▁▃▃▁▁▃▃▃▃▃▁▁▃█▆▆
+  wait histogram:
+          <1us      0 
+        1-10us      3 █
+      10-100us     84 ████████████████████████████████████████
+     100us-1ms     20 ██████████
+        1-10ms      0 
+      10-100ms      0 
+        >100ms      0 
+  run histogram:
+          <1us      0 
+        1-10us      0 
+      10-100us      2 █
+     100us-1ms      6 ██
+        1-10ms     99 ████████████████████████████████████████
+      10-100ms      0 
+        >100ms      0 
+
+=== IO pool ===
+  tasks:        56
+  peak depth:   6  (tasks waiting, not yet started)
+  wait:         p50 10.26ms  p90 14.06ms  p99 25.48ms  max 27.30ms
+  run:          p50 10.65ms  p90 13.39ms  p99 16.35ms  max 17.30ms
+  depth over time: ▂▂▆▁▁▁▇▇▇▇▇▇▇▁▇▇▇▇▇▇▇▇▇▁▇▇▇▁▇▇▁▁▇▇▁▁█▁▁▁▇▇▇▁▁▇▅▁▁▃▁▁▁▁▁▁▂▁▁▂
+  wait histogram:
+          <1us      0 
+        1-10us      0 
+      10-100us     13 █████████████████
+     100us-1ms      1 █
+        1-10ms     11 ██████████████
+      10-100ms     31 ████████████████████████████████████████
+        >100ms      0 
+  run histogram:
+          <1us      0 
+        1-10us      0 
+      10-100us      2 ██
+     100us-1ms      3 ███
+        1-10ms     15 █████████████████
+      10-100ms     36 ████████████████████████████████████████
+        >100ms      0 
+
+  per-thread load (bar = busy time, round-robin imbalance shows here):
+    IOPool0          17 tasks  busy  149.44ms  wait p99   22.39ms  ████████████████████████████████████████
+    IOPool1          13 tasks  busy  140.44ms  wait p99   25.71ms  ██████████████████████████████████████
+    IOPool2          13 tasks  busy  136.31ms  wait p99   22.62ms  ████████████████████████████████████
+    IOPool3          13 tasks  busy  143.66ms  wait p99   19.76ms  ██████████████████████████████████████

--- a/scripts/analyze_task_scheduler_queues.py
+++ b/scripts/analyze_task_scheduler_queues.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Post-hoc analysis of ArcticDB task-scheduler queue behaviour.
+
+Reads a captured log file (or stdin) containing ``task_stats`` records emitted by
+``TaskStatsLoggingObserver``. Each record is one completed task:
+
+    task_stats pool=IO thread=IOPool7 task_id=42 enqueue_ns=1000 wait_ns=250 run_ns=9000 \
+        expired=false priority=3
+
+Enable the logging with two environment variables, both read at ``import arcticdb``:
+
+    ARCTICDB_TaskScheduler_LogTaskStats_int=1   # add the observer to both pools
+    ARCTICDB_schedule_loglevel=DEBUG            # emit the records (schedule logger to debug)
+
+The records go to stderr by default, so capture them with a redirect and feed the file here:
+
+    ARCTICDB_TaskScheduler_LogTaskStats_int=1 ARCTICDB_schedule_loglevel=DEBUG \
+        python your_app.py 2> app.log
+    scripts/analyze_task_scheduler_queues.py app.log
+
+Times are ``steady_clock`` nanoseconds (monotonic, arbitrary origin); the script normalises
+them to the earliest enqueue seen.
+
+From one line per task it reconstructs, per pool:
+  * wait-time and run-time distributions,
+  * the queue-depth (tasks enqueued but not yet started) timeline and its peak,
+and per IO worker thread it shows the round-robin load imbalance that the pool-wide
+``getPendingTaskCount`` cannot reveal.
+
+Usage:
+    scripts/analyze_task_scheduler_queues.py app.log
+    grep task_stats app.log | scripts/analyze_task_scheduler_queues.py -
+
+See ``analyze_task_scheduler_queues.example_output.txt`` (alongside this script) for a sample
+report: a QueryBuilder filter over an S3 backend throttled to 4 I/O threads, where the I/O
+pool queues heavily and the wait histogram shifts into the 10-100ms bucket.
+"""
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+
+_FIELD_RE = re.compile(r"(\w+)=(\S+)")
+_TRAILING_INT_RE = re.compile(r"^(.*?)(\d*)$")
+_SPARK = "▁▂▃▄▅▆▇█"
+
+_LATENCY_EDGES_NS = (1e3, 1e4, 1e5, 1e6, 1e7, 1e8)
+_LATENCY_LABELS = ("<1us", "1-10us", "10-100us", "100us-1ms", "1-10ms", "10-100ms", ">100ms")
+
+
+def thread_sort_key(name):
+    prefix, digits = _TRAILING_INT_RE.match(name).groups()
+    return prefix, int(digits) if digits else -1
+
+
+def histogram(values, edges, labels, width=40):
+    counts = [0] * len(labels)
+    for v in values:
+        b = 0
+        while b < len(edges) and v >= edges[b]:
+            b += 1
+        counts[b] += 1
+    peak = max(counts) if counts else 0
+    lines = []
+    for label, count in zip(labels, counts):
+        bar = "█" * round(count / peak * width) if peak and count else ""
+        lines.append(f"    {label:>10} {count:>6} {bar}")
+    return "\n".join(lines)
+
+
+class Record:
+    __slots__ = ("pool", "thread", "enqueue_ns", "wait_ns", "run_ns", "expired")
+
+    def __init__(self, fields):
+        self.pool = fields["pool"]
+        self.thread = fields["thread"]
+        self.enqueue_ns = int(fields["enqueue_ns"])
+        self.wait_ns = int(fields["wait_ns"])
+        self.run_ns = int(fields["run_ns"])
+        self.expired = fields.get("expired") == "true"
+
+    @property
+    def start_ns(self):
+        return self.enqueue_ns + self.wait_ns
+
+    @property
+    def end_ns(self):
+        return self.start_ns + self.run_ns
+
+
+def parse(lines):
+    records = []
+    for line in lines:
+        idx = line.find("task_stats ")
+        if idx == -1:
+            continue
+        fields = dict(_FIELD_RE.findall(line[idx:]))
+        if "pool" not in fields or "enqueue_ns" not in fields:
+            continue
+        try:
+            records.append(Record(fields))
+        except (KeyError, ValueError):
+            continue
+    return records
+
+
+def percentile(sorted_values, q):
+    if not sorted_values:
+        return 0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    pos = q / 100.0 * (len(sorted_values) - 1)
+    lo = int(pos)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = pos - lo
+    return sorted_values[lo] * (1 - frac) + sorted_values[hi] * frac
+
+
+def fmt_ns(ns):
+    for unit, scale in (("s", 1e9), ("ms", 1e6), ("us", 1e3)):
+        if ns >= scale:
+            return f"{ns / scale:.2f}{unit}"
+    return f"{ns:.0f}ns"
+
+
+def bar(value, peak, width=40):
+    if peak <= 0:
+        return ""
+    return "█" * max(1, round(value / peak * width)) if value > 0 else ""
+
+
+def sparkline(counts):
+    peak = max(counts) if counts else 0
+    if peak <= 0:
+        return " " * len(counts)
+    return "".join(_SPARK[min(len(_SPARK) - 1, round(c / peak * (len(_SPARK) - 1)))] for c in counts)
+
+
+def max_queue_depth(records):
+    events = []
+    for r in records:
+        events.append((r.enqueue_ns, 1))
+        events.append((r.start_ns, -1))
+    events.sort()
+    depth = 0
+    peak = 0
+    for _, delta in events:
+        depth += delta
+        peak = max(peak, depth)
+    return peak
+
+
+def depth_timeline(records, t0, buckets):
+    if not records:
+        return [0] * buckets
+    span = max(r.start_ns for r in records) - t0
+    if span <= 0:
+        return [0] * buckets
+    events = []
+    for r in records:
+        events.append((r.enqueue_ns, 1))
+        events.append((r.start_ns, -1))
+    events.sort()
+    peak_per_bucket = [0] * buckets
+    depth = 0
+    for t, delta in events:
+        depth += delta
+        b = min(buckets - 1, int((t - t0) / span * buckets))
+        peak_per_bucket[b] = max(peak_per_bucket[b], depth)
+    return peak_per_bucket
+
+
+def report_pool(pool, records, t0, buckets):
+    waits = sorted(r.wait_ns for r in records)
+    runs = sorted(r.run_ns for r in records)
+    expired = sum(1 for r in records if r.expired)
+
+    print(f"\n=== {pool} pool ===")
+    print(f"  tasks:        {len(records)}" + (f"  (expired: {expired})" if expired else ""))
+    print(f"  peak depth:   {max_queue_depth(records)}  (tasks waiting, not yet started)")
+    print(
+        "  wait:         "
+        f"p50 {fmt_ns(percentile(waits, 50))}  p90 {fmt_ns(percentile(waits, 90))}  "
+        f"p99 {fmt_ns(percentile(waits, 99))}  max {fmt_ns(waits[-1])}"
+    )
+    print(
+        "  run:          "
+        f"p50 {fmt_ns(percentile(runs, 50))}  p90 {fmt_ns(percentile(runs, 90))}  "
+        f"p99 {fmt_ns(percentile(runs, 99))}  max {fmt_ns(runs[-1])}"
+    )
+    print(f"  depth over time: {sparkline(depth_timeline(records, t0, buckets))}")
+    print("  wait histogram:")
+    print(histogram(waits, _LATENCY_EDGES_NS, _LATENCY_LABELS))
+    print("  run histogram:")
+    print(histogram(runs, _LATENCY_EDGES_NS, _LATENCY_LABELS))
+
+
+def report_io_threads(records):
+    by_thread = defaultdict(list)
+    for r in records:
+        by_thread[r.thread].append(r)
+    if len(by_thread) <= 1:
+        return
+
+    busy = {t: sum(r.run_ns for r in rs) for t, rs in by_thread.items()}
+    peak_busy = max(busy.values())
+    print("\n  per-thread load (bar = busy time, round-robin imbalance shows here):")
+    for thread in sorted(by_thread, key=thread_sort_key):
+        rs = by_thread[thread]
+        waits = sorted(r.wait_ns for r in rs)
+        print(
+            f"    {thread:<12} {len(rs):>6} tasks  busy {fmt_ns(busy[thread]):>9}  "
+            f"wait p99 {fmt_ns(percentile(waits, 99)):>9}  {bar(busy[thread], peak_busy)}"
+        )
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("logfile", help="log file to read, or - for stdin")
+    ap.add_argument("--buckets", type=int, default=60, help="time buckets for the depth sparkline (default 60)")
+    args = ap.parse_args()
+
+    stream = sys.stdin if args.logfile == "-" else open(args.logfile)
+    with stream:
+        records = parse(stream)
+
+    if not records:
+        print("No task_stats records found.", file=sys.stderr)
+        return 1
+
+    t0 = min(r.enqueue_ns for r in records)
+    by_pool = defaultdict(list)
+    for r in records:
+        by_pool[r.pool].append(r)
+
+    for pool in sorted(by_pool):
+        report_pool(pool, by_pool[pool], t0, args.buckets)
+        if pool == "IO":
+            report_io_threads(by_pool[pool])
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Add a setting to enable per-task diagnostics for the CPU and IO threadpools. When set to `1`, ArcticDB logs one record per completed task to the `schedule` log stream, recording which pool and worker thread ran the task, how long it waited in the queue, and how long it ran:

```
task_stats pool=IO thread=IOPool7 task_id=42 enqueue_ns=... wait_ns=... run_ns=... expired=false priority=0
```

The logging is done when the task finishes and is done at the Folly level so covers work submitted outside of our `BaseTask` framework.

Values:
* 0: Disable (Default)
* 1: Enable

The records are logged at the `DEBUG` level, so you must also raise the `schedule` stream to `DEBUG` (see [Logging configuration](#logging-configuration) below). For example, to capture the records to a file:

```
ARCTICDB_TaskScheduler_LogTaskStats_int=1 ARCTICDB_schedule_loglevel=DEBUG \
    python your_app.py 2> task_stats.log
```

The [`scripts/analyze_task_scheduler_queues.py`](https://github.com/man-group/ArcticDB/blob/master/scripts/analyze_task_scheduler_queues.py) script parses the captured log and provides a visualization.

Example output:

```
=== CPU pool ===
  tasks:        107
  peak depth:   4  (tasks waiting, not yet started)
  wait:         p50 29.44us  p90 215.42us  p99 337.90us  max 343.25us
  run:          p50 2.67ms  p90 8.58ms  p99 8.80ms  max 8.82ms
  depth over time: ▁▁▃▁▁▁▃▃▃▃▃▃▃▁▃▃▃▃▃▃▃▃▃▃▁▃▃▁▃▃▁▁▃▃▁▁▅▁▁▁▃▃▃▁▁▃▃▁▁▃▃▃▃▃▁▁▃█▆▆
  wait histogram:
          <1us      0 
        1-10us      3 █
      10-100us     84 ████████████████████████████████████████
     100us-1ms     20 ██████████
        1-10ms      0 
      10-100ms      0 
        >100ms      0 
  run histogram:
          <1us      0 
        1-10us      0 
      10-100us      2 █
     100us-1ms      6 ██
        1-10ms     99 ████████████████████████████████████████
      10-100ms      0 
        >100ms      0 

=== IO pool ===
  tasks:        56
  peak depth:   6  (tasks waiting, not yet started)
  wait:         p50 10.26ms  p90 14.06ms  p99 25.48ms  max 27.30ms
  run:          p50 10.65ms  p90 13.39ms  p99 16.35ms  max 17.30ms
  depth over time: ▂▂▆▁▁▁▇▇▇▇▇▇▇▁▇▇▇▇▇▇▇▇▇▁▇▇▇▁▇▇▁▁▇▇▁▁█▁▁▁▇▇▇▁▁▇▅▁▁▃▁▁▁▁▁▁▂▁▁▂
  wait histogram:
          <1us      0 
        1-10us      0 
      10-100us     13 █████████████████
     100us-1ms      1 █
        1-10ms     11 ██████████████
      10-100ms     31 ████████████████████████████████████████
        >100ms      0 
  run histogram:
          <1us      0 
        1-10us      0 
      10-100us      2 ██
     100us-1ms      3 ███
        1-10ms     15 █████████████████
      10-100ms     36 ████████████████████████████████████████
        >100ms      0 

  per-thread load (bar = busy time, round-robin imbalance shows here):
    IOPool0          17 tasks  busy  149.44ms  wait p99   22.39ms  ████████████████████████████████████████
    IOPool1          13 tasks  busy  140.44ms  wait p99   25.71ms  ██████████████████████████████████████
    IOPool2          13 tasks  busy  136.31ms  wait p99   22.62ms  ████████████████████████████████████
    IOPool3          13 tasks  busy  143.66ms  wait p99   19.76ms  ██████████████████████████████████████
```