### PR TITLE
Enhancement 9929831600: arrow timezone support

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -226,6 +226,15 @@ jobs:
         run: bash build_tooling/vcpkg_upload_assets.sh
         continue-on-error: true
 
+      # Windows ships no IANA tz database, so the date library used by the C++ tests
+      # (via date::locate_zone) can't resolve named timezones without it. pyarrow's helper
+      # downloads it to %USERPROFILE%\Downloads\tzdata, where the date library looks.
+      - name: Download Windows timezone data for the C++ tests
+        if: inputs.job_type == 'cpp-tests' && matrix.os == 'windows'
+        run: |
+          python -m pip install --retries 3 --timeout 180 pyarrow
+          python -c "from pyarrow.util import download_tzdata_on_windows; download_tzdata_on_windows()"
+
       - name: Compile C++ rapidcheck tests
         if: inputs.job_type == 'cpp-tests'
         run: cd cpp; cmake --build --preset $ARCTIC_CMAKE_PRESET --target arcticdb_rapidcheck_tests -j $CMAKE_BUILD_PARALLEL_LEVEL

--- a/cpp/arcticdb/arrow/arrow_utils.cpp
+++ b/cpp/arcticdb/arrow/arrow_utils.cpp
@@ -12,11 +12,15 @@
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/column_store/memory_segment.hpp>
 #include <arcticdb/util/allocator.hpp>
+#include <sparrow/layout/array_access.hpp>
 #include <sparrow/layout/primitive_data_access.hpp>
