### PR TITLE
Homogenise batch and non-batch implementations in LocalVersionedEngine, and fix 12548384234, 12548383860, 12584371808, and 12548367093

### DIFF
--- a/cpp/arcticdb/pipeline/write_options.hpp
+++ b/cpp/arcticdb/pipeline/write_options.hpp
@@ -24,7 +24,9 @@ struct WriteOptions {
                 opt.snapshot_dedup(),
                 opt.dynamic_schema(),
                 opt.ignore_sort_order(),
-                opt.bucketize_dynamic()};
+                opt.bucketize_dynamic(),
+                opt.empty_types(),
+                opt.delayed_deletes()};
     }
 
     size_t column_group_size = 127;
@@ -36,6 +38,7 @@ struct WriteOptions {
     bool dynamic_schema = false;
     bool ignore_sort_order = false;
     bool bucketize_dynamic = false;
-    bool sparsify_floats = false;
+    bool empty_types = false;
+    bool delayed_deletes = false;
 };
 } // namespace arcticdb

--- a/cpp/arcticdb/storage/file/file_store.hpp
+++ b/cpp/arcticdb/storage/file/file_store.hpp
@@ -72,12 +72,8 @@ void write_dataframe_to_file_internal(
     auto key_seg_futs =
             folly::collect(folly::window(
                                    std::move(slices),
-                                   [frame,
-                                    key = std::move(partial_key),
-                                    sparsify_floats = options.sparsify_floats](auto&& slice) {
-                                       return async::submit_cpu_task(
-                                               pipelines::WriteToSegmentTask(frame, slice, key, sparsify_floats)
-                                       );
+                                   [frame, key = std::move(partial_key)](auto&& slice) {
+                                       return async::submit_cpu_task(pipelines::WriteToSegmentTask(frame, slice, key));
                                    },
                                    write_window_size()
                            ))

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -150,7 +150,7 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_inde
         std::vector<AtomKey>&& pruned_indexes, const AtomKey& key_to_keep
 ) {
     try {
-        if (!pruned_indexes.empty() && !cfg().write_options().delayed_deletes()) {
+        if (!pruned_indexes.empty() && !write_options_.delayed_deletes) {
             // TODO: the following function will load all snapshots, which will be horrifyingly inefficient when called
             // multiple times from batch_*
             auto [not_in_snaps, in_snaps] = get_index_keys_partitioned_by_inclusion_in_snapshots(
@@ -488,7 +488,6 @@ VersionedItem LocalVersionedEngine::read_modify_write_internal(
             source_version.has_value(), "Could not find requested version for symbol \"{}\"", source_stream
     );
 
-    const WriteOptions write_options = get_write_options();
     auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), target_stream);
     const auto target_version = get_next_version_from_key(maybe_prev);
 
@@ -502,7 +501,7 @@ VersionedItem LocalVersionedEngine::read_modify_write_internal(
                                            store(),
                                            read_query,
                                            read_options,
-                                           write_options,
+                                           write_options_,
                                            target_partial_index_key,
                                            pipeline_context,
                                            std::move(user_meta_proto)
@@ -633,17 +632,17 @@ std::vector<std::variant<DescriptorItem, DataError>> LocalVersionedEngine::batch
 void LocalVersionedEngine::flush_version_map() { version_map()->flush(); }
 
 std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
-        const StreamId& stream_id, const std::optional<AtomKey>& maybe_prev, const WriteOptions& write_options
+        const StreamId& stream_id, const UpdateInfo& update_info, const WriteOptions& write_options
 ) {
     auto de_dup_map = std::make_shared<DeDupMap>();
-    if (write_options.de_duplication) {
-        if (auto latest_undeleted_index_key = get_latest_undeleted_version(store(), version_map(), stream_id)) {
-            const auto data_keys =
-                    get_data_keys(store(), {std::move(*latest_undeleted_index_key)}, storage::ReadKeyOpts{});
+    // Next version id == 0 => this is the first version, so there is nothing to dedup against
+    if (write_options.de_duplication && update_info.next_version_id_ > 0) {
+        if (update_info.previous_index_key_.has_value()) {
+            const auto data_keys = get_data_keys(store(), *update_info.previous_index_key_, storage::ReadKeyOpts{});
             for (const auto& data_key : data_keys) {
                 de_dup_map->insert_key(data_key);
             }
-        } else if (maybe_prev && write_options.snapshot_dedup) {
+        } else if (write_options.snapshot_dedup) {
             // This means we don't have any live versions(all tombstoned), so will try to dedup from snapshot versions
             auto snap_versions = get_index_keys_in_snapshots(store(), stream_id);
             auto latest_snapshot_it = ranges::max_element(snap_versions, [](const auto& k1, const auto& k2) {
@@ -663,7 +662,7 @@ std::shared_ptr<DeDupMap> LocalVersionedEngine::get_de_dup_map(
 VersionedItem LocalVersionedEngine::sort_index(
         const StreamId& stream_id, bool dynamic_schema, bool prune_previous_versions
 ) {
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
     util::check(update_info.previous_index_key_.has_value(), "Cannot sort_index a non-existent symbol {}", stream_id);
     auto [index_segment_reader, slice_and_keys] =
             index::read_index_to_vector(store(), *update_info.previous_index_key_);
@@ -708,9 +707,8 @@ VersionedItem LocalVersionedEngine::sort_index(
 VersionedItem LocalVersionedEngine::delete_range_internal(
         const StreamId& stream_id, const UpdateQuery& query, const DeleteRangeOptions& option
 ) {
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
-    auto versioned_item =
-            delete_range_impl(store(), stream_id, update_info, query, get_write_options(), option.dynamic_schema_);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
+    auto versioned_item = delete_range_impl(store(), stream_id, update_info, query, option.dynamic_schema_);
     write_version_and_prune_previous(
             option.prune_previous_versions_, versioned_item.key_, update_info.previous_index_key_
     );
@@ -723,130 +721,59 @@ VersionedItem LocalVersionedEngine::update_internal(
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: update");
     py::gil_scoped_release release_gil;
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
-    if (update_info.previous_index_key_.has_value()) {
-        const auto versioned_item =
-                frame->empty()
-                        ? VersionedItem{async::submit_io_task(
-                                                UpdateMetadataTask{store(), update_info, std::move(frame->user_meta)}
-                          )
-                                                .get()}
-                        : update_impl(
-                                  store(),
-                                  update_info,
-                                  query,
-                                  frame,
-                                  get_write_options(),
-                                  dynamic_schema,
-                                  cfg().write_options().empty_types()
-                          );
-        write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
-        return versioned_item;
-    } else {
-        if (upsert) {
-            auto write_options = get_write_options();
-            write_options.dynamic_schema |= dynamic_schema;
-            auto versioned_item = write_dataframe_impl(
-                    store_,
-                    update_info.next_version_id_,
-                    frame,
-                    write_options,
-                    std::make_shared<DeDupMap>(),
-                    false,
-                    true
-            );
-
-            if (cfg_.symbol_list())
-                symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
-
-            version_map()->write_version(store(), versioned_item.key_, std::nullopt);
-            return versioned_item;
-        } else {
-            util::raise_rte("Cannot update non-existent symbol {}", stream_id);
-        }
-    }
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
+    return async_update_internal(
+                   stream_id,
+                   std::move(update_info),
+                   query,
+                   frame,
+                   upsert,
+                   dynamic_schema,
+                   prune_previous_versions,
+                   false
+    )
+            .get();
 }
 
 VersionedItem LocalVersionedEngine::write_versioned_metadata_internal(
         const StreamId& stream_id, bool prune_previous_versions,
         arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
 ) {
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
-    if (update_info.previous_index_key_.has_value()) {
-        ARCTICDB_DEBUG(log::version(), "write_versioned_metadata for stream_id: {}", stream_id);
-        auto index_key = UpdateMetadataTask{store(), update_info, std::move(user_meta)}();
-        write_version_and_prune_previous(prune_previous_versions, index_key, update_info.previous_index_key_);
-        return VersionedItem{std::move(index_key)};
-    } else {
-        auto frame = convert::py_none_to_frame();
-        frame->desc().set_id(stream_id);
-        frame->user_meta = std::move(user_meta);
-        auto versioned_item =
-                write_versioned_dataframe_internal(stream_id, frame, prune_previous_versions, false, false);
-        if (cfg_.symbol_list())
-            symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
-
-        return versioned_item;
-    }
+    py::gil_scoped_release release_gil;
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
+    return async_write_versioned_metadata_internal(
+                   stream_id, std::move(update_info), std::move(user_meta), prune_previous_versions
+    )
+            .get();
 }
 
 std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_write_versioned_metadata_internal(
         const std::vector<StreamId>& stream_ids, bool prune_previous_versions, bool throw_on_error,
         std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos
 ) {
+    py::gil_scoped_release release_gil;
     auto stream_update_info_futures =
-            batch_get_latest_undeleted_version_and_next_version_id_async(store(), version_map(), stream_ids);
+            batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             stream_ids.size() == stream_update_info_futures.size(),
             "stream_ids and stream_update_info_futures must be of the same size"
     );
     std::vector<folly::Future<VersionedItem>> write_metadata_versions_futs;
     for (const auto&& [idx, stream_update_info_fut] : folly::enumerate(stream_update_info_futures)) {
-        write_metadata_versions_futs.push_back(
-                std::move(stream_update_info_fut)
-                        .thenValue(
-                                [this,
-                                 user_meta_proto = std::move(user_meta_protos[idx]),
-                                 &stream_id = stream_ids[idx]](auto&& update_info
-                                ) mutable -> folly::Future<IndexKeyAndUpdateInfo> {
-                                    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
-                                    if (update_info.previous_index_key_.has_value()) {
-                                        index_key_fut = async::submit_io_task(
-                                                UpdateMetadataTask{store(), update_info, std::move(user_meta_proto)}
-                                        );
-                                    } else {
-                                        auto frame = convert::py_none_to_frame();
-                                        frame->desc().set_id(stream_id);
-                                        frame->user_meta = std::move(user_meta_proto);
-                                        auto version_id = 0;
-                                        auto write_options = get_write_options();
-                                        auto de_dup_map = std::make_shared<DeDupMap>();
-                                        index_key_fut = async_write_dataframe_impl(
-                                                store(), version_id, frame, write_options, de_dup_map, false, false
-                                        );
-                                    }
-                                    return std::move(index_key_fut)
-                                            .thenValue(
-                                                    [update_info = std::forward<decltype(update_info)>(update_info
-                                                     )](auto&& index_key) mutable -> IndexKeyAndUpdateInfo {
-                                                        return IndexKeyAndUpdateInfo{
-                                                                std::move(index_key), std::move(update_info)
-                                                        };
-                                                    }
-                                            );
-                                }
-                        )
-                        .thenValue([this, prune_previous_versions](auto&& index_key_and_update_info) {
-                            auto&& [index_key, update_info] = index_key_and_update_info;
-                            return write_index_key_to_version_map_async(
-                                    version_map(),
-                                    std::move(index_key),
-                                    std::move(update_info),
-                                    prune_previous_versions,
-                                    !update_info.previous_index_key_.has_value()
-                            );
-                        })
-        );
+        write_metadata_versions_futs.push_back(std::move(stream_update_info_fut)
+                                                       .via(&async::cpu_executor())
+                                                       .thenValue([this,
+                                                                   user_meta_proto = std::move(user_meta_protos[idx]),
+                                                                   &stream_id = stream_ids[idx],
+                                                                   prune_previous_versions](UpdateInfo&& update_info
+                                                                  ) mutable {
+                                                           return async_write_versioned_metadata_internal(
+                                                                   stream_id,
+                                                                   std::move(update_info),
+                                                                   std::move(user_meta_proto),
+                                                                   prune_previous_versions
+                                                           );
+                                                       }));
     }
 
     auto write_metadata_versions = collectAll(write_metadata_versions_futs).get();
@@ -862,22 +789,15 @@ VersionedItem LocalVersionedEngine::write_versioned_dataframe_internal(
     ARCTICDB_SAMPLE(WriteVersionedDataFrame, 0)
     py::gil_scoped_release release_gil;
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_dataframe");
-    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id);
-    auto version_id = get_next_version_from_key(maybe_prev);
-    ARCTICDB_DEBUG(
-            log::version(), "write_versioned_dataframe for stream_id: {} , version_id = {}", stream_id, version_id
+    // We don't need to load the latest live version unless dedup is enabled. If dedup is disabled, we only care about
+    // the next version ID, which can save some IO traversing the version chain
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(
+            store(), version_map(), stream_id, write_options_.de_duplication
     );
-    auto write_options = get_write_options();
-    auto de_dup_map = get_de_dup_map(stream_id, maybe_prev, write_options);
-
-    auto versioned_item =
-            write_dataframe_impl(store(), version_id, frame, write_options, de_dup_map, allow_sparse, validate_index);
-
-    if (cfg().symbol_list())
-        symbol_list().add_symbol(store(), stream_id, versioned_item.key_.version_id());
-
-    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, deleted ? std::nullopt : maybe_prev);
-    return versioned_item;
+    return async_write_versioned_dataframe_internal(
+                   stream_id, std::move(update_info), frame, prune_previous_versions, allow_sparse, validate_index
+    )
+            .get();
 }
 
 std::pair<VersionedItem, TimeseriesDescriptor> LocalVersionedEngine::restore_version(
@@ -903,22 +823,25 @@ VersionedItem LocalVersionedEngine::write_segment(
             segment.descriptor().id()
     );
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write individual segment");
-    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id);
-    auto version_id = get_next_version_from_key(maybe_prev);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(
+            store(), version_map(), stream_id, write_options_.de_duplication
+    );
     ARCTICDB_DEBUG(
-            log::version(), "write individual segment for stream_id: {} , version_id = {}", stream_id, version_id
+            log::version(),
+            "write individual segment for stream_id: {} , version_id = {}",
+            stream_id,
+            update_info.next_version_id_
     );
 
-    auto write_options = get_write_options();
-    auto de_dup_map = get_de_dup_map(stream_id, maybe_prev, write_options);
+    auto de_dup_map = get_de_dup_map(stream_id, update_info, write_options_);
 
-    if (version_id == 0) {
+    if (update_info.next_version_id_ == 0) {
         auto check_outcome = verify_symbol_key(stream_id, store());
         if (std::holds_alternative<Error>(check_outcome)) {
             std::get<Error>(check_outcome).throw_error();
         }
     }
-    auto partial_key = IndexPartialKey(stream_id, version_id);
+    auto partial_key = IndexPartialKey(stream_id, update_info.next_version_id_);
 
     // TODO: do the segment splitting in parallel
     std::vector<SegmentInMemory> slices;
@@ -927,7 +850,7 @@ VersionedItem LocalVersionedEngine::write_segment(
         slices = std::vector<SegmentInMemory>({segment});
         break;
     case Slicing::RowSlicing:
-        slices = segment.split(get_write_options().segment_row_size, true);
+        slices = segment.split(write_options_.segment_row_size, true);
         break;
     }
 
@@ -992,7 +915,7 @@ VersionedItem LocalVersionedEngine::write_segment(
     if (cfg().symbol_list())
         symbol_list().add_symbol(store(), stream_id, versioned_item.key_.version_id());
 
-    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, deleted ? std::nullopt : maybe_prev);
+    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
     return versioned_item;
 }
 
@@ -1274,7 +1197,7 @@ StageResult LocalVersionedEngine::write_parallel_frame(
     py::gil_scoped_release release_gil;
     WriteIncompleteOptions options{
             .validate_index = validate_index,
-            .write_options = get_write_options(),
+            .write_options = write_options_,
             .sort_on_index = sort_on_index,
             .sort_columns = sort_columns
     };
@@ -1285,7 +1208,7 @@ StageResult LocalVersionedEngine::write_parallel_frame(
 void LocalVersionedEngine::add_to_symbol_list_on_compaction(
         const StreamId& stream_id, const CompactIncompleteParameters& parameters, const UpdateInfo& update_info
 ) {
-    if (cfg_.symbol_list()) {
+    if (cfg().symbol_list()) {
         if (!parameters.append_ || !update_info.previous_index_key_.has_value()) {
             symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
         }
@@ -1298,7 +1221,7 @@ std::variant<VersionedItem, CompactionError> LocalVersionedEngine::compact_incom
 ) {
     log::version().debug("Compacting incomplete symbol {} with options {}", stream_id, parameters);
 
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
     if (update_info.previous_index_key_) {
         ARCTICDB_DEBUG(log::version(), "Found previous version for symbol {}", stream_id);
     } else {
@@ -1310,7 +1233,7 @@ std::variant<VersionedItem, CompactionError> LocalVersionedEngine::compact_incom
     auto delete_keys_on_failure = get_delete_keys_on_failure(pipeline_context, store(), parameters);
 
     auto versioned_item_or_error = compact_incomplete_impl(
-            store_, stream_id, user_meta, update_info, parameters, get_write_options(), pipeline_context
+            store_, stream_id, user_meta, update_info, parameters, write_options_, pipeline_context
     );
     if (std::holds_alternative<CompactionError>(versioned_item_or_error)) {
         return versioned_item_or_error;
@@ -1332,7 +1255,7 @@ std::variant<VersionedItem, CompactionError> LocalVersionedEngine::compact_incom
 }
 
 UpdateInfo LocalVersionedEngine::compact_data_preamble(const StreamId& stream_id) {
-    UpdateInfo update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
     storage::check<ErrorCode::E_SYMBOL_NOT_FOUND>(
             update_info.previous_index_key_.has_value(), "Cannot compact data of non-existent symbol \"{}\".", stream_id
     );
@@ -1354,7 +1277,7 @@ CompactDataInfo LocalVersionedEngine::compact_data_explain_plan_internal(
     py::gil_scoped_release release_gil;
     UpdateInfo update_info = compact_data_preamble(stream_id);
     return compact_data_explain_plan_impl(
-                   store(), update_info, rows_per_segment.value_or(get_write_options().segment_row_size)
+                   store(), update_info, rows_per_segment.value_or(write_options_.segment_row_size)
     )
             .get();
 }
@@ -1364,7 +1287,7 @@ VersionedItem LocalVersionedEngine::maybe_compact_data_and_write_version(
         std::optional<CompactDataFrame> compact_data_frame
 ) {
     auto versioned_item =
-            compact_data_impl(store(), update_info, get_write_options(), rows_per_segment, compact_data_frame).get();
+            compact_data_impl(store(), update_info, write_options_, rows_per_segment, compact_data_frame).get();
     if (versioned_item.has_value()) {
         write_version_and_prune_previous(
                 prune_previous_versions, versioned_item->key_, update_info.previous_index_key_
@@ -1384,15 +1307,14 @@ VersionedItem LocalVersionedEngine::compact_data_internal(
     py::gil_scoped_release release_gil;
     UpdateInfo update_info = compact_data_preamble(stream_id);
     return maybe_compact_data_and_write_version(
-            update_info, rows_per_segment.value_or(get_write_options().segment_row_size), prune_previous_versions
+            update_info, rows_per_segment.value_or(write_options_.segment_row_size), prune_previous_versions
     );
 }
 
 bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) {
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
-    auto options = get_write_options();
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
     auto pre_defragmentation_info = get_pre_defragmentation_info(
-            store(), stream_id, update_info, options, segment_size.value_or(options.segment_row_size)
+            store(), stream_id, update_info, write_options_, segment_size.value_or(write_options_.segment_row_size)
     );
     return is_symbol_fragmented_impl(pre_defragmentation_info.segments_need_compaction);
 }
@@ -1403,20 +1325,19 @@ VersionedItem LocalVersionedEngine::defragment_symbol_data(
     log::version().info("Defragmenting data for symbol {}", stream_id);
 
     // Currently defragmentation only for latest version - is there a use-case to allow compaction for older data?
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
 
-    auto options = get_write_options();
     auto versioned_item = defragment_symbol_data_impl(
             store(),
             stream_id,
             update_info,
-            options,
-            segment_size.has_value() ? *segment_size : options.segment_row_size
+            write_options_,
+            segment_size.has_value() ? *segment_size : write_options_.segment_row_size
     );
 
     write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
 
-    if (cfg_.symbol_list())
+    if (cfg().symbol_list())
         symbol_list().add_symbol(store_, stream_id, versioned_item.key_.version_id());
 
     return versioned_item;
@@ -1706,10 +1627,9 @@ folly::Future<std::vector<AtomKey>> LocalVersionedEngine::batch_write_internal(
     for (size_t idx = 0; idx < stream_ids.size(); idx++) {
         auto& frame = frames[idx];
         auto version_id = version_ids[idx];
-        auto write_options = get_write_options();
-        frame->set_bucketize_dynamic(write_options.bucketize_dynamic);
+        frame->set_bucketize_dynamic(write_options_.bucketize_dynamic);
         auto [partial_key, slicing_policy] =
-                get_partial_key_and_slicing_policy(store(), write_options, *frame, version_id, validate_index);
+                get_partial_key_and_slicing_policy(store(), write_options_, *frame, version_id, validate_index);
         auto fut_slice_keys =
                 slice_and_write(frame, slicing_policy, std::move(partial_key), store(), de_dup_maps[idx], false);
         batch_futures.emplace_back(std::move(fut_slice_keys));
@@ -1734,20 +1654,185 @@ folly::Future<std::vector<AtomKey>> LocalVersionedEngine::batch_write_internal(
             });
 }
 
-VersionIdAndDedupMapInfo LocalVersionedEngine::create_version_id_and_dedup_map(
-        const version_store::UpdateInfo&& update_info, const StreamId& stream_id, const WriteOptions& write_options
+folly::Future<VersionedItem> LocalVersionedEngine::async_write_versioned_dataframe_internal(
+        const StreamId& stream_id, UpdateInfo&& update_info, const std::shared_ptr<InputFrame>& frame,
+        bool prune_previous_versions, bool allow_sparse, bool validate_index
 ) {
-    if (cfg().write_options().de_duplication()) {
-        return VersionIdAndDedupMapInfo{
-                update_info.next_version_id_,
-                get_de_dup_map(stream_id, update_info.previous_index_key_, write_options),
-                std::move(update_info)
-        };
+    const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
+    auto de_dup_map = get_de_dup_map(stream_id, update_info, write_options_);
+    ARCTICDB_DEBUG(
+            log::version(),
+            "write_versioned_dataframe for stream_id: {} , version_id = {}",
+            stream_id,
+            update_info.next_version_id_
+    );
+    return async_write_dataframe_impl(
+                   store(),
+                   update_info.next_version_id_,
+                   frame,
+                   write_options_,
+                   de_dup_map,
+                   allow_sparse,
+                   validate_index
+    )
+            .thenValue([this, update_info = std::move(update_info), prune_previous_versions, add_new_symbol_list_entry](
+                               AtomKey&& index_key
+                       ) mutable {
+                return write_index_key_to_version_map_async(
+                        version_map(),
+                        std::move(index_key),
+                        std::move(update_info),
+                        prune_previous_versions,
+                        add_new_symbol_list_entry
+                );
+            });
+}
+
+folly::Future<VersionedItem> LocalVersionedEngine::async_append_internal(
+        const StreamId& stream_id, UpdateInfo&& update_info, const std::shared_ptr<InputFrame>& frame,
+        const AppendOptions& append_options, const bool batch
+) {
+    const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
+    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
+    if (update_info.previous_index_key_.has_value()) {
+        index_key_fut = frame->empty() ? async_write_metadata_impl(store(), update_info, std::move(frame->user_meta))
+                                       : async_append_impl(
+                                                 store(),
+                                                 update_info,
+                                                 frame,
+                                                 write_options_,
+                                                 append_options.validate_index,
+                                                 write_options_.empty_types
+                                         );
     } else {
-        return VersionIdAndDedupMapInfo{
-                update_info.next_version_id_, std::make_shared<DeDupMap>(), std::move(update_info)
-        };
+        if (!append_options.upsert) {
+            auto error_msg = fmt::format(
+                    "Cannot append to non-existent symbol {}. Using \"write_if_missing=True\" will create the symbol"
+                    "instead of throwing this exception.",
+                    stream_id
+            );
+            if (batch) {
+                missing_data::raise<ErrorCode::E_NO_SUCH_VERSION>(error_msg);
+            } else {
+                util::raise_rte(error_msg);
+            }
+        }
+        // Replace above with this as part of Monday ticket 12551552848 for 7.0.0
+        //        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
+        //                append_options.upsert,
+        //                "Cannot append to non-existent symbol {}. Using \"write_if_missing=True\" will create the
+        //                symbol" "instead of throwing this exception.", stream_id
+        //        );
+        index_key_fut = async_write_dataframe_impl(
+                store(),
+                update_info.next_version_id_,
+                frame,
+                write_options_,
+                std::make_shared<DeDupMap>(),
+                false,
+                append_options.validate_index
+        );
     }
+    return std::move(index_key_fut)
+            .thenValue([this,
+                        update_info = std::move(update_info),
+                        prune_previous_versions = append_options.prune_previous_versions,
+                        add_new_symbol_list_entry](AtomKey&& index_key) mutable {
+                return write_index_key_to_version_map_async(
+                        version_map(),
+                        std::move(index_key),
+                        std::move(update_info),
+                        prune_previous_versions,
+                        add_new_symbol_list_entry
+                );
+            });
+}
+
+folly::Future<VersionedItem> LocalVersionedEngine::async_update_internal(
+        const StreamId& stream_id, UpdateInfo&& update_info, const UpdateQuery& query,
+        const std::shared_ptr<InputFrame>& frame, bool upsert, bool dynamic_schema, bool prune_previous_versions,
+        const bool batch
+) {
+    const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
+    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
+    if (update_info.previous_index_key_.has_value()) {
+        index_key_fut = frame->empty() ? async_write_metadata_impl(store(), update_info, std::move(frame->user_meta))
+                                       : async_update_impl(
+                                                 store(),
+                                                 update_info,
+                                                 query,
+                                                 frame,
+                                                 write_options_,
+                                                 dynamic_schema,
+                                                 write_options_.empty_types
+                                         );
+    } else {
+        if (!upsert) {
+            auto error_msg = fmt::format(
+                    "Cannot update non-existent symbol {}. Using \"upsert=True\" will create the symbol instead of "
+                    "throwing this exception.",
+                    stream_id
+            );
+            if (batch) {
+                missing_data::raise<ErrorCode::E_NO_SUCH_VERSION>(error_msg);
+            } else {
+                util::raise_rte(error_msg);
+            }
+        }
+        // Replace above with this as part of Monday ticket 12551552848 for 7.0.0
+        //        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
+        //                upsert,
+        //                "Cannot update non-existent symbol {}. Using \"upsert=True\" will create the symbol instead of
+        //                " "throwing this exception.", stream_id
+        //        );
+        // Make a copy as we're possibly changing a flag here. dynamic_schema as an explicit argument to modification
+        // methods are on the way out, remove when this is done
+        auto write_options = write_options_;
+        write_options.dynamic_schema |= dynamic_schema;
+        index_key_fut = async_write_dataframe_impl(
+                store(), update_info.next_version_id_, frame, write_options, std::make_shared<DeDupMap>(), false, true
+        );
+    }
+    return std::move(index_key_fut)
+            .thenValue([this, update_info = std::move(update_info), prune_previous_versions, add_new_symbol_list_entry](
+                               AtomKey&& index_key
+                       ) mutable {
+                return write_index_key_to_version_map_async(
+                        version_map(),
+                        std::move(index_key),
+                        std::move(update_info),
+                        prune_previous_versions,
+                        add_new_symbol_list_entry
+                );
+            });
+}
+
+folly::Future<VersionedItem> LocalVersionedEngine::async_write_versioned_metadata_internal(
+        const StreamId& stream_id, UpdateInfo&& update_info,
+        arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta, bool prune_previous_versions
+) {
+    const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
+    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
+    if (update_info.previous_index_key_.has_value()) {
+        index_key_fut = async_write_metadata_impl(store(), update_info, std::move(user_meta));
+    } else {
+        auto frame = convert::py_none_to_frame();
+        frame->desc().set_id(stream_id);
+        frame->user_meta = std::move(user_meta);
+        index_key_fut = async_write_dataframe_impl(store(), update_info.next_version_id_, frame, write_options_);
+    }
+    return std::move(index_key_fut)
+            .thenValue([this, update_info = std::move(update_info), prune_previous_versions, add_new_symbol_list_entry](
+                               AtomKey&& index_key
+                       ) mutable {
+                return write_index_key_to_version_map_async(
+                        version_map(),
+                        std::move(index_key),
+                        std::move(update_info),
+                        prune_previous_versions,
+                        add_new_symbol_list_entry
+                );
+            });
 }
 
 std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_write_versioned_dataframe_internal(
@@ -1756,44 +1841,30 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
 ) {
     py::gil_scoped_release release_gil;
 
-    auto write_options = get_write_options();
-    auto update_info_futs =
-            batch_get_latest_undeleted_version_and_next_version_id_async(store(), version_map(), stream_ids);
+    auto update_info_futs = batch_get_next_version_id_and_optionally_latest_undeleted_version_async(
+            store(), version_map(), stream_ids, write_options_.de_duplication
+    );
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             stream_ids.size() == update_info_futs.size(), "stream_ids and update_info_futs must be of the same size"
     );
     std::vector<folly::Future<VersionedItem>> version_futures;
     for (auto&& update_info_fut : folly::enumerate(update_info_futs)) {
         auto idx = update_info_fut.index;
-        version_futures.push_back(
-                std::move(*update_info_fut)
-                        .thenValue([this, &stream_id = stream_ids[idx], &write_options](auto&& update_info) {
-                            return create_version_id_and_dedup_map(std::move(update_info), stream_id, write_options);
-                        })
-                        .via(&async::cpu_executor())
-                        .thenValue([this,
-                                    &stream_id = stream_ids[idx],
-                                    &write_options,
-                                    &validate_index,
-                                    &frame = frames[idx]](auto&& version_id_and_dedup_map) {
-                            auto& [version_id, de_dup_map, update_info] = version_id_and_dedup_map;
-                            ARCTICDB_SAMPLE(WriteDataFrame, 0)
-                            ARCTICDB_DEBUG(log::version(), "Writing dataframe for stream id {}", stream_id);
-                            auto write_fut = async_write_dataframe_impl(
-                                    store(), version_id, frame, write_options, de_dup_map, false, validate_index
-                            );
-                            return std::move(write_fut).thenValue([update_info = std::move(update_info
-                                                                   )](auto&& index_key) mutable {
-                                return IndexKeyAndUpdateInfo{std::move(index_key), std::move(update_info)};
-                            });
-                        })
-                        .thenValue([this, prune_previous_versions](auto&& index_key_and_update_info) {
-                            auto&& [index_key, update_info] = index_key_and_update_info;
-                            return write_index_key_to_version_map_async(
-                                    version_map(), std::move(index_key), std::move(update_info), prune_previous_versions
-                            );
-                        })
-        );
+        version_futures.push_back(std::move(*update_info_fut)
+                                          .thenValueInline([this,
+                                                            &stream_id = stream_ids[idx],
+                                                            frame = std::move(frames[idx]),
+                                                            prune_previous_versions,
+                                                            validate_index](UpdateInfo&& update_info) {
+                                              return async_write_versioned_dataframe_internal(
+                                                      stream_id,
+                                                      std::move(update_info),
+                                                      frame,
+                                                      prune_previous_versions,
+                                                      false,
+                                                      validate_index
+                                              );
+                                          }));
     }
     auto write_versions = folly::collectAll(version_futures).get();
     TransformBatchResultsFlags flags;
@@ -1856,66 +1927,21 @@ VersionedItem LocalVersionedEngine::append_internal(
         const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, const AppendOptions& append_options
 ) {
     py::gil_scoped_release release_gil;
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
 
     // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data is true,
     // but also when it isn't. However, the read-modify-write pipeline is all built around the PipelineContext class
     // which assumes an existing version. Better if we just make the FixedSlicer smarter so that its logic is more like
     // ReslicingInfo
-    if (update_info.previous_index_key_.has_value()) {
-        if (append_options.compact_data) {
-            auto compact_data_frame = std::make_optional<CompactDataFrame>(
-                    frame, append_options.validate_index, cfg().write_options().empty_types()
-            );
-            return maybe_compact_data_and_write_version(
-                    update_info,
-                    get_write_options().segment_row_size,
-                    append_options.prune_previous_versions,
-                    compact_data_frame
-            );
-        } else {
-            const auto versioned_item =
-                    frame->empty() ? VersionedItem{async::submit_io_task(
-                                                           UpdateMetadataTask{
-                                                                   store(), update_info, std::move(frame->user_meta)
-                                                           }
-                                     )
-                                                           .get()}
-                                   : append_impl(
-                                             store(),
-                                             update_info,
-                                             frame,
-                                             get_write_options(),
-                                             append_options.validate_index,
-                                             cfg().write_options().empty_types()
-                                     );
-            write_version_and_prune_previous(
-                    append_options.prune_previous_versions, versioned_item.key_, update_info.previous_index_key_
-            );
-            return versioned_item;
-        }
-    } else {
-        if (append_options.upsert) {
-            auto write_options = get_write_options();
-            auto versioned_item = write_dataframe_impl(
-                    store_,
-                    update_info.next_version_id_,
-                    frame,
-                    write_options,
-                    std::make_shared<DeDupMap>(),
-                    false,
-                    append_options.validate_index
-            );
-
-            if (cfg_.symbol_list())
-                symbol_list().add_symbol(store_, stream_id, update_info.next_version_id_);
-
-            version_map()->write_version(store(), versioned_item.key_, std::nullopt);
-            return versioned_item;
-        } else {
-            util::raise_rte("Cannot append to non-existent symbol {}", stream_id);
-        }
+    if (update_info.previous_index_key_.has_value() && append_options.compact_data) {
+        auto compact_data_frame =
+                std::make_optional<CompactDataFrame>(frame, append_options.validate_index, write_options_.empty_types);
+        return maybe_compact_data_and_write_version(
+                update_info, write_options_.segment_row_size, append_options.prune_previous_versions, compact_data_frame
+        );
     }
+
+    return async_append_internal(stream_id, std::move(update_info), frame, append_options, false).get();
 }
 
 std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_append_internal(
@@ -1925,7 +1951,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     py::gil_scoped_release release_gil;
 
     auto stream_update_info_futures =
-            batch_get_latest_undeleted_version_and_next_version_id_async(store(), version_map(), stream_ids);
+            batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);
     std::vector<folly::Future<VersionedItem>> append_versions_futs;
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             stream_ids.size() == stream_update_info_futures.size(),
@@ -1935,61 +1961,13 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         append_versions_futs.push_back(
                 std::move(stream_update_info_fut)
                         .via(&async::cpu_executor())
-                        .thenValue(
-                                [this, frame = std::move(frames[idx]), append_options, stream_id = stream_ids[idx]](
-                                        auto&& update_info
-                                ) -> folly::Future<VersionedItem> {
-                                    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
-                                    auto write_options = get_write_options();
-                                    bool add_new_symbol_list_entry{!update_info.previous_index_key_.has_value()};
-                                    if (update_info.previous_index_key_.has_value()) {
-                                        index_key_fut =
-                                                frame->empty()
-                                                        ? async::submit_io_task(UpdateMetadataTask{
-                                                                  store(), update_info, std::move(frame->user_meta)
-                                                          })
-                                                        : async_append_impl(
-                                                                  store(),
-                                                                  update_info,
-                                                                  frame,
-                                                                  write_options,
-                                                                  append_options.validate_index,
-                                                                  cfg().write_options().empty_types()
-                                                          );
-                                    } else {
-                                        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
-                                                append_options.upsert,
-                                                "Cannot append to non-existent symbol {}",
-                                                stream_id
-                                        );
-                                        index_key_fut = async_write_dataframe_impl(
-                                                store(),
-                                                update_info.next_version_id_,
-                                                frame,
-                                                write_options,
-                                                std::make_shared<DeDupMap>(),
-                                                false,
-                                                append_options.validate_index
-                                        );
-                                    }
-                                    return std::move(index_key_fut)
-                                            .thenValue(
-                                                    [this,
-                                                     append_options,
-                                                     add_new_symbol_list_entry,
-                                                     update_info = std::move(update_info)](AtomKey&& index_key
-                                                    ) mutable -> folly::Future<VersionedItem> {
-                                                        return write_index_key_to_version_map_async(
-                                                                version_map(),
-                                                                std::move(index_key),
-                                                                std::move(update_info),
-                                                                append_options.prune_previous_versions,
-                                                                add_new_symbol_list_entry
-                                                        );
-                                                    }
-                                            );
-                                }
-                        )
+                        .thenValue([this, frame = std::move(frames[idx]), append_options, &stream_id = stream_ids[idx]](
+                                           UpdateInfo&& update_info
+                                   ) {
+                            return async_append_internal(
+                                    stream_id, std::move(update_info), frame, append_options, true
+                            );
+                        })
         );
     }
 
@@ -2006,77 +1984,32 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     py::gil_scoped_release release_gil;
 
     auto stream_update_info_futures =
-            batch_get_latest_undeleted_version_and_next_version_id_async(store(), version_map(), stream_ids);
+            batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);
     std::vector<folly::Future<VersionedItem>> update_versions_futs;
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             stream_ids.size() == stream_update_info_futures.size(),
             "stream_ids and stream_update_info_futures must be of the same size"
     );
-    for (const auto&& [idx, stream_update_info_fut] : enumerate(stream_update_info_futures)) {
-        update_versions_futs.push_back(
-                std::move(stream_update_info_fut)
-                        .via(&async::cpu_executor())
-                        .thenValue(
-                                [this,
-                                 frame = std::move(frames[idx]),
-                                 stream_id = stream_ids[idx],
-                                 update_query = update_queries[idx],
-                                 upsert,
-                                 prune_previous_versions](UpdateInfo&& update_info) -> folly::Future<VersionedItem> {
-                                    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
-                                    auto write_options = get_write_options();
-                                    bool add_new_symbol_list_entry{!update_info.previous_index_key_.has_value()};
-                                    if (update_info.previous_index_key_.has_value()) {
-                                        const bool dynamic_schema = cfg().write_options().dynamic_schema();
-                                        const bool empty_types = cfg().write_options().empty_types();
-                                        index_key_fut =
-                                                frame->empty()
-                                                        ? async::submit_io_task(UpdateMetadataTask{
-                                                                  store(), update_info, std::move(frame->user_meta)
-                                                          })
-                                                        : async_update_impl(
-                                                                  store(),
-                                                                  update_info,
-                                                                  update_query,
-                                                                  std::move(frame),
-                                                                  std::move(write_options),
-                                                                  dynamic_schema,
-                                                                  empty_types
-                                                          );
-                                    } else {
-                                        missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
-                                                upsert,
-                                                "Cannot update non-existent symbol {}."
-                                                "Using \"upsert=True\" will create create the symbol instead of "
-                                                "throwing this exception.",
-                                                stream_id
-                                        );
-                                        index_key_fut = async_write_dataframe_impl(
-                                                store(),
-                                                update_info.next_version_id_,
-                                                std::move(frame),
-                                                std::move(write_options),
-                                                std::make_shared<DeDupMap>(),
-                                                false,
-                                                true
-                                        );
-                                    }
-                                    return std::move(index_key_fut)
-                                            .thenValue([this,
-                                                        update_info = std::move(update_info),
-                                                        prune_previous_versions,
-                                                        add_new_symbol_list_entry](auto&& index_key) mutable {
-                                                return write_index_key_to_version_map_async(
-                                                        version_map(),
-                                                        std::move(index_key),
-                                                        std::move(update_info),
-                                                        prune_previous_versions,
-                                                        add_new_symbol_list_entry
-                                                );
-                                            });
-                                }
-                        )
-        );
+    for (const auto&& [idx, stream_update_info_fut] : folly::enumerate(stream_update_info_futures)) {
+        update_versions_futs.push_back(std::move(stream_update_info_fut)
+                                               .via(&async::cpu_executor())
+                                               .thenValue([this,
+                                                           frame = std::move(frames[idx]),
+                                                           &stream_id = stream_ids[idx],
+                                                           update_query = update_queries[idx],
+                                                           upsert,
+                                                           prune_previous_versions](UpdateInfo&& update_info) {
+                                                   return async_update_internal(
+                                                           stream_id,
+                                                           std::move(update_info),
+                                                           update_query,
+                                                           frame,
+                                                           upsert,
+                                                           write_options_.dynamic_schema,
+                                                           prune_previous_versions,
+                                                           true
+                                                   );
+                                               }));
     }
 
     auto update_versions = collectAll(update_versions_futs).get();
@@ -2335,7 +2268,7 @@ std::variant<VersionedItem, CompactionError> LocalVersionedEngine::sort_merge_in
 ) {
     log::version().debug("Sort merge for symbol {} with options {}", stream_id, parameters);
 
-    auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
     if (update_info.previous_index_key_) {
         ARCTICDB_DEBUG(log::version(), "Found previous version for symbol {}", stream_id);
     } else {
@@ -2347,9 +2280,8 @@ std::variant<VersionedItem, CompactionError> LocalVersionedEngine::sort_merge_in
     pipeline_context->version_id_ = update_info.next_version_id_;
     auto delete_keys_on_failure = get_delete_keys_on_failure(pipeline_context, store(), parameters);
 
-    auto sort_merge_result = sort_merge_impl(
-            store_, stream_id, user_meta, update_info, parameters, get_write_options(), pipeline_context
-    );
+    auto sort_merge_result =
+            sort_merge_impl(store_, stream_id, user_meta, update_info, parameters, write_options_, pipeline_context);
     ARCTICDB_DEBUG(log::version(), "Finished sort_merge_impl for symbol {}", stream_id);
     if (std::holds_alternative<CompactionError>(sort_merge_result)) {
         return sort_merge_result;
@@ -2397,6 +2329,7 @@ void LocalVersionedEngine::configure(const storage::LibraryDescriptor::VariantSt
                 );
             }
     );
+    write_options_ = get_write_options();
 }
 
 timestamp LocalVersionedEngine::latest_timestamp(const std::string& symbol) {
@@ -2527,7 +2460,7 @@ VersionedItem LocalVersionedEngine::merge_internal(
             is_valid_merge_strategy(strategy), "Invalid merge strategy: {}", strategy
     );
     py::gil_scoped_release release_gil;
-    UpdateInfo update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
     if (update_info.previous_index_key_.has_value()) {
         if (source->empty()) {
             ARCTICDB_RUNTIME_DEBUG(
@@ -2540,12 +2473,11 @@ VersionedItem LocalVersionedEngine::merge_internal(
             return VersionedItem{*std::move(update_info.previous_index_key_)};
         }
         const ReadOptions read_options;
-        const WriteOptions write_options = get_write_options();
         VersionedItem versioned_item = merge_update_impl(
                                                store(),
                                                VersionedItem{*update_info.previous_index_key_},
                                                read_options,
-                                               write_options,
+                                               write_options_,
                                                IndexPartialKey{stream_id, update_info.next_version_id_},
                                                std::move(on),
                                                strategy,

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -35,16 +35,6 @@ using VersionedItemOrError = std::variant<VersionedItem, DataError>;
  */
 using SpecificAndLatestVersionKeys = std::pair<
         std::shared_ptr<std::unordered_map<StreamId, AtomKey>>, std::shared_ptr<std::unordered_map<StreamId, AtomKey>>>;
-struct VersionIdAndDedupMapInfo {
-    VersionId version_id;
-    std::shared_ptr<DeDupMap> de_dup_map;
-    version_store::UpdateInfo update_info;
-};
-
-struct IndexKeyAndUpdateInfo {
-    entity::AtomKey index_key;
-    version_store::UpdateInfo update_info;
-};
 
 struct KeySizesInfo {
     size_t count;
@@ -372,7 +362,7 @@ class LocalVersionedEngine : public VersionedEngine {
     void force_release_lock(const StreamId& name);
 
     std::shared_ptr<DeDupMap> get_de_dup_map(
-            const StreamId& stream_id, const std::optional<AtomKey>& maybe_prev, const WriteOptions& write_options
+            const StreamId& stream_id, const UpdateInfo& update_info, const WriteOptions& write_options
     );
 
     folly::Future<VersionedItem> write_index_key_to_version_map_async(
@@ -395,10 +385,6 @@ class LocalVersionedEngine : public VersionedEngine {
 
     std::vector<std::variant<folly::Unit, DataError>> batch_delete_symbols_internal(
             const std::vector<std::pair<StreamId, VersionId>>& symbols_to_delete
-    );
-
-    VersionIdAndDedupMapInfo create_version_id_and_dedup_map(
-            const version_store::UpdateInfo&& update_info, const StreamId& stream_id, const WriteOptions& write_options
     );
 
     std::vector<storage::ObjectSizes> scan_object_sizes();
@@ -474,8 +460,33 @@ class LocalVersionedEngine : public VersionedEngine {
     );
     UpdateInfo compact_data_preamble(const StreamId& stream_id);
 
+    // Per-symbol modification pipelines shared by the single-symbol and batch entry points. Each takes the resolved
+    // update_info, produces the new index key, and writes it to the version map. The single-symbol methods obtain
+    // update_info synchronously and block on the returned future; the batch methods chain it per symbol.
+    folly::Future<VersionedItem> async_write_versioned_dataframe_internal(
+            const StreamId& stream_id, UpdateInfo&& update_info, const std::shared_ptr<pipelines::InputFrame>& frame,
+            bool prune_previous_versions, bool allow_sparse, bool validate_index
+    );
+
+    folly::Future<VersionedItem> async_append_internal(
+            const StreamId& stream_id, UpdateInfo&& update_info, const std::shared_ptr<pipelines::InputFrame>& frame,
+            const AppendOptions& append_options, const bool batch
+    );
+
+    folly::Future<VersionedItem> async_update_internal(
+            const StreamId& stream_id, UpdateInfo&& update_info, const UpdateQuery& query,
+            const std::shared_ptr<pipelines::InputFrame>& frame, bool upsert, bool dynamic_schema,
+            bool prune_previous_versions, const bool batch
+    );
+
+    folly::Future<VersionedItem> async_write_versioned_metadata_internal(
+            const StreamId& stream_id, UpdateInfo&& update_info,
+            arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta, bool prune_previous_versions
+    );
+
     std::shared_ptr<Store> store_;
     arcticdb::proto::storage::VersionStoreConfig cfg_;
+    WriteOptions write_options_;
     std::shared_ptr<VersionMap> version_map_ = std::make_shared<VersionMap>();
     std::shared_ptr<SymbolList> symbol_list_;
     std::optional<std::string> license_key_;

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -82,24 +82,6 @@ static void modify_descriptor(
     }
 }
 
-VersionedItem write_dataframe_impl(
-        const std::shared_ptr<Store>& store, VersionId version_id, const std::shared_ptr<InputFrame>& frame,
-        const WriteOptions& options, const std::shared_ptr<DeDupMap>& de_dup_map, bool sparsify_floats,
-        bool validate_index
-) {
-    ARCTICDB_SUBSAMPLE_DEFAULT(WaitForWriteCompletion)
-    ARCTICDB_DEBUG(
-            log::version(),
-            "write_dataframe_impl stream_id: {} , version_id: {}, {} rows",
-            frame->desc().id(),
-            version_id,
-            frame->num_rows
-    );
-    auto atom_key_fut =
-            async_write_dataframe_impl(store, version_id, frame, options, de_dup_map, sparsify_floats, validate_index);
-    return {std::move(atom_key_fut).get()};
-}
-
 std::tuple<IndexPartialKey, SlicingPolicy> get_partial_key_and_slicing_policy(
         const std::shared_ptr<Store>& store, const WriteOptions& options, const InputFrame& frame, VersionId version_id,
         bool validate_index
@@ -273,23 +255,6 @@ folly::Future<AtomKey> async_append_impl(
             });
 }
 
-VersionedItem append_impl(
-        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const std::shared_ptr<InputFrame>& frame,
-        const WriteOptions& options, bool validate_index, bool empty_types
-) {
-
-    ARCTICDB_SUBSAMPLE_DEFAULT(WaitForWriteCompletion)
-    auto version_key_fut = async_append_impl(store, update_info, frame, options, validate_index, empty_types);
-    auto versioned_item = VersionedItem(std::move(version_key_fut).get());
-    ARCTICDB_DEBUG(
-            log::version(),
-            "write_dataframe_impl stream_id: {} , version_id: {}",
-            versioned_item.symbol(),
-            update_info.next_version_id_
-    );
-    return versioned_item;
-}
-
 namespace {
 bool is_before(const IndexRange& a, const IndexRange& b) { return a.start_ < b.start_; }
 
@@ -419,7 +384,7 @@ bool is_fake_index_name(const arcticc::pb2::descriptors_pb2::NormalizationMetada
 
 VersionedItem delete_range_impl(
         const std::shared_ptr<Store>& store, const StreamId& stream_id, const UpdateInfo& update_info,
-        const UpdateQuery& query, const WriteOptions&&, bool dynamic_schema
+        const UpdateQuery& query, bool dynamic_schema
 ) {
 
     util::check(update_info.previous_index_key_.has_value(), "Cannot delete from non-existent symbol {}", stream_id);
@@ -586,17 +551,13 @@ static std::pair<std::vector<SliceAndKey>, size_t> get_slice_and_keys_for_update
 
 folly::Future<AtomKey> async_update_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const UpdateQuery& query,
-        const std::shared_ptr<InputFrame>& frame, WriteOptions&& options, bool dynamic_schema, bool empty_types
+        const std::shared_ptr<InputFrame>& frame, const WriteOptions& options, bool dynamic_schema, bool empty_types
 ) {
     return index::async_get_index_reader(*(update_info.previous_index_key_), store)
             // This future will complete on the IO executor
-            .thenValueInline([store,
-                              update_info,
-                              query,
-                              frame,
-                              options = std::move(options),
-                              dynamic_schema,
-                              empty_types](index::IndexSegmentReader&& index_segment_reader) {
+            .thenValueInline([store, update_info, query, frame, options, dynamic_schema, empty_types](
+                                     index::IndexSegmentReader&& index_segment_reader
+                             ) {
                 check_can_update(*frame, index_segment_reader, dynamic_schema, empty_types);
                 ARCTICDB_DEBUG(
                         log::version(),
@@ -687,17 +648,37 @@ folly::Future<AtomKey> async_update_impl(
             });
 }
 
-VersionedItem update_impl(
-        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const UpdateQuery& query,
-        const std::shared_ptr<InputFrame>& frame, WriteOptions&& options, bool dynamic_schema, bool empty_types
+folly::Future<AtomKey> async_write_metadata_impl(
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info,
+        arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
 ) {
-    auto versioned_item = VersionedItem(
-            async_update_impl(store, update_info, query, frame, std::move(options), dynamic_schema, empty_types).get()
+    util::check(
+            update_info.previous_index_key_.has_value(),
+            "Cannot write metadata as there is no previous index key to update"
     );
     ARCTICDB_DEBUG(
-            log::version(), "updated stream_id: {} , version_id: {}", frame->desc().id(), update_info.next_version_id_
+            log::version(),
+            "write metadata for stream_id: {} , version_id: {}",
+            update_info.previous_index_key_->id(),
+            update_info.next_version_id_
     );
-    return versioned_item;
+    return store->read(*update_info.previous_index_key_)
+            .thenValue([store, update_info, user_meta = std::move(user_meta)](
+                               std::pair<VariantKey, SegmentInMemory>&& key_segment
+                       ) mutable {
+                auto& segment = key_segment.second;
+                *segment.mutable_index_descriptor().mutable_proto().mutable_user_meta() = std::move(user_meta);
+                const auto& index_key = *update_info.previous_index_key_;
+                return store->write(
+                        index_key.type(),
+                        update_info.next_version_id_,
+                        index_key.id(),
+                        index_key.start_index(),
+                        index_key.end_index(),
+                        std::move(segment)
+                );
+            })
+            .thenValueInline([](VariantKey&& key) { return to_atom(std::move(key)); });
 }
 
 folly::Future<ReadVersionOutput> read_multi_key(

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -33,12 +33,6 @@ namespace arcticdb::version_store {
 using namespace entity;
 using namespace pipelines;
 
-VersionedItem write_dataframe_impl(
-        const std::shared_ptr<Store>& store, VersionId version_id, const std::shared_ptr<InputFrame>& frame,
-        const WriteOptions& options, const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
-        bool allow_sparse = false, bool validate_index = false
-);
-
 std::tuple<IndexPartialKey, SlicingPolicy> get_partial_key_and_slicing_policy(
         const std::shared_ptr<Store>& store, const WriteOptions& options, const InputFrame& frame, VersionId version_id,
         bool validate_index
@@ -46,7 +40,8 @@ std::tuple<IndexPartialKey, SlicingPolicy> get_partial_key_and_slicing_policy(
 
 folly::Future<entity::AtomKey> async_write_dataframe_impl(
         const std::shared_ptr<Store>& store, VersionId version_id, const std::shared_ptr<pipelines::InputFrame>& frame,
-        const WriteOptions& options, const std::shared_ptr<DeDupMap>& de_dup_map, bool allow_sparse, bool validate_index
+        const WriteOptions& options, const std::shared_ptr<DeDupMap>& de_dup_map = std::make_shared<DeDupMap>(),
+        bool allow_sparse = false, bool validate_index = false
 );
 
 folly::Future<AtomKey> async_append_impl(
@@ -54,24 +49,19 @@ folly::Future<AtomKey> async_append_impl(
         const WriteOptions& options, bool validate_index, bool empty_types
 );
 
-VersionedItem append_impl(
-        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const std::shared_ptr<InputFrame>& frame,
-        const WriteOptions& options, bool validate_index, bool empty_types
-);
-
-VersionedItem update_impl(
-        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const UpdateQuery& query,
-        const std::shared_ptr<InputFrame>& frame, WriteOptions&& options, bool dynamic_schema, bool empty_types
-);
-
 folly::Future<AtomKey> async_update_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const UpdateQuery& query,
-        const std::shared_ptr<InputFrame>& frame, WriteOptions&& options, bool dynamic_schema, bool empty_types
+        const std::shared_ptr<InputFrame>& frame, const WriteOptions& options, bool dynamic_schema, bool empty_types
+);
+
+folly::Future<AtomKey> async_write_metadata_impl(
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info,
+        arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
 );
 
 VersionedItem delete_range_impl(
         const std::shared_ptr<Store>& store, const StreamId& stream_id, const UpdateInfo& update_info,
-        const UpdateQuery& query, const WriteOptions&& options, bool dynamic_schema
+        const UpdateQuery& query, bool dynamic_schema
 );
 
 folly::Future<IndexInformation> read_index_key_without_column_stats(

--- a/cpp/arcticdb/version/version_functions.hpp
+++ b/cpp/arcticdb/version/version_functions.hpp
@@ -38,16 +38,21 @@ inline std::pair<std::optional<AtomKey>, bool> get_latest_version(
 
 // The next version ID returned will be 0 for brand new symbols, or one greater than the largest ever version created so
 // far
-inline version_store::UpdateInfo get_latest_undeleted_version_and_next_version_id(
-        const std::shared_ptr<Store>& store, const std::shared_ptr<VersionMap>& version_map, const StreamId& stream_id
+inline version_store::UpdateInfo get_next_version_id_and_optionally_latest_undeleted_version(
+        const std::shared_ptr<Store>& store, const std::shared_ptr<VersionMap>& version_map, const StreamId& stream_id,
+        bool get_latest_undeleted_version = true
 ) {
-    ARCTICDB_SAMPLE(GetLatestUndeletedVersionAndHighestVersionId, 0)
-    LoadStrategy load_strategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY};
+    ARCTICDB_SAMPLE(GetLatestVersionAndOptionallyLatestUndeletedVersion, 0)
+    // Note that despite LoadObjective::UNDELETED_ONLY only loading the latest undeleted version, it will always
+    // also load the latest (possibly deleted) version due to the structure of the version chain. This is because a
+    // tombstone or tombstone all key deleting a version is always closer to the head of the chain than the index
+    // key it is deleting.
+    LoadStrategy load_strategy{
+            LoadType::LATEST,
+            get_latest_undeleted_version ? LoadObjective::UNDELETED_ONLY : LoadObjective::INCLUDE_DELETED
+    };
     auto entry = version_map->check_reload(store, stream_id, load_strategy, __FUNCTION__);
-    auto latest_version = entry->get_first_index(true).first;
-    auto latest_undeleted_version = entry->get_first_index(false).first;
-    VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
-    return {latest_undeleted_version, next_version_id};
+    return populate_update_info(*entry);
 }
 
 template<AtomKeyType T = AtomKeyPacked>

--- a/cpp/arcticdb/version/version_map_batch_methods.hpp
+++ b/cpp/arcticdb/version/version_map_batch_methods.hpp
@@ -183,25 +183,23 @@ batch_get_latest_undeleted_and_latest_versions_async(
 }
 
 inline std::vector<folly::Future<version_store::UpdateInfo>>
-batch_get_latest_undeleted_version_and_next_version_id_async(
+batch_get_next_version_id_and_optionally_latest_undeleted_version_async(
         const std::shared_ptr<Store>& store, const std::shared_ptr<VersionMap>& version_map,
-        const std::vector<StreamId>& stream_ids
+        const std::vector<StreamId>& stream_ids, bool get_latest_undeleted_version = true
 ) {
     ARCTICDB_SAMPLE(BatchGetLatestUndeletedVersionAndNextVersionId, 0)
     std::vector<folly::Future<version_store::UpdateInfo>> vector_fut;
     for (auto& stream_id : stream_ids) {
-        vector_fut.push_back(async::submit_io_task(CheckReloadTask{
-                                                           store,
-                                                           version_map,
-                                                           stream_id,
-                                                           LoadStrategy{LoadType::LATEST, LoadObjective::UNDELETED_ONLY}
-                                                   }
-        ).thenValue([](auto entry) {
-            auto latest_version = entry->get_first_index(true).first;
-            auto latest_undeleted_version = entry->get_first_index(false).first;
-            VersionId next_version_id = latest_version.has_value() ? latest_version->version_id() + 1 : 0;
-            return version_store::UpdateInfo{latest_undeleted_version, next_version_id};
-        }));
+        // Note that despite LoadObjective::UNDELETED_ONLY only loading the latest undeleted version, it will always
+        // also load the latest (possibly deleted) version due to the structure of the version chain. This is because a
+        // tombstone or tombstone all key deleting a version is always closer to the head of the chain than the index
+        // key it is deleting.
+        LoadStrategy load_strategy{
+                LoadType::LATEST,
+                get_latest_undeleted_version ? LoadObjective::UNDELETED_ONLY : LoadObjective::INCLUDE_DELETED
+        };
+        vector_fut.push_back(async::submit_io_task(CheckReloadTask{store, version_map, stream_id, load_strategy})
+                                     .thenValue([](auto entry) { return populate_update_info(*entry); }));
     }
     return vector_fut;
 }

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -59,25 +59,15 @@ VersionedItem PythonVersionStore::write_dataframe_specific_version(
         return {std::move(*version_key)};
     }
 
-    auto versioned_item = write_dataframe_impl(
-            store(),
-            VersionId(version_id),
-            convert::py_input_item_to_frame(
-                    stream_id,
-                    item,
-                    norm,
-                    user_meta,
-                    cfg().write_options().empty_types(),
-                    pipelines::SortednessScan::SKIP
-            ),
-            get_write_options()
+    auto input_frame = convert::py_input_item_to_frame(
+            stream_id, item, norm, user_meta, cfg().write_options().empty_types(), pipelines::SortednessScan::SKIP
     );
-
-    version_map()->write_version(store(), versioned_item.key_, std::nullopt);
+    auto index_key = async_write_dataframe_impl(store(), VersionId(version_id), input_frame, get_write_options()).get();
+    version_map()->write_version(store(), index_key, std::nullopt);
     if (cfg().symbol_list())
         symbol_list().add_symbol(store(), stream_id, version_id);
 
-    return versioned_item;
+    return {std::move(index_key)};
 }
 
 std::vector<std::shared_ptr<InputFrame>> create_input_tensor_frames(
@@ -701,27 +691,20 @@ VersionedItem PythonVersionStore::write_partitioned_dataframe(
     std::array<std::shared_ptr<convert::PandasData>, 1> partitioned_dfs{item};
 
     auto write_options = get_write_options();
-    auto de_dup_map = std::make_shared<DeDupMap>();
 
     std::vector<entity::AtomKey> index_keys;
     for (size_t idx = 0; idx < partitioned_dfs.size(); idx++) {
         auto subkeyname = fmt::format("{}-{}", stream_id, partition_value[idx]);
-        auto versioned_item = write_dataframe_impl(
-                store(),
-                version_id,
-                convert::py_input_item_to_frame(
-                        subkeyname,
-                        partitioned_dfs[idx],
-                        norm_meta,
-                        py::none(),
-                        cfg().write_options().empty_types(),
-                        pipelines::SortednessScan::SKIP
-                ),
-                write_options,
-                de_dup_map,
-                false
+        auto input_frame = convert::py_input_item_to_frame(
+                subkeyname,
+                partitioned_dfs[idx],
+                norm_meta,
+                py::none(),
+                cfg().write_options().empty_types(),
+                pipelines::SortednessScan::SKIP
         );
-        index_keys.emplace_back(versioned_item.key_);
+        auto index_key = async_write_dataframe_impl(store(), version_id, input_frame, write_options).get();
+        index_keys.emplace_back(std::move(index_key));
     }
 
     folly::Future<VariantKey> multi_key_fut = folly::Future<VariantKey>::makeEmpty();
@@ -755,10 +738,14 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     ARCTICDB_SAMPLE(WriteVersionedMultiKey, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: write_versioned_composite_data");
 
-    auto [maybe_prev, deleted] = ::arcticdb::get_latest_version(store(), version_map(), stream_id);
-    auto version_id = get_next_version_from_key(maybe_prev);
+    auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(
+            store(), version_map(), stream_id, cfg().write_options().de_duplication()
+    );
     ARCTICDB_DEBUG(
-            log::version(), "write_versioned_composite_data for stream_id: {} , version_id = {}", stream_id, version_id
+            log::version(),
+            "write_versioned_composite_data for stream_id: {} , version_id = {}",
+            stream_id,
+            update_info.next_version_id_
     );
     // TODO: Assuming each sub key is always going to have the same version attached to it.
     std::vector<VersionId> version_ids;
@@ -771,9 +758,9 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
     de_dup_maps.reserve(sub_keys.size());
 
     auto write_options = get_write_options();
-    auto de_dup_map = get_de_dup_map(stream_id, maybe_prev, write_options);
+    auto de_dup_map = get_de_dup_map(stream_id, update_info, write_options);
     for (auto i = 0u; i < sub_keys.size(); ++i) {
-        version_ids.emplace_back(version_id);
+        version_ids.emplace_back(update_info.next_version_id_);
         user_metas.emplace_back(py::none());
         de_dup_maps.emplace_back(de_dup_map);
     }
@@ -792,12 +779,14 @@ VersionedItem PythonVersionStore::write_versioned_composite_data(
             batch_write_internal(std::move(version_ids), sub_keys, std::move(frames), std::move(de_dup_maps), false)
                     .get();
     release_gil.reset();
-    auto multi_key = write_multi_index_entry(store(), index_keys, stream_id, metastruct, user_meta, version_id);
+    auto multi_key = write_multi_index_entry(
+            store(), index_keys, stream_id, metastruct, user_meta, update_info.next_version_id_
+    );
     auto versioned_item = VersionedItem(to_atom(std::move(multi_key)));
-    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, maybe_prev);
+    write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
 
     if (cfg().symbol_list())
-        symbol_list().add_symbol(store(), stream_id, version_id);
+        symbol_list().add_symbol(store(), stream_id, update_info.next_version_id_);
 
     return versioned_item;
 }

--- a/cpp/arcticdb/version/version_store_objects.hpp
+++ b/cpp/arcticdb/version/version_store_objects.hpp
@@ -82,13 +82,13 @@ struct TombstoneVersionResult : PreDeleteChecks {
 };
 
 /**
- * Output from [batch_]get_latest_undeleted_version_and_next_version_id. Contains info needed for writing operations
- * that depend on a previous live version existing:
- *  - update (with upsert false)
- *  - append (with upsert false)
- *  - batch_append (doesn't currently support upsert)
- *  - write_metadata
- *  - batch_write_metadata
+ * Output from [batch_]get_next_version_id_and_optionally_latest_undeleted_version[_async]. Contains info needed for
+ * modification operations. Both functions have a get_latest_undeleted_version bool argument. If this is true,
+ * previous_index_key_ will contain the index key of the latest live version if any exist. If it is false (which is
+ * only the case in [batch_]write calls with dedup disabled), this field may be std::nullopt even if a live version
+ * exists, as all we require is the next_version_id_. While identifying the next version id, it is possible we will
+ * also learn that a previous live version exists, in which case previous_index_key_ is populated, and used to know
+ * that we do not need to write a symbol list key.
  */
 struct UpdateInfo {
     /**

--- a/cpp/arcticdb/version/version_tasks.hpp
+++ b/cpp/arcticdb/version/version_tasks.hpp
@@ -46,42 +46,6 @@ struct IndexInformation {
 // - IndexInformation is a pre-fetched index key + optional column stats, used to avoid re-reading the index
 using VersionIdentifier = std::variant<VersionedItem, StreamId, std::shared_ptr<IndexInformation>>;
 
-struct UpdateMetadataTask : async::BaseTask {
-    const std::shared_ptr<Store> store_;
-    const version_store::UpdateInfo update_info_;
-    const AtomKey index_key_;
-    arcticdb::proto::descriptors::UserDefinedMetadata user_meta_;
-    VersionId version_id_ = 0;
-
-    UpdateMetadataTask(
-            std::shared_ptr<Store> store, version_store::UpdateInfo update_info,
-            arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta
-    ) :
-        store_(std::move(store)),
-        update_info_(std::move(update_info)),
-        user_meta_(std::move(user_meta)) {}
-
-    AtomKey operator()() const {
-        ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: update metadata");
-        util::check(
-                update_info_.previous_index_key_.has_value(),
-                "Cannot update metadata as there is no previous index key to update"
-        );
-        auto index_key = *(update_info_.previous_index_key_);
-        auto segment = store_->read_sync(index_key).second;
-
-        segment.mutable_index_descriptor().mutable_proto().mutable_user_meta()->CopyFrom(user_meta_);
-        return to_atom(store_->write_sync(
-                index_key.type(),
-                update_info_.next_version_id_,
-                index_key.id(),
-                index_key.start_index(),
-                index_key.end_index(),
-                std::move(segment)
-        ));
-    }
-};
-
 struct MaybeDeletedAtomKey {
     AtomKey key;
     bool deleted;

--- a/cpp/arcticdb/version/version_utils.cpp
+++ b/cpp/arcticdb/version/version_utils.cpp
@@ -98,4 +98,17 @@ FrameAndDescriptor frame_and_descriptor_from_segment(SegmentInMemory&& seg) {
     return {SegmentInMemory(std::move(seg)), tsd, {}};
 }
 
+version_store::UpdateInfo populate_update_info(const VersionMapEntry& entry) {
+    // This is used in get_next_version_id_and_optionally_latest_undeleted_version and
+    // batch_get_next_version_id_and_optionally_latest_undeleted_version_async. If the get_latest_undeleted_version flag
+    // is false (which is the case in [batch_]write when dedup is disabled) the entry may not contain any live versions,
+    // and opt_latest_undeleted_version_index will be std::nullopt. We populate the returned previous_index_key_ in this
+    // case only as a small optimisation to avoid writing a symbol list key when we already know a previous live version
+    // exists.
+    auto opt_latest_version_index = entry.get_first_index(true).first;
+    auto opt_latest_undeleted_version_index = entry.get_first_index(false).first;
+    VersionId next_version_id = opt_latest_version_index.has_value() ? opt_latest_version_index->version_id() + 1 : 0;
+    return version_store::UpdateInfo{opt_latest_undeleted_version_index, next_version_id};
+}
+
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_utils.hpp
+++ b/cpp/arcticdb/version/version_utils.hpp
@@ -14,6 +14,7 @@
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/stream/index_aggregator.hpp>
 #include <arcticdb/version/version_map_entry.hpp>
+#include <arcticdb/version/version_store_objects.hpp>
 #include <arcticdb/entity/frame_and_descriptor.hpp>
 #include <utility>
 #include <memory>
@@ -356,13 +357,16 @@ inline bool key_exists_in_ref_entry(
         const LoadStrategy& load_strategy, const VersionMapEntry& ref_entry,
         std::optional<AtomKey>& cached_penultimate_key
 ) {
+    // If we are looking for the latest version, deleted or undeleted, then an index key in the ref key is always
+    // the answer. By construction, any index or tombstone keys further down the chain will have lower version IDs than
+    // this one
+    if (load_strategy.load_type_ == LoadType::LATEST && is_index_key_type(ref_entry.keys_[0].type()))
+        return true;
+
     // The 3 item ref key bypass can be used only when we are loading undeleted versions
     // because otherwise it might skip versions that are deleted but part of snapshots
     if (load_strategy.load_objective_ != LoadObjective::UNDELETED_ONLY)
         return false;
-
-    if (load_strategy.load_type_ == LoadType::LATEST && is_index_key_type(ref_entry.keys_[0].type()))
-        return true;
 
     if (cached_penultimate_key && is_partial_load_type(load_strategy.load_type_)) {
         load_strategy.validate();
@@ -422,5 +426,7 @@ inline SortedValue deduce_sorted(SortedValue existing_frame, SortedValue input_f
 }
 
 FrameAndDescriptor frame_and_descriptor_from_segment(SegmentInMemory&& seg);
+
+version_store::UpdateInfo populate_update_info(const VersionMapEntry& entry);
 
 } // namespace arcticdb

--- a/python/tests/integration/arcticdb/test_admin_tools.py
+++ b/python/tests/integration/arcticdb/test_admin_tools.py
@@ -58,8 +58,8 @@ def test_get_sizes(arctic_client, lib_name, all_recursive_metastructure_versions
     assert 3000 < sizes[KeyType.TABLE_INDEX].bytes_compressed < 6000
     assert sizes[KeyType.TABLE_DATA].count == 7
     assert 20e6 < sizes[KeyType.TABLE_DATA].bytes_compressed < 30e6
-    assert sizes[KeyType.SYMBOL_LIST].count == 4
-    assert 500 < sizes[KeyType.SYMBOL_LIST].bytes_compressed < 3000
+    assert sizes[KeyType.SYMBOL_LIST].count == 2
+    assert 250 < sizes[KeyType.SYMBOL_LIST].bytes_compressed < 3000
     assert sizes[KeyType.LOG].count == 5
 
     for t in (KeyType.APPEND_DATA, KeyType.SNAPSHOT_REF, KeyType.LOG_COMPACTED, KeyType.MULTI_KEY):
@@ -72,11 +72,11 @@ def test_get_sizes(arctic_client, lib_name, all_recursive_metastructure_versions
     assert sizes[KeyType.VERSION].count == 6
     assert sizes[KeyType.TABLE_INDEX].count == 1
     assert sizes[KeyType.TABLE_DATA].count == 3
-    assert sizes[KeyType.SYMBOL_LIST].count == 5
+    assert sizes[KeyType.SYMBOL_LIST].count == 3
     assert 10e6 < sizes[KeyType.TABLE_DATA].bytes_compressed < 15e6
 
     total_size = sum_sizes(sizes.values())
-    assert total_size.count == 23
+    assert total_size.count == 21
     assert total_size.bytes_compressed == sum(s.bytes_compressed for s in sizes.values())
 
     # Check the other key types

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -549,8 +549,9 @@ def test_prune_previous_versions_write(basic_store, sym):
     assert len(keys_for_sym) == 3
     latest_ver_key = max(keys_for_sym, key=lambda x: x.version_id)
     check_write_and_prune_previous_version_keys(lib_tool, sym, latest_ver_key)
-    # Then - we got 3 symbol keys: 1 for each of the writes
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 3
+    # Then - we got 1 symbol key from the first write, and none from the subsequent as there was a live version already
+    # on the second and third writes
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 1
 
 
 @pytest.mark.storage
@@ -632,8 +633,51 @@ def test_prune_previous_versions_write_batch(basic_store):
         assert len(keys_for_sym) == 3
         latest_ver_key = max(keys_for_sym, key=lambda x: x.version_id)
         check_write_and_prune_previous_version_keys(lib_tool, sym, latest_ver_key)
-    # Then - we got 6 symbol keys: 1 for each of the writes
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 6
+    # Then - we got 2 symbol list keys from the first batch_write, and none from the subsequent calls as both symbols
+    # had known live versions when these were called
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
+
+
+@pytest.mark.storage
+def test_prune_previous_versions_write_metadata(basic_store):
+    """Verify that the write metadata method correctly prunes previous versions when the corresponding option is specified."""
+    # Given
+    lib = basic_store
+    lib_tool = lib.library_tool()
+    sym = "test_prune_previous_versions_write_metadata"
+    meta0 = {"a": 0}
+    meta1 = {"a": 1}
+    meta2 = {"a": 2}
+
+    # When
+    lib.write(sym, None, metadata=meta0)
+    lib.write(sym, None, metadata=meta1)
+    ref_key = lib_tool.find_keys_for_id(KeyType.VERSION_REF, sym)[0]
+    keys_in_ref = lib_tool.read_to_keys(ref_key)
+    assert len(lib.list_versions(sym)) == 2
+    check_append_ref_key_structure(keys_in_ref)
+
+    lib.write_metadata(sym, meta2, prune_previous_version=True)
+
+    ref_key = lib_tool.find_keys_for_id(KeyType.VERSION_REF, sym)[0]
+    keys_in_ref = lib_tool.read_to_keys(ref_key)
+    assert len(lib.list_versions(sym)) == 1
+    check_regular_write_ref_key_structure(keys_in_ref, latest_version_id=2)
+
+    # Then - only latest version and keys should survive
+    assert len(lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, sym)) == 1
+    assert len(lib_tool.find_keys_for_id(KeyType.TABLE_DATA, sym)) == 1
+
+    # Then - we got 2 version keys per symbol: version 0, version 1 that contains the tombstone_all
+    keys_for_sym = lib_tool.find_keys_for_id(KeyType.VERSION, sym)
+
+    assert len(keys_for_sym) == 3
+    latest_ver_key = max(keys_for_sym, key=lambda x: x.version_id)
+    check_write_and_prune_previous_version_keys(lib_tool, sym, latest_ver_key)
+
+    # Then - we got 1 symbol list key from the first write, and none from the subsequent calls as the symbol had known
+    # live versions when these were called
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 1
 
 
 @pytest.mark.storage
@@ -677,9 +721,9 @@ def test_prune_previous_versions_batch_write_metadata(basic_store):
         latest_ver_key = max(keys_for_sym, key=lambda x: x.version_id)
         check_write_and_prune_previous_version_keys(lib_tool, sym, latest_ver_key)
 
-    # Then - we got 4 symbol keys: 1 for each of the batch_write calls
-    # batch_write_metadata should not create any new symbol keys
-    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 4
+    # Then - we got 2 symbol list keys from the first batch_write_metadata, and none from the subsequent calls as both
+    # symbols had known live versions when these were called
+    assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/version_store/test_num_storage_operations.py
+++ b/python/tests/integration/arcticdb/version_store/test_num_storage_operations.py
@@ -156,7 +156,7 @@ def test_delete_over_time(lib_name, s3_and_nfs_storage_bucket, clear_query_stats
 
 
 def test_write_and_prune_previous_over_time(lib_name, s3_and_nfs_storage_bucket, clear_query_stats):
-    expected_ops = 17
+    expected_ops = 15
     with config_context("VersionMap.ReloadInterval", 0):
         lib = s3_and_nfs_storage_bucket.create_version_store_factory(lib_name)()
         qs.enable()
@@ -448,11 +448,10 @@ def test_update_num_reads(s3_store_factory, clear_query_stats, dynamic_schema, u
             # - Second time to construct the new slice after the updated range
             expected_data_keys *= 2
 
-        # Update does 4 extra reads to the data keys:
+        # Update does 3 extra reads to the data keys:
         # - 2 reads of VERSION_REF
-        # - read VERSION
         # - read TABLE_INDEX
-        assert sum_operations_by_type(stats, "S3_GetObject") == expected_data_keys + 4
+        assert sum_operations_by_type(stats, "S3_GetObject") == expected_data_keys + 3
 
         expected_df = ArcticSymbolSimulator.simulate_arctic_update(init_df, update_df, dynamic_schema=False)
         result_df = lib.read(sym).data

--- a/python/tests/integration/arcticdb/version_store/test_num_storage_operations.py
+++ b/python/tests/integration/arcticdb/version_store/test_num_storage_operations.py
@@ -181,13 +181,15 @@ def test_write_and_prune_previous_over_time(lib_name, s3_and_nfs_storage_bucket,
             assert sum_all_operations(stats) == base_ops_count, visualize_stats_diff(base_stats, stats)
 
 
-def test_read_after_write_and_prune_previous(lib_name, s3_and_nfs_storage_bucket, clear_query_stats):
+@pytest.mark.parametrize("repeat", list(range(10)))
+def test_read_after_write_and_prune_previous(lib_name, s3_and_nfs_storage_bucket, clear_query_stats, repeat):
     expected_ops = 3
     lib = s3_and_nfs_storage_bucket.create_version_store_factory(lib_name)()
     lib.write("s", data=create_df())
     lib.write("s", data=create_df(), prune_previous_version=True)
 
     with config_context("VersionMap.ReloadInterval", 0):
+        qs.reset_stats()
         qs.enable()
         lib.read("s")
         stats = qs.get_query_stats()

--- a/python/tests/integration/toolbox/test_query_stats.py
+++ b/python/tests/integration/toolbox/test_query_stats.py
@@ -322,54 +322,6 @@ def test_query_stats_metadata(s3_version_store_v1, clear_query_stats):
         s3_version_store_v1.read_metadata("a")
         s3_version_store_v1.read_metadata("a")
     stats = qs.get_query_stats()
-    # {
-    #     "storage_operations": {
-    #         "S3_GetObject": {
-    #             "TABLE_INDEX": {
-    #                 "count": 3,
-    #                 "size_bytes": 3036,
-    #                 "total_time_ms": 48
-    #             },
-    #             "VERSION": {
-    #                 "count": 4,
-    #                 "size_bytes": 581,
-    #                 "total_time_ms": 69
-    #             },
-    #             "VERSION_REF": {
-    #                 "count": 7,
-    #                 "size_bytes": 2466,
-    #                 "total_time_ms": 118
-    #             }
-    #         },
-    #         "S3_PutObject": {
-    #             "SYMBOL_LIST": {
-    #                 "count": 2,
-    #                 "size_bytes": 322,
-    #                 "total_time_ms": 31
-    #             },
-    #             "TABLE_DATA": {
-    #                 "count": 1,
-    #                 "size_bytes": 79,
-    #                 "total_time_ms": 17
-    #             },
-    #             "TABLE_INDEX": {
-    #                 "count": 2,
-    #                 "size_bytes": 2024,
-    #                 "total_time_ms": 30
-    #             },
-    #             "VERSION": {
-    #                 "count": 2,
-    #                 "size_bytes": 1192,
-    #                 "total_time_ms": 30
-    #             },
-    #             "VERSION_REF": {
-    #                 "count": 2,
-    #                 "size_bytes": 1233,
-    #                 "total_time_ms": 30
-    #             }
-    #         }
-    #     }
-    # }
     assert "storage_operations" in stats
     storage_operations = stats["storage_operations"]
 
@@ -382,19 +334,23 @@ def test_query_stats_metadata(s3_version_store_v1, clear_query_stats):
     assert expected_get_keys == get_object_stats.keys()
 
     assert get_object_stats["TABLE_INDEX"]["count"] == 3
-    assert get_object_stats["VERSION"]["count"] == 4
-    assert get_object_stats["VERSION_REF"]["count"] == 7
+    assert get_object_stats["VERSION"]["count"] == 2
+    assert get_object_stats["VERSION_REF"]["count"] == 6
 
     for key in expected_get_keys:
         stats_entry = get_object_stats[key]
-        assert stats_entry["size_bytes"] > 0
+        # Version keys are attempted to be read when attempting to read the version ref key and it does not exist
+        # for legacy compatability with the implementation of the version chain. These reads always fail as the
+        # version key does not exist either, so size_bytes will be zero here as no other version key reads are
+        # required
+        assert (stats_entry["size_bytes"] == 0) if key == "VERSION" else (stats_entry["size_bytes"] > 0)
         assert stats_entry["total_time_ms"] < 8000
 
     put_object_stats = storage_operations["S3_PutObject"]
     assert expected_put_keys == put_object_stats.keys()
 
     # Check specific count values from the sample output
-    assert put_object_stats["SYMBOL_LIST"]["count"] == 2
+    assert put_object_stats["SYMBOL_LIST"]["count"] == 1
     assert put_object_stats["TABLE_DATA"]["count"] == 1
     assert put_object_stats["TABLE_INDEX"]["count"] == 2
     assert put_object_stats["VERSION"]["count"] == 2
@@ -420,59 +376,6 @@ def test_query_stats_batch(s3_version_store_v1, clear_query_stats):
         s3_version_store_v1.batch_read([sym1, sym2])
 
     stats = qs.get_query_stats()
-    # {
-    #     "storage_operations": {
-    #         "S3_GetObject": {
-    #             "TABLE_DATA": {
-    #                 "count": 4,
-    #                 "size_bytes": 986,
-    #                 "total_time_ms": 63
-    #             },
-    #             "TABLE_INDEX": {
-    #                 "count": 4,
-    #                 "size_bytes": 4287,
-    #                 "total_time_ms": 70
-    #             },
-    #             "VERSION": {
-    #                 "count": 6,
-    #                 "size_bytes": 1204,
-    #                 "total_time_ms": 99
-    #             },
-    #             "VERSION_REF": {
-    #                 "count": 12,
-    #                 "size_bytes": 5231,
-    #                 "total_time_ms": 223
-    #             }
-    #         },
-    #         "S3_PutObject": {
-    #             "SYMBOL_LIST": {
-    #                 "count": 4,
-    #                 "size_bytes": 680,
-    #                 "total_time_ms": 60
-    #             },
-    #             "TABLE_DATA": {
-    #                 "count": 4,
-    #                 "size_bytes": 986,
-    #                 "total_time_ms": 67
-    #             },
-    #             "TABLE_INDEX": {
-    #                 "count": 4,
-    #                 "size_bytes": 4287,
-    #                 "total_time_ms": 64
-    #             },
-    #             "VERSION": {
-    #                 "count": 4,
-    #                 "size_bytes": 2494,
-    #                 "total_time_ms": 61
-    #             },
-    #             "VERSION_REF": {
-    #                 "count": 4,
-    #                 "size_bytes": 2655,
-    #                 "total_time_ms": 62
-    #             }
-    #         }
-    #     }
-    # }
     assert "storage_operations" in stats
     storage_operations = stats["storage_operations"]
 
@@ -486,23 +389,30 @@ def test_query_stats_batch(s3_version_store_v1, clear_query_stats):
 
     assert get_object_stats["TABLE_DATA"]["count"] == 4
     assert get_object_stats["TABLE_INDEX"]["count"] == 4
-    assert get_object_stats["VERSION"]["count"] == 6
+    assert get_object_stats["VERSION"]["count"] == 4
     assert get_object_stats["VERSION_REF"]["count"] == 12
 
     put_object_stats = storage_operations["S3_PutObject"]
     assert expected_put_keys == put_object_stats.keys()
 
-    assert put_object_stats["SYMBOL_LIST"]["count"] == 4
+    assert put_object_stats["SYMBOL_LIST"]["count"] == 2
     assert put_object_stats["TABLE_DATA"]["count"] == 4
     assert put_object_stats["TABLE_INDEX"]["count"] == 4
     assert put_object_stats["VERSION"]["count"] == 4
     assert put_object_stats["VERSION_REF"]["count"] == 4
 
-    for op_stats in storage_operations.values():
-        for key_stat in op_stats.values():
+    for op_type, op_stats in storage_operations.items():
+        for key_type, key_stat in op_stats.items():
             assert key_stat["count"] > 0
-            assert key_stat["size_bytes"] > 0
             assert key_stat["total_time_ms"] < 8000
+            # Version keys are attempted to be read when attempting to read the version ref key and it does not exist
+            # for legacy compatability with the implementation of the version chain. These reads always fail as the
+            # version key does not exist either, so size_bytes will be zero here as no other version key reads are
+            # required
+            if op_type == "S3_GetObject" and key_type == "VERSION":
+                assert key_stat["size_bytes"] == 0
+            else:
+                assert key_stat["size_bytes"] > 0
 
 
 def test_query_stats_staged_data(s3_version_store_v1, clear_query_stats, sym):

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -581,72 +581,53 @@ def test_dynamic_schema_incompatible_types_do_not_orphan_data_keys(in_memory_sto
     assert len(lt.find_keys(KeyType.TABLE_DATA)) == 1
 
 
-@pytest.mark.parametrize(
-    "batch",
-    [pytest.param(True, marks=pytest.mark.xfail(reason="Raises E_NON_INCREASING_INDEX_VERSION", strict=True)), False],
-)
+@pytest.mark.parametrize("batch", [True, False])
 def test_write_metadata_version_number_when_no_live_versions(in_memory_version_store, batch):
     lib = in_memory_version_store
     sym = "test_write_metadata_version_number_when_no_live_versions"
     lib.write(sym, 0)  # Create version 0
     lib.delete(sym)
-    # Should create version 1
-    # Batch raises E_NON_INCREASING_INDEX_VERSION as it resets the version number to 0
     lib.batch_write_metadata([sym], ["metadata"]) if batch else lib.write_metadata(sym, "metadata")
     assert lib.read_metadata(sym).version == 1
 
 
-@pytest.mark.parametrize(
-    "batch", [True, pytest.param(False, marks=pytest.mark.xfail(reason="Writes 2 symbol list keys", strict=True))]
-)
+@pytest.mark.parametrize("batch", [True, False])
 def test_write_metadata_symbol_list_key_count(in_memory_version_store, batch):
     lib = in_memory_version_store
     sym = "test_write_metadata_symbol_list_key_count"
     lib.batch_write_metadata([sym], ["metadata"]) if batch else lib.write_metadata(sym, "metadata")
     lt = lib.library_tool()
-    # Non-batch writes 2 symbol list keys
     assert lt.count_keys(KeyType.SYMBOL_LIST) == 1
 
 
-@pytest.mark.parametrize(
-    "batch", [pytest.param(True, marks=pytest.mark.xfail(reason="Writes a symbol list key", strict=True)), False]
-)
+@pytest.mark.parametrize("batch", [True, False])
 def test_write_metadata_symbol_list_written_when_symbol_list_disabled(in_memory_store_factory, batch):
     lib = in_memory_store_factory(symbol_list=False)
     sym = "test_write_metadata_symbol_list_written_when_symbol_list_disabled"
     lib.batch_write_metadata([sym], ["metadata"]) if batch else lib.write_metadata(sym, "metadata")
     lt = lib.library_tool()
-    # Batch writes a symbol list key
     assert lt.count_keys(KeyType.SYMBOL_LIST) == 0
 
 
-@pytest.mark.parametrize(
-    "batch", [pytest.param(True, marks=pytest.mark.xfail(reason="Writes a symbol list key", strict=True)), False]
-)
+@pytest.mark.parametrize("batch", [True, False])
 def test_write_symbol_list_written_when_symbol_list_disabled(in_memory_store_factory, batch):
     lib = in_memory_store_factory(symbol_list=False)
     sym = "test_write_symbol_list_written_when_symbol_list_disabled"
     lib.batch_write([sym], [0]) if batch else lib.write(sym, 0)
     lt = lib.library_tool()
-    # Batch writes a symbol list key
     assert lt.count_keys(KeyType.SYMBOL_LIST) == 0
 
 
-@pytest.mark.parametrize(
-    "batch", [pytest.param(True, marks=pytest.mark.xfail(reason="Writes a symbol list key", strict=True)), False]
-)
+@pytest.mark.parametrize("batch", [True, False])
 def test_append_upsert_symbol_list_written_when_symbol_list_disabled(in_memory_store_factory, batch):
     lib = in_memory_store_factory(symbol_list=False)
     sym = "test_append_upsert_symbol_list_written_when_symbol_list_disabled"
     lib.batch_append([sym], [pd.DataFrame({"col": [1]})]) if batch else lib.append(sym, pd.DataFrame({"col": [1]}))
     lt = lib.library_tool()
-    # Batch writes a symbol list key
     assert lt.count_keys(KeyType.SYMBOL_LIST) == 0
 
 
-@pytest.mark.parametrize(
-    "batch", [pytest.param(True, marks=pytest.mark.xfail(reason="Writes a symbol list key", strict=True)), False]
-)
+@pytest.mark.parametrize("batch", [True, False])
 def test_update_upsert_symbol_list_written_when_symbol_list_disabled(in_memory_store_factory, batch):
     lib = in_memory_store_factory(symbol_list=False)
     sym = "test_update_upsert_symbol_list_written_when_symbol_list_disabled"
@@ -658,17 +639,14 @@ def test_update_upsert_symbol_list_written_when_symbol_list_disabled(in_memory_s
         else lib.update(sym, pd.DataFrame({"col": [1]}, index=[pd.Timestamp(0)]), upsert=True)
     )
     lt = lib.library_tool()
-    # Batch writes a symbol list key
     assert lt.count_keys(KeyType.SYMBOL_LIST) == 0
 
 
-@pytest.mark.parametrize(
-    "batch",
-    [pytest.param(True, marks=pytest.mark.xfail(reason="Latest live version is always loaded", strict=True)), False],
-)
-def test_write_version_chain_minimal_io(in_memory_version_store, clear_query_stats, batch):
+@pytest.mark.parametrize("batch", [True, False])
+@pytest.mark.parametrize("dedup", [True, False])
+def test_write_version_chain_minimal_io(in_memory_store_factory, clear_query_stats, batch, dedup):
     with config_context("VersionMap.ReloadInterval", 0):
-        lib = in_memory_version_store
+        lib = in_memory_store_factory(de_duplication=dedup)
         lib.version_store.clear()
         sym = "test_write_version_chain_minimal_io"
         # Create 10 versions
@@ -687,4 +665,4 @@ def test_write_version_chain_minimal_io(in_memory_version_store, clear_query_sta
         # The version chain is loaded twice with the cache disabled, once to identify the version number to write, and
         # again when the version map is being written. Ideally this would only be loaded once and the 4 below would be a
         # 2
-        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION") == 4
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION") == (13 if dedup else 4)


### PR DESCRIPTION
#### Reference Issues/PRs
[12548384234](https://man312219.monday.com/boards/7852509418/pulses/12548384234)
[12548383860](https://man312219.monday.com/boards/7852509418/pulses/12548383860)
[12548371808](https://man312219.monday.com/boards/7852509418/pulses/12548371808)
[12548367093](https://man312219.monday.com/boards/7852509418/pulses/12548367093)

#### What does this implement or fix?
The main part of the change refactors write, append, update, write_metadata, and their batch variants in `LocalVersionedEngine`. There was previously a lot of duplicated code between both the different modification methods, and between modification methods and their batch versions. There were also many inconsistencies in how they initially loaded version chains, handled empty frames, wrote back to the version chain, and added symbol list keys, which led to a lot of the bugs listed above.
While performing the refactor, I noticed a few other opportunities to cleanup:

- The `UpdateMetadataTask` was a different pattern to the other modification methods. This has been moved to `async_write_metadata_impl`, and it's threading model improved.
- The sync `*_impl` methods in `version_core.cpp` just called the async methods and `.get()` immediately. This responsibility has been pushed up to methods in `LocalVersionedEngine`
- `get_write_options()` was called a lot to convert protobuf to a struct. However, the protobuf is never modified after library initialization, so this struct is now just generated once and stored as a member of `LocalVersionedEngine`
- The `sparsify_floats` member of `WriteOptions` was redundant, and has been removed