### PR TITLE
Read Index Key Only Once When Creating Column Stats

### DIFF
--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -251,31 +251,6 @@ ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
     offset_to_stat_info_set_ = true;
 }
 
-void ColumnStats::calculate_offsets(const TimeseriesDescriptor& tsd, utils::MissingColumnsBehavior missing_columns) {
-    util::check(!offset_to_stat_info_set_, "Should not calculate offsets twice");
-    std::unordered_set<std::string> unmangled_names;
-    for (const auto& k : user_specified_column_stats_ | ranges::views::keys) {
-        unmangled_names.insert(k);
-    }
-    auto offsets_and_mangled_names =
-            utils::find_offset_and_mangled_name(unmangled_names, tsd.as_stream_descriptor(), missing_columns);
-    util::check(
-            missing_columns == utils::MissingColumnsBehavior::IGNORE_MISSING ||
-                    offsets_and_mangled_names.size() == user_specified_column_stats_.size(),
-            "Expect calculated offsets_and_mangled_names to match column_stats_"
-    );
-    for (auto& offset_and_mangled_name : offsets_and_mangled_names) {
-        offset_to_stat_info_.emplace(
-                offset_and_mangled_name.offset,
-                NameAndStatTypes{
-                        offset_and_mangled_name.mangled_name,
-                        user_specified_column_stats_.at(offset_and_mangled_name.unmangled_name)
-                }
-        );
-    }
-    offset_to_stat_info_set_ = true;
-}
-
 namespace {
 std::unordered_set<ColumnStatTypeInternal> external_to_internal(ColumnStatType type) {
     switch (type) {
@@ -328,7 +303,6 @@ std::vector<std::string> ColumnStats::drop(const ColumnStats& to_drop, bool warn
             ++it;
         }
     }
-    user_specified_column_stats_ = {};
     return dropped_names;
 }
 
@@ -376,14 +350,10 @@ std::optional<Clause> ColumnStats::clause() const {
     return ColumnStatsGenerationClause(std::move(input_columns), index_generation_aggregators);
 }
 
-bool ColumnStats::empty() const { return user_specified_column_stats_.empty() && offset_to_stat_info_.empty(); }
+bool ColumnStats::empty() const { return offset_to_stat_info_.empty(); }
 
 bool ColumnStats::operator==(const ColumnStats& right) const {
-    if (offset_to_stat_info_set_) {
-        return offset_to_stat_info_ == right.offset_to_stat_info_;
-    } else {
-        return user_specified_column_stats_ == right.user_specified_column_stats_;
-    }
+    return offset_to_stat_info_ == right.offset_to_stat_info_;
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -2,6 +2,7 @@
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/processing/aggregation_interface.hpp>
 #include <arcticdb/processing/unsorted_aggregation.hpp>
+#include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
@@ -133,21 +134,6 @@ void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::
     }
 }
 
-ColumnStats::ColumnStats(const std::unordered_map<std::string, std::unordered_set<std::string>>& column_stats) {
-    for (const auto& [column, column_stat_names] : column_stats) {
-        if (!column_stat_names.empty()) {
-            user_specified_column_stats_[column] = {};
-            for (const auto& column_stat_name : column_stat_names) {
-                auto opt_index_type = name_to_type(column_stat_name);
-                user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                        opt_index_type.has_value(), "Unknown column stat type provided: {}", column_stat_name
-                );
-                user_specified_column_stats_[column].emplace(*opt_index_type);
-            }
-        }
-    }
-}
-
 ColumnStats::ColumnStats(
         const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, const TimeseriesDescriptor& tsd
 ) {
@@ -176,6 +162,65 @@ ColumnStats::ColumnStats(
                 offset_to_stat_info_.emplace(data_col_offset, NameAndStatTypes{name, {external_type}});
             }
         }