+#include <sparrow/utils/temporal.hpp>
 #include <sparrow/record_batch.hpp>
 #include <utility>
 
 namespace arcticdb {
+
+using ArrowMeta = proto::descriptors::NormalizationMetadata::ExperimentalArrow;
 
 std::optional<sparrow::validity_bitmap> create_validity_bitmap(
         size_t offset, const Column& column, size_t bitmap_size
@@ -37,14 +41,14 @@ std::optional<sparrow::validity_bitmap> create_validity_bitmap(
 }
 
 template<typename T>
-sparrow::primitive_array<T> create_primitive_array(
+sparrow::array create_primitive_array(
         T* data_ptr, size_t data_size, std::optional<sparrow::validity_bitmap>&& validity_bitmap
 ) {
     sparrow::u8_buffer<T> buffer(data_ptr, data_size, get_detachable_allocator());
     if (validity_bitmap) {
-        return sparrow::primitive_array<T>{std::move(buffer), data_size, std::move(*validity_bitmap)};
+        return sparrow::array{sparrow::primitive_array<T>{std::move(buffer), data_size, std::move(*validity_bitmap)}};
     } else {
-        return sparrow::primitive_array<T>{std::move(buffer), data_size};
+        return sparrow::array{sparrow::primitive_array<T>{std::move(buffer), data_size}};
     }
 }
 
@@ -80,43 +84,57 @@ sparrow::array create_packed_bool_array(
     return arr;
 }
 
-template<typename T>
-sparrow::timestamp_without_timezone_nanoseconds_array create_timestamp_array(
-        T* data_ptr, size_t data_size, std::optional<sparrow::validity_bitmap>&& validity_bitmap
+sparrow::array create_timestamp_array(
+        timestamp* data_ptr, size_t data_size, std::optional<sparrow::validity_bitmap>&& validity_bitmap,
+        const date::time_zone* tz = nullptr
 ) {
-    static_assert(sizeof(T) == sizeof(sparrow::zoned_time_without_timezone_nanoseconds));
-    // We default to using timestamps without timezones. If the normalization metadata contains a timezone it will be
-    // applied during normalization in python layer.
-    sparrow::u8_buffer<sparrow::zoned_time_without_timezone_nanoseconds> buffer(
-            reinterpret_cast<sparrow::zoned_time_without_timezone_nanoseconds*>(data_ptr),
-            data_size,
-            get_detachable_allocator()
-    );
-    if (validity_bitmap) {
-        return sparrow::timestamp_without_timezone_nanoseconds_array{
-                std::move(buffer), data_size, std::move(*validity_bitmap)
-        };
+    static_assert(sizeof(timestamp) == sizeof(sparrow::zoned_time_without_timezone_nanoseconds));
+    if (tz == nullptr) {
+        // Timezone naive
+        sparrow::u8_buffer<sparrow::zoned_time_without_timezone_nanoseconds> buffer(
+                reinterpret_cast<sparrow::zoned_time_without_timezone_nanoseconds*>(data_ptr),
+                data_size,
+                get_detachable_allocator()
+        );
+        if (validity_bitmap) {
+            return sparrow::array{sparrow::timestamp_without_timezone_nanoseconds_array{
+                    std::move(buffer), data_size, std::move(*validity_bitmap)
+            }};
+        } else {
+            return sparrow::array{sparrow::timestamp_without_timezone_nanoseconds_array{std::move(buffer), data_size}};
+        }
     } else {
-        return sparrow::timestamp_without_timezone_nanoseconds_array{std::move(buffer), data_size};
+        // Timezone aware. Arrow stores the timestamp in UTC regardless of timezone, so no transformations are required
+        // from our internal format
+        sparrow::u8_buffer<timestamp> buffer(
+                reinterpret_cast<timestamp*>(data_ptr), data_size, get_detachable_allocator()
+        );
+        if (validity_bitmap) {
+            return sparrow::array{
+                    sparrow::timestamp_nanoseconds_array{tz, std::move(buffer), std::move(*validity_bitmap)}
+            };
+        } else {
+            return sparrow::array{sparrow::timestamp_nanoseconds_array{tz, std::move(buffer)}};
+        }
     }
 }
 
 template<typename T>
-sparrow::dictionary_encoded_array<T> create_dict_array(
+sparrow::array create_dict_array(
         sparrow::array&& dict_values_array, sparrow::u8_buffer<T>&& dict_keys_buffer,
         std::optional<sparrow::validity_bitmap>&& validity_bitmap
 ) {
     if (validity_bitmap) {
-        return sparrow::dictionary_encoded_array<T>{
+        return sparrow::array{sparrow::dictionary_encoded_array<T>{
                 typename sparrow::dictionary_encoded_array<T>::keys_buffer_type(std::move(dict_keys_buffer)),
                 std::move(dict_values_array),
                 std::move(*validity_bitmap)
-        };
+        }};
     } else {
-        return sparrow::dictionary_encoded_array<T>{
+        return sparrow::array{sparrow::dictionary_encoded_array<T>{
                 typename sparrow::dictionary_encoded_array<T>::keys_buffer_type(std::move(dict_keys_buffer)),
                 std::move(dict_values_array),
-        };
+        }};
     }
 }
 
@@ -239,13 +257,20 @@ sparrow::array string_dict_from_block(
     auto dict_encoded = create_dict_array<int32_t>(
             sparrow::array{std::move(dict_values_array)}, std::move(dict_keys_buffer), std::move(maybe_bitmap)
     );
+    dict_encoded.set_name(name);
+    return dict_encoded;
+}
 
-    sparrow::array arr{std::move(dict_encoded)};
-    arr.set_name(name);
-    return arr;
+const date::time_zone* timezone(const std::optional<ArrowMeta::ColumnMeta>& column_meta) {
+    if (column_meta.has_value() && column_meta->has_timezone()) {
+        return date::locate_zone(column_meta->timezone());
+    } else {
+        return nullptr;
+    }
 }
 
 template<typename TagType>
+requires(!is_time_type(TagType::DataTypeTag::data_type))
 sparrow::array arrow_array_from_block(
         TypedBlockData<TagType>& block, std::string_view name, std::optional<sparrow::validity_bitmap>&& maybe_bitmap
 ) {
@@ -253,20 +278,14 @@ sparrow::array arrow_array_from_block(
     using RawType = typename DataTagType::raw_type;
     auto* data_ptr = block.release();
     const auto data_size = block.row_count();
-    auto arr = [&]() {
-        if constexpr (is_time_type(TagType::DataTypeTag::data_type)) {
-            auto timestamp_array = create_timestamp_array<RawType>(data_ptr, data_size, std::move(maybe_bitmap));
-            return sparrow::array{std::move(timestamp_array)};
-        } else {
-            auto primitive_array = create_primitive_array<RawType>(data_ptr, data_size, std::move(maybe_bitmap));
-            return sparrow::array{std::move(primitive_array)};
-        }
-    }();
+    auto arr = create_primitive_array<RawType>(data_ptr, data_size, std::move(maybe_bitmap));
     arr.set_name(name);
     return arr;
 }
 
-sparrow::array empty_arrow_array_for_column(const Column& column, std::string_view name) {
+sparrow::array empty_arrow_array_for_column(
+        const Column& column, std::string_view name, const std::optional<ArrowMeta::ColumnMeta>& opt_column_meta
+) {
     auto res = details::visit_scalar(column.type(), [&](auto&& tdt) {
         using TagType = std::decay_t<decltype(tdt)>;
         using DataTagType = typename TagType::DataTypeTag;
@@ -279,37 +298,42 @@ sparrow::array empty_arrow_array_for_column(const Column& column, std::string_vi
             } else {
                 sparrow::u8_buffer<int32_t> dict_keys_buffer{nullptr, 0, get_detachable_allocator()};
                 auto dict_values_array = minimal_strings_for_dict();
-                return sparrow::array{create_dict_array<int32_t>(
+                return create_dict_array<int32_t>(
                         sparrow::array{std::move(dict_values_array)},
                         std::move(dict_keys_buffer),
                         std::move(validity_bitmap)
-                )};
+                );
             }
         } else if constexpr (is_time_type(TagType::DataTypeTag::data_type)) {
-            return sparrow::array{create_timestamp_array<RawType>(nullptr, 0, std::move(validity_bitmap))};
+            return create_timestamp_array(nullptr, 0, std::move(validity_bitmap), timezone(opt_column_meta));
         } else {
-            return sparrow::array{create_primitive_array<RawType>(nullptr, 0, std::move(validity_bitmap))};
+            return create_primitive_array<RawType>(nullptr, 0, std::move(validity_bitmap));
         }
     });
     res.set_name(name);
     return res;
 }
 
-std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::string_view name) {
+std::vector<sparrow::array> arrow_arrays_from_column(
+        const Column& column, std::string_view name, const std::optional<ArrowMeta::ColumnMeta>& opt_column_meta
+) {
     std::vector<sparrow::array> vec;
     auto column_data = column.data();
     vec.reserve(column.num_blocks());
-    details::visit_scalar(column.type(), [&vec, &column_data, &column, name](auto&& impl) {
+    details::visit_scalar(column.type(), [&vec, &column_data, &column, name, &opt_column_meta](auto&& impl) {
         using TagType = std::decay_t<decltype(impl)>;
         if (column_data.num_blocks() == 0) {
             // For empty columns we want to return one empty array instead of no arrays.
-            vec.emplace_back(empty_arrow_array_for_column(column, name));
+            vec.emplace_back(empty_arrow_array_for_column(column, name, opt_column_meta));
+            return;
         }
+        // Only used with timestamp columns
+        const date::time_zone* tz = timezone(opt_column_meta);
         while (auto block = column_data.next<TagType>()) {
             if (block->row_count() == 0) {
                 // Empty blocks should produce empty arrays, without reading extra buffers, because they share the same
                 // offset as the next block.
-                vec.emplace_back(empty_arrow_array_for_column(column, name));
+                vec.emplace_back(empty_arrow_array_for_column(column, name, opt_column_meta));
                 continue;
             }
             if constexpr (is_bool_type(TagType::DataTypeTag::data_type)) {
@@ -330,6 +354,10 @@ std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::
                     } else {
                         vec.emplace_back(string_dict_from_block<TagType>(*block, column, name, std::move(bitmap)));
                     }
+                } else if constexpr (is_time_type(TagType::DataTypeTag::data_type)) {
+                    vec.emplace_back(create_timestamp_array(block->release(), block->row_count(), std::move(bitmap), tz)
+                    );
+                    vec.back().set_name(name);
                 } else {
                     vec.emplace_back(arrow_array_from_block<TagType>(*block, name, std::move(bitmap)));
                 }
@@ -339,7 +367,21 @@ std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::
     return vec;
 }
 
-std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segment) {
+std::optional<ArrowMeta::ColumnMeta> column_metadata(
+        const proto::descriptors::NormalizationMetadata& norm_meta, std::string_view column_name
+) {
+    if (norm_meta.has_experimental_arrow()) {
+        if (const auto it = norm_meta.experimental_arrow().columns().find(column_name);
+            it != norm_meta.experimental_arrow().columns().end()) {
+            return it->second;
+        }
+    }
+    return std::nullopt;
+}
+
+std::vector<sparrow::record_batch> segment_to_arrow_data(
+        SegmentInMemory& segment, const proto::descriptors::NormalizationMetadata& norm_meta
+) {
     const auto total_blocks = segment.num_blocks();
     const auto num_columns = segment.num_columns();
     if (num_columns == 0) {
@@ -354,6 +396,7 @@ std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segmen
     // provided outside of the time range covered by the symbol)
     std::vector<sparrow::record_batch> output{column_blocks == 0 ? 1 : column_blocks, sparrow::record_batch{}};
     for (auto i = 0UL; i < num_columns; ++i) {
+        const auto& column_name = segment.field(i).name();
         auto& column = segment.column(static_cast<position_t>(i));
         util::check(
                 column.num_blocks() == column_blocks,
@@ -361,8 +404,8 @@ std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segmen
                 column.num_blocks(),
                 column_blocks
         );
-
-        auto column_arrays = arrow_arrays_from_column(column, segment.field(i).name());
+        const auto opt_column_meta = column_metadata(norm_meta, column_name);
+        auto column_arrays = arrow_arrays_from_column(column, column_name, opt_column_meta);
         util::check(
                 column_arrays.size() == output.size(),
                 "Unexpected number of arrow arrays returned: {} != {}",
@@ -372,9 +415,7 @@ std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segmen
 
         for (auto block_idx = 0UL; block_idx < column_arrays.size(); ++block_idx) {
             util::check(block_idx < output.size(), "Block index overflow {} > {}", block_idx, output.size());
-            output[block_idx].add_column(
-                    static_cast<std::string>(segment.field(i).name()), std::move(column_arrays[block_idx])
-            );
+            output[block_idx].add_column(static_cast<std::string>(column_name), std::move(column_arrays[block_idx]));
         }
     }
     return output;
@@ -433,25 +474,49 @@ DataType arcticdb_type_from_arrow_array(const sparrow::array& array) {
     }
 }
 
+std::optional<ArrowMeta::ColumnMeta> generate_column_metadata(const sparrow::array& array, DataType data_type) {
+    std::optional<ArrowMeta::ColumnMeta> opt_column_meta;
+    switch (data_type) {
+    case DataType::NANOSECONDS_UTC64: {
+        opt_column_meta.emplace();
+        const auto& proxy = sparrow::detail::array_access::get_arrow_proxy(array);
+        if (const date::time_zone* dtz = sparrow::get_timezone(proxy); dtz != nullptr) {
+            opt_column_meta->set_timezone(dtz->name());
+        }
+        break;
+    }
+    default:
+        break;
+    }
+    return opt_column_meta;
+}
+
 std::pair<std::vector<Column>, entity::StreamDescriptor> record_batches_to_columns(
-        const std::vector<sparrow::record_batch>& record_batches, bool has_index
+        const std::vector<sparrow::record_batch>& record_batches, ArrowMeta& norm_meta
 ) {
     if (record_batches.empty()) {
         return {};
     }
     const auto& first_batch = record_batches.front();
     schema::check<ErrorCode::E_COLUMN_DOESNT_EXIST>(
-            !has_index || first_batch.nb_columns() > 0, "Cannot use index_column=True on a table with no columns"
+            !norm_meta.has_index() || first_batch.nb_columns() > 0,
+            "Cannot use index_column=True on a table with no columns"
     );
     auto column_names = first_batch.names();
     std::vector<Column> columns;
     columns.reserve(first_batch.nb_columns());
     StreamDescriptor desc;
     for (size_t idx = 0; idx < first_batch.nb_columns(); ++idx) {
-        auto data_type = arcticdb_type_from_arrow_array(first_batch.get_column(idx));
+        const auto& column_name = column_names[idx];
+        const auto& array = first_batch.get_column(idx);
+        auto data_type = arcticdb_type_from_arrow_array(array);
+        auto opt_column_meta = generate_column_metadata(array, data_type);
+        if (opt_column_meta.has_value()) {
+            (*norm_meta.mutable_columns())[column_name] = std::move(*opt_column_meta);
+        }
         // The Arrow data may be semantically sparse, but this buffer is still dense, hence Sparsity::NOT_PERMITTED
         columns.emplace_back(make_scalar_type(data_type), Sparsity::NOT_PERMITTED, ChunkedBuffer());
-        desc.add_field(scalar_field(data_type, column_names[idx]));
+        desc.add_field(scalar_field(data_type, column_name));
     }
 
     uint64_t start_row{0};
@@ -506,7 +571,7 @@ std::pair<std::vector<Column>, entity::StreamDescriptor> record_batches_to_colum
 
             if (array.null_count() > 0) {
                 schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
-                        !(has_index && idx == 0),
+                        !(norm_meta.has_index() && idx == 0),
                         "Index column '{}' cannot contain null values, but {} nulls were found",
                         column_names[idx],
                         array.null_count()
@@ -531,7 +596,8 @@ std::pair<std::vector<Column>, entity::StreamDescriptor> record_batches_to_colum
 
 RecordBatchData empty_record_batch_from_descriptor(
         const entity::StreamDescriptor& stream_desc, const ArrowOutputConfig& arrow_output_config,
-        const std::optional<ankerl::unordered_dense::set<std::string_view>>& columns
+        const std::optional<ankerl::unordered_dense::set<std::string_view>>& columns,
+        const proto::descriptors::NormalizationMetadata& norm_meta
 ) {
     // The logic here is similar to empty_arrow_array_for_column, but there the string format is dictated by the
     // column's buffers, whereas here we rely on the ArrowOutputConfig
@@ -565,11 +631,11 @@ RecordBatchData empty_record_batch_from_descriptor(
                     case ArrowOutputStringFormat::CATEGORICAL: {
                         sparrow::u8_buffer<int32_t> dict_keys_buffer{nullptr, 0, get_detachable_allocator()};
                         auto dict_values_array = minimal_strings_for_dict();
-                        return sparrow::array{create_dict_array<int32_t>(
+                        return create_dict_array<int32_t>(
                                 sparrow::array{std::move(dict_values_array)},
                                 std::move(dict_keys_buffer),
                                 std::move(validity_bitmap)
-                        )};
+                        );
                     }
                     default:
                         util::raise_rte("Unknown ArrowOutputStringFormat {}", static_cast<uint64_t>(string_format));
@@ -578,9 +644,10 @@ RecordBatchData empty_record_batch_from_descriptor(
                         return sparrow::array{};
                     }
                 } else if constexpr (is_time_type(TagType::DataTypeTag::data_type)) {
-                    return sparrow::array{create_timestamp_array<RawType>(nullptr, 0, std::move(validity_bitmap))};
+                    auto opt_column_meta = column_metadata(norm_meta, field.name());
+                    return create_timestamp_array(nullptr, 0, std::move(validity_bitmap), timezone(opt_column_meta));
                 } else {
-                    return sparrow::array{create_primitive_array<RawType>(nullptr, 0, std::move(validity_bitmap))};
+                    return create_primitive_array<RawType>(nullptr, 0, std::move(validity_bitmap));
                 }
             });
             arr.set_name(field.name());

--- a/cpp/arcticdb/arrow/arrow_utils.hpp
+++ b/cpp/arcticdb/arrow/arrow_utils.hpp
@@ -7,13 +7,14 @@
  */
 #pragma once
 
-#include <memory>
 #include <optional>
-#include <string>
 #include <string_view>
 #include <vector>
 
 #include <ankerl/unordered_dense.h>
+
+#include <arcticdb/entity/protobufs.hpp>
+#include <arcticdb/entity/types.hpp>
 
 // Anything that transitively includes sparrow.array.hpp takes ages to build the (unused by us) std::format impl
 // So avoid including sparrow in headers where possible until this is resolved
@@ -33,12 +34,27 @@ class Column;
 struct ArrowOutputConfig;
 struct RecordBatchData;
 
-std::vector<sparrow::array> arrow_arrays_from_column(const Column& column, std::string_view name);
+std::vector<sparrow::array> arrow_arrays_from_column(
+        const Column& column, std::string_view name,
+        const std::optional<proto::descriptors::NormalizationMetadata::ExperimentalArrow::ColumnMeta>& opt_column_meta =
+                std::nullopt
+);
 
-std::vector<sparrow::record_batch> segment_to_arrow_data(SegmentInMemory& segment);
+std::optional<proto::descriptors::NormalizationMetadata::ExperimentalArrow::ColumnMeta> column_metadata(
+        const proto::descriptors::NormalizationMetadata& norm_meta, std::string_view column_name
+);
+
+std::vector<sparrow::record_batch> segment_to_arrow_data(
+        SegmentInMemory& segment, const proto::descriptors::NormalizationMetadata& norm_meta
+);
+
+std::optional<proto::descriptors::NormalizationMetadata::ExperimentalArrow::ColumnMeta> generate_column_metadata(
+        const sparrow::array& array, entity::DataType data_type
+);
 
 std::pair<std::vector<Column>, entity::StreamDescriptor> record_batches_to_columns(
-        const std::vector<sparrow::record_batch>& record_batches, bool has_index = false
+        const std::vector<sparrow::record_batch>& record_batches,
+        proto::descriptors::NormalizationMetadata::ExperimentalArrow& norm_meta
 );
 
 // We only really need the ArrowSchema from here, but we return a zero-row record batch instead because:
@@ -46,7 +62,8 @@ std::pair<std::vector<Column>, entity::StreamDescriptor> record_batches_to_colum
 // - sparrow lacks support for easy construction of ArrowSchema directly without going through record batches anyway
 RecordBatchData empty_record_batch_from_descriptor(
         const entity::StreamDescriptor& stream_desc, const ArrowOutputConfig& arrow_output_config,
-        const std::optional<ankerl::unordered_dense::set<std::string_view>>& columns
+        const std::optional<ankerl::unordered_dense::set<std::string_view>>& columns,
+        const proto::descriptors::NormalizationMetadata& norm_meta
 );
 
 } // namespace arcticdb

--- a/cpp/arcticdb/arrow/test/benchmark_arrow_writes.cpp
+++ b/cpp/arcticdb/arrow/test/benchmark_arrow_writes.cpp
@@ -34,8 +34,10 @@ static void BM_arrow_convert_single_record_batch_to_segment(benchmark::State& st
     }
     std::vector<sparrow::record_batch> record_batches;
     record_batches.emplace_back(create_record_batch(columns));
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    arrow_meta.set_has_index(has_index);
     for (auto _ : state) {
-        record_batches_to_columns(record_batches, has_index);
+        record_batches_to_columns(record_batches, arrow_meta);
     }
 }
 
@@ -63,8 +65,10 @@ static void BM_arrow_convert_multiple_record_batches_to_segment(benchmark::State
         }
         record_batches.emplace_back(create_record_batch(columns));
     }
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    arrow_meta.set_has_index(false);
     for (auto _ : state) {
-        record_batches_to_columns(record_batches);
+        record_batches_to_columns(record_batches, arrow_meta);
     }
 }
 

--- a/cpp/arcticdb/arrow/test/test_arrow_read.cpp
+++ b/cpp/arcticdb/arrow/test/test_arrow_read.cpp
@@ -102,6 +102,32 @@ void fill_chunked_string_column(
     }
 }
 
+TEST(ColumnMetadata, NonArrow) {
+    proto::descriptors::NormalizationMetadata norm_meta;
+    // Accessing like this sets the oneof to df
+    norm_meta.mutable_df();
+    ASSERT_FALSE(column_metadata(norm_meta, "col").has_value());
+}
+
+TEST(ColumnMetadata, MissingColumn) {
+    proto::descriptors::NormalizationMetadata norm_meta;
+    (*norm_meta.mutable_experimental_arrow()->mutable_columns())["col"] =
+            proto::descriptors::NormalizationMetadata::ExperimentalArrow::ColumnMeta();
+    ASSERT_FALSE(column_metadata(norm_meta, "missing col").has_value());
+}
+
+TEST(ColumnMetadata, PresentColumn) {
+    std::string tz{"Europe/Brussels"};
+    proto::descriptors::NormalizationMetadata norm_meta;
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow::ColumnMeta col_meta;
+    col_meta.set_timezone(tz);
+    (*norm_meta.mutable_experimental_arrow()->mutable_columns())["col"] = col_meta;
+    auto new_col_meta = column_metadata(norm_meta, "col");
+    ASSERT_TRUE(new_col_meta.has_value());
+    ASSERT_TRUE(new_col_meta->has_timezone());
+    ASSERT_EQ(new_col_meta->timezone(), tz);
+}
+
 TEST(ArrowRead, ZeroCopy) {
     size_t num_rows{10};
     uint8_t* data_ptr = get_detachable_allocator().allocate(sizeof(uint64_t) * num_rows);
@@ -273,7 +299,8 @@ TEST(ArrowRead, ConvertSegmentBasic) {
     // Verify the index column has the expected number of chunks
     EXPECT_EQ(segment.column(0).num_blocks(), num_chunks);
 
-    auto arrow_data = segment_to_arrow_data(segment);
+    proto::descriptors::NormalizationMetadata norm_meta;
+    auto arrow_data = segment_to_arrow_data(segment, norm_meta);
     // We expect to see num_chunks record batches
     EXPECT_EQ(arrow_data.size(), num_chunks);
     for (const auto& record_batch : arrow_data) {
@@ -290,6 +317,51 @@ TEST(ArrowRead, ConvertSegmentBasic) {
         EXPECT_EQ(columns[2].data_type(), sparrow::data_type::INT64);
         EXPECT_EQ(names[3], "floats");
         EXPECT_EQ(columns[3].data_type(), sparrow::data_type::DOUBLE);
+        for (const auto& col : columns) {
+            EXPECT_EQ(col.size(), chunk_size);
+        }
+    }
+}
+
+TEST(ArrowRead, ConvertSegmentWithTimezones) {
+    const auto num_rows = 100u;
+    const auto chunk_size = 10u;
+    const auto num_chunks = num_rows / chunk_size;
+    const auto fields = std::array{
+            scalar_field(DataType::NANOSECONDS_UTC64, "col_with_tz"),
+            scalar_field(DataType::NANOSECONDS_UTC64, "col_without_tz"),
+    };
+    auto segment = get_detachable_segment(fields, num_rows, chunk_size, ReadOptions{});
+    // Verify the index column has the expected number of chunks
+    EXPECT_EQ(segment.column(0).num_blocks(), num_chunks);
+
+    std::string tz_str{"Europe/Brussels"};
+    proto::descriptors::NormalizationMetadata norm_meta;
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow::ColumnMeta column_meta;
+    column_meta.set_timezone(tz_str);
+    (*norm_meta.mutable_experimental_arrow()->mutable_columns())["col_with_tz"] = column_meta;
+    auto arrow_data = segment_to_arrow_data(segment, norm_meta);
+    // We expect to see num_chunks record batches
+    EXPECT_EQ(arrow_data.size(), num_chunks);
+    for (const auto& record_batch : arrow_data) {
+        auto names = record_batch.names();
+        auto columns = record_batch.columns();
+        // Each record batch should have all columns for the row range (including the index)
+        EXPECT_EQ(names.size(), fields.size() + 1);
+        EXPECT_EQ(columns.size(), fields.size() + 1);
+        EXPECT_EQ(names[0], "time");
+        EXPECT_EQ(columns[0].data_type(), sparrow::data_type::TIMESTAMP_NANOSECONDS);
+        const date::time_zone* dtz = sparrow::get_timezone(sparrow::detail::array_access::get_arrow_proxy(columns[0]));
+        ASSERT_TRUE(dtz == nullptr);
+        EXPECT_EQ(names[1], "col_with_tz");
+        EXPECT_EQ(columns[1].data_type(), sparrow::data_type::TIMESTAMP_NANOSECONDS);
+        dtz = sparrow::get_timezone(sparrow::detail::array_access::get_arrow_proxy(columns[1]));
+        ASSERT_FALSE(dtz == nullptr);
+        ASSERT_EQ(dtz->name(), tz_str);
+        EXPECT_EQ(names[2], "col_without_tz");
+        EXPECT_EQ(columns[2].data_type(), sparrow::data_type::TIMESTAMP_NANOSECONDS);
+        dtz = sparrow::get_timezone(sparrow::detail::array_access::get_arrow_proxy(columns[2]));
+        ASSERT_TRUE(dtz == nullptr);
         for (const auto& col : columns) {
             EXPECT_EQ(col.size(), chunk_size);
         }
@@ -338,7 +410,8 @@ TEST(ArrowRead, ConvertSegmentMultipleStringColumns) {
     segment.set_string_pool(string_pool);
 
     // Convert to arrow
-    auto arrow_data = segment_to_arrow_data(segment);
+    proto::descriptors::NormalizationMetadata norm_meta;
+    auto arrow_data = segment_to_arrow_data(segment, norm_meta);
     EXPECT_EQ(arrow_data.size(), num_chunks);
     for (auto i = 0u; i < num_chunks; ++i) {
         auto row_count = std::min(chunk_size, num_rows - i * chunk_size);

--- a/cpp/arcticdb/arrow/test/test_arrow_write.cpp
+++ b/cpp/arcticdb/arrow/test/test_arrow_write.cpp
@@ -24,25 +24,69 @@ using namespace arcticdb;
 
 // Duplicated from arrow_utils.cpp to keep build times down until sparrow array formatting is moved out of
 // sparrow/array.hpp
-template<typename T>
-sparrow::timestamp_without_timezone_nanoseconds_array create_timestamp_array(
-        T* data_ptr, size_t data_size, std::optional<sparrow::validity_bitmap>&& validity_bitmap
+sparrow::array create_timestamp_array(
+        timestamp* data_ptr, size_t data_size, std::optional<sparrow::validity_bitmap>&& validity_bitmap,
+        const date::time_zone* tz = nullptr
 ) {
-    static_assert(sizeof(T) == sizeof(sparrow::zoned_time_without_timezone_nanoseconds));
-    // We default to using timestamps without timezones. If the normalization metadata contains a timezone it will be
-    // applied during normalization in python layer.
-    sparrow::u8_buffer<sparrow::zoned_time_without_timezone_nanoseconds> buffer(
-            reinterpret_cast<sparrow::zoned_time_without_timezone_nanoseconds*>(data_ptr),
-            data_size,
-            get_detachable_allocator()
-    );
-    if (validity_bitmap) {
-        return sparrow::timestamp_without_timezone_nanoseconds_array{
-                std::move(buffer), data_size, std::move(*validity_bitmap)
-        };
+    static_assert(sizeof(timestamp) == sizeof(sparrow::zoned_time_without_timezone_nanoseconds));
+    if (tz == nullptr) {
+        // Timezone naive
+        sparrow::u8_buffer<sparrow::zoned_time_without_timezone_nanoseconds> buffer(
+                reinterpret_cast<sparrow::zoned_time_without_timezone_nanoseconds*>(data_ptr),
+                data_size,
+                get_detachable_allocator()
+        );
+        if (validity_bitmap) {
+            return sparrow::array{sparrow::timestamp_without_timezone_nanoseconds_array{
+                    std::move(buffer), data_size, std::move(*validity_bitmap)
+            }};
+        } else {
+            return sparrow::array{sparrow::timestamp_without_timezone_nanoseconds_array{std::move(buffer), data_size}};
+        }
     } else {
-        return sparrow::timestamp_without_timezone_nanoseconds_array{std::move(buffer), data_size};
+        // Timezone aware. Arrow stores the timestamp in UTC regardless of timezone, so no transformations are required
+        // from our internal format
+        sparrow::u8_buffer<timestamp> buffer(
+                reinterpret_cast<timestamp*>(data_ptr), data_size, get_detachable_allocator()
+        );
+        if (validity_bitmap) {
+            return sparrow::array{
+                    sparrow::timestamp_nanoseconds_array{tz, std::move(buffer), std::move(*validity_bitmap)}
+            };
+        } else {
+            return sparrow::array{sparrow::timestamp_nanoseconds_array{tz, std::move(buffer)}};
+        }
     }
+}
+
+TEST(ArrowGenerateColumnMetadata, NonTimestamp) {
+    std::vector<uint8_t> data(10);
+    std::iota(data.begin(), data.end(), 0U);
+    auto array = create_array(data);
+    ASSERT_FALSE(generate_column_metadata(array, DataType::UINT8).has_value());
+}
+
+TEST(ArrowGenerateColumnMetadata, TimezoneNaive) {
+    size_t num_rows = 10;
+    auto* data_ptr = reinterpret_cast<timestamp*>(allocate_detachable_memory(num_rows * sizeof(timestamp)));
+    std::iota(data_ptr, data_ptr + num_rows, 0UL);
+    auto array = create_timestamp_array(data_ptr, num_rows, std::optional<sparrow::validity_bitmap>());
+    auto opt_column_metadata = generate_column_metadata(array, DataType::NANOSECONDS_UTC64);
+    ASSERT_TRUE(opt_column_metadata.has_value());
+    ASSERT_FALSE(opt_column_metadata->has_timezone());
+}
+
+TEST(ArrowGenerateColumnMetadata, TimezoneAware) {
+    size_t num_rows = 10;
+    auto* data_ptr = reinterpret_cast<timestamp*>(allocate_detachable_memory(num_rows * sizeof(timestamp)));
+    std::iota(data_ptr, data_ptr + num_rows, 0UL);
+    std::string tz_str("Europe/Brussels");
+    const auto* tz = date::locate_zone(tz_str);
+    auto array = create_timestamp_array(data_ptr, num_rows, std::optional<sparrow::validity_bitmap>(), tz);
+    auto opt_column_metadata = generate_column_metadata(array, DataType::NANOSECONDS_UTC64);
+    ASSERT_TRUE(opt_column_metadata.has_value());
+    ASSERT_TRUE(opt_column_metadata->has_timezone());
+    ASSERT_EQ(opt_column_metadata->timezone(), tz_str);
 }
 
 template<typename types>
@@ -69,7 +113,8 @@ TYPED_TEST(ArrowDataToSegmentNumeric, Simple) {
 
     std::vector<sparrow::record_batch> record_batches;
     record_batches.emplace_back(std::move(record_batch));
-    auto [cols, desc] = record_batches_to_columns(record_batches);
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    auto [cols, desc] = record_batches_to_columns(record_batches, arrow_meta);
 
     ASSERT_EQ(desc.fields().size(), 1);
     ASSERT_EQ(cols.size(), 1);
@@ -112,7 +157,8 @@ TYPED_TEST(ArrowDataToSegmentNumeric, MultiColumn) {
 
     std::vector<sparrow::record_batch> record_batches;
     record_batches.emplace_back(std::move(record_batch));
-    auto [cols, desc] = record_batches_to_columns(record_batches);
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    auto [cols, desc] = record_batches_to_columns(record_batches, arrow_meta);
 
     ASSERT_EQ(desc.fields().size(), num_columns);
     ASSERT_EQ(cols.size(), num_columns);
@@ -152,7 +198,8 @@ TYPED_TEST(ArrowDataToSegmentNumeric, MultipleRecordBatches) {
         auto array = create_array(data);
         record_batches.emplace_back(create_record_batch({{"col", array}}));
     }
-    auto [cols, desc] = record_batches_to_columns(record_batches);
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    auto [cols, desc] = record_batches_to_columns(record_batches, arrow_meta);
 
     ASSERT_EQ(desc.fields().size(), 1);
     ASSERT_EQ(cols.size(), 1);
@@ -187,16 +234,17 @@ TYPED_TEST(ArrowDataToSegmentNumeric, MultipleRecordBatches) {
     ASSERT_EQ(buffer.block_offsets().back(), size);
 }
 
-TEST(ArrowDataToSegmentTimestamp, Simple) {
+TEST(ArrowDataToSegmentTimestamp, TimezoneNaive) {
     size_t num_rows = 10;
     auto* data_ptr = reinterpret_cast<timestamp*>(allocate_detachable_memory(num_rows * sizeof(timestamp)));
     std::iota(data_ptr, data_ptr + num_rows, 0UL);
-    auto array = sparrow::array{create_timestamp_array(data_ptr, num_rows, std::nullopt)};
+    auto array = create_timestamp_array(data_ptr, num_rows, std::nullopt);
     auto record_batch = create_record_batch({{"col", array}});
 
     std::vector<sparrow::record_batch> record_batches;
     record_batches.emplace_back(std::move(record_batch));
-    auto [cols, desc] = record_batches_to_columns(record_batches);
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    auto [cols, desc] = record_batches_to_columns(record_batches, arrow_meta);
 
     ASSERT_EQ(desc.fields().size(), 1);
     ASSERT_EQ(cols.size(), 1);
@@ -208,6 +256,51 @@ TEST(ArrowDataToSegmentTimestamp, Simple) {
     ASSERT_FALSE(col.is_sparse());
     for (size_t idx = 0; idx < num_rows; ++idx) {
         ASSERT_EQ(*col.scalar_at<timestamp>(idx), idx);
+    }
+}
+
+TEST(ArrowDataToSegmentTimestamp, TimezoneAware) {
+    size_t num_rows = 10;
+    auto* data_ptr = reinterpret_cast<timestamp*>(allocate_detachable_memory(num_rows * sizeof(timestamp)));
+    std::iota(data_ptr, data_ptr + num_rows, 0UL);
+    std::string tz_str("Europe/Brussels");
+    const auto* tz = date::locate_zone(tz_str);
+    auto array_with_tz = create_timestamp_array(data_ptr, num_rows, std::nullopt, tz);
+    data_ptr = reinterpret_cast<timestamp*>(allocate_detachable_memory(num_rows * sizeof(timestamp)));
+    std::iota(data_ptr, data_ptr + num_rows, 10UL);
+    auto array_without_tz = create_timestamp_array(data_ptr, num_rows, std::nullopt);
+    auto record_batch = create_record_batch({{"col_with_tz", array_with_tz}, {"col_without_tz", array_without_tz}});
+
+    std::vector<sparrow::record_batch> record_batches;
+    record_batches.emplace_back(std::move(record_batch));
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    auto [cols, desc] = record_batches_to_columns(record_batches, arrow_meta);
+
+    ASSERT_TRUE(arrow_meta.columns().contains("col_without_tz"));
+    ASSERT_FALSE(arrow_meta.columns().at("col_without_tz").has_timezone());
+    ASSERT_TRUE(arrow_meta.columns().contains("col_with_tz"));
+    const auto& col_meta = arrow_meta.columns().at("col_with_tz");
+    ASSERT_TRUE(col_meta.has_timezone());
+    ASSERT_EQ(col_meta.timezone(), tz_str);
+
+    ASSERT_EQ(desc.fields().size(), 2);
+    ASSERT_EQ(cols.size(), 2);
+    ASSERT_EQ(desc.field(0).name(), "col_with_tz");
+    const auto& col_with_tz = cols[0];
+    ASSERT_EQ(col_with_tz.type(), make_scalar_type(DataType::NANOSECONDS_UTC64));
+    ASSERT_EQ(col_with_tz.row_count(), num_rows);
+    ASSERT_EQ(col_with_tz.last_row(), num_rows - 1);
+    ASSERT_FALSE(col_with_tz.is_sparse());
+    for (size_t idx = 0; idx < num_rows; ++idx) {
+        ASSERT_EQ(*col_with_tz.scalar_at<timestamp>(idx), idx);
+    }
+    const auto& col_without_tz = cols[1];
+    ASSERT_EQ(col_without_tz.type(), make_scalar_type(DataType::NANOSECONDS_UTC64));
+    ASSERT_EQ(col_without_tz.row_count(), num_rows);
+    ASSERT_EQ(col_without_tz.last_row(), num_rows - 1);
+    ASSERT_FALSE(col_without_tz.is_sparse());
+    for (size_t idx = 0; idx < num_rows; ++idx) {
+        ASSERT_EQ(*col_without_tz.scalar_at<timestamp>(idx), idx + 10);
     }
 }
 
@@ -239,7 +332,8 @@ TEST(ArrowDataToSegment, MultiColumnDifferentTypes) {
 
     std::vector<sparrow::record_batch> record_batches;
     record_batches.emplace_back(std::move(record_batch));
-    auto [cols, desc] = record_batches_to_columns(record_batches);
+    proto::descriptors::NormalizationMetadata::ExperimentalArrow arrow_meta;
+    auto [cols, desc] = record_batches_to_columns(record_batches, arrow_meta);
 
     auto num_columns = numeric_data_types.size();
     ASSERT_EQ(desc.fields().size(), num_columns);

--- a/cpp/arcticdb/entity/protobufs.hpp
+++ b/cpp/arcticdb/entity/protobufs.hpp
@@ -23,6 +23,7 @@
 
 namespace arcticdb::proto {
 
+namespace descriptors = arcticc::pb2::descriptors_pb2;
 namespace encoding = arcticc::pb2::encoding_pb2;
 namespace storage = arcticc::pb2::storage_pb2;
 namespace s3_storage = arcticc::pb2::s3_storage_pb2;

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/preconditions.hpp>
 #include <arcticdb/util/constructors.hpp>
 #include <arcticdb/storage/memory_layout.hpp>
@@ -23,12 +24,6 @@
 #include <BaseTsd.h>
 using ssize_t = SSIZE_T;
 #endif
-
-#include <descriptors.pb.h>
-
-namespace arcticdb::proto {
-namespace descriptors = arcticc::pb2::descriptors_pb2;
-}
 
 namespace arcticdb {
 

--- a/cpp/arcticdb/pipeline/index_utils.cpp
+++ b/cpp/arcticdb/pipeline/index_utils.cpp
@@ -140,6 +140,28 @@ proto::descriptors::NormalizationMetadata merge_normalization_metadata(
     if (result.has_np()) {
         // Only append is allowed for numpy arrays, and it's checked up the callstack.
         (*result.mutable_np()->mutable_shape())[0] += new_frame.norm_meta.np().shape()[0];
+    } else if (result.has_experimental_arrow()) {
+        // With static schema, there is an earlier check that all timezones match exactly between the existing data and
+        // the new frame
+        result = new_frame.norm_meta;
+        auto& new_col_meta_map = *result.mutable_experimental_arrow()->mutable_columns();
+        const auto& old_col_meta_map = existing_tsd.normalization().experimental_arrow().columns();
+        // We only need to iterate over the old norm meta, as anything present in the new norm meta that is missing from
+        // the old norm meta is a new column with dynamic schema, so we just leave it's column metadata as is
+        for (const auto& [col_name, old_col_meta] : old_col_meta_map) {
+            if (auto it = new_col_meta_map.find(col_name); it != new_col_meta_map.end()) {
+                auto& new_col_meta = it->second;
+                // Column has metadata in both the old and new norm metadata
+                if (!google::protobuf::util::MessageDifferencer::Equals(old_col_meta, new_col_meta)) {
+                    // Column metadata differed between the old and new, so set to timezone naive
+                    new_col_meta.clear_timezone();
+                } // else column meta is same in old and new, so new is already correct
+            } else {
+                // Column had metadata in the old, but not the new norm meta. That implies the column is missing from
+                // the new data, so maintain the metadata from the previous version
+                new_col_meta_map[col_name] = old_col_meta;
+            }
+        }
     }
 
     if (existing_tsd.index().type() == IndexDescriptor::Type::ROWCOUNT) {

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -77,7 +77,7 @@ inline ReadResult create_python_read_result(
 
     auto get_python_frame = [output_format](auto& result) -> OutputFrame {
         if (output_format == OutputFormat::ARROW) {
-            return ArrowOutputFrame{segment_to_arrow_data(result.frame_)};
+            return ArrowOutputFrame{segment_to_arrow_data(result.frame_, result.desc_.proto().normalization())};
         } else {
             return pipelines::PandasOutputFrame{result.frame_};
         }

--- a/cpp/arcticdb/python/normalization_utils.cpp
+++ b/cpp/arcticdb/python/normalization_utils.cpp
@@ -6,6 +6,8 @@
  * will be governed by the Apache License, version 2.0.
  */
 
+#include <google/protobuf/util/message_differencer.h>
+
 #include <arcticdb/python/normalization_utils.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/util/preconditions.hpp>
@@ -195,8 +197,37 @@ bool check_ndarray_append(const NormalizationMetadata& old_norm, NormalizationMe
     return false;
 }
 
+void check_arrow_column_metadata(
+        const proto::descriptors::NormalizationMetadata::ExperimentalArrow& old_norm,
+        proto::descriptors::NormalizationMetadata::ExperimentalArrow& new_norm, bool dynamic_schema
+) {
+    if (!dynamic_schema) {
+        const auto& old_col_meta_map = old_norm.columns();
+        auto& new_col_meta_map = *new_norm.mutable_columns();
+        // Column metadata must match exactly
+        bool should_raise{old_col_meta_map.size() != new_col_meta_map.size()};
+        if (!should_raise) {
+            for (const auto& [col_name, old_col_meta] : old_col_meta_map) {
+                if (auto it = new_col_meta_map.find(col_name); it == new_col_meta_map.end()) {
+                    should_raise = true;
+                    break;
+                } else {
+                    if (!google::protobuf::util::MessageDifferencer::Equals(old_col_meta, it->second)) {
+                        should_raise = true;
+                        break;
+                    }
+                }
+            }
+        }
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                !should_raise, "Column metadata does not match between existing data and input frame"
+        );
+    }
+}
+
 void fix_normalization_or_throw(
-        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr, const pipelines::InputFrame& new_frame
+        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr,
+        const pipelines::InputFrame& new_frame, bool dynamic_schema
 ) {
     auto& old_norm = existing_isr.tsd().proto().normalization();
     auto& new_norm = new_frame.norm_meta;
@@ -222,6 +253,11 @@ void fix_normalization_or_throw(
         // ndarray normalizes to a ROWCOUNT frame and we don't support update on those
         normalization::check<ErrorCode::E_UPDATE_NOT_SUPPORTED>(
                 !old_norm.has_np() && !new_norm.has_np(), "current normalization scheme doesn't allow update of ndarray"
+        );
+    }
+    if (old_norm.has_experimental_arrow() && new_norm.has_experimental_arrow()) {
+        check_arrow_column_metadata(
+                old_norm.experimental_arrow(), *new_norm.mutable_experimental_arrow(), dynamic_schema
         );
     }
 }

--- a/cpp/arcticdb/python/normalization_utils.hpp
+++ b/cpp/arcticdb/python/normalization_utils.hpp
@@ -29,7 +29,8 @@ struct IndexSegmentReader;
  * The new frame for append/update is compatible with the existing index. Throws various exceptions if not.
  */
 void fix_normalization_or_throw(
-        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr, const pipelines::InputFrame& new_frame
+        bool is_append, const pipelines::index::IndexSegmentReader& existing_isr,
+        const pipelines::InputFrame& new_frame, bool dynamic_schema
 );
 
 proto::descriptors::NormalizationMetadata generate_norm_meta(

--- a/cpp/arcticdb/python/python_to_tensor_frame.cpp
+++ b/cpp/arcticdb/python/python_to_tensor_frame.cpp
@@ -343,7 +343,7 @@ void record_batches_to_frame(
     util::check(
             frame.norm_meta.has_experimental_arrow(), "Unexpected non-Arrow norm metadata provided with Arrow data"
     );
-    const auto& arrow_norm_metadata = frame.norm_meta.experimental_arrow();
+    auto& arrow_norm_metadata = *frame.norm_meta.mutable_experimental_arrow();
     // Move the ArrowArray/ArrowSchema out of each RecordBatchData into owning sparrow record_batches.
     // sparrow::record_batch(ArrowArray&&, ArrowSchema&&) takes ownership and will decref the arrow buffers on
     // destruction.
@@ -352,7 +352,7 @@ void record_batches_to_frame(
     for (const auto& rbd : record_batches) {
         sparrow_record_batches.emplace_back(std::move(rbd->array_), std::move(rbd->schema_));
     }
-    auto [columns, descriptor] = record_batches_to_columns(sparrow_record_batches, arrow_norm_metadata.has_index());
+    auto [columns, descriptor] = record_batches_to_columns(sparrow_record_batches, arrow_norm_metadata);
     frame.set_from_columns(
             std::move(columns), std::move(descriptor), std::move(sparrow_record_batches), sortedness_scan
     );

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -1248,8 +1248,9 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                         return std::nullopt;
                     }
                 }();
-                auto record_batch =
-                        empty_record_batch_from_descriptor(stream_desc, read_options.arrow_output_config(), columns);
+                auto record_batch = empty_record_batch_from_descriptor(
+                        stream_desc, read_options.arrow_output_config(), columns, norm
+                );
                 return std::make_pair(std::move(record_batch), python_util::pb_to_python(schema.norm_metadata_));
             }
     );

--- a/cpp/arcticdb/version/schema_checks.cpp
+++ b/cpp/arcticdb/version/schema_checks.cpp
@@ -229,7 +229,7 @@ void fix_descriptor_mismatch_or_throw(
         const pipelines::InputFrame& new_frame, bool empty_types
 ) {
 
-    fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame);
+    fix_normalization_or_throw(operation == APPEND, existing_isr, new_frame, dynamic_schema);
     check_normalization_index_match(operation, existing_isr, new_frame, empty_types);
 
     const auto& old_sd = existing_isr.tsd().as_stream_descriptor();

--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -225,7 +225,12 @@ message NormalizationMetadata {
     }
 
     message ExperimentalArrow {
+        message ColumnMeta {
+            optional string timezone = 1;
+        }
+
         bool has_index = 1;
+        map<string, ColumnMeta> columns = 2;
     }
 
     oneof input_type {

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -401,25 +401,243 @@ def test_write_owned_and_non_owned_buffers(in_memory_version_store_tiny_segment_
     assert table.equals(received)
 
 
-@pytest.mark.xfail(reason="Not implemented yet, issue number 9929831600")
-def test_write_with_timezone(in_memory_version_store_arrow):
+def test_roundtrip_timezones(in_memory_version_store_arrow):
     lib = in_memory_version_store_arrow
-    sym = "test_write_with_timezone"
+    sym = "test_roundtrip_timezones"
     table = pa.table(
         {
             "ts": pa.Array.from_pandas(
                 pd.date_range("2025-01-01", periods=2, tz="America/New_York"),
                 type=pa.timestamp("ns", tz="America/New_York"),
             ),
-            "col": pa.Array.from_pandas(
-                pd.date_range("2025-01-03", periods=2, tz="Europe/Amsterdam"),
-                type=pa.timestamp("ns", tz="Europe/Amsterdam"),
+            "col_utc": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Etc/UTC"),
+                type=pa.timestamp("ns", tz="Etc/UTC"),
+            ),
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2),
+                type=pa.timestamp("ns"),
             ),
         }
     )
-    lib.write(sym, table)
+    lib.write(sym, table, index_column=True)
     received = lib.read(sym).data
     assert table.equals(received)
+
+
+def test_roundtrip_timezones_zero_rows(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
+    sym = "test_roundtrip_timezones_zero_rows"
+    table = pa.table(
+        {
+            "ts": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="America/New_York"),
+                type=pa.timestamp("ns", tz="America/New_York"),
+            ),
+            "col_utc": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Etc/UTC"),
+                type=pa.timestamp("ns", tz="Etc/UTC"),
+            ),
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2),
+                type=pa.timestamp("ns"),
+            ),
+        }
+    )
+    lib.write(sym, table, index_column=True)
+    # Choose a date range that filters out all rows
+    received = lib.read(sym, date_range=(pd.Timestamp("2026-01-01"), pd.Timestamp("2026-01-02"))).data
+    assert table.slice(0, 0).equals(received)
+
+
+def test_append_valid_timezones_static(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
+    sym = "test_append_valid_timezones_static"
+    table = pa.table(
+        {
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=4, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=4),
+                type=pa.timestamp("ns"),
+            ),
+        }
+    )
+    lib.write(sym, table.slice(length=2))
+    lib.append(sym, table.slice(offset=2))
+    received = lib.read(sym).data
+    assert table.equals(received)
+
+
+@pytest.mark.parametrize("method", ["append", "update"])
+@pytest.mark.parametrize(
+    "col_with_tz_timezone,col_without_tz_timezone",
+    [
+        pytest.param("America/New_York", None, id="col_with_tz has wrong timezone"),
+        pytest.param(None, None, id="col_with_tz has no timezone"),
+        pytest.param("Europe/Brussels", "America/New_York", id="col_without_tz has a timezone"),
+    ],
+)
+def test_append_and_update_invalid_timezones_static(
+    in_memory_version_store_arrow, method, col_with_tz_timezone, col_without_tz_timezone
+):
+    lib = in_memory_version_store_arrow
+    sym = "test_append_and_update_invalid_timezones_static"
+    # Initial table has Europe/Brussels as the timezone for col_with_tz and col_without_tz is timezone-naive
+    write_table = pa.table(
+        {
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2),
+                type=pa.timestamp("ns"),
+            ),
+        }
+    )
+    lib.write(sym, write_table.slice(length=2), index_column=True)
+    mismatch_table = pa.table(
+        {
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz=col_with_tz_timezone),
+                type=pa.timestamp("ns", tz=col_with_tz_timezone),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz=col_without_tz_timezone),
+                type=pa.timestamp("ns", tz=col_without_tz_timezone),
+            ),
+        }
+    )
+    with pytest.raises(SchemaException):
+        getattr(lib, method)(sym, mismatch_table, index_column=True)
+
+
+@pytest.mark.parametrize("method", ["append", "update"])
+@pytest.mark.parametrize(
+    "col_with_tz_timezone,col_without_tz_timezone",
+    [
+        pytest.param("America/New_York", None, id="col_with_tz_has different timezone"),
+        pytest.param(None, None, id="col_with_tz has no timezone"),
+        pytest.param("Europe/Brussels", "America/New_York", id="col_without_tz has a timezone"),
+    ],
+)
+def test_append_and_update_changing_timezones_dynamic(
+    in_memory_version_store_dynamic_schema_arrow, method, col_with_tz_timezone, col_without_tz_timezone
+):
+    lib = in_memory_version_store_dynamic_schema_arrow
+    sym = "test_append_and_update_changing_timezones_dynamic"
+    # Initial table has Europe/Brussels as the timezone for col_with_tz and col_without_tz is timezone-naive
+    write_table = pa.table(
+        {
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2),
+                type=pa.timestamp("ns"),
+            ),
+        }
+    )
+    lib.write(sym, write_table, index_column=True)
+    append_table = pa.table(
+        {
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz=col_with_tz_timezone),
+                type=pa.timestamp("ns", tz=col_with_tz_timezone),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz=col_without_tz_timezone),
+                type=pa.timestamp("ns", tz=col_without_tz_timezone),
+            ),
+        }
+    )
+    getattr(lib, method)(sym, append_table, index_column=True)
+    received = lib.read(sym).data
+    # pyarrow will not concat timezone-aware and timezone-naive arrays together, so cast to result timezone first
+    first_col_timezone = "Europe/Brussels" if col_with_tz_timezone == "Europe/Brussels" else None
+    write_table = write_table.set_column(
+        0, "col_with_tz", write_table.column(0).cast(pa.timestamp("ns", tz=first_col_timezone))
+    )
+    append_table = append_table.set_column(
+        0, "col_with_tz", append_table.column(0).cast(pa.timestamp("ns", tz=first_col_timezone))
+    )
+    # Casting to timezone-naive returns the time as if it was UTC
+    append_table = append_table.set_column(1, "col_without_tz", append_table.column(1).cast(pa.timestamp("ns")))
+    expected = pa.concat_tables([write_table, append_table], promote_options="permissive")
+    assert expected.equals(received)
+
+
+def test_append_timezones_changing_col_order_dynamic(in_memory_version_store_dynamic_schema_arrow):
+    lib = in_memory_version_store_dynamic_schema_arrow
+    sym = "test_append_timezones_changing_col_order_dynamic"
+    write_table = pa.table(
+        {
+            "col_a": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_b": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="America/New_York"),
+                type=pa.timestamp("ns", tz="America/New_York"),
+            ),
+            "col_c": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="Etc/UTC"),
+                type=pa.timestamp("ns", tz="Etc/UTC"),
+            ),
+        }
+    )
+    lib.write(sym, write_table)
+    append_table = pa.table(
+        {
+            "col_b": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="America/New_York"),
+                type=pa.timestamp("ns", tz="America/New_York"),
+            ),
+            "col_a": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_d": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Europe/Malta"),
+                type=pa.timestamp("ns", tz="Europe/Malta"),
+            ),
+        }
+    )
+    lib.append(sym, append_table)
+    expected = pa.table(
+        {
+            "col_a": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=4, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_b": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=4, tz="America/New_York"),
+                type=pa.timestamp("ns", tz="America/New_York"),
+            ),
+            "col_c": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="Etc/UTC").append(pd.DatetimeIndex([pd.NaT, pd.NaT])),
+                type=pa.timestamp("ns", tz="Etc/UTC"),
+            ),
+            "col_d": pa.Array.from_pandas(
+                pd.DatetimeIndex([pd.NaT, pd.NaT]).append(pd.date_range("2025-01-03", periods=2, tz="Europe/Malta")),
+                type=pa.timestamp("ns", tz="Europe/Malta"),
+            ),
+        }
+    )
+    received = lib.read(sym).data
+    assert expected.equals(received)
 
 
 def test_write_with_index_and_read_with_column_slicing(in_memory_version_store_arrow):
@@ -606,7 +824,7 @@ def test_wrong_index_name(in_memory_version_store_arrow, method, arrow_output_fo
             "col": pa.array([3, 4], pa.int64()),
         }
     )
-    with pytest.raises(StreamDescriptorMismatch):
+    with pytest.raises(SchemaException):
         getattr(lib, method)(sym, to_format(table_1, arrow_output_format), index_column=True)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_collect_schema.py
+++ b/python/tests/unit/arcticdb/version_store/test_collect_schema.py
@@ -105,6 +105,41 @@ def test_collect_schema_index_with_timezone(lmdb_library):
     assert lib.read(sym, columns=["col2"], lazy=True)._collect_schema() == lib.read(sym, columns=["col2"]).data.schema
 
 
+def test_collect_schema_with_timezones(lmdb_library):
+    lib = lmdb_library
+    lib._nvs.set_output_format(OutputFormat.POLARS)
+    lib._nvs._set_allow_arrow_input()
+    sym = "test_collect_schema_with_timezones"
+    # No column selection
+    table = pa.table(
+        {
+            "ts": pa.Array.from_pandas(
+                pd.date_range("2025-01-01", periods=2, tz="America/New_York"),
+                type=pa.timestamp("ns", tz="America/New_York"),
+            ),
+            "col_utc": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Etc/UTC"),
+                type=pa.timestamp("ns", tz="Etc/UTC"),
+            ),
+            "col_with_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2, tz="Europe/Brussels"),
+                type=pa.timestamp("ns", tz="Europe/Brussels"),
+            ),
+            "col_without_tz": pa.Array.from_pandas(
+                pd.date_range("2025-01-03", periods=2),
+                type=pa.timestamp("ns"),
+            ),
+        }
+    )
+    lib.write(sym, table, index_column=True)
+    assert lib.read(sym, lazy=True)._collect_schema() == lib.read(sym).data.schema
+    # With column selection
+    assert (
+        lib.read(sym, columns=["col_with_tz", "col_without_tz"], lazy=True)._collect_schema()
+        == lib.read(sym, columns=["col_with_tz", "col_without_tz"]).data.schema
+    )
+
+
 def test_collect_schema_multiindex(lmdb_library):
     lib = lmdb_library
     lib._nvs.set_output_format(OutputFormat.POLARS)

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     pandas <3
     numpy
     attrs