+    }
+    offset_to_stat_info_set_ = true;
+}
+
+namespace {
+bool is_col_eligible_for_stats(DataType col_data_type) { return is_numeric_type(col_data_type) || is_bool_type(col_data_type); }
+
+std::string to_user_facing_name_key(
+        const std::string& field_name, const arcticdb::proto::descriptors::NormalizationMetadata::Pandas& common
+) {
+    auto it = common.col_names().find(field_name);
+
+    if (it == common.col_names().end())
+        return "str:" + field_name;
+
+    const auto& info = it->second;
+
+    if (info.is_none())
+        return "none:";
+    if (info.is_empty())
+        return "empty:";
+    if (info.is_int())
+        return "int:" + info.original_name();
+    if (!info.original_name().empty())
+        return "str:" + info.original_name();
+
+    return {};
+}
+
+} // namespace
+
+// Build MINMAX stats for every eligible column, computed directly from the TSD.
+// The outer/primary index is skipped.
+// Rejects symbols with duplicated data-column names.
+ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
+    const auto& fields = tsd.fields();
+    const auto& norm = tsd.normalization();
+
+    const bool has_outer_index = tsd.index().field_count() > 0;
+    const size_t start_filed_index = has_outer_index ? 1 : 0;
+
+    std::unordered_set<std::string> seen_user_names;
+
+    for (size_t field_index = start_filed_index; field_index < fields.size(); ++field_index) {
+        if (!is_col_eligible_for_stats(fields.at(field_index).type().data_type())) {
+            continue;
+        }
+
+        std::string field_name{fields.at(field_index).name()};
+
+        if (norm.has_df()) {
+            user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                    seen_user_names.insert(to_user_facing_name_key(field_name, norm.df().common())).second,
+                    "Cannot create column stats: symbol has duplicated data column name [{}]",
+                    field_name
+            );
+        }
+
+        offset_to_stat_info_.emplace(field_index, NameAndStatTypes{std::move(field_name), {ColumnStatType::MINMAX}});
     }
     offset_to_stat_info_set_ = true;
 }

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -167,18 +167,20 @@ ColumnStats::ColumnStats(
 }
 
 namespace {
-bool is_col_eligible_for_stats(DataType col_data_type) { return is_numeric_type(col_data_type) || is_bool_type(col_data_type); }
+bool is_col_eligible_for_stats(DataType col_data_type) {
+    return is_numeric_type(col_data_type) || is_bool_type(col_data_type);
+}
 
+// Type-disambiguated key for duplicate detection, so that e.g. an integer column labelled 2
+// and a string column labelled "2" are not treated as duplicates.
 std::string to_user_facing_name_key(
-        const std::string& field_name, const arcticdb::proto::descriptors::NormalizationMetadata::Pandas& common
+        std::string_view field_name, const arcticdb::proto::descriptors::NormalizationMetadata::Pandas& common
 ) {
-    auto it = common.col_names().find(field_name);
-
+    auto it = common.col_names().find(std::string{field_name});
     if (it == common.col_names().end())
-        return "str:" + field_name;
+        return "str:" + std::string{field_name};
 
     const auto& info = it->second;
-
     if (info.is_none())
         return "none:";
     if (info.is_empty())
@@ -188,7 +190,26 @@ std::string to_user_facing_name_key(
     if (!info.original_name().empty())
         return "str:" + info.original_name();
 
-    return {};
+    return "str:" + std::string{field_name};
+}
+
+// The denormalized column name as the user sees it, for error messages.
+std::string to_user_facing_display_name(
+        std::string_view field_name, const arcticdb::proto::descriptors::NormalizationMetadata::Pandas& common
+) {
+    auto it = common.col_names().find(std::string{field_name});
+    if (it == common.col_names().end())
+        return std::string{field_name};
+
+    const auto& info = it->second;
+    if (info.is_none())
+        return "None";
+    if (info.is_empty())
+        return "";
+    if (info.is_int() || !info.original_name().empty())
+        return info.original_name();
+
+    return std::string{field_name};
 }
 
 } // namespace

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -194,14 +194,14 @@ std::string to_user_facing_name_key(
 } // namespace
 
 // Build MINMAX stats for every eligible column, computed directly from the TSD.
-// The outer/primary index is skipped.
+// The timeseries index is skipped.
 // Rejects symbols with duplicated data-column names.
 ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
     const auto& fields = tsd.fields();
     const auto& norm = tsd.normalization();
 
-    const bool has_outer_index = tsd.index().field_count() > 0;
-    const size_t start_filed_index = has_outer_index ? 1 : 0;
+    const bool has_timeseries_index = tsd.index().field_count() > 0;
+    const size_t start_field_index = has_timeseries_index ? 1 : 0;
 
     std::unordered_set<std::string> seen_user_names;
 

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -205,19 +205,24 @@ ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
 
     std::unordered_set<std::string> seen_user_names;
 
-    for (size_t field_index = start_filed_index; field_index < fields.size(); ++field_index) {
-        if (!is_col_eligible_for_stats(fields.at(field_index).type().data_type())) {
+    for (const auto& [field_index, field] : folly::enumerate(fields)) {
+        if (field_index < start_field_index) {
+            continue;
+        }
+        if (!is_col_eligible_for_stats(field.type().data_type())) {
             continue;
         }
 
-        std::string field_name{fields.at(field_index).name()};
+        std::string field_name{field.name()};
 
         if (norm.has_df()) {
-            user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                    seen_user_names.insert(to_user_facing_name_key(field_name, norm.df().common())).second,
-                    "Cannot create column stats: symbol has duplicated data column name [{}]",
-                    field_name
-            );
+            const auto& common = norm.df().common();
+            if (!seen_user_names.insert(to_user_facing_name_key(field.name(), common)).second) {
+                user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                        "Cannot create column stats: symbol has duplicated data column name [{}]",
+                        to_user_facing_display_name(field.name(), common)
+                );
+            }
         }
 
         offset_to_stat_info_.emplace(field_index, NameAndStatTypes{std::move(field_name), {ColumnStatType::MINMAX}});

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -40,7 +40,7 @@ std::string to_segment_column_name(const std::string& column, ColumnStatTypeInte
 
 class ColumnStats {
   public:
-    explicit ColumnStats(const std::unordered_map<std::string, std::unordered_set<std::string>>& column_stats);
+    explicit ColumnStats(const TimeseriesDescriptor& tsd);
     explicit ColumnStats(
             const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, const TimeseriesDescriptor& tsd
     );

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -48,12 +48,6 @@ class ColumnStats {
     // Returns the segment column names of the dropped stats (e.g. "v1_MIN(col)", "v1_MAX(col)")
     std::vector<std::string> drop(const ColumnStats& to_drop, bool warn_if_missing = true);
 
-    // Calculate the fields to which the column stats refer.
-    void calculate_offsets(
-            const TimeseriesDescriptor& tsd,
-            utils::MissingColumnsBehavior missing_columns = utils::MissingColumnsBehavior::RAISE
-    );
-
     std::unordered_map<std::string, std::unordered_set<std::string>> to_map() const;
     std::optional<Clause> clause() const;
     bool empty() const;
@@ -61,8 +55,6 @@ class ColumnStats {
     bool operator==(const ColumnStats& right) const;
 
   private:
-    // Use ordered map/set here for consistent ordering in the resulting stats objects
-    std::map<std::string, std::set<ColumnStatType>> user_specified_column_stats_;
     std::unordered_map<size_t, NameAndStatTypes> offset_to_stat_info_;
     bool offset_to_stat_info_set_{false};
 };

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -172,16 +172,15 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_inde
 }
 
 void LocalVersionedEngine::create_column_stats_internal(
-        const VersionedItem& versioned_item, ColumnStats& column_stats, const ReadOptions& read_options
+        const VersionedItem& versioned_item, const ReadOptions& read_options
 ) {
     ARCTICDB_RUNTIME_SAMPLE(CreateColumnStatsInternal, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: create_column_stats");
-    create_column_stats_impl(store(), versioned_item, column_stats, read_options);
+    create_column_stats_impl(store(), versioned_item, read_options);
 }
 
 void LocalVersionedEngine::create_column_stats_version_internal(
-        const StreamId& stream_id, ColumnStats& column_stats, const VersionQuery& version_query,
-        const ReadOptions& read_options
+        const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options
 ) {
     auto versioned_item = get_version_to_read(stream_id, version_query);
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
@@ -189,7 +188,7 @@ void LocalVersionedEngine::create_column_stats_version_internal(
             "create_column_stats_version_internal: version not found for stream '{}'",
             stream_id
     );
-    create_column_stats_internal(versioned_item.value(), column_stats, read_options);
+    create_column_stats_internal(versioned_item.value(), read_options);
 }
 
 void LocalVersionedEngine::drop_column_stats_internal(

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -191,17 +191,14 @@ void LocalVersionedEngine::create_column_stats_version_internal(
     create_column_stats_internal(versioned_item.value(), read_options);
 }
 
-void LocalVersionedEngine::drop_column_stats_internal(
-        const VersionedItem& versioned_item, const std::optional<ColumnStats>& column_stats_to_drop
-) {
+void LocalVersionedEngine::drop_column_stats_internal(const VersionedItem& versioned_item) {
     ARCTICDB_RUNTIME_SAMPLE(DropColumnStatsInternal, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: drop_column_stats");
-    drop_column_stats_impl(store(), versioned_item, column_stats_to_drop);
+    drop_column_stats_impl(store(), versioned_item);
 }
 
 void LocalVersionedEngine::drop_column_stats_version_internal(
-        const StreamId& stream_id, const std::optional<ColumnStats>& column_stats_to_drop,
-        const VersionQuery& version_query
+        const StreamId& stream_id, const VersionQuery& version_query
 ) {
     auto versioned_item = get_version_to_read(stream_id, version_query);
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
@@ -209,7 +206,7 @@ void LocalVersionedEngine::drop_column_stats_version_internal(
             "drop_column_stats_version_internal: version not found for stream '{}'",
             stream_id
     );
-    drop_column_stats_internal(versioned_item.value(), column_stats_to_drop);
+    drop_column_stats_internal(versioned_item.value());
 }
 
 FrameAndDescriptor LocalVersionedEngine::read_column_stats_internal(const VersionedItem& versioned_item) {

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -246,13 +246,10 @@ class LocalVersionedEngine : public VersionedEngine {
             const VersionQuery& version_query
     );
 
-    void create_column_stats_internal(
-            const VersionedItem& versioned_item, ColumnStats& column_stats, const ReadOptions& read_options
-    );
+    void create_column_stats_internal(const VersionedItem& versioned_item, const ReadOptions& read_options);
 
     void create_column_stats_version_internal(
-            const StreamId& stream_id, ColumnStats& column_stats, const VersionQuery& version_query,
-            const ReadOptions& read_options
+            const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options
     );
 
     void drop_column_stats_internal(

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -252,14 +252,9 @@ class LocalVersionedEngine : public VersionedEngine {
             const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options
     );
 
-    void drop_column_stats_internal(
-            const VersionedItem& versioned_item, const std::optional<ColumnStats>& column_stats_to_drop
-    );
+    void drop_column_stats_internal(const VersionedItem& versioned_item);
 
-    void drop_column_stats_version_internal(
-            const StreamId& stream_id, const std::optional<ColumnStats>& column_stats_to_drop,
-            const VersionQuery& version_query
-    );
+    void drop_column_stats_version_internal(const StreamId& stream_id, const VersionQuery& version_query);
 
     FrameAndDescriptor read_column_stats_internal(const VersionedItem& versioned_item);
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -569,9 +569,7 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             .value("ASCENDING", SortedValue::ASCENDING)
             .value("DESCENDING", SortedValue::DESCENDING);
 
-    py::class_<ColumnStats>(version, "ColumnStats")
-            .def(py::init<std::unordered_map<std::string, std::unordered_set<std::string>>>())
-            .def("to_map", &ColumnStats::to_map);
+    py::class_<ColumnStats>(version, "ColumnStats").def("to_map", &ColumnStats::to_map);
 
     py::class_<ColumnName>(version, "ColumnName").def(py::init([](const std::string& name) {
         return ColumnName(name);

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2124,86 +2124,11 @@ void create_column_stats_impl(
     }
 }
 
-void drop_column_stats_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item,
-        const std::optional<ColumnStats>& column_stats_to_drop
-) {
+void drop_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item) {
     storage::RemoveOpts remove_opts;
     remove_opts.ignores_missing_key_ = true;
     auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
-    if (!column_stats_to_drop.has_value()) {
-        // Drop all column stats
-        store->remove_key(column_stats_key, remove_opts).get();
-        return;
-    }
-
-    storage::ReadKeyOpts read_opts;
-    read_opts.dont_warn_about_missing_key = true;
-    auto stats_future = store->read(column_stats_key, read_opts);
-    auto tsd_future = store->read_timeseries_descriptor(versioned_item.key_, read_opts);
-    auto [stats_try, tsd_try] = folly::collectAll(std::move(stats_future), std::move(tsd_future)).get();
-
-    if (stats_try.hasException()) {
-        log::version().warn("No column stats exist to drop: {}", stats_try.exception().what());
-        return;
-    }
-    if (tsd_try.hasException()) {
-        log::version().warn(
-                "Could not find index key associated with stats - cannot drop: key={} error={}",
-                versioned_item.key_,
-                tsd_try.exception().what()
-        );
-        return;
-    }
-
-    auto segment_in_memory = std::move(stats_try).value().second;
-    auto tsd = std::move(tsd_try).value().second;
-
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader column_stats_header;
-    auto* metadata = segment_in_memory.metadata();
-    if (!metadata) {
-        log::version().warn("Found Column Stats key without metadata? {}", column_stats_key);
-        return;
-    }
-    bool unpacked = metadata->UnpackTo(&column_stats_header);
-    util::check(unpacked, "Failed to unpack column stats header while dropping column stats");
-    ColumnStats column_stats{column_stats_header, tsd};
-    // Ignore missing columns since dropping a non-existent column is a no-op
-    ColumnStats to_drop = *column_stats_to_drop;
-    to_drop.calculate_offsets(tsd, utils::MissingColumnsBehavior::IGNORE_MISSING);
-    auto dropped_names = column_stats.drop(to_drop);
-    if (column_stats.empty()) {
-        // Drop all column stats
-        store->remove_key(column_stats_key, remove_opts).get();
-    } else {
-        ankerl::unordered_dense::set<std::string> dropped_names_set(dropped_names.begin(), dropped_names.end());
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader new_header;
-        new_header.set_version(column_stats_header.version());
-        // Stats columns start at field index 2 (after start_index=0 and end_index=1)
-        auto new_offset = static_cast<size_t>(index::Fields::end_index) + 1;
-        for (const auto& [data_col_offset, entry_list] : column_stats_header.stats_by_column()) {
-            for (const auto& entry : entry_list.entries()) {
-                auto field_name = std::string{segment_in_memory.descriptor().field(entry.stats_seg_offset()).name()};
-                if (dropped_names_set.count(field_name) == 0) {
-                    auto& new_entry_list = (*new_header.mutable_stats_by_column())[data_col_offset];
-                    auto* new_entry = new_entry_list.add_entries();
-                    new_entry->set_type(entry.type());
-                    new_entry->set_stats_seg_offset(new_offset++);
-                }
-            }
-        }
-        google::protobuf::Any any;
-        any.PackFrom(new_header);
-        segment_in_memory.reset_metadata();
-        segment_in_memory.set_metadata(std::move(any));
-
-        for (const auto& name : dropped_names) {
-            segment_in_memory.drop_column(name);
-        }
-        storage::UpdateOpts update_opts;
-        update_opts.upsert_ = true;
-        store->update(column_stats_key, std::move(segment_in_memory), update_opts).get();
-    }
+    store->remove_key(column_stats_key, remove_opts).get();
 }
 
 FrameAndDescriptor read_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item) {

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1987,8 +1987,7 @@ AtomKey index_key_to_column_stats_key(const IndexTypeKey& index_key) {
 }
 
 void create_column_stats_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, ColumnStats& column_stats,
-        const ReadOptions& read_options
+        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options
 ) {
     using namespace arcticdb::pipelines;
     auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
@@ -2027,9 +2026,10 @@ void create_column_stats_impl(
             "Cannot create column stats on pickled data"
     );
 
-    // column_stats contains a user-specified map of string col names to stats. Map these to offsets in to the TSD's
-    // fields.
-    column_stats.calculate_offsets(tsd);
+    ColumnStats column_stats{tsd};
+    if (column_stats.empty()) {
+        return;
+    }
 
     std::optional<SegmentInMemory> old_segment;
     if (column_stats_try.hasException()) {

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -82,10 +82,7 @@ void create_column_stats_impl(
         const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options
 );
 
-void drop_column_stats_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item,
-        const std::optional<ColumnStats>& column_stats_to_drop
-);
+void drop_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item);
 
 FrameAndDescriptor read_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item);
 

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -79,8 +79,7 @@ IndexInformation read_index_key_without_column_stats(const std::shared_ptr<Store
 AtomKey index_key_to_column_stats_key(const IndexTypeKey& index_key);
 
 void create_column_stats_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, ColumnStats& column_stats,
-        const ReadOptions& read_options
+        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options
 );
 
 void drop_column_stats_impl(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -899,12 +899,10 @@ VersionedItem PythonVersionStore::write_metadata(
     return write_versioned_metadata_internal(stream_id, prune_previous_versions, std::move(user_meta_proto));
 }
 
-void PythonVersionStore::create_column_stats_version(
-        const StreamId& stream_id, ColumnStats& column_stats, const VersionQuery& version_query
-) {
+void PythonVersionStore::create_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(cfg().write_options().dynamic_schema());
-    create_column_stats_version_internal(stream_id, column_stats, version_query, read_options);
+    create_column_stats_version_internal(stream_id, version_query, read_options);
 }
 
 void PythonVersionStore::drop_column_stats_version(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -905,11 +905,8 @@ void PythonVersionStore::create_column_stats_version(const StreamId& stream_id, 
     create_column_stats_version_internal(stream_id, version_query, read_options);
 }
 
-void PythonVersionStore::drop_column_stats_version(
-        const StreamId& stream_id, const std::optional<ColumnStats>& column_stats_to_drop,
-        const VersionQuery& version_query
-) {
-    drop_column_stats_version_internal(stream_id, column_stats_to_drop, version_query);
+void PythonVersionStore::drop_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query) {
+    drop_column_stats_version_internal(stream_id, version_query);
 }
 
 ReadResult PythonVersionStore::read_column_stats_version(

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -106,10 +106,7 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     void create_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query);
 
-    void drop_column_stats_version(
-            const StreamId& stream_id, const std::optional<ColumnStats>& column_stats_to_drop,
-            const VersionQuery& version_query
-    );
+    void drop_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query);
 
     ReadResult read_column_stats_version(
             const StreamId& stream_id, const VersionQuery& version_query, std::any& handler_data

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -104,9 +104,7 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     VersionedItem write_metadata(const StreamId& stream_id, const py::object& user_meta, bool prune_previous_versions);
 
-    void create_column_stats_version(
-            const StreamId& stream_id, ColumnStats& column_stats, const VersionQuery& version_query
-    );
+    void create_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query);
 
     void drop_column_stats_version(
             const StreamId& stream_id, const std::optional<ColumnStats>& column_stats_to_drop,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1305,8 +1305,6 @@ class NativeVersionStore:
         -------
         None
         """
-        # Eligible-column detection is done in the C++ layer so that the symbol's index key is
-        # read only once (during stats generation) rather than an extra time here.
         version_query = self._get_version_query(as_of)
         self.version_store.create_column_stats_version(symbol, version_query)
 
@@ -1326,7 +1324,7 @@ class NativeVersionStore:
         None
         """
         version_query = self._get_version_query(as_of)
-        self.version_store.drop_column_stats_version(symbol, None, version_query)
+        self.version_store.drop_column_stats_version(symbol, version_query)
 
     def read_column_stats_experimental(
         self, symbol: str, as_of: Optional[VersionQueryInput] = None, **kwargs

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -68,7 +68,6 @@ from arcticdb_ext.version_store import PythonVersionStoreUpdateQuery as _PythonV
 from arcticdb_ext.version_store import PythonVersionStoreReadOptions as _PythonVersionStoreReadOptions
 from arcticdb_ext.version_store import PythonVersionStoreBatchReadOptions as _PythonVersionStoreBatchReadOptions
 from arcticdb_ext.version_store import PythonVersionStoreVersionQuery as _PythonVersionStoreVersionQuery
-from arcticdb_ext.version_store import ColumnStats as _ColumnStats
 from arcticdb_ext.version_store import StreamDescriptorMismatch
 from arcticdb_ext.version_store import DataError, KeyNotFoundInStageResultInfo
 from arcticdb_ext.version_store import sorted_value_name, PreloadedIndexQuery as _PreloadedIndexQuery
@@ -1306,62 +1305,10 @@ class NativeVersionStore:
         -------
         None
         """
-        column_stats = self._get_eligible_column_stats_spec(symbol, as_of)
-        if not column_stats:
-            return
-
-        column_stats = self._convert_to_native_column_stats(column_stats)
+        # Eligible-column detection is done in the C++ layer so that the symbol's index key is
+        # read only once (during stats generation) rather than an extra time here.
         version_query = self._get_version_query(as_of)
-
-        self.version_store.create_column_stats_version(symbol, column_stats, version_query)
-
-    def _get_eligible_column_stats_spec(self, symbol: str, as_of: Optional[VersionQueryInput]) -> Dict[str, Set[str]]:
-        numeric_value_types = {
-            TypeDescriptor.ValueType.UINT,
-            TypeDescriptor.ValueType.INT,
-            TypeDescriptor.ValueType.FLOAT,
-            TypeDescriptor.ValueType.BOOL,
-            TypeDescriptor.ValueType.NANOSECONDS_UTC,
-        }
-        timeseries_descriptor = self._get_info(symbol, as_of).timeseries_descriptor
-        fields = list(timeseries_descriptor.fields)
-        num_index_fields = self._num_physically_stored_index_fields(timeseries_descriptor)
-
-        start = 1 if num_index_fields > 0 else 0
-        eligible_fields = [field for field in fields[start:] if field.type.value_type in numeric_value_types]
-
-        self._reject_duplicated_data_columns(
-            [field for field in fields[num_index_fields:] if field.type.value_type in numeric_value_types],
-            timeseries_descriptor,
-        )
-
-        return {field.name: {"MINMAX"} for field in eligible_fields}
-
-    @staticmethod
-    def _num_physically_stored_index_fields(timeseries_descriptor) -> int:
-        num_index_fields = timeseries_descriptor.index.field_count()
-
-        normalization = timeseries_descriptor.normalization
-        if normalization.WhichOneof("input_type") != "df":
-            return num_index_fields
-
-        common = normalization.df.common
-        if common.WhichOneof("index_type") == "multi_index":
-            num_index_fields += common.multi_index.field_count
-
-        return num_index_fields
-
-    @staticmethod
-    def _reject_duplicated_data_columns(data_fields, timeseries_descriptor) -> None:
-        normalization = timeseries_descriptor.normalization
-        if normalization.WhichOneof("input_type") != "df":
-            return
-        names, _ = _denormalize_columns_names([field.name for field in data_fields], normalization.df)
-        seen = set()
-        for name in names:
-            if name in seen:
-                raise UserInputException(f"Cannot create column stats: symbol has duplicated column name [{name}]")
-            seen.add(name)
+        self.version_store.create_column_stats_version(symbol, version_query)
 
     def drop_column_stats_experimental(self, symbol: str, as_of: Optional[VersionQueryInput] = None) -> None:
         """
@@ -2447,16 +2394,6 @@ class NativeVersionStore:
             date_range=date_range, row_range=row_range, columns=columns, query_builder=query_builder
         )
         return version_query, read_options, read_query, output_format
-
-    def _convert_to_native_column_stats(self, column_stats):
-        if column_stats is None:
-            return None
-        for k, v in column_stats.items():
-            if k is None:
-                raise UserInputException("Found None key in provided column_stats")
-            if not isinstance(k, str):
-                raise UserInputException(f"Found non-str key in provided column_stats [{k}]")
-        return _ColumnStats(column_stats)
 
     def _postprocess_df_with_only_rowcount_idx(self, read_result, row_range):
         index_meta = read_result.norm.df.common.index

--- a/python/tests/integration/toolbox/test_query_stats.py
+++ b/python/tests/integration/toolbox/test_query_stats.py
@@ -766,42 +766,6 @@ def test_query_stats_in_mem_delete(in_memory_version_store, clear_query_stats):
         assert lists[key_type]["size_bytes"] == 0
 
 
-def test_query_stats_column_stats(s3_version_store_v1, clear_query_stats, sym):
-    df0 = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
-    df1 = pd.DataFrame({"col_1": [3, 4], "col_2": ["c", "d"]}, index=pd.date_range("2000-01-03", periods=2))
-
-    s3_version_store_v1.write(sym, df0)
-    s3_version_store_v1.append(sym, df1)
-
-    qs.enable()
-    s3_version_store_v1.create_column_stats_experimental(sym)
-    stats = qs.get_query_stats()
-    import json
-
-    print(json.dumps(stats, indent=4))
-    # {
-    #     "storage_operations": {
-    #         "S3_PutObject": {
-    #             "COLUMN_STATS": {
-    #                 "count": 1,
-    #                 "size_bytes": 320,
-    #                 "total_time_ms": 15
-    #             }
-    #         }
-    #     }
-    # }
-    assert "storage_operations" in stats
-    storage_operations = stats["storage_operations"]
-
-    assert "S3_PutObject" in storage_operations, storage_operations
-    assert "COLUMN_STATS" in storage_operations["S3_PutObject"], storage_operations
-
-    column_stats = storage_operations["S3_PutObject"]["COLUMN_STATS"]
-    assert column_stats["count"] == 1, column_stats
-    assert column_stats["size_bytes"] > 0, column_stats
-    assert column_stats["total_time_ms"] < 8000, column_stats
-
-
 def test_query_stats_disabled_after_exception(clear_query_stats):
     import arcticdb_ext.tools.query_stats as qs_ext
 

--- a/python/tests/integration/toolbox/test_query_stats.py
+++ b/python/tests/integration/toolbox/test_query_stats.py
@@ -766,6 +766,42 @@ def test_query_stats_in_mem_delete(in_memory_version_store, clear_query_stats):
         assert lists[key_type]["size_bytes"] == 0
 
 
+def test_query_stats_column_stats(s3_version_store_v1, clear_query_stats, sym):
+    df0 = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"col_1": [3, 4], "col_2": ["c", "d"]}, index=pd.date_range("2000-01-03", periods=2))
+
+    s3_version_store_v1.write(sym, df0)
+    s3_version_store_v1.append(sym, df1)
+
+    qs.enable()
+    s3_version_store_v1.create_column_stats_experimental(sym)
+    stats = qs.get_query_stats()
+    import json
+
+    print(json.dumps(stats, indent=4))
+    # {
+    #     "storage_operations": {
+    #         "S3_PutObject": {
+    #             "COLUMN_STATS": {
+    #                 "count": 1,
+    #                 "size_bytes": 320,
+    #                 "total_time_ms": 15
+    #             }
+    #         }
+    #     }
+    # }
+    assert "storage_operations" in stats
+    storage_operations = stats["storage_operations"]
+
+    assert "S3_PutObject" in storage_operations, storage_operations
+    assert "COLUMN_STATS" in storage_operations["S3_PutObject"], storage_operations
+
+    column_stats = storage_operations["S3_PutObject"]["COLUMN_STATS"]
+    assert column_stats["count"] == 1, column_stats
+    assert column_stats["size_bytes"] > 0, column_stats
+    assert column_stats["total_time_ms"] < 8000, column_stats
+
+
 def test_query_stats_disabled_after_exception(clear_query_stats):
     import arcticdb_ext.tools.query_stats as qs_ext
 

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -30,41 +30,27 @@ def get_table_index_read_count():
     return query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX")
 
 
+def get_column_stats_write_count():
+    stats = qs.get_query_stats()
+    return query_stats_operation_count(stats, "Memory_PutObject", "COLUMN_STATS")
+
+
 sym = "sym"
 
 
-def _write_single_segment(lib):
-    df = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
-    lib.write(sym, df)
-
-
-def _write_multi_segment(lib):
+def test_create_column_stats_reads_index_key_once_and_writes_single_key(in_memory_version_store, clear_query_stats):
+    lib = in_memory_version_store
     df0 = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
     df1 = pd.DataFrame({"col_1": [3, 4], "col_2": ["c", "d"]}, index=pd.date_range("2000-01-03", periods=2))
     lib.write(sym, df0)
     lib.append(sym, df1)
-
-
-def _write_multi_index(lib):
-    index = pd.MultiIndex.from_arrays([pd.date_range("2000-01-01", periods=2), [10, 20]], names=["dt", "level"])
-    df = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=index)
-    lib.write(sym, df)
-
-
-@pytest.mark.parametrize(
-    "writer",
-    [_write_single_segment, _write_multi_segment, _write_multi_index],
-    ids=["single_segment", "multi_segment", "multi_index"],
-)
-def test_create_column_stats_reads_index_key_once(in_memory_version_store, clear_query_stats, writer):
-    lib = in_memory_version_store
-    writer(lib)
 
     qs.enable()
     qs.reset_stats()
     lib.create_column_stats_experimental(sym)
 
     assert get_table_index_read_count() == 1, qs.get_query_stats()
+    assert get_column_stats_write_count() == 1, qs.get_query_stats()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -24,7 +24,54 @@ def get_column_stats_read_count():
     return query_stats_operation_count(stats, "Memory_GetObject", "COLUMN_STATS")
 
 
+def get_table_index_read_count():
+    """Get the number of TABLE_INDEX keys read from query stats."""
+    stats = qs.get_query_stats()
+    return query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX")
+
+
 sym = "sym"
+
+
+def _write_single_segment(lib):
+    df = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
+    lib.write(sym, df)
+
+
+def _write_multi_segment(lib):
+    df0 = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"col_1": [3, 4], "col_2": ["c", "d"]}, index=pd.date_range("2000-01-03", periods=2))
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+
+
+def _write_multi_index(lib):
+    index = pd.MultiIndex.from_arrays(
+        [pd.date_range("2000-01-01", periods=2), [10, 20]], names=["dt", "level"]
+    )
+    df = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=index)
+    lib.write(sym, df)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Eligibility computation does a separate descriptor read; to be removed once the "
+    "eligible-column detection is moved into the C++ stats-generation path.",
+)
+@pytest.mark.parametrize(
+    "writer",
+    [_write_single_segment, _write_multi_segment, _write_multi_index],
+    ids=["single_segment", "multi_segment", "multi_index"],
+)
+def test_create_column_stats_reads_index_key_once(in_memory_version_store, clear_query_stats, writer):
+    lib = in_memory_version_store
+    writer(lib)
+
+    qs.enable()
+    qs.reset_stats()
+    lib.create_column_stats_experimental(sym)
+
+    assert get_table_index_read_count() == 1, qs.get_query_stats()
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -46,18 +46,11 @@ def _write_multi_segment(lib):
 
 
 def _write_multi_index(lib):
-    index = pd.MultiIndex.from_arrays(
-        [pd.date_range("2000-01-01", periods=2), [10, 20]], names=["dt", "level"]
-    )
+    index = pd.MultiIndex.from_arrays([pd.date_range("2000-01-01", periods=2), [10, 20]], names=["dt", "level"])
     df = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=index)
     lib.write(sym, df)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Eligibility computation does a separate descriptor read; to be removed once the "
-    "eligible-column detection is moved into the C++ stats-generation path.",
-)
 @pytest.mark.parametrize(
     "writer",
     [_write_single_segment, _write_multi_segment, _write_multi_index],


### PR DESCRIPTION
## Summary
  
  `create_column_stats_experimental` was reading the symbol's `TABLE_INDEX` (index) key
  **twice**: once in the Python layer to work out which columns are eligible for MINMAX
  stats, and again in the C++ stats-generation path. The C++ layer already reads the index
  key and has the `TimeseriesDescriptor` in hand, so this moves eligible-column detection
  into C++ and reads the index key **once**.

  ## Before
  
  - **Python** (`_store.py`): `create_column_stats_experimental` called
    `_get_eligible_column_stats_spec` → `_get_info(...)`, which **read the index key** to
    fetch the `timeseries_descriptor`, computed eligible columns, rejected duplicated
    data-column names, and passed an explicit `ColumnStats` down to C++.
  - **C++** (`create_column_stats_impl`): **read the index key again** to get the same
    `tsd`, then mapped the supplied column names to offsets.

  Query stats for a 2-row-slice symbol:

  ```json
  "storage_operations": {
      "S3_GetObject": {
          "COLUMN_STATS": { "count": 1, "size_bytes": 0,    "total_time_ms": 18 },
          "TABLE_DATA":   { "count": 2, "size_bytes": 703,  "total_time_ms": 30 },
          "TABLE_INDEX":  { "count": 2, "size_bytes": 2550, "total_time_ms": 31 } 
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      },
      "S3_PutObject": {
          "COLUMN_STATS": { "count": 1, "size_bytes": 677,  "total_time_ms": 14 }
      }
  }
  ```
   ##  After

  - Python: create_column_stats_experimental no longer reads the index — it just calls
  create_column_stats_version(symbol, version_query).
  - C++: a new ColumnStats(const TimeseriesDescriptor&) constructor derives the eligible
  columns directly from the tsd that create_column_stats_impl already reads. The
  column_stats argument is dropped through the whole create chain.

  Same scenario, index key now read once:

 ```json
  "storage_operations": {
      "S3_GetObject": {
          "COLUMN_STATS": { "count": 1, "size_bytes": 0,    "total_time_ms": 18 },
          "TABLE_DATA":   { "count": 2, "size_bytes": 703,  "total_time_ms": 32 },
          "TABLE_INDEX":  { "count": 1, "size_bytes": 1275, "total_time_ms": 15 }
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      },
      "S3_PutObject": {
          "COLUMN_STATS": { "count": 1, "size_bytes": 518,  "total_time_ms": 14 }
      }
  }
  ```
  TABLE_INDEX GetObject: 2 → 1 (and size_bytes ~halved).

 