-    protobuf >=3.5.0.post1, < 7 # Per https://github.com/grpc/grpc/blob/v1.45.3/requirements.txt
+    protobuf >=3.15.0, < 7 # Minimum required for optional support
     msgpack >=0.5.0 # msgpack 0.5.0 is required for strict_types argument, needed for correct pickling fallback
     pyyaml
     packaging

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ class CompileProto(Command):
     # The upper bound on "6" keeps the bundled protoc at major 6: grpcio-tools>=1.82 bundles a
     # protoc that emits protobuf-7 gencode while still accepting a protobuf 6.* runtime, which would
     # bake gencode 7.x into proto/6 and fail to load against a protobuf<7 runtime.
-    _PROTOBUF_TO_GRPC_VERSION = {"3": "<1.31", "4": ">=1.49", "5": ">=1.68.1", "6": ">=1.73.0,<1.82"}
+    _PROTOBUF_TO_GRPC_VERSION = {"3": ">=1.46", "4": ">=1.49", "5": ">=1.68.1", "6": ">=1.73.0,<1.82"}
 
     description = '"protoc" generate code _pb2.py from .proto files'
     user_options = [


### PR DESCRIPTION
#### Reference Issues/PRs
[9929831600](https://man312219.monday.com/boards/7852509418/pulses/9929831600)

#### What does this implement or fix?
Adds support for storing timestamp columns' timezones with data written as Arrow. Behaviour with append/update is as follows:

- Static schema - timezone of column in the new table must match that of the existing data exactly (or both be timezone-naive)
- Dynamic schema - timezones can differ arbitrarily. If they are different, the result will be timezone-naive