### PR TITLE
Implement insertion strategy for merge update in timeseries

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1121,7 +1121,7 @@ if(${TEST})
             processing/test/test_unsorted_aggregation.cpp
             processing/test/test_merge_update.cpp
             storage/test/test_lmdb_cve.cpp
-            processing/test/test_split_by_time_slice.cpp
+            processing/test/test_structure_by_time_slice.cpp
             storage/test/test_local_storages.cpp
             storage/test/test_memory_storage.cpp
             storage/test/test_s3_storage.cpp

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1121,6 +1121,7 @@ if(${TEST})
             processing/test/test_unsorted_aggregation.cpp
             processing/test/test_merge_update.cpp
             storage/test/test_lmdb_cve.cpp
+            processing/test/test_split_by_time_slice.cpp
             storage/test/test_local_storages.cpp
             storage/test/test_memory_storage.cpp
             storage/test/test_s3_storage.cpp

--- a/cpp/arcticdb/column_store/column_algorithms.hpp
+++ b/cpp/arcticdb/column_store/column_algorithms.hpp
@@ -579,6 +579,18 @@ ColumnData::ColumnDataIterator<TDT, IT, ID, true> exponential_lower_bound(
     return lower_bound<TDT, IT, ID>(bracket_start, bracket_end, value);
 }
 
+template<
+        util::type_descriptor_tag TDT, IteratorType IT = IteratorType::REGULAR,
+        IteratorDensity ID = IteratorDensity::DENSE>
+requires SortedSearchInputs<TDT, ID>
+ColumnData::ColumnDataIterator<TDT, IT, ID, true> exponential_lower_bound(
+        const ColumnData& data, typename TDT::DataTypeTag::raw_type value
+) {
+    auto start = data.cbegin<TDT, IT, ID>();
+    auto end = data.cend<TDT, IT, ID>();
+    return exponential_lower_bound(start, end, value);
+}
+
 // Exponential (galloping) upper_bound.
 template<typename TDT, IteratorType IT, IteratorDensity ID>
 requires SortedSearchInputs<TDT, ID>
@@ -599,6 +611,18 @@ ColumnData::ColumnDataIterator<TDT, IT, ID, true> exponential_upper_bound(
                 return probe <= v;
             });
     return upper_bound<TDT, IT, ID>(bracket_start, bracket_end, value);
+}
+
+template<
+        util::type_descriptor_tag TDT, IteratorType IT = IteratorType::REGULAR,
+        IteratorDensity ID = IteratorDensity::DENSE>
+requires SortedSearchInputs<TDT, ID>
+ColumnData::ColumnDataIterator<TDT, IT, ID, true> exponential_upper_bound(
+        const ColumnData& data, typename TDT::DataTypeTag::raw_type value
+) {
+    auto start = data.cbegin<TDT, IT, ID>();
+    auto end = data.cend<TDT, IT, ID>();
+    return exponential_upper_bound(start, end, value);
 }
 
 namespace search_detail {

--- a/cpp/arcticdb/column_store/column_data_random_accessor.cpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.cpp
@@ -168,8 +168,8 @@ class ColumnDataRandomAccessorDense {
     ChunkedBufferRandomAccessor<TDT> chunked_buffer_random_accessor_;
 };
 
-template<typename TDT>
-requires(util::instantiation_of<TDT, TypeDescriptorTag> && (TDT::dimension() == Dimension::Dim0))
+template<util::type_descriptor_tag TDT>
+requires(TDT::dimension() == Dimension::Dim0)
 ColumnDataRandomAccessor<TDT> random_accessor(ColumnData* parent) {
     bool sparse = parent->bit_vector() != nullptr;
     if (parent->buffer().num_blocks() == 1) {

--- a/cpp/arcticdb/column_store/column_data_random_accessor.hpp
+++ b/cpp/arcticdb/column_store/column_data_random_accessor.hpp
@@ -15,7 +15,7 @@
 
 namespace arcticdb {
 
-template<typename TDT>
+template<util::type_descriptor_tag TDT>
 struct IColumnDataRandomAccessor {
     template<class Base>
     struct Interface : Base {
@@ -28,10 +28,10 @@ struct IColumnDataRandomAccessor {
     using Members = folly::PolyMembers<&T::at, &T::ptr_at>;
 };
 
-template<typename TDT>
+template<util::type_descriptor_tag TDT>
 using ColumnDataRandomAccessor = folly::Poly<IColumnDataRandomAccessor<TDT>>;
 
-template<typename TDT>
-requires(util::instantiation_of<TDT, TypeDescriptorTag> && (TDT::dimension() == Dimension::Dim0))
+template<util::type_descriptor_tag TDT>
+requires(TDT::dimension() == Dimension::Dim0)
 ColumnDataRandomAccessor<TDT> random_accessor(ColumnData* parent);
 } // namespace arcticdb

--- a/cpp/arcticdb/column_store/memory_segment.cpp
+++ b/cpp/arcticdb/column_store/memory_segment.cpp
@@ -118,6 +118,10 @@ position_t SegmentInMemory::add_column(FieldRef field_ref, size_t num_rows, Allo
     return impl_->add_column(field_ref, num_rows, presize);
 }
 
+position_t SegmentInMemory::add_column(const Field& field, Column&& column) {
+    return impl_->add_column(field, std::make_shared<Column>(std::move(column)));
+}
+
 size_t SegmentInMemory::num_blocks() const { return impl_->num_blocks(); }
 
 void SegmentInMemory::append(const SegmentInMemory& other) { impl_->append(*other.impl_); }

--- a/cpp/arcticdb/column_store/memory_segment.hpp
+++ b/cpp/arcticdb/column_store/memory_segment.hpp
@@ -133,6 +133,8 @@ class SegmentInMemory {
 
     position_t add_column(FieldRef field_ref, size_t num_rows, AllocationType presize);
 
+    position_t add_column(const Field& field, Column&& column);
+
     [[nodiscard]] size_t num_blocks() const;
 
     void append(const SegmentInMemory& other);

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -141,6 +141,7 @@ std::string_view StringPool::get_const_view(offset_t o) const { return block_.co
 void StringPool::clear() {
     map_.clear();
     block_.clear();
+    shapes_.clear();
 }
 
 const Buffer& StringPool::shapes() const {

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -141,6 +141,55 @@ struct NativeTensor {
         return (&(reinterpret_cast<const T*>(ptr)[signed_pos]));
     }
 
+    template<typename T>
+    std::span<const T> span(size_t offset = 0, size_t count = std::dynamic_extent) const {
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE, ndim() == 1, "Cannot create a span from a multi-dimensional tensor"
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                elsize() == sizeof(T),
+                "Mismatched tensor byte size {} and span element type size {}",
+                elsize(),
+                sizeof(T)
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                count == std::dynamic_extent || count <= nbytes() / sizeof(T) - offset,
+                "Span count {} is out of bounds for tensor of size {}",
+                count,
+                nbytes() / sizeof(T)
+        );
+        return std::span<const T>(
+                static_cast<const T*>(ptr) + offset,
+                count == std::dynamic_extent ? nbytes() / sizeof(T) - offset : count
+        );
+    }
+
+    template<typename T>
+    std::span<T> span(size_t offset = 0, size_t count = std::dynamic_extent) {
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE, ndim() == 1, "Cannot create a span from a multi-dimensional tensor"
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                elsize() == sizeof(T),
+                "Mismatched tensor byte size {} and span element type size {}",
+                elsize(),
+                sizeof(T)
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                count == std::dynamic_extent || count <= nbytes() / sizeof(T) - offset,
+                "Span count {} is out of bounds for tensor of size {}",
+                count,
+                nbytes() / sizeof(T)
+        );
+        return std::span<T>(
+                static_cast<T*>(ptr) + offset, count == std::dynamic_extent ? nbytes() / sizeof(T) - offset : count
+        );
+    }
+
     // returns number of elements, not bytesize
     [[nodiscard]] ssize_t size() const { return calc_elements(shape(), ndim()); }
 
@@ -259,6 +308,7 @@ struct TypedTensor : public NativeTensor {
     }
 
     const T* data() const { return static_cast<const T*>(NativeTensor::data()); }
+    std::span<const T> span() const { return std::span<const T>(data(), size()); }
 
   private:
     void check_ptr_within_bounds(const NativeTensor& tensor, size_t rows) {

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -141,53 +141,27 @@ struct NativeTensor {
         return (&(reinterpret_cast<const T*>(ptr)[signed_pos]));
     }
 
+    /// @brief Returns a std::span over the tensor data.
+    /// @param offset Number of elements to skip from the start of the tensor.
+    /// @param count Number of elements after offset to include in the span. If std::dynamic_extent, the span will
+    /// include all elements from the offset to the end of the tensor.
     template<typename T>
-    std::span<const T> span(size_t offset = 0, size_t count = std::dynamic_extent) const {
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE, ndim() == 1, "Cannot create a span from a multi-dimensional tensor"
-        );
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE,
-                elsize() == sizeof(T),
-                "Mismatched tensor byte size {} and span element type size {}",
-                elsize(),
-                sizeof(T)
-        );
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE,
-                count == std::dynamic_extent || count <= nbytes() / sizeof(T) - offset,
-                "Span count {} is out of bounds for tensor of size {}",
-                count,
-                nbytes() / sizeof(T)
-        );
+    std::span<const T> span(const size_t offset = 0, const size_t count = std::dynamic_extent) const {
+        validate_can_take_span<T>(offset, count);
         return std::span<const T>(
                 static_cast<const T*>(ptr) + offset,
                 count == std::dynamic_extent ? nbytes() / sizeof(T) - offset : count
         );
     }
 
+    /// @brief Returns a std::span over the tensor data.
+    /// @param offset Number of elements to skip from the start of the tensor.
+    /// @param count Number of elements after offset to include in the span. If std::dynamic_extent, the span will
+    /// include all elements from the offset to the end of the tensor.
     template<typename T>
-    std::span<T> span(size_t offset = 0, size_t count = std::dynamic_extent) {
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE, ndim() == 1, "Cannot create a span from a multi-dimensional tensor"
-        );
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE,
-                elsize() == sizeof(T),
-                "Mismatched tensor byte size {} and span element type size {}",
-                elsize(),
-                sizeof(T)
-        );
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE,
-                count == std::dynamic_extent || count <= nbytes() / sizeof(T) - offset,
-                "Span count {} is out of bounds for tensor of size {}",
-                count,
-                nbytes() / sizeof(T)
-        );
-        return std::span<T>(
-                static_cast<T*>(ptr) + offset, count == std::dynamic_extent ? nbytes() / sizeof(T) - offset : count
-        );
+    std::span<T> span(const size_t offset = 0, const size_t count = std::dynamic_extent) {
+        const std::span<const T> as_const = std::as_const(*this).span<T>(offset, count);
+        return {const_cast<T*>(as_const.data()), as_const.size()};
     }
 
     // returns number of elements, not bytesize
@@ -207,6 +181,43 @@ struct NativeTensor {
     /// API providing the strides and shapes arrays, expanded_dim is what ArcticDB thinks of the tensor and using it
     /// can lead to out of bounds reads from strides and shapes.
     int expanded_dim_;
+
+  private:
+    template<typename T>
+    void validate_can_take_span([[maybe_unused]] const size_t offset, [[maybe_unused]] const size_t count) const {
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE, ndim() == 1, "Cannot create a span from a multi-dimensional tensor"
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                elsize() == sizeof(T),
+                "Mismatched tensor byte size {} and span element type size {}",
+                elsize(),
+                sizeof(T)
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                size() == 0 || strides(ndim() - 1) == elsize(),
+                "Converting a fortran style NativeTensor to span is not possible"
+        );
+        // offset == size is allowed: it yields an empty span at one-past-the-end, and keeps nbytes() / sizeof(T) -
+        // offset from underflowing below.
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                offset <= nbytes() / sizeof(T),
+                "Span offset {} is out of bounds for tensor of size {}",
+                offset,
+                nbytes() / sizeof(T)
+        );
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                count == std::dynamic_extent || count <= nbytes() / sizeof(T) - offset,
+                "Span count {} is out of bounds for tensor of size {} with offset {}",
+                count,
+                nbytes() / sizeof(T),
+                offset
+        );
+    }
 };
 
 template<ssize_t>
@@ -308,7 +319,6 @@ struct TypedTensor : public NativeTensor {
     }
 
     const T* data() const { return static_cast<const T*>(NativeTensor::data()); }
-    std::span<const T> span() const { return std::span<const T>(data(), size()); }
 
   private:
     void check_ptr_within_bounds(const NativeTensor& tensor, size_t rows) {

--- a/cpp/arcticdb/entity/native_tensor.hpp
+++ b/cpp/arcticdb/entity/native_tensor.hpp
@@ -15,6 +15,7 @@
 
 // for std::accumulate
 #include <numeric>
+#include <span>
 
 #include <pybind11/numpy.h>
 

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <arcticdb/pipeline/write_options.hpp>
-
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/processing/expression_context.hpp>
 #include <arcticdb/processing/expression_node.hpp>
@@ -23,6 +21,7 @@
 #include <arcticdb/pipeline/pipeline_common.hpp>
 #include <arcticdb/version/merge_options.hpp>
 #include <arcticdb/util/string_utils.hpp>
+#include <arcticdb/pipeline/input_frame.hpp>
 
 #include <vector>
 #include <string>
@@ -31,6 +30,10 @@
 #include <ranges>
 
 namespace arcticdb {
+
+struct MergeUpdateInsertedRowsEntity {
+    size_t inserted_rows;
+};
 
 using ResampleOrigin = std::variant<std::string, timestamp>;
 
@@ -885,44 +888,70 @@ struct MergeUpdateClause {
     OutputSchema join_schemas(std::vector<OutputSchema>&&) const;
 
     [[nodiscard]] std::string to_string() const;
+    class MatchRecord {
+      public:
+        MatchRecord(std::span<ProcessingUnit> row_slices, size_t num_source_rows);
+        void add_match(size_t source_row, size_t target_row_slice, size_t target_row);
+        void add_match(size_t source_row, size_t target_row_slice, std::span<size_t> target_rows);
+        void filter_matching_rows(
+                std::string_view column_name, DataType source_type, DataType target_type, size_t source_offset,
+                std::span<const std::byte> source_data_bytes
+        );
+        void clone_source_match(size_t source_row_src, size_t source_row_dst, size_t row_slice);
+        void validate_rows_to_update(const MergeStrategy& strategy) const;
+        [[nodiscard]] size_t total_unmatched_source_rows() const;
+        [[nodiscard]] std::span<const std::vector<size_t>> matched_rows(size_t target_row_slice) const;
+        [[nodiscard]] bool is_source_row_matched(size_t source_row) const;
+
+      private:
+        /// For each row slice, for each source row, store all target rows that match it
+        std::vector<std::vector<std::vector<size_t>>> matched_target_rows_;
+        std::span<ProcessingUnit> row_slices_;
+        std::vector<size_t> source_row_matched_count_;
+        size_t total_matched_target_rows_count_ = 0;
+    };
 
   private:
-    bool update_and_insert(
-            const std::span<const NativeTensor> source_tensors, const StreamDescriptor& source_descriptor,
-            const ProcessingUnit& proc, const std::span<const std::vector<size_t>> rows_to_update
+    std::pair<std::vector<ProcessingUnit>, bool> update_and_insert(
+            const MatchRecord& match_record, const StreamDescriptor& target_descriptor,
+            std::vector<ProcessingUnit>&& row_slices
+    ) const;
+
+    std::pair<std::vector<ProcessingUnit>, bool> update(
+            const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices
     ) const;
 
     /// Filter segments which will be affected by the merge. The complexity is O(m * log(n)) where n is the number
     /// of rows in the source data and m is the number of row slices in the library
     std::vector<std::vector<size_t>> structure_for_processing_log(std::vector<RangesAndKey>& ranges_and_keys);
 
-    /// @return Vector of size equal to the number of source data rows that are within the row slice being
-    /// processed. Each element is a vector of the rows from the target data that has the same index as the
-    /// corresponding source row
-    std::vector<std::vector<size_t>> filter_index_match(
-            const Column& target_index, const std::span<const timestamp> source_index, const ProcessingUnit& proc
-    ) const;
+    MatchRecord match(std::span<ProcessingUnit> row_slices) const;
 
-    std::vector<std::vector<size_t>> filter_on_additional_columns_match(
+    MatchRecord filter_on_additional_columns_match(
             const StreamDescriptor& source_descriptor, const StreamDescriptor& target_descriptor,
-            const std::span<const NativeTensor> source_tensors, ProcessingUnit& proc,
-            std::optional<std::vector<std::vector<size_t>>>&& index_match
+            std::span<ProcessingUnit> proc, std::optional<MatchRecord>&& match_record
     ) const;
 
-    std::vector<std::vector<size_t>> initialize_rows_to_update_for_rowrange_indexed_data(
-            ProcessingUnit& proc, const StreamDescriptor& source_descriptor
+    MatchRecord initialize_rows_to_update_for_row_range_indexed_data(
+            std::span<ProcessingUnit> row_slices, const StreamDescriptor& source_descriptor
     ) const;
 
     size_t field_index_for_matching_on_column(std::string_view name, const StreamDescriptor& descriptor) const;
 
     bool is_update_only() const;
 
-    /// For each timestamp range stores the first and last row in the source that overlaps with the row range. The
-    /// interval is closed in the start and open in the end: [start, end)
-    ankerl::unordered_dense::map<TimestampRange, std::pair<size_t, size_t>, folly::hasher<TimestampRange>>
-            source_start_end_for_row_range_;
+    /// For each processing group, identified by its row range, stores the first and last row in the source that
+    /// overlaps with it. The interval is closed in the start and open in the end: [start, end). The key is the row
+    /// range rather than the timestamp range because overlapping-window groups can share a timestamp range when
+    /// boundary index values repeat.
+    ankerl::unordered_dense::map<RowRange, std::pair<size_t, size_t>> source_start_end_for_row_range_;
+    std::pair<size_t, size_t> get_source_start_end(std::span<const ProcessingUnit> row_slice) const;
 
-    std::pair<size_t, size_t> get_source_start_end(const ProcessingUnit& proc) const;
+    [[nodiscard]] bool must_structure_by_time_slice() const;
+
+    std::span<const timestamp> get_source_index(std::span<const ProcessingUnit> row_slices) const;
+
+    std::span<const std::byte> get_source_data_bytes(size_t field_index, std::pair<size_t, size_t> range) const;
 };
 
 struct CompactDataClause {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -31,10 +31,6 @@
 
 namespace arcticdb {
 
-struct MergeUpdateInsertedRowsEntity {
-    size_t inserted_rows;
-};
-
 using ResampleOrigin = std::variant<std::string, timestamp>;
 
 using RangesAndKey = pipelines::RangesAndKey;
@@ -900,8 +896,9 @@ struct MergeUpdateClause {
         void clone_source_match(size_t source_row_src, size_t source_row_dst, size_t row_slice);
         void validate_rows_to_update(const MergeStrategy& strategy) const;
         [[nodiscard]] size_t total_unmatched_source_rows() const;
-        [[nodiscard]] std::span<const std::vector<size_t>> matched_rows(size_t target_row_slice) const;
+        [[nodiscard]] const std::vector<std::vector<size_t>>& matched_rows(size_t target_row_slice) const;
         [[nodiscard]] bool is_source_row_matched(size_t source_row) const;
+        [[nodiscard]] bool has_matched_target_rows() const;
 
       private:
         /// For each row slice, for each source row, store all target rows that match it
@@ -912,28 +909,31 @@ struct MergeUpdateClause {
     };
 
   private:
-    std::pair<std::vector<ProcessingUnit>, bool> update_and_insert(
+    std::vector<ProcessingUnit> update_and_insert(
             const MatchRecord& match_record, const StreamDescriptor& target_descriptor,
-            std::vector<ProcessingUnit>&& row_slices
+            std::vector<ProcessingUnit>&& row_slices, std::pair<size_t, size_t> source_start_end
     ) const;
 
-    std::pair<std::vector<ProcessingUnit>, bool> update(
-            const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices
+    std::vector<ProcessingUnit> update(
+            const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices,
+            std::pair<size_t, size_t> source_start_end
     ) const;
 
     /// Filter segments which will be affected by the merge. The complexity is O(m * log(n)) where n is the number
     /// of rows in the source data and m is the number of row slices in the library
     std::vector<std::vector<size_t>> structure_for_processing_log(std::vector<RangesAndKey>& ranges_and_keys);
 
-    MatchRecord match(std::span<ProcessingUnit> row_slices) const;
+    MatchRecord match(std::span<ProcessingUnit> row_slices, std::pair<size_t, size_t> source_start_end) const;
 
     MatchRecord filter_on_additional_columns_match(
             const StreamDescriptor& source_descriptor, const StreamDescriptor& target_descriptor,
-            std::span<ProcessingUnit> proc, std::optional<MatchRecord>&& match_record
+            std::span<ProcessingUnit> proc, std::optional<MatchRecord>&& match_record,
+            std::pair<size_t, size_t> source_start_end
     ) const;
 
     MatchRecord initialize_rows_to_update_for_row_range_indexed_data(
-            std::span<ProcessingUnit> row_slices, const StreamDescriptor& source_descriptor
+            std::span<ProcessingUnit> row_slices, const StreamDescriptor& source_descriptor,
+            std::pair<size_t, size_t> source_start_end
     ) const;
 
     size_t field_index_for_matching_on_column(std::string_view name, const StreamDescriptor& descriptor) const;
@@ -949,7 +949,7 @@ struct MergeUpdateClause {
 
     [[nodiscard]] bool must_structure_by_time_slice() const;
 
-    std::span<const timestamp> get_source_index(std::span<const ProcessingUnit> row_slices) const;
+    std::span<const timestamp> get_source_index(std::pair<size_t, size_t> source_start_end) const;
 
     std::span<const std::byte> get_source_data_bytes(size_t field_index, std::pair<size_t, size_t> range) const;
 };

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -22,6 +22,16 @@
 
 namespace {
 using namespace arcticdb;
+
+template<util::type_descriptor_tag TDT>
+using SourceRawType =
+        std::conditional_t<is_sequence_type(TDT::data_type()), PyObject* const, typename TDT::DataTypeTag::raw_type>;
+
+struct TargetRange {
+    size_t start_row_in_first_row_slice{};
+    size_t end_row_in_last_row_slice{};
+};
+
 /// Remove all row slice entities and ranges and keys whose indexes do not appear in row_slices_to_keep
 /// @param offsets Must be structured by row slice with ranges and keys
 /// @param ranges_and_keys Must be structured by row slice with offsets
@@ -43,17 +53,22 @@ void filter_selected_ranges_and_keys_and_reindex_entities(
     size_t new_entity_id = 0;
     std::vector<RangesAndKey> new_ranges_and_keys;
     new_ranges_and_keys.reserve(ranges_and_keys.size());
+    ankerl::unordered_dense::map<size_t, size_t> offset_to_entity;
     for (std::span<size_t> row_slice : offsets) {
         for (size_t& entity_id : row_slice) {
-            new_ranges_and_keys.emplace_back(std::move(ranges_and_keys[entity_id]));
-            entity_id = new_entity_id++;
+            auto [it, inserted] = offset_to_entity.emplace(entity_id, new_entity_id);
+            if (inserted) {
+                new_ranges_and_keys.emplace_back(std::move(ranges_and_keys[entity_id]));
+                ++new_entity_id;
+            }
+
+            entity_id = it->second;
         }
     }
     ranges_and_keys = std::move(new_ranges_and_keys);
 }
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 position_t write_py_string_to_pool_or_throw(
         PyObject* const py_string_object, const size_t row_in_segment, const RowRange& row_range,
         std::optional<ScopedGILLock>& gil_lock, StringPool& new_string_pool, const std::string_view column_name
@@ -68,16 +83,15 @@ position_t write_py_string_to_pool_or_throw(
     );
 }
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 void rebuild_sequence_column_in_new_pool(
         Column& target_column, const StringPool& old_string_pool, StringPool& new_string_pool,
-        const util::BitSet* rows_to_add_in_new_pool = nullptr
+        const util::BitSet* target_rows_to_add_in_new_pool = nullptr
 ) {
-    if (rows_to_add_in_new_pool) {
+    if (target_rows_to_add_in_new_pool) {
         ColumnData target_column_data = target_column.data();
         auto accessor = random_accessor<TDT>(&target_column_data);
-        for (auto row = rows_to_add_in_new_pool->first(); row != rows_to_add_in_new_pool->end(); ++row) {
+        for (auto row = target_rows_to_add_in_new_pool->first(); row != target_rows_to_add_in_new_pool->end(); ++row) {
             if (is_a_string(accessor[*row])) {
                 const std::string_view string_value = old_string_pool.get_const_view(accessor[*row]);
                 const OffsetString& new_offset = new_string_pool.get(string_value);
@@ -95,86 +109,13 @@ void rebuild_sequence_column_in_new_pool(
     }
 }
 
-/// When merge update is performed on a string column the string pool is rebuild from scratch, thus we must iterate over
-/// all rows in the column. When the column is a part of a timeseries all target rows stored in rows_to_update will be
-/// ordered (i.e. sorted(flatten(rows_to_update)) = true). This means we can iterate over the target column row and
-/// at the same time forward iterate on the source rows. It's a nested loop but the complexity is O(n + m + k)
-/// where n is the total number of rows in the target, m are the rows in the source, and k are the total matches between
-/// source and target (i.e. sum(rows_to_update[i] for i in range(len(rows_to_update))))
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
-bool merge_update_string_column_timeseries(
-        Column& target_column, const std::span<const std::vector<size_t>> rows_to_update, const Field& target_field,
+template<util::type_descriptor_tag TDT>
+bool merge_update_string_column(
+        Column& target_column, const std::span<const std::vector<size_t>> rows_to_update, std::string_view column_name,
         const RowRange& row_range, const StringPool& target_string_pool,
         const std::span<PyObject* const> source_column_view, StringPool& new_string_pool
 ) {
-    bool is_column_changed = false;
-    if constexpr (is_fixed_string_type(TDT::data_type())) {
-        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                "Fixed string sequences are not supported for merge update"
-        );
-    } else if constexpr (is_dynamic_string_type(TDT::data_type())) {
-        // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
-        // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
-        // If such a string is encountered in a column, then the GIL will be held until that whole column has
-        // been processed, on the assumption that if a column has one such string it will probably have many.
-        std::optional<ScopedGILLock> gil_lock;
-        // TODO: Create new column in case of insertion
-        auto source_row_it = rows_to_update.begin();
-        auto next_target_row_to_update = source_row_it->begin();
-        // TODO: Handle sparse target columns Monday 10756321294
-        arcticdb::for_each_enumerated<TDT>(target_column, [&](auto row) {
-            source_row_it = std::find_if(
-                    source_row_it,
-                    rows_to_update.end(),
-                    [&, new_row = false](const std::vector<size_t>& vec) mutable {
-                        // TODO: Handle inserts. Empty vec means insert.
-                        next_target_row_to_update = std::find_if(
-                                new_row ? vec.begin() : next_target_row_to_update,
-                                vec.end(),
-                                [&](const int64_t target_row_to_update) { return target_row_to_update >= row.idx(); }
-                        );
-                        if (next_target_row_to_update == vec.end()) {
-                            new_row = true;
-                        }
-                        return next_target_row_to_update != vec.end();
-                    }
-            );
-            const bool current_target_row_is_matched = source_row_it != rows_to_update.end() &&
-                                                       next_target_row_to_update != source_row_it->end() &&
-                                                       static_cast<int64_t>(*next_target_row_to_update) == row.idx();
-            if (current_target_row_is_matched) {
-                is_column_changed = true;
-                const auto py_string_object = source_column_view[source_row_it - rows_to_update.begin()];
-                row.value() = write_py_string_to_pool_or_throw<TDT>(
-                        py_string_object, row.idx(), row_range, gil_lock, new_string_pool, target_field.name()
-                );
-            } else {
-                if (is_a_string(row.value())) {
-                    const std::string_view string_in_target = target_string_pool.get_const_view(row.value());
-                    const OffsetString offset_in_new_pool = new_string_pool.get(string_in_target);
-                    row.value() = offset_in_new_pool.offset();
-                }
-            }
-        });
-    }
-    return is_column_changed;
-}
-
-/// When merge update is performed on a string column the string pool is rebuild from scratch, thus we must iterate over
-/// all rows in the column. When the column is *not* part of a timeseries the rows in rows_to_update are in random
-/// order. To avoid having quadratic complexity (i.e. O(n * k) where n are the rows in the target and k are all matches
-/// i.e. sum(rows_to_update[i] for i in range(len(rows_to_update)))) we invert the loops and iterate over all
-/// rows_to_update perform the update and then add additional loop over all rows in target to rebuild the string pool.
-/// Asymptotically this will yield the same complexity as the timeseries case but practically is a bit slower.
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
-bool merge_update_string_column_rowrange(
-        Column& target_column, const std::span<const std::vector<size_t>> rows_to_update, const Field& target_field,
-        const RowRange& row_range, const StringPool& target_string_pool,
-        const std::span<PyObject* const> source_column_view, StringPool& new_string_pool
-) {
-    bool is_column_changed = false;
+    bool column_is_changed = false;
     if constexpr (is_fixed_string_type(TDT::data_type())) {
         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                 "Fixed string sequences are not supported for merge update"
@@ -192,9 +133,9 @@ bool merge_update_string_column_rowrange(
             for (size_t target_row : rows_to_update[source_row]) {
                 const auto py_string_object = source_column_view[source_row];
                 target_column_accessor[target_row] = write_py_string_to_pool_or_throw<TDT>(
-                        py_string_object, target_row, row_range, gil_lock, new_string_pool, target_field.name()
+                        py_string_object, target_row, row_range, gil_lock, new_string_pool, column_name
                 );
-                is_column_changed = true;
+                column_is_changed = true;
                 target_rows_not_matched_by_source.set(target_row);
             }
         }
@@ -203,50 +144,35 @@ bool merge_update_string_column_rowrange(
                 target_column, target_string_pool, new_string_pool, &target_rows_not_matched_by_source
         );
     }
-    return is_column_changed;
+    return column_is_changed;
 }
 
 struct MergeUpdateStringColumnFlags {
-    /// The column is part of a timeseries dataframe
-    bool is_timeseries = false;
     /// Only move the data to a new string pool.
     bool data_not_changed = false;
 };
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 bool merge_update_string_column(
         Column& target_column, const MergeUpdateStringColumnFlags& flags,
-        const std::span<const std::vector<size_t>> rows_to_update, const Field& target_field, const RowRange& row_range,
-        const StringPool& target_string_pool, const std::span<PyObject* const> source_column_view,
-        StringPool& new_string_pool
+        const std::span<const std::vector<size_t>> rows_to_update, std::string_view column_name,
+        const RowRange& row_range, const StringPool& target_string_pool,
+        const std::span<PyObject* const> source_column_view, StringPool& new_string_pool
 ) {
     if (flags.data_not_changed) {
         rebuild_sequence_column_in_new_pool<TDT>(target_column, target_string_pool, new_string_pool);
         return false;
-    } else {
-        if (flags.is_timeseries) {
-            return merge_update_string_column_timeseries<TDT>(
-                    target_column,
-                    rows_to_update,
-                    target_field,
-                    row_range,
-                    target_string_pool,
-                    source_column_view,
-                    new_string_pool
-            );
-        } else {
-            return merge_update_string_column_rowrange<TDT>(
-                    target_column,
-                    rows_to_update,
-                    target_field,
-                    row_range,
-                    target_string_pool,
-                    source_column_view,
-                    new_string_pool
-            );
-        }
     }
+
+    return merge_update_string_column<TDT>(
+            target_column,
+            rows_to_update,
+            column_name,
+            row_range,
+            target_string_pool,
+            source_column_view,
+            new_string_pool
+    );
 }
 
 struct NaNAwareFloatComparator {
@@ -271,7 +197,8 @@ struct NaNAwareFloatHasher {
 };
 
 template<
-        typename SourceTDT, typename TargetTDT, typename SourceValueRawType = TargetTDT::DataTypeTag::raw_type,
+        util::type_descriptor_tag SourceTDT, util::type_descriptor_tag TargetTDT,
+        typename SourceValueRawType = TargetTDT::DataTypeTag::raw_type,
         typename TargetValueRawType = TargetTDT::DataTypeTag::raw_type>
 requires std::same_as<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>
 std::variant<bool, convert::StringEncodingError> are_merge_values_matching(
@@ -305,8 +232,7 @@ std::variant<bool, convert::StringEncodingError> are_merge_values_matching(
     }
 }
 
-template<typename TDT>
-requires util::instantiation_of<TDT, TypeDescriptorTag>
+template<util::type_descriptor_tag TDT>
 auto map_column_values_to_rows(const ColumnWithStrings& column) {
     constexpr static bool is_target_sequence_type = is_sequence_type(TDT::data_type());
     constexpr static bool is_target_floating_point_type = is_floating_point_type(TDT::data_type());
@@ -322,15 +248,421 @@ auto map_column_values_to_rows(const ColumnWithStrings& column) {
     arcticdb::for_each_enumerated<TDT>(*column.column_, [&](auto row) {
         if constexpr (is_target_sequence_type) {
             if (is_a_string(row.value())) {
-                target_values[column.string_at_offset(row.value())].push_back(row.idx());
+                target_values[column.string_at_offset(row.value())].emplace_back(row.idx());
             } else {
-                target_values[std::nullopt].push_back(row.idx());
+                target_values[std::nullopt].emplace_back(row.idx());
             }
         } else {
-            target_values[row.value()].push_back(row.idx());
+            target_values[row.value()].emplace_back(row.idx());
         }
     });
     return target_values;
+}
+
+template<typename SourceRawType>
+struct InsertSourceData {
+    std::span<const timestamp> index;
+    std::span<const SourceRawType> data;
+    std::pair<size_t, size_t> global_row_range;
+};
+
+struct InsertTargetData {
+    std::span<ColumnWithStrings> indexes;
+    std::span<ColumnWithStrings> columns;
+    TypeDescriptor type;
+    TargetRange range;
+    StringPool& new_string_pool;
+};
+
+/// Performs merging of sorted lists with update on matching rows. The index column dictates the ordering of the rows.
+/// The target is composed of multiple row slices the following hods:
+/// is_sorted(index in row slice i) && all(index values in row slice i) <= all(index values in row slice j) for i < j.
+/// The source is a single row slice.  Insertion is stable and all new values are inserted after all existing values
+/// with the same index value. The source and target must have the same index type.
+template<util::type_descriptor_tag TargetColumnTypeDescriptorTag, typename SourceRawType>
+requires(TargetColumnTypeDescriptorTag::dimension() == Dimension::Dim0)
+Column merge(
+        const InsertSourceData<SourceRawType>& source, const InsertTargetData& target,
+        const MergeUpdateClause::MatchRecord& match_record, const MergeStrategy& strategy
+) {
+    using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+    // One index value can appear in more than one row slice. In that case it can be shared by two processing units
+    // in that case. Each processing unit works on part of the target data.
+    const size_t num_rows_out_of_target_range =
+            target.range.start_row_in_first_row_slice +
+            (target.columns.back().column_->row_count() - target.range.end_row_in_last_row_slice);
+    const size_t combined_row_count =
+            std::accumulate(
+                    target.columns.begin(),
+                    target.columns.end(),
+                    match_record.total_unmatched_source_rows(),
+                    [](size_t acc, const ColumnWithStrings& col) { return acc + col.column_->row_count(); }
+            ) -
+            num_rows_out_of_target_range;
+    Column new_column(target.type, combined_row_count, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);
+    ColumnData new_column_data = new_column.data();
+    auto new_column_it = new_column_data.begin<TargetColumnTypeDescriptorTag>();
+    auto new_data = random_accessor<TargetColumnTypeDescriptorTag>(&new_column_data);
+
+    size_t target_row_slice = 0;
+    ColumnData target_index_data = target.indexes[target_row_slice].column_->data();
+    auto target_index_it = target_index_data.begin<IndexType>();
+    std::advance(target_index_it, target.range.start_row_in_first_row_slice);
+    auto target_index_end = target_index_data.end<IndexType>();
+
+    ColumnData target_column_data = target.columns[target_row_slice].column_->data();
+    auto target_data = random_accessor<TargetColumnTypeDescriptorTag>(&target_column_data);
+    size_t target_row_idx = target.range.start_row_in_first_row_slice;
+    size_t new_column_row_idx{};
+
+    std::vector<size_t> row_slice_start_in_output(target.columns.size());
+    std::vector<size_t> inserted_rows(target.columns.size(), 0);
+
+    StringPool intermediate_pool;
+
+    const auto target_index_is_exhausted = [&] {
+        return target_row_slice == target.columns.size() - 1 && target_index_it == target_index_end;
+    };
+
+    const auto advance_target = [&] {
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                !target_index_is_exhausted(),
+                "Cannot advance target index iterator past the end"
+        );
+        ++target_index_it;
+        ++target_row_idx;
+        if (target_index_it == target_index_end && target_row_slice < target.columns.size() - 1) [[unlikely]] {
+            ++target_row_slice;
+            row_slice_start_in_output[target_row_slice] = new_column_row_idx;
+            target_row_idx = 0;
+            target_column_data = target.columns[target_row_slice].column_->data();
+            target_index_data = target.indexes[target_row_slice].column_->data();
+            target_index_it = target_index_data.begin<IndexType>();
+            target_index_end = target_index_data.end<IndexType>();
+            target_data = random_accessor<TargetColumnTypeDescriptorTag>(&target_column_data);
+            if (target_row_slice == target.columns.size() - 1 &&
+                target.range.end_row_in_last_row_slice !=
+                        static_cast<size_t>(target.columns.back().column_->row_count())) [[unlikely]] {
+                target_index_end = std::next(target_index_it, target.range.end_row_in_last_row_slice);
+            }
+        }
+    };
+
+    const auto advance_output = [&] {
+        ++new_column_row_idx;
+        ++new_column_it;
+    };
+
+    // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
+    // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
+    // If such a string is encountered in a column, then the GIL will be held until that whole column has
+    // been processed, on the assumption that if a column has one such string it will probably have many.
+    std::optional<ScopedGILLock> scoped_gil_lock;
+
+    const auto set_string_from_source = [&](size_t row) {
+        if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+            *new_column_it = write_py_string_to_pool_or_throw<TargetColumnTypeDescriptorTag>(
+                    source.data[row],
+                    row,
+                    RowRange{source.global_row_range.first, source.global_row_range.second},
+                    scoped_gil_lock,
+                    intermediate_pool,
+                    target.columns.front().column_name_
+            );
+        }
+    };
+
+    const auto set_string_from_source_at = [&](size_t source_row, size_t output_row) {
+        if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+            new_data[output_row] = write_py_string_to_pool_or_throw<TargetColumnTypeDescriptorTag>(
+                    source.data[source_row],
+                    source_row,
+                    RowRange{source.global_row_range.first, source.global_row_range.second},
+                    scoped_gil_lock,
+                    intermediate_pool,
+                    target.columns.front().column_name_
+            );
+        }
+    };
+
+    const auto set_string_from_target = [&](size_t target_row) {
+        if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+            const position_t offset = target_data[target_row];
+            if (is_a_string(offset)) {
+                const StringPool& pool = *target.columns[target_row_slice].string_pool_;
+                const std::string_view string_data = pool.get_const_view(offset);
+                *new_column_it = intermediate_pool.get(string_data).offset();
+            } else {
+                *new_column_it = offset;
+            }
+        }
+    };
+
+    size_t source_row_idx = 0;
+
+    // Stable merge target and source into the new column. If there is a sequence of repeated index values and new
+    // rows must be inserted, the new rows will appear after the rows from the target
+    while (!target_index_is_exhausted() && source_row_idx < source.index.size()) {
+        // Copy all target values smaller than the current source index to the output buffer
+        while (!target_index_is_exhausted() && *target_index_it < source.index[source_row_idx]) {
+            if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                set_string_from_target(target_row_idx);
+            } else {
+                *new_column_it = target_data[target_row_idx];
+            }
+            advance_output();
+            advance_target();
+        }
+
+        if (target_index_is_exhausted()) {
+            break;
+        }
+
+        // Target index values are equal to the source index values. Since the index is matching, it's possible to
+        // perform both an update and an insert. First, copy all target values to the output buffer and then append
+        // the new values. In case rows_to_update[source_row_idx] is not empty, then an update must happen. The
+        // update is performed in place in the new output buffer. It is crucial to take into account that the
+        // indexes in rows_to_update[source_row_idx] are pointing to rows in the original column (before any
+        // insertions happened)
+
+        // Source and target index values are equal. Copy the target data first.
+        const size_t pre_equal_run_row_slice = target_row_slice;
+        const timestamp equal_run_index_value = *target_index_it;
+        // Since the index is ordered, no index in source_index[source_row_idx] can be less than target_row_idx.
+        while (!target_index_is_exhausted() && *target_index_it == equal_run_index_value &&
+               source.index[source_row_idx] == equal_run_index_value) {
+            if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                set_string_from_target(target_row_idx);
+            } else {
+                *new_column_it = target_data[target_row_idx];
+            }
+            advance_output();
+            advance_target();
+        }
+
+        // For each source row equal to the target row, there are two options.
+        // * the output buffer must be updated.
+        // * insertion must happen by appending to the end of the output buffer.
+        size_t inserted_rows_with_matching_index = 0;
+        while (source_row_idx < source.index.size() && source.index[source_row_idx] == equal_run_index_value) {
+            if (!match_record.is_source_row_matched(source_row_idx)) {
+                if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                    set_string_from_source(source_row_idx);
+                } else {
+                    *new_column_it = source.data[source_row_idx];
+                }
+                advance_output();
+                ++inserted_rows_with_matching_index;
+            } else if (strategy.update()) {
+                for (size_t i = pre_equal_run_row_slice; i <= target_row_slice; ++i) {
+                    // TODO: this is suboptimal for string columns. This approach first places all target value and
+                    // then updates the output buffer with the source values. The rows to update are not ordered. So
+                    // unless we build a map or iterate each time the rows to updated to check if a row must be updated
+                    // this approach is faster for non-string columns. However for string columns this can introduce
+                    // ghost string data into the string pool, thus the string pool is rebuilt at the end of the
+                    // function.
+                    std::span<const std::vector<size_t>> matched_rows = match_record.matched_rows(i);
+                    for (const size_t target_row_to_update_in_slice : matched_rows[source_row_idx]) {
+                        const size_t target_offset = i == 0 ? target.range.start_row_in_first_row_slice : 0;
+                        // matched_rows holds indexes into the target segment. But the output segment can start at
+                        // an offest in the target in case the work is shared between two processing units. Only
+                        // the first and last row slices of a time slice can be requested by more than one
+                        // processing unit
+                        const size_t output_row_to_update = target_row_to_update_in_slice +
+                                                            row_slice_start_in_output[i] + inserted_rows[i] -
+                                                            target_offset;
+                        if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                            set_string_from_source_at(source_row_idx, output_row_to_update);
+                        } else {
+                            new_data[output_row_to_update] = source.data[source_row_idx];
+                        }
+                    }
+                }
+            }
+            ++source_row_idx;
+        }
+        inserted_rows[target_row_slice] += inserted_rows_with_matching_index;
+
+        if (target_index_it == target_index_end) {
+            break;
+        }
+
+        // Target index values are larger than the source index value. Append the source data to the output buffer.
+        while (source_row_idx < source.index.size() && *target_index_it > source.index[source_row_idx]) {
+            if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                set_string_from_source(source_row_idx);
+            } else {
+                *new_column_it = source.data[source_row_idx];
+            }
+            ++source_row_idx;
+            advance_output();
+            ++inserted_rows[target_row_slice];
+        }
+    }
+    // Not all target rows were processed, copy the rest
+    while (!target_index_is_exhausted()) {
+        if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+            set_string_from_target(target_row_idx);
+        } else {
+            *new_column_it = target_data[target_row_idx];
+        }
+        advance_target();
+        advance_output();
+    }
+
+    // Not all source rows were processed, copy the rest
+    if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+        for (; source_row_idx < source.index.size(); ++source_row_idx) {
+            set_string_from_source(source_row_idx);
+            advance_output();
+        }
+    } else {
+        std::copy(source.data.begin() + source_row_idx, source.data.end(), new_column_it);
+    }
+
+    if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+        rebuild_sequence_column_in_new_pool<TargetColumnTypeDescriptorTag>(
+                new_column, intermediate_pool, target.new_string_pool
+        );
+    }
+    return new_column;
+}
+
+template<util::type_descriptor_tag ScalarType>
+bool update_column(
+        const MergeStrategy& strategy, const StringPool& old_string_pool,
+        const std::span<const SourceRawType<ScalarType>> source_data,
+        const std::span<const std::vector<size_t>> rows_to_update, const RowRange& row_range,
+        const bool is_matching_column, std::string_view column_name, Column& target_column, StringPool& new_string_pool
+) {
+    bool row_slice_changed = false;
+    if constexpr (is_sequence_type(ScalarType::data_type())) {
+        const MergeUpdateStringColumnFlags column_update_flags{
+                .data_not_changed = is_matching_column && strategy.update_only()
+        };
+        row_slice_changed = merge_update_string_column<ScalarType>(
+                target_column,
+                column_update_flags,
+                rows_to_update,
+                column_name,
+                row_range,
+                old_string_pool,
+                source_data,
+                new_string_pool
+        );
+    } else {
+        if (is_matching_column) {
+            return false;
+        }
+        ColumnData target_column_data = target_column.data();
+        auto target = random_accessor<ScalarType>(&target_column_data);
+        for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
+            row_slice_changed |= !rows_to_update[source_row_idx].empty();
+            for (const size_t target_row_idx : rows_to_update[source_row_idx]) {
+                target[target_row_idx] = source_data[source_row_idx];
+            }
+        }
+    }
+    return row_slice_changed;
+}
+
+std::vector<std::vector<size_t>> split_by_row_slice(
+        const std::span<const RangesAndKey> ranges, std::span<const size_t> indexes
+) {
+    std::vector<std::vector<size_t>> res = {{indexes.front()}};
+    RowRange prev_row_range = ranges[indexes.front()].row_range();
+    for (size_t idx : indexes.subspan(1)) {
+        const RowRange current_row_range = ranges[idx].row_range();
+        if (current_row_range != prev_row_range) {
+            res.emplace_back();
+        }
+        res.back().emplace_back(idx);
+        prev_row_range = current_row_range;
+    }
+    return res;
+}
+
+pipelines::RowRange get_row_range(std::span<const ProcessingUnit> row_slice) {
+    return {row_slice.front().row_ranges_->front()->first, row_slice.back().row_ranges_->back()->second};
+}
+
+ssize_t first_different_index_value_position(const ColumnData index) {
+    using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+    auto it = index.cbegin<IndexType, IteratorType::ENUMERATED>();
+    const timestamp first_source_row = it->value();
+    return exponential_upper_bound(++it, index.cend<IndexType, IteratorType::ENUMERATED>(), first_source_row)->idx();
+};
+
+TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
+    TargetRange result{
+            .start_row_in_first_row_slice = 0,
+            .end_row_in_last_row_slice = row_slices.back().segments_->back()->row_count()
+    };
+    if (!row_slices.empty() && row_slices.front().entity_fetch_count_) {
+        if (row_slices.front().entity_fetch_count_->front() > 1) {
+            const ColumnData index = row_slices.front().segments_->front()->column(0).data();
+            result.start_row_in_first_row_slice = first_different_index_value_position(index);
+        }
+        if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
+            const ColumnData index = row_slices.back().segments_->back()->column(0).data();
+            result.end_row_in_last_row_slice = first_different_index_value_position(index);
+        }
+    }
+    return result;
+}
+
+/// For each row of source that falls in the row slice in proc find all rows whose index matches the source index
+/// value. The matching rows will be sorted in increasing order. Since both source and target are timestamp indexed
+/// and ordered, only forward iteration on both source and target is needed and binary search can be used to check
+/// if a source index value exists in the target index. At the end some vectors in the output can be empty which
+/// means that that particular row in source did not match anything in the target. It is allowed for one row in
+/// target to be matched by multiple rows in source only if MergeUpdateClause::on_ is not empty. If
+/// MergeUpdateClause::on_ is not empty, there will be further filtering that might remove some matches. Otherwise,
+/// one row will be updated multiple times, which is not allowed.
+///
+/// Complexity: $$O(m * log_2(n) + n)$$ where: m is the count of source rows in the bounds of the segment, n is the
+/// number of target rows in the segment.
+MergeUpdateClause::MatchRecord filter_index_match(
+        std::span<const timestamp> source_index, std::span<ProcessingUnit> row_slices
+) {
+    using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+    MergeUpdateClause::MatchRecord result(row_slices, source_index.size());
+    if (source_index.empty()) {
+        return result;
+    }
+    for (size_t i = 0; i < row_slices.size(); ++i) {
+        const ProcessingUnit& proc = row_slices[i];
+        const Column& target_index = proc.segments_->front()->column(0);
+        ColumnData target_index_column_data = target_index.data();
+        auto last_target_row_it = exponential_upper_bound<IndexType, IteratorType::ENUMERATED>(
+                target_index_column_data, source_index.back()
+        );
+        size_t source_row{};
+        auto target_row_it = target_index_column_data.cbegin<IndexType, IteratorType::ENUMERATED>();
+        // This loop can be inverted so that if source_row_end - source_row_start is > len(target) the complexity
+        // becomes O(n * log_2(m)) where: m is the count of source rows in the bounds of the segment, n is the number of
+        // target rows in the segment.
+        while (target_row_it != last_target_row_it && source_row < source_index.size()) {
+            const timestamp source_ts = source_index[source_row];
+            auto target_match_it = exponential_lower_bound(target_row_it, last_target_row_it, source_ts);
+            if (target_match_it == last_target_row_it) {
+                break;
+            }
+            target_row_it = target_match_it;
+            while (target_row_it != last_target_row_it && target_row_it->value() == source_ts) {
+                result.add_match(source_row, i, target_row_it->idx());
+                ++target_row_it;
+            }
+            // Optimizes the case of repeated index values. All matched rows corresponding to a particular index value
+            // must be the same, so just copy the matched rows in case index values are repeated.
+            while (++source_row < source_index.size() && source_index[source_row] == source_ts) {
+                result.clone_source_match(source_row - 1, source_row, i);
+            }
+        }
+    }
+
+    return result;
 }
 
 } // namespace
@@ -348,9 +680,6 @@ MergeUpdateClause::MergeUpdateClause(
     strategy_(strategy),
     source_(std::move(source)) {
     std::erase_if(on_, [&](const std::string& column) { return !on_set_.insert(column).second; });
-    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-            strategy_.not_matched_by_target == MergeAction::DO_NOTHING, "Merge cannot perform insertion at the moment"
-    );
 }
 
 std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys
@@ -369,7 +698,8 @@ std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing_log
 ) {
 
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    std::vector<std::vector<size_t>> offsets = structure_by_row_slice(ranges_and_keys);
+    std::vector<std::vector<size_t>> offsets = must_structure_by_time_slice() ? structure_by_time_slice(ranges_and_keys)
+                                                                              : structure_by_row_slice(ranges_and_keys);
     std::vector<size_t> row_slices_to_keep;
     // TODO: Arrow is not supported yet.
     const TypedTensor<IndexType::DataTypeTag::raw_type> index_tensor(source_->get_tensor(0));
@@ -389,26 +719,83 @@ std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing_log
         ranges_and_keys.clear();
         return {};
     }
-    std::span index(static_cast<const IndexType::DataTypeTag::raw_type*>(index_tensor.data()), source_->num_rows);
+
+    std::span source_index(index_tensor.data(), source_->num_rows);
     for (size_t row_slice_idx = 0; row_slice_idx < offsets.size(); ++row_slice_idx) {
-        // TODO: Add logic for insertion.
-        const TimestampRange& time_range = ranges_and_keys[offsets[row_slice_idx].front()].key_.time_range();
-        if (source_start_end_for_row_range_.contains(time_range)) {
-            row_slices_to_keep.push_back(row_slice_idx);
-            continue;
-        }
-        const auto source_range_start = std::ranges::lower_bound(index, time_range.first);
-        if (source_range_start == index.end()) {
+        const std::vector<std::vector<size_t>>& row_slice_offsets =
+                must_structure_by_time_slice() ? ::split_by_row_slice(ranges_and_keys, offsets[row_slice_idx])
+                                               : std::vector<std::vector<size_t>>{offsets[row_slice_idx]};
+        const TimestampRange time_range{
+                ranges_and_keys[row_slice_offsets.front().front()].key_.time_range().first,
+                ranges_and_keys[row_slice_offsets.back().back()].key_.time_range().second
+        };
+
+        const auto source_range_start = [&] {
+            if (strategy_.insert() && row_slice_idx == 0 && source_index.front() < time_range.first) {
+                // In case of inserting all data before the first segment gets prepended to it
+                return source_index.begin();
+            }
+            return ranges::lower_bound(source_index, time_range.first);
+        }();
+
+        if (source_range_start == source_index.end()) {
+            // All remaining row ranges start after the last index value of the source, thus not match is possible.
             break;
         }
-        if (*source_range_start < time_range.second) {
-            auto source_range_end = std::upper_bound(source_range_start, index.end(), time_range.second - 1);
-            const std::pair<size_t, size_t> source_row_range = {
-                    source_range_start - index.begin(), source_range_end - index.begin()
-            };
-            source_start_end_for_row_range_.insert({time_range, source_row_range});
-            row_slices_to_keep.push_back(row_slice_idx);
+
+        auto source_range_end = source_index.end();
+        if (*source_range_start >= time_range.second) {
+            // The current segment does not contain any source value because all source values larger than the
+            // segment start are also larger than the segment end.
+            if (!strategy_.insert()) {
+                // If insertion is not allowed, continue checking next row slices until segment's start is larger
+                // than the source index end.
+                continue;
+            }
+            if (row_slice_idx != offsets.size() - 1) {
+                // In case insertion is enabled, source values in between two row slices will be appended to the
+                // former. This is done by extending the time range of the current row slice so that it's 1 ns less than
+                // the start of the next row slice.
+                const timestamp next_row_slice_start =
+                        ranges_and_keys[offsets[row_slice_idx + 1].front()].key_.time_range().first;
+                if (*source_range_start >= next_row_slice_start) {
+                    // The extended segment does not contain any source values. All source values are after the
+                    // extended segment end. Continue checking next row slices.
+                    continue;
+                }
+                const timestamp extended_segment_end = next_row_slice_start - 1;
+                source_range_end = std::upper_bound(source_range_start, source_index.end(), extended_segment_end);
+            }
+        } else {
+            if (strategy_.insert()) {
+                if (row_slice_idx == offsets.size() - 1) {
+                    // When strategy allows insertion and this is the last segment all remaining source values get
+                    // attributed to the last segment
+                    source_range_end = source_index.end();
+                } else {
+                    // The segment contains source values. In addition, unmatched source values that fall in the gap
+                    // between this segment and the next one are appended to this segment (as in the branch above, where
+                    // the segment had no source values of its own). std::max keeps at least the segment's own range in
+                    // case the next segment starts before this one ends (overlapping time slices).
+                    const timestamp next_row_slice_start =
+                            ranges_and_keys[offsets[row_slice_idx + 1].front()].key_.time_range().first;
+                    const timestamp extended_segment_end = std::max(time_range.second, next_row_slice_start) - 1;
+                    source_range_end =
+                            ranges::upper_bound(source_range_start, source_index.end(), extended_segment_end);
+                }
+            } else {
+                source_range_end = ranges::upper_bound(source_range_start, source_index.end(), time_range.second - 1);
+            }
         }
+        const std::pair<size_t, size_t> source_row_range = {
+                source_range_start - source_index.begin(), source_range_end - source_index.begin()
+        };
+        const pipelines::RowRange row_range{
+                ranges_and_keys[row_slice_offsets.front().front()].row_range().first,
+                ranges_and_keys[row_slice_offsets.back().back()].row_range().second
+        };
+        source_start_end_for_row_range_.insert({row_range, source_row_range});
+        row_slices_to_keep.push_back(row_slice_idx);
     }
     filter_selected_ranges_and_keys_and_reindex_entities(row_slices_to_keep, offsets, ranges_and_keys);
     return offsets;
@@ -428,6 +815,9 @@ std::vector<std::vector<EntityId>> MergeUpdateClause::structure_for_processing(s
 /// This means that the ordering of the columns in MergeUpdateClause::on_ matters and it would be more efficient to
 /// start with the columns that have a lesser chance of matching.
 std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_ids) const {
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            source_->has_only_tensors(), "Arrow format is not supported as input for merge update"
+    );
     if (entity_ids.empty()) {
         return {};
     }
@@ -435,418 +825,446 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
             std::shared_ptr<SegmentInMemory>,
             std::shared_ptr<RowRange>,
             std::shared_ptr<ColRange>,
-            std::shared_ptr<AtomKey>>(*component_manager_, std::move(entity_ids));
-    // TODO: Add exception handling two source rows matching the same target row. This should be done in the
-    // function
-    //  handling the "on" parameter matching multiple columns. Monday 10655943156
-    auto matched = [&]() -> std::optional<std::vector<std::vector<size_t>>> {
-        std::optional<std::vector<std::vector<size_t>>> result;
-        if (source_->has_index()) {
-            using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-            const TypedTensor<IndexType::DataTypeTag::raw_type> index_tensor(source_->get_tensor(0));
-            result.emplace(filter_index_match(
-                    proc.segments_->front()->column(0), std::span(index_tensor.data(), source_->num_rows), proc
-            ));
+            std::shared_ptr<AtomKey>,
+            EntityFetchCount>(*component_manager_, std::move(entity_ids));
+    std::vector<ProcessingUnit> row_slices =
+            must_structure_by_time_slice() ? split_by_row_slice(std::move(proc)) : std::vector{std::move(proc)};
+    const MatchRecord matched = match(row_slices);
+    matched.validate_rows_to_update(strategy_);
+    if (strategy_.update_only()) {
+        if (auto [new_row_slices, time_slice_changed] = update(matched, std::move(row_slices)); time_slice_changed) {
+            std::vector<EntityId> res;
+            for (ProcessingUnit& row_slice : new_row_slices) {
+                const size_t entity_count = row_slice.segments_->size();
+                std::vector<EntityId> entts = component_manager_->add_entities(
+                        std::move(*row_slice.segments_),
+                        std::move(*row_slice.row_ranges_),
+                        std::move(*row_slice.col_ranges_),
+                        std::vector<EntityFetchCount>(entity_count, 1)
+                );
+                res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
+            }
+            return res;
         }
-        return result;
-    }();
-    if (!source_->has_only_tensors()) {
-        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>("Arrow format is not supported as input for merge update"
-        );
-    }
-    // source_tensors holds only data columns; the index (if any) sits at columns_[0] and is handled separately
-    // by filter_index_match above.
-    const auto index_fields = source_->desc().index().field_count();
-    std::vector<NativeTensor> source_tensors;
-    source_tensors.reserve(source_->num_columns() - index_fields);
-    for (size_t i = index_fields; i < source_->num_columns(); ++i) {
-        source_tensors.push_back(source_->get_tensor(i));
-    }
-    // TODO: Source and target descriptor can differ for dynamic schema
-    matched = filter_on_additional_columns_match(
-            source_->desc(), source_->desc(), source_tensors, proc, std::move(matched)
-    );
-    if (update_and_insert(source_tensors, source_->desc(), proc, *matched)) {
-        return push_entities(*component_manager_, std::move(proc));
+    } else if (strategy_.insert()) {
+        const StreamDescriptor& target_descriptor = source_->desc(); // TODO: Not true for dynamic schema
+        auto [new_row_slices, time_slice_changed] =
+                update_and_insert(matched, target_descriptor, std::move(row_slices));
+        if (time_slice_changed) {
+            std::vector<EntityId> res;
+            for (auto& row_slice : new_row_slices) {
+                const size_t entity_count = row_slice.segments_->size();
+                std::vector<EntityId> entts = component_manager_->add_entities(
+                        std::move(*row_slice.segments_),
+                        std::move(*row_slice.row_ranges_),
+                        std::move(*row_slice.col_ranges_),
+                        std::vector<EntityFetchCount>(entity_count, 1),
+                        std::vector(entity_count, MergeUpdateInsertedRowsEntity{matched.total_unmatched_source_rows()})
+                );
+                res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
+            }
+            return res;
+        }
     }
     return {};
 }
 
-std::vector<std::vector<size_t>> MergeUpdateClause::initialize_rows_to_update_for_rowrange_indexed_data(
-        ProcessingUnit& proc, const StreamDescriptor& source_descriptor
+MergeUpdateClause::MatchRecord MergeUpdateClause::initialize_rows_to_update_for_row_range_indexed_data(
+        std::span<ProcessingUnit> row_slices, const StreamDescriptor& source_descriptor
 ) const {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !on_.empty(),
             "MergeUpdate requires at least one column in the \"on\" parameter when the DataFrame is not a "
             "timeseries"
     );
+    const std::pair<size_t, size_t> source_range = get_source_start_end(row_slices);
+    MatchRecord result(row_slices, source_range.second - source_range.first);
     // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
     // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
     // If such a string is encountered in a column, then the GIL will be held until that whole column has
     // been processed, on the assumption that if a column has one such string it will probably have many.
     std::optional<ScopedGILLock> scoped_gil_lock;
-    const std::string_view column_name = on_.front();
-    std::vector<std::vector<size_t>> result;
-    result.resize(source_->num_rows);
-    const size_t source_field_position = field_index_for_matching_on_column(column_name, source_descriptor);
-    const Field& source_field = source_descriptor.field(source_field_position);
-    details::visit_type(source_field.type().data_type(), [&](auto source_field_dt) {
-        using SourceTDT = ScalarTagType<std::decay_t<decltype(source_field_dt)>>;
-        using SourceRawType = typename SourceTDT::DataTypeTag::raw_type;
-        const ColumnWithStrings target_column = std::get<ColumnWithStrings>(proc.get(ColumnName{column_name}));
-        details::visit_type(target_column.column_->type().data_type(), [&](auto target_field_dt) {
-            using TargetTDT = ScalarTagType<decltype(target_field_dt)>;
-            if constexpr (std::is_same_v<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>) {
-                using SourceType =
-                        std::conditional_t<is_sequence_type(SourceTDT::data_type()), PyObject* const, SourceRawType>;
-                auto target_values_to_rows = map_column_values_to_rows<TargetTDT>(target_column);
-                const size_t column_position_in_source_tensors =
-                        source_field_position - source_descriptor.index().field_count();
-                std::span source_data(
-                        static_cast<const SourceType*>(source_->get_tensor(column_position_in_source_tensors).data()),
-                        source_->num_rows
-                );
-                for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
-                    auto source_value = source_data[source_row_idx];
-                    if constexpr (is_sequence_type(SourceTDT::data_type())) {
-                        if (is_py_none(source_value) || is_py_nan(source_value)) {
-                            result[source_row_idx] = target_values_to_rows[std::nullopt];
+    for (size_t row_slice_idx = 0; row_slice_idx < row_slices.size(); ++row_slice_idx) {
+        ProcessingUnit& proc = row_slices[row_slice_idx];
+        const std::string_view column_name = on_.front();
+        const size_t source_field_position = field_index_for_matching_on_column(column_name, source_descriptor);
+        const Field& source_field = source_descriptor.field(source_field_position);
+        details::visit_type(source_field.type().data_type(), [&](auto source_field_dt) {
+            using SourceTDT = ScalarTagType<std::decay_t<decltype(source_field_dt)>>;
+            using SourceType = SourceRawType<SourceTDT>;
+            const ColumnWithStrings target_column = std::get<ColumnWithStrings>(proc.get(ColumnName{column_name}));
+            details::visit_type(target_column.column_->type().data_type(), [&](auto target_field_dt) {
+                using TargetTDT = ScalarTagType<decltype(target_field_dt)>;
+                if constexpr (std::same_as<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>) {
+                    auto target_values_to_rows = map_column_values_to_rows<TargetTDT>(target_column);
+                    std::span source_data = source_->get_tensor(source_field_position).span<SourceType>();
+                    for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
+                        auto source_value = source_data[source_row_idx];
+                        if constexpr (is_sequence_type(SourceTDT::data_type())) {
+                            if (is_py_none(source_value) || is_py_nan(source_value)) {
+                                result.add_match(source_row_idx, row_slice_idx, target_values_to_rows[std::nullopt]);
+                            } else {
+                                util::variant_match(
+                                        create_py_object_wrapper_or_error<SourceTDT::data_type()>(
+                                                source_value, scoped_gil_lock
+                                        ),
+                                        [&](convert::StringEncodingError&& err) {
+                                            err.row_index_in_slice_ = source_row_idx;
+                                            err.raise(column_name, 0);
+                                        },
+                                        [&](convert::PyStringWrapper&& wrapper) {
+                                            std::string_view wrapper_view{wrapper.buffer_, wrapper.length_};
+                                            result.add_match(
+                                                    source_row_idx,
+                                                    row_slice_idx,
+                                                    target_values_to_rows[std::optional{wrapper_view}]
+                                            );
+                                        }
+                                );
+                            }
                         } else {
-                            util::variant_match(
-                                    create_py_object_wrapper_or_error<SourceTDT::data_type()>(
-                                            source_value, scoped_gil_lock
-                                    ),
-                                    [&](convert::StringEncodingError&& err) {
-                                        err.row_index_in_slice_ = source_row_idx;
-                                        err.raise(column_name, 0);
-                                    },
-                                    [&](convert::PyStringWrapper&& wrapper) {
-                                        std::string_view wrapper_view{wrapper.buffer_, wrapper.length_};
-                                        result[source_row_idx] = target_values_to_rows[std::optional{wrapper_view}];
-                                    }
-                            );
+                            result.add_match(source_row_idx, row_slice_idx, target_values_to_rows[source_value]);
                         }
-                    } else {
-                        result[source_row_idx] = target_values_to_rows[source_value];
                     }
+                } else {
+                    schema::raise<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                            "Source type {} does not match target type {}. Dynamic schema is not implemented yet",
+                            SourceTDT::data_type(),
+                            TargetTDT::data_type()
+                    );
                 }
-            } else {
-                schema::raise<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                        "Source type {} does not match target type {}. Dynamic schema is not implemented yet",
-                        SourceTDT::data_type(),
-                        TargetTDT::data_type()
-                );
-            }
+            });
         });
-    });
+    }
+
     return result;
 }
 
-std::pair<size_t, size_t> MergeUpdateClause::get_source_start_end(const ProcessingUnit& proc) const {
+std::pair<size_t, size_t> MergeUpdateClause::get_source_start_end(std::span<const ProcessingUnit> row_slices) const {
     if (source_->has_index()) {
-        const std::span<const std::shared_ptr<AtomKey>> atom_keys = *proc.atom_keys_;
-        const auto source_row_range_it = source_start_end_for_row_range_.find(atom_keys.front()->time_range());
-        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+        const pipelines::RowRange row_range = get_row_range(row_slices);
+        const auto source_row_range_it = source_start_end_for_row_range_.find(row_range);
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
                 source_row_range_it != source_start_end_for_row_range_.end(),
-                "Missing mapping between AtomKey timerange {} {} and source row start/end",
-                atom_keys.front()->time_range().first,
-                atom_keys.front()->time_range().second
+                "Source row range for row range [{}, {}] not found",
+                row_range.first,
+                row_range.second
         );
-        return source_row_range_it->second;
+        const std::pair<size_t, size_t> source_range = source_row_range_it->second;
+        if (!row_slices.empty() && row_slices.front().entity_fetch_count_) {
+            // An index value is spanning more than one row slices.
+            std::pair<size_t, size_t> result = source_range;
+            std::span<const timestamp> source_index =
+                    source_->get_tensor(0).span<timestamp>(result.first, result.second - result.first);
+            if (row_slices.front().entity_fetch_count_->front() > 1) {
+                // This is the last row slice containing the index value that spans multiple row slices. It appears at
+                // the beginning of the row slices, which means that the other processing unit will handle all rows of
+                // the segment containing the index value; this processing unit must handle only the rows that do not
+                // contain index value. Example:
+                //     0         1         2         3
+                // [a, b, c] [c, c, c] [c, d, e] [e, f, g]
+                // When the source contains value "c," the structure for processing will be [0, 1, 2] [2, 3]. This case
+                // handles processing [2, 3].
+                auto next_index_value = std::ranges::upper_bound(
+                        source_index, row_slices.front().atom_keys_->front()->time_range().first
+                );
+                result.first += next_index_value - source_index.begin();
+            }
+            if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
+                // This is the last row slice containing the index value that spans multiple row slices. It appears at
+                // the end of the row slices, which means that the other processing unit will handle all rows of
+                // the segment not containing the index value; this processing unit must handle only the rows that
+                // contain index value. Example:
+                //     0         1         2         3
+                // [a, b, c] [c, c, c] [c, d, e] [e, f, g]
+                // When the source contains value "c," the structure for processing will be [0, 1, 2] [2, 3]. This case
+                // handles processing [0, 1, 2].
+                const auto last_index_value = std::ranges::upper_bound(
+                        source_index, row_slices.back().atom_keys_->back()->time_range().first
+                );
+                result.second = source_range.first + (last_index_value - source_index.begin());
+            }
+            return result;
+        } else {
+            return source_range;
+        }
     } else {
         return std::pair{0, source_->num_rows};
     }
 }
 
-bool MergeUpdateClause::update_and_insert(
-        const std::span<const NativeTensor> source_tensors, const StreamDescriptor& source_descriptor,
-        const ProcessingUnit& proc, const std::span<const std::vector<size_t>> rows_to_update
+std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update_and_insert(
+        const MatchRecord& match_record, const StreamDescriptor& target_descriptor,
+        std::vector<ProcessingUnit>&& row_slices
+
 ) const {
-    const std::span<const std::shared_ptr<SegmentInMemory>> target_segments = *proc.segments_;
-    const std::span<const std::shared_ptr<RowRange>> row_ranges = *proc.row_ranges_;
-    const std::span<const std::shared_ptr<ColRange>> col_ranges = *proc.col_ranges_;
-    const auto [source_row_start, source_row_end] = get_source_start_end(proc);
-    bool row_slice_changed = false;
-    const bool is_timeseries = source_->desc().index().type() == IndexDescriptor::Type::TIMESTAMP;
-    util::BitSet matched_target_rows(row_ranges.front()->diff());
-    // TODO: This can be inlined in the loop iterating over all columns to avoid iterating the source one more
-    // time. The loop structure makes it not intuitive. The performance cost must be evaluated. Monday: 10655963947
-    for (size_t source_row_idx = 0; source_row_idx < rows_to_update.size(); ++source_row_idx) {
-        for (const size_t target_row : rows_to_update[source_row_idx]) {
-            user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                    !matched_target_rows[target_row],
-                    "Multiple source rows match the same target row. This is not allowed as it's not clear which "
-                    "source row should be used for the update. Target row is {}, the second source row to match it is "
-                    "{}",
-                    target_row,
-                    source_row_idx + source_row_start
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            strategy_.insert(),
+            "MergeUpdateClause::update_and_insert should only be called for strategies that allow insertion"
+    );
+    // A group with nothing to insert can be left untouched only if it is self-contained. If it
+    // co-owns a boundary slice (entity_fetch_count > 1) with a neighbouring group that does insert,
+    // that neighbour rewrites part of the shared slice; this group must therefore also re-emit its
+    // owned portion, otherwise the stale old slice overlaps the neighbour's new slice during index
+    // reconstruction (merge_slices_and_keys) and produces a non-contiguous, unreadable index.
+    // Only the first and last row slices of a group can be shared with a neighbour (a group is a
+    // contiguous window of row slices), matching how get_source_start_end/get_target_start_end trim.
+    const bool co_owns_shared_slice = !row_slices.empty() && (row_slices.front().entity_fetch_count_->front() > 1 ||
+                                                              row_slices.back().entity_fetch_count_->back() > 1);
+    if (strategy_.insert_only() && match_record.total_unmatched_source_rows() == 0 && !co_owns_shared_slice) {
+        return {std::move(row_slices), false};
+    }
+    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
+            source_->desc().index().type() == IndexDescriptor::Type::TIMESTAMP,
+            "Merge update with insertion is implemented only for timeseries"
+    );
+    const std::pair<size_t, size_t> source_start_end = get_source_start_end(row_slices);
+    const std::span<const timestamp> source_index = get_source_index(row_slices);
+    const StreamDescriptor source_descriptor = source_->desc();
+    const size_t num_col_slices = row_slices.begin()->col_ranges_->size();
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            std::ranges::all_of(
+                    row_slices, [&](const auto& proc) { return proc.col_ranges_->size() == num_col_slices; }
+            ),
+            "All row slices should have the same number of column ranges"
+    );
+
+    ProcessingUnit result{};
+    result.segments_.emplace();
+    result.segments_->reserve(num_col_slices);
+    result.col_ranges_ = row_slices.front().col_ranges_;
+    std::vector<ColumnWithStrings> target_datas, target_index_datas;
+    target_index_datas.reserve(row_slices.size());
+    std::ranges::transform(row_slices, std::back_inserter(target_index_datas), [&](const auto& proc) {
+        return ColumnWithStrings(proc.segments_->front()->column_ptr(0), nullptr, target_descriptor.field(0).name());
+    });
+    StringPool new_string_pool;
+    bool has_string_column_in_column_slice = false;
+    const TargetRange target_range = get_target_start_end(row_slices);
+    using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
+    auto new_index = std::make_shared<Column>(merge<IndexType>(
+            InsertSourceData{.index = source_index, .data = source_index, .global_row_range = source_start_end},
+            InsertTargetData{
+                    .indexes = target_index_datas,
+                    .columns = target_index_datas,
+                    .type = TypeDescriptor{DataType::NANOSECONDS_UTC64, Dimension::Dim0},
+                    .range = target_range,
+                    .new_string_pool = new_string_pool
+            },
+            match_record,
+            MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
+    ));
+    size_t col_slice_idx = 0;
+    const auto [source_start, source_end] = get_source_start_end(row_slices);
+    for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
+         ++field_idx) {
+        const Field& target_field = target_descriptor.field(field_idx);
+        const std::string_view column_name = target_field.name();
+        target_datas.clear();
+        std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
+            return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
+        });
+        Column new_column = details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
+            using TargetDataTDT = ScalarTagType<TypeTag>;
+            has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
+            return merge<TargetDataTDT>(
+                    InsertSourceData{
+                            .index = source_index,
+                            .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
+                                    source_start, source_end - source_start
+                            ),
+                            .global_row_range = source_start_end
+                    },
+                    InsertTargetData{
+                            .indexes = target_index_datas,
+                            .columns = target_datas,
+                            .type = target_field.type(),
+                            .range = target_range,
+                            .new_string_pool = new_string_pool
+                    },
+                    match_record,
+                    // By construction, we cannot update the columns used to perform the match; only inserts are
+                    // allowed
+                    on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
+                                                  : strategy_
             );
-            matched_target_rows[target_row] = true;
+        });
+        if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
+            const StreamDescriptor& desc = (*row_slices.front().segments_)[col_slice_idx]->descriptor();
+            result.segments_->emplace_back(std::make_shared<SegmentInMemory>(desc, new_index->row_count()));
+            result.segments_->back()->columns()[0] = new_index;
+        }
+        const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
+        result.segments_->back()->columns()[col_in_slice] = std::make_shared<Column>(std::move(new_column));
+        if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
+            result.segments_->back()->set_row_data(new_index->row_count() - 1);
+            ++col_slice_idx;
+            if (has_string_column_in_column_slice) {
+                result.segments_->back()->string_pool() = std::move(new_string_pool);
+                new_string_pool.clear();
+                has_string_column_in_column_slice = false;
+            }
         }
     }
-    // Update one column at a time to increase cache coherency and to avoid calling visit_field for each row
-    // being updated
-    for (size_t segment_idx = 0; segment_idx < target_segments.size(); ++segment_idx) {
-        StringPool new_string_pool;
-        bool segment_contains_string_column = false;
-        SegmentInMemory& target_segment = *target_segments[segment_idx];
-        const size_t slice_size = target_segment.num_columns();
-        const int index_fields = source_descriptor.index().field_count();
-        for (size_t column_index_in_slice = index_fields; column_index_in_slice < slice_size; ++column_index_in_slice) {
-            const Field& target_field = target_segment.descriptor().field(column_index_in_slice);
-            details::visit_type(target_field.type().data_type(), [&]<typename DataTypeTag>(DataTypeTag) {
-                using RawType = DataTypeTag::raw_type;
-                using ScalarType = ScalarTagType<DataTypeTag>;
-                // All column slices start with the index. Subtract the index field count so that we don't count the
-                // index twice.
-                const size_t column_position_in_ts_descriptor =
-                        col_ranges[segment_idx]->start() + column_index_in_slice - index_fields;
-                // For pandas input the index NativeTensor is stored separately from the field NativeTensors.
-                // Subtract the index fields to get the correct position in the source descriptor
-                const size_t column_position_in_source = column_position_in_ts_descriptor - index_fields;
-                user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                        util::is_cstyle_array<RawType>(source_tensors[column_position_in_source]),
-                        "Fortran-style arrays are not supported by merge update yet. Column \"{}\" has data type "
-                        "{} of "
-                        "size {} bytes but the stride is {} bytes",
-                        target_field.name(),
-                        target_field.type(),
-                        sizeof(RawType),
-                        source_tensors[column_position_in_source].strides()[0]
-                );
-                Column& target_column = target_segment.column(column_index_in_slice);
-                const NativeTensor& source_tensor = source_tensors[column_position_in_source];
-                using SourceType =
-                        std::conditional_t<is_sequence_type(DataTypeTag::data_type), PyObject* const, RawType>;
-                const std::span source_data(
-                        static_cast<const SourceType*>(source_tensor.data()) + source_row_start,
-                        source_row_end - source_row_start
-                );
-                internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                        rows_to_update.size() == source_data.size(), "Mismatched source row sizes"
-                );
-                internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                        !rows_to_update.empty(), "There must be at least one source row inside the target row slice."
-                );
-                if constexpr (is_sequence_type(DataTypeTag::data_type)) {
-                    // String columns are always recreated from scratch regardless if an update or insert is
-                    // happening. This is done because the string pool must be updated. With data read from disk,
-                    // the map_ member of the pool is not populated. Which means that the mapping between a string
-                    // and offset in the pool is missing. To get it, we need to rebuild the pool anyway.
-                    segment_contains_string_column = true;
-                    const MergeUpdateStringColumnFlags column_update_flags{
-                            .is_timeseries = is_timeseries,
-                            .data_not_changed = on_set_.contains(target_field.name()) && strategy_.update_only()
-                    };
-                    row_slice_changed |= merge_update_string_column<ScalarType>(
-                            target_column,
-                            column_update_flags,
-                            rows_to_update,
-                            target_field,
-                            *row_ranges[segment_idx],
-                            target_segment.string_pool(),
-                            source_data,
-                            new_string_pool
-                    );
-                } else {
-                    if (is_update_only() && on_set_.contains(target_field.name())) {
-                        return;
-                    }
-                    ColumnData target_column_data = target_column.data();
-                    if (is_timeseries) {
-                        auto target_row_to_update_it = target_column_data.begin<ScalarType>();
-                        size_t target_row_to_update_idx = 0;
-                        for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
-                            // TODO: Handle insert. Empty rows_to_update[source_row_idx] means that update must be done
-                            row_slice_changed |= !rows_to_update[source_row_idx].empty();
-                            for (const size_t target_row_idx : rows_to_update[source_row_idx]) {
-                                const size_t rows_to_skip = target_row_idx - target_row_to_update_idx;
-                                std::advance(target_row_to_update_it, rows_to_skip);
-                                *target_row_to_update_it = source_data[source_row_idx];
-                                target_row_to_update_idx = target_row_idx;
-                            }
-                        }
-                    } else {
-                        auto target = random_accessor<ScalarType>(&target_column_data);
-                        for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
-                            // TODO: Handle insert. Empty rows_to_update[source_row_idx] means that update must be done
-                            row_slice_changed |= !rows_to_update[source_row_idx].empty();
-                            for (const size_t target_row_idx : rows_to_update[source_row_idx]) {
-                                target[target_row_idx] = source_data[source_row_idx];
-                            }
-                        }
-                    }
-                }
-            });
-        }
-        if (segment_contains_string_column) {
-            target_segment.set_string_pool(std::make_shared<StringPool>(std::move(new_string_pool)));
-        }
-    }
-    return row_slice_changed;
+    const auto new_row_range = std::make_shared<RowRange>(
+            row_slices.front().row_ranges_->front()->first + target_range.start_row_in_first_row_slice,
+            row_slices.back().row_ranges_->back()->first + target_range.end_row_in_last_row_slice
+    );
+    result.row_ranges_ = std::vector(num_col_slices, new_row_range);
+    return {std::vector{std::move(result)}, true};
 }
 
-/// For each row of source that falls in the row slice in proc find all rows whose index matches the source index
-/// value. The matching rows will be sorted in increasing order. Since both source and target are timestamp indexed
-/// and ordered, only forward iteration on both source and target is needed and binary search can be used to check
-/// if a source index value exists in the target index. At the end some vectors in the output can be empty which
-/// means that that particular row in source did not match anything in the target. It is allowed for one row in
-/// target to be matched by multiple rows in source only if MergeUpdateClause::on_ is not empty. If
-/// MergeUpdateClause::on_ is not empty, there will be further filtering that might remove some matches. Otherwise,
-/// one row will be updated multiple times, which is not allowed.
-///
-/// Complexity: $$O(m * log_2(n) + n)$$ where: m is the count of source rows in the bounds of the segment, n is the
-/// number of target rows in the segment.
-std::vector<std::vector<size_t>> MergeUpdateClause::filter_index_match(
-        const Column& target_index, const std::span<const timestamp> source_index, const ProcessingUnit& proc
+std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update(
+        const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices
 ) const {
-    using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    ColumnData target_index_column_data = target_index.data();
-    const auto target_index_accessor = random_accessor<IndexType>(&target_index_column_data);
-    const auto [source_row_start, source_row_end] = get_source_start_end(proc);
-    const size_t last_target_row_to_consider = [&] {
-        auto row_indexes = ranges::iota_view{position_t{0}, target_index.row_count()};
-        const auto upper_bound = ranges::upper_bound(
-                row_indexes,
-                source_index.back(),
-                [&](const timestamp value, const int64_t row_idx) { return value < target_index_accessor.at(row_idx); }
-        );
-        return upper_bound == row_indexes.end() ? target_index.row_count() : *upper_bound;
-    }();
-    size_t source_row = source_row_start;
-    const size_t source_rows_in_row_slice = source_row_end - source_row;
-    std::vector<std::vector<size_t>> matched_rows(source_rows_in_row_slice);
-    size_t target_row = 0;
-    // This loop can be inverted so that if source_row_end - source_row_start is > len(target) the complexity becomes
-    // O(n * log_2(m)) where: m is the count of source rows in the bounds of the segment, n is the number of target rows
-    // in the segment.
-    while (target_row < last_target_row_to_consider && source_row < source_row_end) {
-        const timestamp source_ts = source_index[source_row];
-        // TODO: Profile performance and try different optimizations. See Monday 10655963947
-        auto row_index_view = std::ranges::iota_view{target_row, last_target_row_to_consider};
-        auto target_match_it =
-                ranges::lower_bound(row_index_view, source_ts, [&](const size_t row_idx, const timestamp source) {
-                    return target_index_accessor.at(row_idx) < source;
+    ARCTICDB_DEBUG_CHECK(
+            ErrorCode::E_ASSERTION_FAILURE,
+            strategy_.update_only(),
+            "MergeUpdateClause::update should only be called for prue updates without insertion"
+    );
+    std::vector<ProcessingUnit> result;
+    const StreamDescriptor& source_descriptor = source_->desc();
+    bool time_slice_changed = false;
+    const auto [source_start, source_end] = get_source_start_end(row_slices);
+    for (size_t i = 0; i < row_slices.size(); ++i) {
+        const ProcessingUnit& proc = row_slices[i];
+        const std::span<const std::shared_ptr<SegmentInMemory>> target_segments = *proc.segments_;
+
+        const std::span<const std::shared_ptr<ColRange>> col_ranges = *proc.col_ranges_;
+        // Update one column at a time to increase cache coherency and to avoid calling visit_field for each row
+        // being updated
+        for (size_t segment_idx = 0; segment_idx < target_segments.size(); ++segment_idx) {
+            StringPool new_string_pool;
+            bool segment_contains_string_column = false;
+            SegmentInMemory& target_segment = *target_segments[segment_idx];
+            const size_t slice_size = target_segment.num_columns();
+            const int index_fields = source_descriptor.index().field_count();
+            for (size_t column_index_in_slice = index_fields; column_index_in_slice < slice_size;
+                 ++column_index_in_slice) {
+                const Field& target_field = target_segment.descriptor().field(column_index_in_slice);
+                details::visit_type(target_field.type().data_type(), [&]<typename DataTypeTag>(DataTypeTag) {
+                    using RawType = DataTypeTag::raw_type;
+                    using ScalarType = ScalarTagType<DataTypeTag>;
+                    // All column slices start with the index. Subtract the index field count so that we don't count the
+                    // index twice.
+                    const size_t column_position_in_ts_descriptor =
+                            col_ranges[segment_idx]->start() + column_index_in_slice - index_fields;
+                    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                            util::is_cstyle_array<RawType>(source_->get_tensor(column_position_in_ts_descriptor)),
+                            "Fortran-style arrays are not supported by merge update yet. Column \"{}\" has data type "
+                            "{} of size {} bytes but the stride is {} bytes",
+                            target_field.name(),
+                            target_field.type(),
+                            sizeof(RawType),
+                            source_->get_tensor(column_position_in_ts_descriptor).strides()[0]
+                    );
+                    Column& target_column = target_segment.column(column_index_in_slice);
+                    const std::span source_data =
+                            source_->get_tensor(column_position_in_ts_descriptor)
+                                    .span<SourceRawType<ScalarType>>(source_start, source_end - source_start);
+                    std::span<const std::vector<size_t>> rows_to_update = match_record.matched_rows(i);
+                    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                            !rows_to_update.empty(),
+                            "There must be at least one source row inside the target row slice."
+                    );
+                    // String columns are always recreated from scratch regardless if an update or insert is happening.
+                    // This is because the string pool must be updated. With data read from disk, the map_ member of the
+                    // pool is not populated. Which means that the mapping between a string and offset in the pool is
+                    // missing. To get it, we need to rebuild the pool anyway.
+                    segment_contains_string_column |= is_sequence_type(DataTypeTag::data_type);
+                    time_slice_changed |= update_column<ScalarType>(
+                            strategy_,
+                            target_segment.string_pool(),
+                            source_data,
+                            rows_to_update,
+                            *(*proc.row_ranges_)[segment_idx],
+                            on_set_.contains(target_field.name()),
+                            target_field.name(),
+                            target_column,
+                            new_string_pool
+                    );
                 });
-        if (target_match_it == row_index_view.end()) {
-            break;
+            }
+            if (segment_contains_string_column) {
+                target_segment.set_string_pool(std::make_shared<StringPool>(std::move(new_string_pool)));
+            }
         }
-        target_row = *target_match_it;
-        while (target_row < last_target_row_to_consider && target_index_accessor.at(target_row) == source_ts) {
-            matched_rows[source_row - source_row_start].push_back(target_row);
-            ++target_row;
-        }
-        // Optimizes the case of repeated index values. All matched rows corresponding to a particular index value must
-        // be the same, so just copy the matched rows in case index values are repeated.
-        while (++source_row < source_row_end && source_index[source_row] == source_ts) {
-            const size_t source_row_offset = source_row - source_row_start;
-            matched_rows[source_row_offset] = matched_rows[source_row_offset - 1];
-        }
+        result.emplace_back(std::move(row_slices[i]));
     }
-    return matched_rows;
+
+    return {std::move(result), time_slice_changed};
+}
+
+MergeUpdateClause::MatchRecord MergeUpdateClause::match(std::span<ProcessingUnit> row_slices) const {
+    std::optional<MatchRecord> maybe_index_match;
+    if (source_->has_index()) {
+        maybe_index_match.emplace(filter_index_match(get_source_index(row_slices), row_slices));
+    }
+    return filter_on_additional_columns_match(
+            source_->desc(), source_->desc(), row_slices, std::move(maybe_index_match)
+    );
+}
+
+std::span<const std::byte> MergeUpdateClause::get_source_data_bytes(size_t field_index, std::pair<size_t, size_t> range)
+        const {
+    auto [first_source_row, last_source_row] = range;
+    const NativeTensor& tensor = source_->get_tensor(field_index);
+    const size_t num_rows = last_source_row - first_source_row;
+    const size_t first_source_byte = first_source_row * tensor.elsize();
+    const void* source_data = tensor.data();
+    return std::span{static_cast<const std::byte*>(source_data) + first_source_byte, num_rows * tensor.elsize()};
 }
 
 /// Complexity: $$O(c * n * m)$$ m is the count of source rows in the bounds of the segment, n is the  number of target
 /// rows in the segment. c is the number of columns in MergeUpdateClause::on_. It can be reached if the data in source
 /// and target is the same up to the very last column in MergeUpdateClause::on_.
-std::vector<std::vector<size_t>> MergeUpdateClause::filter_on_additional_columns_match(
+MergeUpdateClause::MatchRecord MergeUpdateClause::filter_on_additional_columns_match(
         const StreamDescriptor& source_descriptor, const StreamDescriptor& target_descriptor,
-        const std::span<const NativeTensor> source_tensors, ProcessingUnit& proc,
-        std::optional<std::vector<std::vector<size_t>>>&& index_match
+        std::span<ProcessingUnit> row_slices, std::optional<MatchRecord>&& index_match
 ) const {
     ranges::subrange on = on_;
-    std::vector<std::vector<size_t>> matched_rows;
-    const IndexDescriptor::Type source_index_type = source_descriptor.index().type();
-    const IndexDescriptor::Type target_index_type = target_descriptor.index().type();
-    if (index_match) {
-        user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                (source_index_type == target_index_type) && (source_index_type == IndexDescriptor::Type::TIMESTAMP),
-                "Source and target index types must both be TIMESTAMP. Source: {}, target: {}",
-                source_index_type,
-                target_index_type
-        );
-        matched_rows = std::move(*index_match);
-    } else {
+    MatchRecord matched_rows = [&] {
+        const IndexDescriptor::Type source_index_type = source_descriptor.index().type();
+        const IndexDescriptor::Type target_index_type = target_descriptor.index().type();
+        if (index_match) {
+            user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                    (source_index_type == target_index_type) && (source_index_type == IndexDescriptor::Type::TIMESTAMP),
+                    "Source and target index types must both be TIMESTAMP. Source: {}, target: {}",
+                    source_index_type,
+                    target_index_type
+            );
+            return std::move(*index_match);
+        }
         user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                 (source_index_type == target_index_type) && (source_index_type == IndexDescriptor::Type::ROWCOUNT),
                 "Source and target index types to be both ROWCOUNT. Source: {}, target: {}",
                 source_index_type,
                 target_index_type
         );
-        matched_rows = initialize_rows_to_update_for_rowrange_indexed_data(proc, source_descriptor);
         on = on.next();
-    }
+        return initialize_rows_to_update_for_row_range_indexed_data(row_slices, source_descriptor);
+    }();
+
     if (on.empty()) {
         return matched_rows;
     }
-    const auto [source_row_start, source_row_end] = get_source_start_end(proc);
-    // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
-    // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
-    // If such a string is encountered in a column, then the GIL will be held until that whole column has
-    // been processed, on the assumption that if a column has one such string it will probably have many.
-    std::optional<ScopedGILLock> scoped_gil_lock;
-    for (std::string_view column_name : on) {
+    const std::pair<size_t, size_t> source_range = get_source_start_end(row_slices);
+    for (const std::string_view column_name : on) {
         const size_t source_field_position = field_index_for_matching_on_column(column_name, source_descriptor);
         const Field& source_field = source_descriptor.field(source_field_position);
-        details::visit_type(source_field.type().data_type(), [&]<typename SourceDataTypeTag>(SourceDataTypeTag) {
-            using SourceTDT = ScalarTagType<SourceDataTypeTag>;
-            using SourceType = std::conditional_t<
-                    is_sequence_type(SourceDataTypeTag::data_type),
-                    PyObject* const*,
-                    const typename SourceDataTypeTag::raw_type*>;
-            const size_t column_position_in_source_tensors =
-                    source_field_position - source_descriptor.index().field_count();
-            std::span source_data(
-                    static_cast<SourceType>(source_tensors[column_position_in_source_tensors].data()) +
-                            source_row_start,
-                    source_row_end - source_row_start
-            );
-            // TODO: For dynamic schema the two fields might have different indexes
-            const size_t target_field_position = source_field_position;
-            const ColumnWithStrings target_column = std::get<ColumnWithStrings>(
-                    proc.get(ColumnName{target_descriptor.field(target_field_position).name()})
-            );
-            ColumnData target_data = target_column.column_->data();
-            details::visit_type(
-                    target_column.column_->type().data_type(),
-                    [&]<typename TargetDataTypeTag>(TargetDataTypeTag) {
-                        using TargetTDT = ScalarTagType<TargetDataTypeTag>;
-                        using TargetRawType = TargetDataTypeTag::raw_type;
-                        // TODO: Relax for dynamic schema
-                        if constexpr (std::same_as<std::decay_t<SourceDataTypeTag>, std::decay_t<TargetDataTypeTag>>) {
-                            auto target_accessor = random_accessor<TargetTDT>(&target_data);
-                            for (size_t source_row_idx = 0; source_row_idx < matched_rows.size(); ++source_row_idx) {
-                                std::erase_if(matched_rows[source_row_idx], [&](const size_t target_row_idx) {
-                                    const TargetRawType target_value = target_accessor.at(target_row_idx);
-                                    const auto& source_value = source_data[source_row_idx];
-                                    auto are_values_equal = are_merge_values_matching<SourceTDT, TargetTDT>(
-                                            source_value, target_value, *target_column.string_pool_, scoped_gil_lock
-                                    );
-                                    if constexpr (is_sequence_type(TargetDataTypeTag::data_type)) {
-                                        return util::variant_match(
-                                                are_values_equal,
-                                                [](const bool equal) { return !equal; },
-                                                [&](convert::StringEncodingError& err) -> bool {
-                                                    err.row_index_in_slice_ = source_row_idx;
-                                                    err.raise(column_name, source_row_start);
-                                                }
-                                        );
-                                    } else {
-                                        return !std::get<bool>(are_values_equal);
-                                    }
-                                });
-                            }
-                        } else {
-                            internal::raise<ErrorCode::E_ASSERTION_FAILURE>(
-                                    "Target column \"{}\" has unexpected type {}. Source type: {}",
-                                    column_name,
-                                    TargetDataTypeTag::data_type,
-                                    SourceDataTypeTag::data_type
-                            );
-                        }
-                    }
-            );
-        });
+        // TODO: For dynamic schema the two fields might have different indexes
+        const size_t target_field_position = source_field_position;
+        const Field& target_field = target_descriptor.field(target_field_position);
+        matched_rows.filter_matching_rows(
+                target_field.name(),
+                source_field.type().data_type(),
+                target_field.type().data_type(),
+                source_range.first,
+                get_source_data_bytes(source_field_position, source_range)
+        );
     }
     return matched_rows;
 }
@@ -918,6 +1336,155 @@ size_t MergeUpdateClause::field_index_for_matching_on_column(std::string_view na
             descriptor
     );
     return std::distance(descriptor.fields().begin(), field_it);
+}
+
+bool MergeUpdateClause::must_structure_by_time_slice() const {
+    return source_->has_index() && !on_.empty() && strategy_.insert();
+}
+
+std::span<const timestamp> MergeUpdateClause::get_source_index(std::span<const ProcessingUnit> row_slices) const {
+    const auto [start, end] = get_source_start_end(row_slices);
+    return source_->get_tensor(0).span<timestamp>(start, end - start);
+}
+
+MergeUpdateClause::MatchRecord::MatchRecord(std::span<ProcessingUnit> row_slices, const size_t num_source_rows) :
+    matched_target_rows_(row_slices.size(), std::vector<std::vector<size_t>>(num_source_rows)),
+    row_slices_(row_slices),
+    source_row_matched_count_(num_source_rows) {}
+
+void MergeUpdateClause::MatchRecord::add_match(size_t source_row, size_t target_row_slice, size_t target_row) {
+    ++source_row_matched_count_[source_row];
+    matched_target_rows_[target_row_slice][source_row].push_back(target_row);
+    ++total_matched_target_rows_count_;
+}
+void MergeUpdateClause::MatchRecord::add_match(
+        size_t source_row, size_t target_row_slice, std::span<size_t> target_rows
+) {
+    ++source_row_matched_count_[source_row];
+    const auto end = matched_target_rows_[target_row_slice][source_row].end();
+    matched_target_rows_[target_row_slice][source_row].insert(end, target_rows.begin(), target_rows.end());
+    total_matched_target_rows_count_ += target_rows.size();
+}
+
+void MergeUpdateClause::MatchRecord::filter_matching_rows(
+        std::string_view column_name, const DataType source_type, const DataType target_type,
+        const size_t source_offset, const std::span<const std::byte> opaque_source_data
+) {
+    if (total_matched_target_rows_count_ == 0) {
+        // This function can only remove matches in case of a mismatch. In case there are no matched
+        // target rows, there's nothing left to remove.
+        return;
+    }
+    // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
+    // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
+    // If such a string is encountered in a column, then the GIL will be held until that whole column has
+    // been processed, on the assumption that if a column has one such string it will probably have many.
+    std::optional<ScopedGILLock> scoped_gil_lock;
+    details::visit_type(source_type, [&]<typename SourceDataTypeTag>(SourceDataTypeTag) {
+        using SourceTDT = ScalarTagType<SourceDataTypeTag>;
+        std::span<const SourceRawType<SourceTDT>> source_data{
+                reinterpret_cast<const SourceRawType<SourceTDT>*>(opaque_source_data.data()),
+                opaque_source_data.size() / sizeof(SourceRawType<SourceTDT>)
+        };
+        details::visit_type(target_type, [&]<typename TargetDataTypeTag>(TargetDataTypeTag) {
+            using TargetTDT = ScalarTagType<TargetDataTypeTag>;
+            using TargetRawType = TargetDataTypeTag::raw_type;
+            // TODO: Relax for dynamic schema
+            if constexpr (std::same_as<std::decay_t<SourceDataTypeTag>, std::decay_t<TargetDataTypeTag>>) {
+                for (size_t row_slice_idx = 0; row_slice_idx < matched_target_rows_.size(); ++row_slice_idx) {
+                    ProcessingUnit& row_slice = row_slices_[row_slice_idx];
+                    const ColumnWithStrings target_column =
+                            std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
+                    ColumnData col_data = target_column.column_->data();
+                    auto target_column_accessor = random_accessor<TargetTDT>(&col_data);
+                    std::vector<std::vector<size_t>>& matched_rows = matched_target_rows_[row_slice_idx];
+                    for (size_t source_row_idx = 0; source_row_idx < matched_rows.size(); ++source_row_idx) {
+                        const size_t discarded_matches =
+                                std::erase_if(matched_rows[source_row_idx], [&](const size_t target_row) {
+                                    const TargetRawType target_value = target_column_accessor[target_row];
+                                    const auto& source_value = source_data[source_row_idx];
+                                    auto are_values_equal = are_merge_values_matching<SourceTDT, TargetTDT>(
+                                            source_value, target_value, *target_column.string_pool_, scoped_gil_lock
+                                    );
+                                    bool discard_match = false;
+                                    if constexpr (is_sequence_type(TargetDataTypeTag::data_type)) {
+                                        discard_match = util::variant_match(
+                                                are_values_equal,
+                                                [](const bool equal) { return !equal; },
+                                                [&](convert::StringEncodingError& err) -> bool {
+                                                    err.row_index_in_slice_ = source_row_idx;
+                                                    err.raise(column_name, source_offset);
+                                                }
+                                        );
+                                    } else {
+                                        discard_match = !std::get<bool>(are_values_equal);
+                                    }
+                                    return discard_match;
+                                });
+                        source_row_matched_count_[source_row_idx] -= discarded_matches;
+                        total_matched_target_rows_count_ -= discarded_matches;
+                        if (total_matched_target_rows_count_ == 0) {
+                            return;
+                        }
+                    }
+                }
+            } else {
+                internal::raise<ErrorCode::E_NOT_IMPLEMENTED>(
+                        "Target column \"{}\" type {} does not match source's type {}. Dynamic schema is not "
+                        "implemented for merge updates yet.",
+                        column_name,
+                        TargetDataTypeTag::data_type,
+                        SourceDataTypeTag::data_type
+                );
+            }
+        });
+    });
+}
+
+void MergeUpdateClause::MatchRecord::clone_source_match(
+        size_t source_row_src, size_t source_row_dst, size_t row_slice
+) {
+    source_row_matched_count_[source_row_dst] = source_row_matched_count_[source_row_src];
+    matched_target_rows_[row_slice][source_row_dst] = matched_target_rows_[row_slice][source_row_src];
+    total_matched_target_rows_count_ += source_row_matched_count_[source_row_dst];
+}
+
+size_t MergeUpdateClause::MatchRecord::total_unmatched_source_rows() const {
+    return std::ranges::count_if(source_row_matched_count_, [](const size_t count) { return count == 0; });
+}
+void MergeUpdateClause::MatchRecord::validate_rows_to_update(const MergeStrategy& strategy) const {
+    // TODO: This can be inlined in the loop iterating over all columns to avoid iterating the source one more
+    // time. The loop structure makes it not intuitive. The performance cost must be evaluated. Monday:
+    // 10655963947
+    if (!strategy.update() || total_matched_target_rows_count_ == 0) {
+        return;
+    }
+    util::BitSet matched_rows;
+    for (size_t row_slice_idx = 0; row_slice_idx < matched_target_rows_.size(); ++row_slice_idx) {
+        const RowRange row_range = *row_slices_[row_slice_idx].row_ranges_->front();
+        matched_rows.resize(row_range.diff());
+        for (size_t source_row_idx = 0; source_row_idx < matched_target_rows_[row_slice_idx].size(); ++source_row_idx) {
+            for (const size_t target_row : matched_target_rows_[row_slice_idx][source_row_idx]) {
+                user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                        matched_rows[target_row] == false,
+                        "Multiple source rows match the same target row: {}. Second source index to match is {} Final "
+                        "value is ambiguous.",
+                        row_range.start() + target_row,
+                        source_row_idx
+                );
+                matched_rows[target_row] = true;
+            }
+        }
+        matched_rows.clear();
+    }
+}
+
+std::span<const std::vector<size_t>> MergeUpdateClause::MatchRecord::matched_rows(size_t target_row_slice) const {
+    return matched_target_rows_[target_row_slice];
+}
+
+bool MergeUpdateClause::MatchRecord::is_source_row_matched(size_t source_row) const {
+    return source_row_matched_count_[source_row] > 0;
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -32,9 +32,12 @@ struct TargetRange {
     size_t end_row_in_last_row_slice{};
 };
 
-/// Remove all row slice entities and ranges and keys whose indexes do not appear in row_slices_to_keep
-/// @param offsets Must be structured by row slice with ranges and keys
-/// @param ranges_and_keys Must be structured by row slice with offsets
+/// Keep only the row slice groups listed in row_slices_to_keep, then compact ranges_and_keys to the entities still
+/// referenced and renumber the entries in offsets to their new positions.
+/// @param row_slices_to_keep Indices into offsets of the groups to retain; must be sorted and unique.
+/// @param offsets Row slice groups, each an ordered list of indices into ranges_and_keys. Filtered and reindexed in
+/// place.
+/// @param ranges_and_keys Flat list of entities indexed by offsets. Compacted in place to the retained entities.
 void filter_selected_ranges_and_keys_and_reindex_entities(
         const std::span<const size_t> row_slices_to_keep, std::vector<std::vector<size_t>>& offsets,
         std::vector<RangesAndKey>& ranges_and_keys
@@ -110,12 +113,11 @@ void rebuild_sequence_column_in_new_pool(
 }
 
 template<util::type_descriptor_tag TDT>
-bool merge_update_string_column(
+void merge_update_string_column(
         Column& target_column, const std::span<const std::vector<size_t>> rows_to_update, std::string_view column_name,
         const RowRange& row_range, const StringPool& target_string_pool,
         const std::span<PyObject* const> source_column_view, StringPool& new_string_pool
 ) {
-    bool column_is_changed = false;
     if constexpr (is_fixed_string_type(TDT::data_type())) {
         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                 "Fixed string sequences are not supported for merge update"
@@ -135,7 +137,6 @@ bool merge_update_string_column(
                 target_column_accessor[target_row] = write_py_string_to_pool_or_throw<TDT>(
                         py_string_object, target_row, row_range, gil_lock, new_string_pool, column_name
                 );
-                column_is_changed = true;
                 target_rows_not_matched_by_source.set(target_row);
             }
         }
@@ -144,7 +145,6 @@ bool merge_update_string_column(
                 target_column, target_string_pool, new_string_pool, &target_rows_not_matched_by_source
         );
     }
-    return column_is_changed;
 }
 
 struct MergeUpdateStringColumnFlags {
@@ -153,7 +153,7 @@ struct MergeUpdateStringColumnFlags {
 };
 
 template<util::type_descriptor_tag TDT>
-bool merge_update_string_column(
+void merge_update_string_column(
         Column& target_column, const MergeUpdateStringColumnFlags& flags,
         const std::span<const std::vector<size_t>> rows_to_update, std::string_view column_name,
         const RowRange& row_range, const StringPool& target_string_pool,
@@ -161,10 +161,10 @@ bool merge_update_string_column(
 ) {
     if (flags.data_not_changed) {
         rebuild_sequence_column_in_new_pool<TDT>(target_column, target_string_pool, new_string_pool);
-        return false;
+        return;
     }
 
-    return merge_update_string_column<TDT>(
+    merge_update_string_column<TDT>(
             target_column,
             rows_to_update,
             column_name,
@@ -274,8 +274,21 @@ struct InsertTargetData {
     StringPool& new_string_pool;
 };
 
+std::vector<size_t> compute_target_slice_offset(const InsertTargetData& target) {
+    std::vector<size_t> result;
+    std::transform_exclusive_scan(
+            target.indexes.begin(),
+            target.indexes.end(),
+            std::back_inserter(result),
+            size_t{0},
+            std::plus{},
+            [](const ColumnWithStrings& col) -> size_t { return col.column_->row_count(); }
+    );
+    return result;
+}
+
 /// Performs merging of sorted lists with update on matching rows. The index column dictates the ordering of the rows.
-/// The target is composed of multiple row slices the following hods:
+/// The target is composed of multiple row slices. The following holds:
 /// is_sorted(index in row slice i) && all(index values in row slice i) <= all(index values in row slice j) for i < j.
 /// The source is a single row slice.  Insertion is stable and all new values are inserted after all existing values
 /// with the same index value. The source and target must have the same index type.
@@ -286,8 +299,8 @@ Column merge(
         const MergeUpdateClause::MatchRecord& match_record, const MergeStrategy& strategy
 ) {
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    // One index value can appear in more than one row slice. In that case it can be shared by two processing units
-    // in that case. Each processing unit works on part of the target data.
+    // One index value can appear in more than one row slice. In that case it can be shared by two processing units,
+    // each working on part of the target data.
     const size_t num_rows_out_of_target_range =
             target.range.start_row_in_first_row_slice +
             (target.columns.back().column_->row_count() - target.range.end_row_in_last_row_slice);
@@ -299,6 +312,8 @@ Column merge(
                     [](size_t acc, const ColumnWithStrings& col) { return acc + col.column_->row_count(); }
             ) -
             num_rows_out_of_target_range;
+    const std::vector<size_t> target_slice_offset = compute_target_slice_offset(target);
+
     Column new_column(target.type, combined_row_count, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);
     ColumnData new_column_data = new_column.data();
     auto new_column_it = new_column_data.begin<TargetColumnTypeDescriptorTag>();
@@ -315,11 +330,6 @@ Column merge(
     size_t target_row_idx = target.range.start_row_in_first_row_slice;
     size_t new_column_row_idx{};
 
-    std::vector<size_t> row_slice_start_in_output(target.columns.size());
-    std::vector<size_t> inserted_rows(target.columns.size(), 0);
-
-    StringPool intermediate_pool;
-
     const auto target_index_is_exhausted = [&] {
         return target_row_slice == target.columns.size() - 1 && target_index_it == target_index_end;
     };
@@ -334,7 +344,6 @@ Column merge(
         ++target_row_idx;
         if (target_index_it == target_index_end && target_row_slice < target.columns.size() - 1) [[unlikely]] {
             ++target_row_slice;
-            row_slice_start_in_output[target_row_slice] = new_column_row_idx;
             target_row_idx = 0;
             target_column_data = target.columns[target_row_slice].column_->data();
             target_index_data = target.indexes[target_row_slice].column_->data();
@@ -367,7 +376,7 @@ Column merge(
                     row,
                     RowRange{source.global_row_range.first, source.global_row_range.second},
                     scoped_gil_lock,
-                    intermediate_pool,
+                    target.new_string_pool,
                     target.columns.front().column_name_
             );
         }
@@ -380,7 +389,7 @@ Column merge(
                     source_row,
                     RowRange{source.global_row_range.first, source.global_row_range.second},
                     scoped_gil_lock,
-                    intermediate_pool,
+                    target.new_string_pool,
                     target.columns.front().column_name_
             );
         }
@@ -392,14 +401,18 @@ Column merge(
             if (is_a_string(offset)) {
                 const StringPool& pool = *target.columns[target_row_slice].string_pool_;
                 const std::string_view string_data = pool.get_const_view(offset);
-                *new_column_it = intermediate_pool.get(string_data).offset();
+                *new_column_it = target.new_string_pool.get(string_data).offset();
             } else {
                 *new_column_it = offset;
             }
         }
     };
 
+    util::BitSet updated(new_column.row_count());
+    std::vector<size_t> source_rows_to_insert;
+
     size_t source_row_idx = 0;
+    size_t total_inserted_rows = 0;
 
     // Stable merge target and source into the new column. If there is a sequence of repeated index values and new
     // rows must be inserted, the new rows will appear after the rows from the target
@@ -420,69 +433,61 @@ Column merge(
         }
 
         // Target index values are equal to the source index values. Since the index is matching, it's possible to
-        // perform both an update and an insert. First, copy all target values to the output buffer and then append
-        // the new values. In case rows_to_update[source_row_idx] is not empty, then an update must happen. The
-        // update is performed in place in the new output buffer. It is crucial to take into account that the
-        // indexes in rows_to_update[source_row_idx] are pointing to rows in the original column (before any
-        // insertions happened)
+        // perform both an update and an insert.
+        // 1. Perform the update using the random accessor to the target
+        // 2. Iterate over all target rows with the same index value and place them in the output, skipping the ones
+        //    updated in the previous step
+        // 3. Append the source rows which were not matched
 
-        // Source and target index values are equal. Copy the target data first.
-        const size_t pre_equal_run_row_slice = target_row_slice;
-        const timestamp equal_run_index_value = *target_index_it;
-        // Since the index is ordered, no index in source_index[source_row_idx] can be less than target_row_idx.
-        while (!target_index_is_exhausted() && *target_index_it == equal_run_index_value &&
-               source.index[source_row_idx] == equal_run_index_value) {
-            if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
-                set_string_from_target(target_row_idx);
-            } else {
-                *new_column_it = target_data[target_row_idx];
-            }
-            advance_output();
-            advance_target();
-        }
-
-        // For each source row equal to the target row, there are two options.
-        // * the output buffer must be updated.
-        // * insertion must happen by appending to the end of the output buffer.
-        size_t inserted_rows_with_matching_index = 0;
-        while (source_row_idx < source.index.size() && source.index[source_row_idx] == equal_run_index_value) {
-            if (!match_record.is_source_row_matched(source_row_idx)) {
-                if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
-                    set_string_from_source(source_row_idx);
-                } else {
-                    *new_column_it = source.data[source_row_idx];
-                }
-                advance_output();
-                ++inserted_rows_with_matching_index;
-            } else if (strategy.update()) {
-                for (size_t i = pre_equal_run_row_slice; i <= target_row_slice; ++i) {
-                    // TODO: this is suboptimal for string columns. This approach first places all target value and
-                    // then updates the output buffer with the source values. The rows to update are not ordered. So
-                    // unless we build a map or iterate each time the rows to updated to check if a row must be updated
-                    // this approach is faster for non-string columns. However for string columns this can introduce
-                    // ghost string data into the string pool, thus the string pool is rebuilt at the end of the
-                    // function.
-                    std::span<const std::vector<size_t>> matched_rows = match_record.matched_rows(i);
-                    for (const size_t target_row_to_update_in_slice : matched_rows[source_row_idx]) {
-                        const size_t target_offset = i == 0 ? target.range.start_row_in_first_row_slice : 0;
-                        // matched_rows holds indexes into the target segment. But the output segment can start at
-                        // an offest in the target in case the work is shared between two processing units. Only
-                        // the first and last row slices of a time slice can be requested by more than one
-                        // processing unit
-                        const size_t output_row_to_update = target_row_to_update_in_slice +
-                                                            row_slice_start_in_output[i] + inserted_rows[i] -
-                                                            target_offset;
+        source_rows_to_insert.clear();
+        const timestamp current_index_value = *target_index_it;
+        // If the source has no row at the current target index value, all remaining source rows are smaller than it and
+        // must be inserted before it. The target rows are left to the next iteration.
+        const bool source_has_index_value = source.index[source_row_idx] == current_index_value;
+        // Apply updates
+        while (source_row_idx < source.index.size() && source.index[source_row_idx] == current_index_value) {
+            if (strategy.update()) {
+                for (size_t i = 0; i < target.columns.size(); ++i) {
+                    const std::vector<size_t>& matched = match_record.matched_rows(i)[source_row_idx];
+                    for (size_t target_row : matched) {
+                        const size_t index_in_output = target_slice_offset[i] + total_inserted_rows + target_row -
+                                                       target.range.start_row_in_first_row_slice;
+                        updated.set(index_in_output);
                         if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
-                            set_string_from_source_at(source_row_idx, output_row_to_update);
+                            set_string_from_source_at(source_row_idx, index_in_output);
                         } else {
-                            new_data[output_row_to_update] = source.data[source_row_idx];
+                            new_data[index_in_output] = source.data[source_row_idx];
                         }
                     }
                 }
             }
+            if (!match_record.is_source_row_matched(source_row_idx)) {
+                source_rows_to_insert.emplace_back(source_row_idx);
+            }
             ++source_row_idx;
         }
-        inserted_rows[target_row_slice] += inserted_rows_with_matching_index;
+        // Place target values on non-updated output positions
+        while (source_has_index_value && !target_index_is_exhausted() && *target_index_it == current_index_value) {
+            if (!updated.test(new_column_row_idx)) {
+                if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                    set_string_from_target(target_row_idx);
+                } else {
+                    *new_column_it = target_data[target_row_idx];
+                }
+            }
+            advance_target();
+            advance_output();
+        }
+        // Append unmatched source rows
+        total_inserted_rows += source_rows_to_insert.size();
+        for (size_t source_row_to_insert : source_rows_to_insert) {
+            if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
+                set_string_from_source(source_row_to_insert);
+            } else {
+                *new_column_it = source.data[source_row_to_insert];
+            }
+            advance_output();
+        }
 
         if (target_index_it == target_index_end) {
             break;
@@ -497,7 +502,7 @@ Column merge(
             }
             ++source_row_idx;
             advance_output();
-            ++inserted_rows[target_row_slice];
+            ++total_inserted_rows;
         }
     }
     // Not all target rows were processed, copy the rest
@@ -521,27 +526,21 @@ Column merge(
         std::copy(source.data.begin() + source_row_idx, source.data.end(), new_column_it);
     }
 
-    if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
-        rebuild_sequence_column_in_new_pool<TargetColumnTypeDescriptorTag>(
-                new_column, intermediate_pool, target.new_string_pool
-        );
-    }
     return new_column;
 }
 
 template<util::type_descriptor_tag ScalarType>
-bool update_column(
+void update_column(
         const MergeStrategy& strategy, const StringPool& old_string_pool,
         const std::span<const SourceRawType<ScalarType>> source_data,
         const std::span<const std::vector<size_t>> rows_to_update, const RowRange& row_range,
         const bool is_matching_column, std::string_view column_name, Column& target_column, StringPool& new_string_pool
 ) {
-    bool row_slice_changed = false;
     if constexpr (is_sequence_type(ScalarType::data_type())) {
         const MergeUpdateStringColumnFlags column_update_flags{
                 .data_not_changed = is_matching_column && strategy.update_only()
         };
-        row_slice_changed = merge_update_string_column<ScalarType>(
+        merge_update_string_column<ScalarType>(
                 target_column,
                 column_update_flags,
                 rows_to_update,
@@ -553,37 +552,19 @@ bool update_column(
         );
     } else {
         if (is_matching_column) {
-            return false;
+            return;
         }
         ColumnData target_column_data = target_column.data();
         auto target = random_accessor<ScalarType>(&target_column_data);
         for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
-            row_slice_changed |= !rows_to_update[source_row_idx].empty();
             for (const size_t target_row_idx : rows_to_update[source_row_idx]) {
                 target[target_row_idx] = source_data[source_row_idx];
             }
         }
     }
-    return row_slice_changed;
 }
 
-std::vector<std::vector<size_t>> split_by_row_slice(
-        const std::span<const RangesAndKey> ranges, std::span<const size_t> indexes
-) {
-    std::vector<std::vector<size_t>> res = {{indexes.front()}};
-    RowRange prev_row_range = ranges[indexes.front()].row_range();
-    for (size_t idx : indexes.subspan(1)) {
-        const RowRange current_row_range = ranges[idx].row_range();
-        if (current_row_range != prev_row_range) {
-            res.emplace_back();
-        }
-        res.back().emplace_back(idx);
-        prev_row_range = current_row_range;
-    }
-    return res;
-}
-
-pipelines::RowRange get_row_range(std::span<const ProcessingUnit> row_slice) {
+RowRange get_row_range(std::span<const ProcessingUnit> row_slice) {
     return {row_slice.front().row_ranges_->front()->first, row_slice.back().row_ranges_->back()->second};
 }
 
@@ -599,7 +580,7 @@ TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
             .start_row_in_first_row_slice = 0,
             .end_row_in_last_row_slice = row_slices.back().segments_->back()->row_count()
     };
-    if (!row_slices.empty() && row_slices.front().entity_fetch_count_) {
+    if (row_slices.front().entity_fetch_count_) {
         if (row_slices.front().entity_fetch_count_->front() > 1) {
             const ColumnData index = row_slices.front().segments_->front()->column(0).data();
             result.start_row_in_first_row_slice = first_different_index_value_position(index);
@@ -621,7 +602,7 @@ TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
 /// MergeUpdateClause::on_ is not empty, there will be further filtering that might remove some matches. Otherwise,
 /// one row will be updated multiple times, which is not allowed.
 ///
-/// Complexity: $$O(m * log_2(n) + n)$$ where: m is the count of source rows in the bounds of the segment, n is the
+/// Complexity: $$O(m * log(n/m) + n)$$ where: m is the count of source rows in the bounds of the segment, n is the
 /// number of target rows in the segment.
 MergeUpdateClause::MatchRecord filter_index_match(
         std::span<const timestamp> source_index, std::span<ProcessingUnit> row_slices
@@ -631,6 +612,8 @@ MergeUpdateClause::MatchRecord filter_index_match(
     if (source_index.empty()) {
         return result;
     }
+    size_t source_row_start_for_next_slice{};
+    size_t source_row{};
     for (size_t i = 0; i < row_slices.size(); ++i) {
         const ProcessingUnit& proc = row_slices[i];
         const Column& target_index = proc.segments_->front()->column(0);
@@ -638,31 +621,68 @@ MergeUpdateClause::MatchRecord filter_index_match(
         auto last_target_row_it = exponential_upper_bound<IndexType, IteratorType::ENUMERATED>(
                 target_index_column_data, source_index.back()
         );
-        size_t source_row{};
         auto target_row_it = target_index_column_data.cbegin<IndexType, IteratorType::ENUMERATED>();
+        if (target_row_it->value() == source_index[source_row_start_for_next_slice]) {
+            source_row = source_row_start_for_next_slice;
+        }
+
         // This loop can be inverted so that if source_row_end - source_row_start is > len(target) the complexity
-        // becomes O(n * log_2(m)) where: m is the count of source rows in the bounds of the segment, n is the number of
-        // target rows in the segment.
+        // becomes O(n * log_2(m/n) + m) where: m is the count of source rows in the bounds of the segment, n is the
+        // number of target rows in the segment.
         while (target_row_it != last_target_row_it && source_row < source_index.size()) {
             const timestamp source_ts = source_index[source_row];
             auto target_match_it = exponential_lower_bound(target_row_it, last_target_row_it, source_ts);
             if (target_match_it == last_target_row_it) {
                 break;
             }
+            source_row_start_for_next_slice = source_row;
             target_row_it = target_match_it;
             while (target_row_it != last_target_row_it && target_row_it->value() == source_ts) {
                 result.add_match(source_row, i, target_row_it->idx());
                 ++target_row_it;
             }
+            ++source_row;
             // Optimizes the case of repeated index values. All matched rows corresponding to a particular index value
             // must be the same, so just copy the matched rows in case index values are repeated.
-            while (++source_row < source_index.size() && source_index[source_row] == source_ts) {
+            while (source_row < source_index.size() && source_index[source_row] == source_ts) {
                 result.clone_source_match(source_row - 1, source_row, i);
+                ++source_row;
             }
         }
     }
 
     return result;
+}
+
+std::span<const timestamp>::iterator source_range_start_for_group(
+        std::span<const timestamp> source_index, timestamp segment_start, size_t row_slice_group,
+        const MergeStrategy& strategy
+) {
+    if (strategy.insert() && row_slice_group == 0 && source_index.front() < segment_start) {
+        // When inserting, all source data before the first row slice is prepended to it.
+        return source_index.begin();
+    }
+    return std::ranges::lower_bound(source_index, segment_start);
+}
+
+std::span<const timestamp>::iterator source_range_end_for_group(
+        std::span<const timestamp> source_index, std::span<const timestamp>::iterator source_range_start,
+        timestamp segment_end, size_t row_slice_group, const std::vector<std::vector<size_t>>& offsets,
+        const std::vector<RangesAndKey>& ranges_and_keys, const MergeStrategy& strategy
+) {
+    // When inserting, unmatched source values in the gap before the next row slice are appended to this one, and the
+    // last row slice group takes all remaining source values. std::max keeps at least the segment's own end in case
+    // the next row slice starts before this one ends (overlapping time slices).
+    if (strategy.insert() && row_slice_group == offsets.size() - 1) {
+        return source_index.end();
+    }
+    const timestamp effective_segment_end =
+            strategy.insert()
+                    ? std::max(
+                              segment_end, ranges_and_keys[offsets[row_slice_group + 1].front()].key_.time_range().first
+                      )
+                    : segment_end;
+    return std::ranges::upper_bound(source_range_start, source_index.end(), effective_segment_end - 1);
 }
 
 } // namespace
@@ -700,7 +720,7 @@ std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing_log
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
     std::vector<std::vector<size_t>> offsets = must_structure_by_time_slice() ? structure_by_time_slice(ranges_and_keys)
                                                                               : structure_by_row_slice(ranges_and_keys);
-    std::vector<size_t> row_slices_to_keep;
+    std::vector<size_t> row_slice_groups_to_keep;
     // TODO: Arrow is not supported yet.
     const TypedTensor<IndexType::DataTypeTag::raw_type> index_tensor(source_->get_tensor(0));
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -720,84 +740,44 @@ std::vector<std::vector<size_t>> MergeUpdateClause::structure_for_processing_log
         return {};
     }
 
-    std::span source_index(index_tensor.data(), source_->num_rows);
-    for (size_t row_slice_idx = 0; row_slice_idx < offsets.size(); ++row_slice_idx) {
-        const std::vector<std::vector<size_t>>& row_slice_offsets =
-                must_structure_by_time_slice() ? ::split_by_row_slice(ranges_and_keys, offsets[row_slice_idx])
-                                               : std::vector<std::vector<size_t>>{offsets[row_slice_idx]};
+    std::span source_index = index_tensor.span<const timestamp>();
+    for (size_t row_slice_group = 0; row_slice_group < offsets.size(); ++row_slice_group) {
         const TimestampRange time_range{
-                ranges_and_keys[row_slice_offsets.front().front()].key_.time_range().first,
-                ranges_and_keys[row_slice_offsets.back().back()].key_.time_range().second
+                ranges_and_keys.at(offsets.at(row_slice_group).front()).key_.time_range().first,
+                ranges_and_keys.at(offsets.at(row_slice_group).back()).key_.time_range().second
         };
 
-        const auto source_range_start = [&] {
-            if (strategy_.insert() && row_slice_idx == 0 && source_index.front() < time_range.first) {
-                // In case of inserting all data before the first segment gets prepended to it
-                return source_index.begin();
-            }
-            return ranges::lower_bound(source_index, time_range.first);
-        }();
-
+        const auto source_range_start =
+                source_range_start_for_group(source_index, time_range.first, row_slice_group, strategy_);
         if (source_range_start == source_index.end()) {
-            // All remaining row ranges start after the last index value of the source, thus not match is possible.
+            // All remaining row slice groups start after the last source index value, so no match is possible.
             break;
         }
 
-        auto source_range_end = source_index.end();
-        if (*source_range_start >= time_range.second) {
-            // The current segment does not contain any source value because all source values larger than the
-            // segment start are also larger than the segment end.
-            if (!strategy_.insert()) {
-                // If insertion is not allowed, continue checking next row slices until segment's start is larger
-                // than the source index end.
-                continue;
-            }
-            if (row_slice_idx != offsets.size() - 1) {
-                // In case insertion is enabled, source values in between two row slices will be appended to the
-                // former. This is done by extending the time range of the current row slice so that it's 1 ns less than
-                // the start of the next row slice.
-                const timestamp next_row_slice_start =
-                        ranges_and_keys[offsets[row_slice_idx + 1].front()].key_.time_range().first;
-                if (*source_range_start >= next_row_slice_start) {
-                    // The extended segment does not contain any source values. All source values are after the
-                    // extended segment end. Continue checking next row slices.
-                    continue;
-                }
-                const timestamp extended_segment_end = next_row_slice_start - 1;
-                source_range_end = std::upper_bound(source_range_start, source_index.end(), extended_segment_end);
-            }
-        } else {
-            if (strategy_.insert()) {
-                if (row_slice_idx == offsets.size() - 1) {
-                    // When strategy allows insertion and this is the last segment all remaining source values get
-                    // attributed to the last segment
-                    source_range_end = source_index.end();
-                } else {
-                    // The segment contains source values. In addition, unmatched source values that fall in the gap
-                    // between this segment and the next one are appended to this segment (as in the branch above, where
-                    // the segment had no source values of its own). std::max keeps at least the segment's own range in
-                    // case the next segment starts before this one ends (overlapping time slices).
-                    const timestamp next_row_slice_start =
-                            ranges_and_keys[offsets[row_slice_idx + 1].front()].key_.time_range().first;
-                    const timestamp extended_segment_end = std::max(time_range.second, next_row_slice_start) - 1;
-                    source_range_end =
-                            ranges::upper_bound(source_range_start, source_index.end(), extended_segment_end);
-                }
-            } else {
-                source_range_end = ranges::upper_bound(source_range_start, source_index.end(), time_range.second - 1);
-            }
+        const auto source_range_end = source_range_end_for_group(
+                source_index,
+                source_range_start,
+                time_range.second,
+                row_slice_group,
+                offsets,
+                ranges_and_keys,
+                strategy_
+        );
+        if (source_range_start == source_range_end) {
+            // This row slice group owns no source rows.
+            continue;
         }
         const std::pair<size_t, size_t> source_row_range = {
                 source_range_start - source_index.begin(), source_range_end - source_index.begin()
         };
-        const pipelines::RowRange row_range{
-                ranges_and_keys[row_slice_offsets.front().front()].row_range().first,
-                ranges_and_keys[row_slice_offsets.back().back()].row_range().second
+        const RowRange row_range{
+                ranges_and_keys[offsets[row_slice_group].front()].row_range().first,
+                ranges_and_keys[offsets[row_slice_group].back()].row_range().second
         };
         source_start_end_for_row_range_.insert({row_range, source_row_range});
-        row_slices_to_keep.push_back(row_slice_idx);
+        row_slice_groups_to_keep.push_back(row_slice_group);
     }
-    filter_selected_ranges_and_keys_and_reindex_entities(row_slices_to_keep, offsets, ranges_and_keys);
+    filter_selected_ranges_and_keys_and_reindex_entities(row_slice_groups_to_keep, offsets, ranges_and_keys);
     return offsets;
 }
 
@@ -805,15 +785,13 @@ std::vector<std::vector<EntityId>> MergeUpdateClause::structure_for_processing(s
     internal::raise<ErrorCode::E_ASSERTION_FAILURE>("MergeUpdate clause should be the first clause in the pipeline");
 }
 
-/// Decide which rows of should be updated and which rows from source should be inserted.
-/// 1. If there's a timestamp index  use MergeUpdateClause::filter_index_match this will produce a vector of size
-/// equal to the number of rows from the source that fall into the processed slice. Each vector will contain a
-/// vector of row-indexes in target that match the corresponding source index value.
-/// 2. For each column in MergeUpdateClause::on_ iterate over the vector of vectors produced in the previous step.
-/// Checking for match only the target rows that are in the inner vector. If there is no match for this particular
-/// column remove the target row index.
-/// This means that the ordering of the columns in MergeUpdateClause::on_ matters and it would be more efficient to
-/// start with the columns that have a lesser chance of matching.
+/// Decide which target rows are updated and which source rows are inserted.
+/// 1. If there is a timestamp index, MergeUpdateClause::match uses filter_index_match to build a MatchRecord: for each
+/// source row that falls in the processed slice it records the target rows whose index value matches.
+/// 2. For each column in MergeUpdateClause::on_, filter_on_additional_columns_match prunes the MatchRecord, dropping
+/// any recorded target row whose value in that column differs from the source row's.
+/// The ordering of the columns in MergeUpdateClause::on_ therefore matters: starting with the columns least likely to
+/// match prunes candidates earlier and is more efficient.
 std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_ids) const {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             source_->has_only_tensors(), "Arrow format is not supported as input for merge update"
@@ -829,56 +807,60 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
             EntityFetchCount>(*component_manager_, std::move(entity_ids));
     std::vector<ProcessingUnit> row_slices =
             must_structure_by_time_slice() ? split_by_row_slice(std::move(proc)) : std::vector{std::move(proc)};
-    const MatchRecord matched = match(row_slices);
+    const std::pair<size_t, size_t> source_start_end = get_source_start_end(row_slices);
+    const MatchRecord matched = match(row_slices, source_start_end);
     matched.validate_rows_to_update(strategy_);
     if (strategy_.update_only()) {
-        if (auto [new_row_slices, time_slice_changed] = update(matched, std::move(row_slices)); time_slice_changed) {
-            std::vector<EntityId> res;
-            for (ProcessingUnit& row_slice : new_row_slices) {
-                const size_t entity_count = row_slice.segments_->size();
-                std::vector<EntityId> entts = component_manager_->add_entities(
-                        std::move(*row_slice.segments_),
-                        std::move(*row_slice.row_ranges_),
-                        std::move(*row_slice.col_ranges_),
-                        std::vector<EntityFetchCount>(entity_count, 1)
-                );
-                res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
-            }
-            return res;
+        if (!matched.has_matched_target_rows()) {
+            // No target row in this row slice changes, so emit nothing. merge_slices_and_keys keeps the
+            // existing data keys for row slices that are not re-emitted.
+            return {};
         }
-    } else if (strategy_.insert()) {
-        const StreamDescriptor& target_descriptor = source_->desc(); // TODO: Not true for dynamic schema
-        auto [new_row_slices, time_slice_changed] =
-                update_and_insert(matched, target_descriptor, std::move(row_slices));
-        if (time_slice_changed) {
-            std::vector<EntityId> res;
-            for (auto& row_slice : new_row_slices) {
-                const size_t entity_count = row_slice.segments_->size();
-                std::vector<EntityId> entts = component_manager_->add_entities(
-                        std::move(*row_slice.segments_),
-                        std::move(*row_slice.row_ranges_),
-                        std::move(*row_slice.col_ranges_),
-                        std::vector<EntityFetchCount>(entity_count, 1),
-                        std::vector(entity_count, MergeUpdateInsertedRowsEntity{matched.total_unmatched_source_rows()})
-                );
-                res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
-            }
-            return res;
+        auto new_row_slices = update(matched, std::move(row_slices), source_start_end);
+        std::vector<EntityId> res;
+        for (ProcessingUnit& row_slice : new_row_slices) {
+            const size_t entity_count = row_slice.segments_->size();
+            std::vector<EntityId> entts = component_manager_->add_entities(
+                    std::move(*row_slice.segments_),
+                    std::move(*row_slice.row_ranges_),
+                    std::move(*row_slice.col_ranges_),
+                    std::vector<EntityFetchCount>(entity_count, 1),
+                    // Updating never inserts rows, but merge_slices_and_keys requires every emitted row range to
+                    // declare its inserted row count.
+                    std::vector(entity_count, MergeUpdateInsertedRowsEntity{0})
+            );
+            res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
         }
+        return res;
     }
-    return {};
+    const StreamDescriptor& target_descriptor = source_->desc(); // TODO: Not true for dynamic schema
+    auto new_row_slices = update_and_insert(matched, target_descriptor, std::move(row_slices), source_start_end);
+
+    std::vector<EntityId> res;
+    for (auto& row_slice : new_row_slices) {
+        const size_t entity_count = row_slice.segments_->size();
+        std::vector<EntityId> entts = component_manager_->add_entities(
+                std::move(*row_slice.segments_),
+                std::move(*row_slice.row_ranges_),
+                std::move(*row_slice.col_ranges_),
+                std::vector<EntityFetchCount>(entity_count, 1),
+                std::vector(entity_count, MergeUpdateInsertedRowsEntity{matched.total_unmatched_source_rows()})
+        );
+        res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
+    }
+    return res;
 }
 
 MergeUpdateClause::MatchRecord MergeUpdateClause::initialize_rows_to_update_for_row_range_indexed_data(
-        std::span<ProcessingUnit> row_slices, const StreamDescriptor& source_descriptor
+        std::span<ProcessingUnit> row_slices, const StreamDescriptor& source_descriptor,
+        std::pair<size_t, size_t> source_start_end
 ) const {
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !on_.empty(),
             "MergeUpdate requires at least one column in the \"on\" parameter when the DataFrame is not a "
             "timeseries"
     );
-    const std::pair<size_t, size_t> source_range = get_source_start_end(row_slices);
-    MatchRecord result(row_slices, source_range.second - source_range.first);
+    MatchRecord result(row_slices, source_start_end.second - source_start_end.first);
     // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
     // In this case a PyObject will be allocated by convert::py_unicode_to_buffer
     // If such a string is encountered in a column, then the GIL will be held until that whole column has
@@ -944,60 +926,54 @@ std::pair<size_t, size_t> MergeUpdateClause::get_source_start_end(std::span<cons
     if (source_->has_index()) {
         const pipelines::RowRange row_range = get_row_range(row_slices);
         const auto source_row_range_it = source_start_end_for_row_range_.find(row_range);
-        ARCTICDB_DEBUG_CHECK(
-                ErrorCode::E_ASSERTION_FAILURE,
+        util::check(
                 source_row_range_it != source_start_end_for_row_range_.end(),
                 "Source row range for row range [{}, {}] not found",
                 row_range.first,
                 row_range.second
         );
         const std::pair<size_t, size_t> source_range = source_row_range_it->second;
-        if (!row_slices.empty() && row_slices.front().entity_fetch_count_) {
-            // An index value is spanning more than one row slices.
-            std::pair<size_t, size_t> result = source_range;
-            std::span<const timestamp> source_index =
-                    source_->get_tensor(0).span<timestamp>(result.first, result.second - result.first);
-            if (row_slices.front().entity_fetch_count_->front() > 1) {
-                // This is the last row slice containing the index value that spans multiple row slices. It appears at
-                // the beginning of the row slices, which means that the other processing unit will handle all rows of
-                // the segment containing the index value; this processing unit must handle only the rows that do not
-                // contain index value. Example:
-                //     0         1         2         3
-                // [a, b, c] [c, c, c] [c, d, e] [e, f, g]
-                // When the source contains value "c," the structure for processing will be [0, 1, 2] [2, 3]. This case
-                // handles processing [2, 3].
-                auto next_index_value = std::ranges::upper_bound(
-                        source_index, row_slices.front().atom_keys_->front()->time_range().first
-                );
-                result.first += next_index_value - source_index.begin();
-            }
-            if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
-                // This is the last row slice containing the index value that spans multiple row slices. It appears at
-                // the end of the row slices, which means that the other processing unit will handle all rows of
-                // the segment not containing the index value; this processing unit must handle only the rows that
-                // contain index value. Example:
-                //     0         1         2         3
-                // [a, b, c] [c, c, c] [c, d, e] [e, f, g]
-                // When the source contains value "c," the structure for processing will be [0, 1, 2] [2, 3]. This case
-                // handles processing [0, 1, 2].
-                const auto last_index_value = std::ranges::upper_bound(
-                        source_index, row_slices.back().atom_keys_->back()->time_range().first
-                );
-                result.second = source_range.first + (last_index_value - source_index.begin());
-            }
-            return result;
-        } else {
-            return source_range;
+        std::pair<size_t, size_t> result = source_range;
+        std::span<const timestamp> source_index =
+                source_->get_tensor(0).span<timestamp>(result.first, result.second - result.first);
+        // A shared boundary row slice (entity_fetch_count > 1) is co-owned with a neighbouring group; trim the source
+        // range to the portion this processing unit owns. If neither boundary is shared both branches are skipped and
+        // the full source range is returned.
+        if (row_slices.front().entity_fetch_count_->front() > 1) {
+            // The index value spanning multiple row slices appears at the beginning of the row slices, which means that
+            // the other processing unit will handle all rows of the segment containing the index value; this processing
+            // unit must handle only the rows that do not contain index value. Example:
+            //     0         1         2         3
+            // [a, b, c] [c, c, c] [c, d, e] [e, f, g]
+            // When the source contains value "c," structure_by_time_slice produces [0, 1, 2] [2, 3] [3]; the last group
+            // is dropped because it does not contain "c," leaving [0, 1, 2] [2, 3] to process. This case handles the
+            // group [2, 3].
+            auto next_index_value =
+                    std::ranges::upper_bound(source_index, row_slices.front().atom_keys_->front()->time_range().first);
+            result.first += next_index_value - source_index.begin();
         }
+        if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
+            // The index value spanning multiple row slices appears at the end of the row slices, which means that the
+            // other processing unit will handle all rows of the segment not containing the index value; this processing
+            // unit must handle only the rows that contain index value. Example:
+            //     0         1         2         3
+            // [a, b, c] [c, c, c] [c, d, e] [e, f, g]
+            // When the source contains value "c," structure_by_time_slice produces [0, 1, 2] [2, 3] [3]; the last group
+            // is dropped because it does not contain "c," leaving [0, 1, 2] [2, 3] to process. This case handles the
+            // group [0, 1, 2].
+            const auto last_index_value =
+                    std::ranges::upper_bound(source_index, row_slices.back().atom_keys_->back()->time_range().first);
+            result.second = source_range.first + (last_index_value - source_index.begin());
+        }
+        return result;
     } else {
         return std::pair{0, source_->num_rows};
     }
 }
 
-std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update_and_insert(
+std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
         const MatchRecord& match_record, const StreamDescriptor& target_descriptor,
-        std::vector<ProcessingUnit>&& row_slices
-
+        std::vector<ProcessingUnit>&& row_slices, std::pair<size_t, size_t> source_start_end
 ) const {
     ARCTICDB_DEBUG_CHECK(
             ErrorCode::E_ASSERTION_FAILURE,
@@ -1011,17 +987,18 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update_and_inser
     // reconstruction (merge_slices_and_keys) and produces a non-contiguous, unreadable index.
     // Only the first and last row slices of a group can be shared with a neighbour (a group is a
     // contiguous window of row slices), matching how get_source_start_end/get_target_start_end trim.
-    const bool co_owns_shared_slice = !row_slices.empty() && (row_slices.front().entity_fetch_count_->front() > 1 ||
-                                                              row_slices.back().entity_fetch_count_->back() > 1);
+    const bool co_owns_shared_slice =
+            row_slices.front().entity_fetch_count_->front() > 1 || row_slices.back().entity_fetch_count_->back() > 1;
     if (strategy_.insert_only() && match_record.total_unmatched_source_rows() == 0 && !co_owns_shared_slice) {
-        return {std::move(row_slices), false};
+        // Nothing to insert and no match to update: leave the group untouched and emit nothing.
+        // merge_slices_and_keys keeps the existing data keys for row slices that are not re-emitted.
+        return {};
     }
     internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
             source_->desc().index().type() == IndexDescriptor::Type::TIMESTAMP,
             "Merge update with insertion is implemented only for timeseries"
     );
-    const std::pair<size_t, size_t> source_start_end = get_source_start_end(row_slices);
-    const std::span<const timestamp> source_index = get_source_index(row_slices);
+    const std::span<const timestamp> source_index = get_source_index(source_start_end);
     const StreamDescriptor source_descriptor = source_->desc();
     const size_t num_col_slices = row_slices.begin()->col_ranges_->size();
     ARCTICDB_DEBUG_CHECK(
@@ -1036,7 +1013,8 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update_and_inser
     result.segments_.emplace();
     result.segments_->reserve(num_col_slices);
     result.col_ranges_ = row_slices.front().col_ranges_;
-    std::vector<ColumnWithStrings> target_datas, target_index_datas;
+    std::vector<ColumnWithStrings> target_datas;
+    std::vector<ColumnWithStrings> target_index_datas;
     target_index_datas.reserve(row_slices.size());
     std::ranges::transform(row_slices, std::back_inserter(target_index_datas), [&](const auto& proc) {
         return ColumnWithStrings(proc.segments_->front()->column_ptr(0), nullptr, target_descriptor.field(0).name());
@@ -1058,7 +1036,7 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update_and_inser
             MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
     ));
     size_t col_slice_idx = 0;
-    const auto [source_start, source_end] = get_source_start_end(row_slices);
+    const auto [source_start, source_end] = source_start_end;
     for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
          ++field_idx) {
         const Field& target_field = target_descriptor.field(field_idx);
@@ -1114,11 +1092,12 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update_and_inser
             row_slices.back().row_ranges_->back()->first + target_range.end_row_in_last_row_slice
     );
     result.row_ranges_ = std::vector(num_col_slices, new_row_range);
-    return {std::vector{std::move(result)}, true};
+    return std::vector{std::move(result)};
 }
 
-std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update(
-        const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices
+std::vector<ProcessingUnit> MergeUpdateClause::update(
+        const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices,
+        std::pair<size_t, size_t> source_start_end
 ) const {
     ARCTICDB_DEBUG_CHECK(
             ErrorCode::E_ASSERTION_FAILURE,
@@ -1127,8 +1106,7 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update(
     );
     std::vector<ProcessingUnit> result;
     const StreamDescriptor& source_descriptor = source_->desc();
-    bool time_slice_changed = false;
-    const auto [source_start, source_end] = get_source_start_end(row_slices);
+    const auto [source_start, source_end] = source_start_end;
     for (size_t i = 0; i < row_slices.size(); ++i) {
         const ProcessingUnit& proc = row_slices[i];
         const std::span<const std::shared_ptr<SegmentInMemory>> target_segments = *proc.segments_;
@@ -1175,7 +1153,7 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update(
                     // pool is not populated. Which means that the mapping between a string and offset in the pool is
                     // missing. To get it, we need to rebuild the pool anyway.
                     segment_contains_string_column |= is_sequence_type(DataTypeTag::data_type);
-                    time_slice_changed |= update_column<ScalarType>(
+                    update_column<ScalarType>(
                             strategy_,
                             target_segment.string_pool(),
                             source_data,
@@ -1195,16 +1173,18 @@ std::pair<std::vector<ProcessingUnit>, bool> MergeUpdateClause::update(
         result.emplace_back(std::move(row_slices[i]));
     }
 
-    return {std::move(result), time_slice_changed};
+    return result;
 }
 
-MergeUpdateClause::MatchRecord MergeUpdateClause::match(std::span<ProcessingUnit> row_slices) const {
+MergeUpdateClause::MatchRecord MergeUpdateClause::match(
+        std::span<ProcessingUnit> row_slices, std::pair<size_t, size_t> source_start_end
+) const {
     std::optional<MatchRecord> maybe_index_match;
     if (source_->has_index()) {
-        maybe_index_match.emplace(filter_index_match(get_source_index(row_slices), row_slices));
+        maybe_index_match.emplace(filter_index_match(get_source_index(source_start_end), row_slices));
     }
     return filter_on_additional_columns_match(
-            source_->desc(), source_->desc(), row_slices, std::move(maybe_index_match)
+            source_->desc(), source_->desc(), row_slices, std::move(maybe_index_match), source_start_end
     );
 }
 
@@ -1223,7 +1203,8 @@ std::span<const std::byte> MergeUpdateClause::get_source_data_bytes(size_t field
 /// and target is the same up to the very last column in MergeUpdateClause::on_.
 MergeUpdateClause::MatchRecord MergeUpdateClause::filter_on_additional_columns_match(
         const StreamDescriptor& source_descriptor, const StreamDescriptor& target_descriptor,
-        std::span<ProcessingUnit> row_slices, std::optional<MatchRecord>&& index_match
+        std::span<ProcessingUnit> row_slices, std::optional<MatchRecord>&& index_match,
+        std::pair<size_t, size_t> source_start_end
 ) const {
     ranges::subrange on = on_;
     MatchRecord matched_rows = [&] {
@@ -1245,13 +1226,13 @@ MergeUpdateClause::MatchRecord MergeUpdateClause::filter_on_additional_columns_m
                 target_index_type
         );
         on = on.next();
-        return initialize_rows_to_update_for_row_range_indexed_data(row_slices, source_descriptor);
+        return initialize_rows_to_update_for_row_range_indexed_data(row_slices, source_descriptor, source_start_end);
     }();
 
     if (on.empty()) {
         return matched_rows;
     }
-    const std::pair<size_t, size_t> source_range = get_source_start_end(row_slices);
+    const std::pair<size_t, size_t> source_range = source_start_end;
     for (const std::string_view column_name : on) {
         const size_t source_field_position = field_index_for_matching_on_column(column_name, source_descriptor);
         const Field& source_field = source_descriptor.field(source_field_position);
@@ -1342,8 +1323,8 @@ bool MergeUpdateClause::must_structure_by_time_slice() const {
     return source_->has_index() && !on_.empty() && strategy_.insert();
 }
 
-std::span<const timestamp> MergeUpdateClause::get_source_index(std::span<const ProcessingUnit> row_slices) const {
-    const auto [start, end] = get_source_start_end(row_slices);
+std::span<const timestamp> MergeUpdateClause::get_source_index(std::pair<size_t, size_t> source_start_end) const {
+    const auto [start, end] = source_start_end;
     return source_->get_tensor(0).span<timestamp>(start, end - start);
 }
 
@@ -1360,7 +1341,7 @@ void MergeUpdateClause::MatchRecord::add_match(size_t source_row, size_t target_
 void MergeUpdateClause::MatchRecord::add_match(
         size_t source_row, size_t target_row_slice, std::span<size_t> target_rows
 ) {
-    ++source_row_matched_count_[source_row];
+    source_row_matched_count_[source_row] += target_rows.size();
     const auto end = matched_target_rows_[target_row_slice][source_row].end();
     matched_target_rows_[target_row_slice][source_row].insert(end, target_rows.begin(), target_rows.end());
     total_matched_target_rows_count_ += target_rows.size();
@@ -1444,6 +1425,9 @@ void MergeUpdateClause::MatchRecord::filter_matching_rows(
 void MergeUpdateClause::MatchRecord::clone_source_match(
         size_t source_row_src, size_t source_row_dst, size_t row_slice
 ) {
+    util::check(
+            matched_target_rows_[row_slice][source_row_dst].empty(), "Destination source row must not have matches"
+    );
     source_row_matched_count_[source_row_dst] = source_row_matched_count_[source_row_src];
     matched_target_rows_[row_slice][source_row_dst] = matched_target_rows_[row_slice][source_row_src];
     total_matched_target_rows_count_ += source_row_matched_count_[source_row_dst];
@@ -1479,12 +1463,14 @@ void MergeUpdateClause::MatchRecord::validate_rows_to_update(const MergeStrategy
     }
 }
 
-std::span<const std::vector<size_t>> MergeUpdateClause::MatchRecord::matched_rows(size_t target_row_slice) const {
+const std::vector<std::vector<size_t>>& MergeUpdateClause::MatchRecord::matched_rows(size_t target_row_slice) const {
     return matched_target_rows_[target_row_slice];
 }
 
 bool MergeUpdateClause::MatchRecord::is_source_row_matched(size_t source_row) const {
     return source_row_matched_count_[source_row] > 0;
 }
+
+bool MergeUpdateClause::MatchRecord::has_matched_target_rows() const { return total_matched_target_rows_count_ > 0; }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -76,32 +76,18 @@ std::vector<std::vector<size_t>> structure_by_time_slice(std::span<RangesAndKey>
                std::tie(right.row_range().first, right.col_range().first);
     });
     std::vector<std::vector<size_t>> res;
-    TimestampRange previous_time_range{std::numeric_limits<timestamp>::min(), std::numeric_limits<timestamp>::min()};
-    size_t overlapping_ranges{};
-    for (const auto& [idx, ranges_and_key] : folly::enumerate(ranges)) {
-        const TimestampRange& current_time_range = ranges_and_key.key_.time_range();
-        if (previous_time_range.second <= current_time_range.first) {
-            res.emplace_back();
-            const TimestampRange& first_overlap = ranges[idx - overlapping_ranges].key_.time_range();
-            for (size_t i = idx - overlapping_ranges; i < idx; ++i) {
-                res.back().emplace_back(i);
+    size_t first_group_slice = 0;
+    while (first_group_slice < ranges.size()) {
+        const timestamp group_end_time = ranges[first_group_slice].key_.end_time();
+        std::vector<size_t>& group = res.emplace_back();
+        size_t next_group_start_first_slice = first_group_slice;
+        for (size_t i = first_group_slice; i < ranges.size() && ranges[i].key_.start_time() < group_end_time; ++i) {
+            group.emplace_back(i);
+            if (next_group_start_first_slice == i && ranges[i].key_.end_time() == group_end_time) {
+                ++next_group_start_first_slice;
             }
-            if (first_overlap.second <= current_time_range.first) {
-                res.emplace_back();
-                previous_time_range = current_time_range;
-            } else {
-                previous_time_range = first_overlap;
-            }
-            overlapping_ranges = 0;
         }
-        overlapping_ranges += current_time_range.second != previous_time_range.second;
-        res.back().emplace_back(idx);
-    }
-    if (overlapping_ranges > 0) {
-        res.emplace_back();
-        for (size_t i = ranges.size() - overlapping_ranges; i < ranges.size(); ++i) {
-            res.back().emplace_back(i);
-        }
+        first_group_slice = next_group_start_first_slice;
     }
     return res;
 }

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -46,6 +46,66 @@ std::vector<std::vector<EntityId>> structure_by_row_slice(
     return res;
 }
 
+template<typename T>
+requires util::any_of<T, RangesAndKey, RangesAndEntity>
+std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<T>& ranges) {
+    std::ranges::sort(ranges, [](const T& left, const T& right) {
+        return std::tie(left.row_range().first, left.col_range().first) <
+               std::tie(right.row_range().first, right.col_range().first);
+    });
+
+    std::vector<std::vector<size_t>> res;
+    RowRange previous_row_range{std::numeric_limits<size_t>::max(), std::numeric_limits<size_t>::max()};
+    for (const auto& [idx, ranges_and_key] : folly::enumerate(ranges)) {
+        RowRange current_row_range{ranges_and_key.row_range()};
+        if (current_row_range != previous_row_range) {
+            res.emplace_back();
+        }
+        res.back().emplace_back(idx);
+        previous_row_range = current_row_range;
+    }
+    return res;
+}
+
+template std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<RangesAndKey>& ranges);
+template std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<RangesAndEntity>& ranges);
+
+std::vector<std::vector<size_t>> structure_by_time_slice(std::span<RangesAndKey> ranges) {
+    std::ranges::sort(ranges, [](const RangesAndKey& left, const RangesAndKey& right) {
+        return std::tie(left.row_range().first, left.col_range().first) <
+               std::tie(right.row_range().first, right.col_range().first);
+    });
+    std::vector<std::vector<size_t>> res;
+    TimestampRange previous_time_range{std::numeric_limits<timestamp>::min(), std::numeric_limits<timestamp>::min()};
+    size_t overlapping_ranges{};
+    for (const auto& [idx, ranges_and_key] : folly::enumerate(ranges)) {
+        const TimestampRange& current_time_range = ranges_and_key.key_.time_range();
+        if (previous_time_range.second <= current_time_range.first) {
+            res.emplace_back();
+            const TimestampRange& first_overlap = ranges[idx - overlapping_ranges].key_.time_range();
+            for (size_t i = idx - overlapping_ranges; i < idx; ++i) {
+                res.back().emplace_back(i);
+            }
+            if (first_overlap.second <= current_time_range.first) {
+                res.emplace_back();
+                previous_time_range = current_time_range;
+            } else {
+                previous_time_range = first_overlap;
+            }
+            overlapping_ranges = 0;
+        }
+        overlapping_ranges += current_time_range.second != previous_time_range.second;
+        res.back().emplace_back(idx);
+    }
+    if (overlapping_ranges > 0) {
+        res.emplace_back();
+        for (size_t i = ranges.size() - overlapping_ranges; i < ranges.size(); ++i) {
+            res.back().emplace_back(i);
+        }
+    }
+    return res;
+}
+
 std::vector<std::vector<EntityId>> offsets_to_entity_ids(
         const std::vector<std::vector<size_t>>& offsets, const std::vector<RangesAndEntity>& ranges_and_entities
 ) {

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -100,25 +100,10 @@ struct RangesAndEntity {
 };
 
 template<typename T>
-requires std::is_same_v<T, RangesAndKey> || std::is_same_v<T, RangesAndEntity>
-std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<T>& ranges) {
-    std::sort(std::begin(ranges), std::end(ranges), [](const T& left, const T& right) {
-        return std::tie(left.row_range().first, left.col_range().first) <
-               std::tie(right.row_range().first, right.col_range().first);
-    });
+requires util::any_of<T, RangesAndKey, RangesAndEntity>
+std::vector<std::vector<size_t>> structure_by_row_slice(std::vector<T>& ranges);
 
-    std::vector<std::vector<size_t>> res;
-    RowRange previous_row_range{-1, -1};
-    for (const auto& [idx, ranges_and_key] : folly::enumerate(ranges)) {
-        RowRange current_row_range{ranges_and_key.row_range()};
-        if (current_row_range != previous_row_range) {
-            res.emplace_back();
-        }
-        res.back().emplace_back(idx);
-        previous_row_range = current_row_range;
-    }
-    return res;
-}
+std::vector<std::vector<size_t>> structure_by_time_slice(std::span<RangesAndKey> ranges);
 
 template<ResampleBoundary closed_boundary>
 bool index_range_outside_bucket_range(

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -128,6 +128,18 @@ class ComponentManager {
         return get_entities_impl<Args...>(ids, false);
     }
 
+    template<typename ProcessComponents>
+    void process_entities(ProcessComponents&& process_fn) {
+        using ArgTypes = util::function_arg_types<std::decay_t<ProcessComponents>>::args_t;
+        using NoRefArgs = decltype([]<typename... Ts>(std::tuple<Ts...>*) {
+            return std::tuple<std::remove_reference_t<Ts>...>{};
+        }(static_cast<ArgTypes*>(nullptr)));
+        return [&]<typename... Args>(std::tuple<Args...>*) {
+            auto view = registry_.view<Args...>();
+            return view.each(std::forward<ProcessComponents>(process_fn));
+        }(static_cast<NoRefArgs*>(nullptr));
+    }
+
   private:
     void decrement_entity_fetch_count(EntityId id);
     void update_entity_fetch_count(EntityId id, EntityFetchCount count);

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -26,6 +26,17 @@ using bucket_id = uint8_t;
 
 using namespace entt::literals;
 
+/// Used only by the MergeUpdateClause. Do not use in other clauses. The merge update clause expects it's the only
+/// clause adding this entity and then after read_modify_write it reads it in order to compute the correct row ranges
+/// accounting for insertion. If any other piece of code adds this entity to the component manager the merge updates
+/// will iterate over them as well, producing wrong results. See merge_update_impl and Monday 12618296803
+struct MergeUpdateInsertedRowsEntity {
+    MergeUpdateInsertedRowsEntity() = default;
+    MergeUpdateInsertedRowsEntity(const size_t inserted_rows) : inserted_rows(inserted_rows) {}
+    operator size_t() const { return inserted_rows; }
+    size_t inserted_rows = 0;
+};
+
 class ComponentManager {
   public:
     ComponentManager() = default;
@@ -131,9 +142,11 @@ class ComponentManager {
     template<typename ProcessComponents>
     void process_entities(ProcessComponents&& process_fn) {
         using ArgTypes = util::function_arg_types<std::decay_t<ProcessComponents>>::args_t;
-        using NoRefArgs = decltype([]<typename... Ts>(std::tuple<Ts...>*) {
-            return std::tuple<std::remove_reference_t<Ts>...>{};
-        }(static_cast<ArgTypes*>(nullptr)));
+        // Derive the component tuple type (references stripped) without default-constructing it, as
+        // the component types need not be default-constructible.
+        using NoRefArgs = std::remove_pointer_t<decltype([]<typename... Ts>(std::tuple<Ts...>*) {
+            return static_cast<std::tuple<std::remove_reference_t<Ts>...>*>(nullptr);
+        }(static_cast<ArgTypes*>(nullptr)))>;
         return [&]<typename... Args>(std::tuple<Args...>*) {
             auto view = registry_.view<Args...>();
             return view.each(std::forward<ProcessComponents>(process_fn));

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -33,6 +33,7 @@ struct ColumnWithStrings {
     std::shared_ptr<Column> column_;
     const std::shared_ptr<StringPool> string_pool_;
     std::string column_name_;
+
     ColumnWithStrings(std::unique_ptr<Column>&& col, std::string_view col_name);
 
     ColumnWithStrings(

--- a/cpp/arcticdb/processing/expression_node.hpp
+++ b/cpp/arcticdb/processing/expression_node.hpp
@@ -33,7 +33,6 @@ struct ColumnWithStrings {
     std::shared_ptr<Column> column_;
     const std::shared_ptr<StringPool> string_pool_;
     std::string column_name_;
-
     ColumnWithStrings(std::unique_ptr<Column>&& col, std::string_view col_name);
 
     ColumnWithStrings(

--- a/cpp/arcticdb/processing/processing_unit.cpp
+++ b/cpp/arcticdb/processing/processing_unit.cpp
@@ -8,6 +8,8 @@
 
 #include <arcticdb/processing/processing_unit.hpp>
 
+#include <ranges>
+
 namespace arcticdb {
 
 void ProcessingUnit::apply_filter(util::BitSet&& bitset, PipelineOptimisation optimisation) {
@@ -83,13 +85,12 @@ std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc) {
             input.col_ranges_.has_value(), "split_by_row_slice needs ColRanges"
     );
     auto include_entity_fetch_count = input.entity_fetch_count_.has_value();
+    const bool has_atom_keys = input.atom_keys_.has_value();
 
     std::vector<ProcessingUnit> output;
     // Some clauses (e.g. AggregationClause) are lossy about row-ranges. We can assume that if all of the input column
     // ranges start with zero, that every segment belongs to a different logical row-slice
-    if (std::all_of(input.col_ranges_->begin(), input.col_ranges_->end(), [](const auto& col_range) {
-            return col_range->start() == 0;
-        })) {
+    if (std::ranges::all_of(*input.col_ranges_, [](const auto& col_range) { return col_range->start() == 0; })) {
         output.reserve(input.segments_->size());
         for (size_t idx = 0; idx < input.segments_->size(); ++idx) {
             ProcessingUnit proc_tmp(
@@ -99,6 +100,9 @@ std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc) {
             );
             if (include_entity_fetch_count) {
                 proc_tmp.set_entity_fetch_count({input.entity_fetch_count_->at(idx)});
+            }
+            if (has_atom_keys) {
+                proc_tmp.set_atom_keys({input.atom_keys_->at(idx)});
             }
             output.emplace_back(std::move(proc_tmp));
         }
@@ -112,6 +116,9 @@ std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc) {
                 if (include_entity_fetch_count) {
                     it->second.entity_fetch_count_->emplace_back(input.entity_fetch_count_->at(idx));
                 }
+                if (has_atom_keys) {
+                    it->second.atom_keys_->emplace_back(input.atom_keys_->at(idx));
+                }
             } else {
                 auto [inserted_it, _] = output_map.emplace(*row_range_ptr, ProcessingUnit{});
                 inserted_it->second.segments_.emplace(1, input.segments_->at(idx));
@@ -120,10 +127,13 @@ std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc) {
                 if (include_entity_fetch_count) {
                     inserted_it->second.entity_fetch_count_.emplace(1, input.entity_fetch_count_->at(idx));
                 }
+                if (has_atom_keys) {
+                    inserted_it->second.atom_keys_.emplace(1, input.atom_keys_->at(idx));
+                }
             }
         }
         output.reserve(output_map.size());
-        for (auto&& [_, processing_unit] : output_map) {
+        for (auto& processing_unit : output_map | std::views::values) {
             output.emplace_back(std::move(processing_unit));
         }
     }
@@ -142,9 +152,8 @@ std::vector<ProcessingUnit> split_by_row_slice(ProcessingUnit&& proc) {
                     entity_fetch_count
             );
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                    std::all_of(
-                            row_slice->entity_fetch_count_->begin(),
-                            row_slice->entity_fetch_count_->end(),
+                    std::ranges::all_of(
+                            *row_slice->entity_fetch_count_,
                             [&entity_fetch_count](uint64_t i) { return i == entity_fetch_count; }
                     ),
                     "All segments in same row slice should have same entity_fetch_count in split_by_row_slice"

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -15,12 +15,14 @@
 using namespace arcticdb;
 using namespace std::ranges;
 
-constexpr static MergeStrategy update_only_strategy{
+namespace {
+constexpr MergeStrategy update_only_strategy{.matched = MergeAction::UPDATE};
+constexpr MergeStrategy update_and_insert_strategy{
         .matched = MergeAction::UPDATE,
-        .not_matched_by_target = MergeAction::DO_NOTHING
+        .not_matched_by_target = MergeAction::INSERT
 };
 
-constexpr static std::array non_string_fields = {
+constexpr std::array non_string_fields = {
         FieldRef(TypeDescriptor(DataType::INT8, Dimension::Dim0), "int8"),
         FieldRef(TypeDescriptor(DataType::UINT32, Dimension::Dim0), "uint32"),
         FieldRef(TypeDescriptor(DataType::BOOL8, Dimension::Dim0), "bool8"),
@@ -110,33 +112,57 @@ MergeUpdateClause create_clause(
 }
 
 std::vector<EntityId> push_selected_entities(
-        ComponentManager& component_manager, const std::span<const RangesAndKey> ranges_and_keys,
+        ComponentManager& component_manager, const std::span<const std::vector<size_t>> structure_indices,
         std::vector<SegmentInMemory>&& segments_in, std::vector<ColRange>&& col_ranges_in,
-        std::vector<RowRange>&& row_ranges_in
+        std::vector<RowRange>&& row_ranges_in, std::vector<RangesAndKey>&& ranges_and_keys
 ) {
-    size_t idx = 0;
     std::vector<std::shared_ptr<SegmentInMemory>> segments;
     std::vector<std::shared_ptr<ColRange>> col_ranges;
     std::vector<std::shared_ptr<RowRange>> row_ranges;
     std::vector<std::shared_ptr<AtomKey>> atom_keys;
-    for (const RangesAndKey& range : ranges_and_keys) {
-        while ((idx < segments_in.size()) &&
-               (range.row_range() != row_ranges_in[idx] || range.col_range() != col_ranges_in[idx])) {
-            ++idx;
+
+    util::BitSet used(segments_in.size());
+    for (const size_t i : structure_indices | std::views::join) {
+        if (used[i]) {
+            continue;
         }
-        segments.emplace_back(std::make_shared<SegmentInMemory>(std::move(segments_in[idx])));
-        col_ranges.emplace_back(std::make_shared<ColRange>(std::move(col_ranges_in[idx])));
-        row_ranges.emplace_back(std::make_shared<RowRange>(std::move(row_ranges_in[idx])));
-        atom_keys.emplace_back(std::make_shared<AtomKey>(range.key_));
+        used[i] = true;
+        RangesAndKey& range_and_key = ranges_and_keys[i];
+        size_t segment_to_add = 0;
+        while (segment_to_add < segments_in.size() && (col_ranges_in[segment_to_add] != range_and_key.col_range() ||
+                                                       row_ranges_in[segment_to_add] != range_and_key.row_range())) {
+            ++segment_to_add;
+        }
+        util::check(
+                segment_to_add < segments_in.size(),
+                "Could not find segment for row range {} and col range {}",
+                range_and_key.row_range(),
+                range_and_key.col_range()
+        );
+        segments.push_back(std::make_shared<SegmentInMemory>(std::move(segments_in[segment_to_add])));
+        col_ranges.push_back(std::make_shared<ColRange>(range_and_key.col_range()));
+        row_ranges.push_back(std::make_shared<RowRange>(range_and_key.row_range()));
+        atom_keys.push_back(std::make_shared<AtomKey>(std::move(range_and_key.key_)));
     }
+    const size_t num_entities = used.count();
+    std::vector<EntityFetchCount> fetch_counts = *generate_segment_fetch_counts(structure_indices, num_entities);
     return component_manager.add_entities(
             std::move(segments),
             std::move(col_ranges),
             std::move(row_ranges),
             std::move(atom_keys),
-            std::vector<EntityFetchCount>(ranges_and_keys.size(), 0)
+            std::move(fetch_counts)
     );
 }
+
+std::vector<SegmentInMemory> clone_segments(std::span<const SegmentInMemory> segments) {
+    std::vector<SegmentInMemory> result;
+    result.reserve(segments.size());
+    std::ranges::transform(segments, std::back_inserter(result), [](const auto& segment) { return segment.clone(); });
+    return result;
+}
+
+} // namespace
 
 struct MergeUpdateClauseUpdateStrategyTestBase {
     MergeUpdateClauseUpdateStrategyTestBase(
@@ -157,13 +183,14 @@ struct MergeUpdateClauseUpdateStrategyTestBase {
         return ::create_clause(strategy_, component_manager_, std::move(input_frame), std::move(on));
     }
 
-    std::vector<EntityId> push_entities() {
+    std::vector<EntityId> push_entities(const std::span<const std::vector<size_t>> structure_indices) {
         return push_selected_entities(
                 *component_manager_,
-                ranges_and_keys_,
+                structure_indices,
                 std::move(segments_),
                 std::move(col_ranges_),
-                std::move(row_ranges_)
+                std::move(row_ranges_),
+                std::move(ranges_and_keys_)
         );
     }
 
@@ -297,15 +324,17 @@ TEST_P(MergeUpdateClauseUpdateStrategyMatchAllSegTest, SourceIndexMatchesAllSegm
             descriptor_,
             rows_per_segment(),
             cols_per_segment(),
-            iota_view(timestamp{0}, timestamp{3 * rows_per_segment()}),
+            iota_view<timestamp, timestamp>(0, 15),
             std::array<int8_t, 15>{10, 1, 2, 3, 4, 5, 6, 20, 8, 9, 10, 11, 12, 13, 30},
             std::array<unsigned, 15>{100, 1, 2, 3, 4, 5, 6, 200, 8, 9, 10, 11, 12, 13, 300},
-            std::array<bool, 15>{1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1},
+            std::array{true, true, false, true, false, true, false, false, false, true, false, true, false, true, true},
             std::array<float, 15>{11.1f, 1, 2, 3, 4, 5, 6, 22.2f, 8, 9, 10, 11, 12, 13, 33.3f},
             std::array<timestamp, 15>{1000, 1, 2, 3, 4, 5, 6, 2000, 8, 9, 10, 11, 12, 13, 3000}
     );
     sort_by_rowslice(expected_row_ranges, expected_col_ranges, expected_segments);
-    assert_process_results_match_expected(clause, expected_segments, structure_indices, push_entities());
+    assert_process_results_match_expected(
+            clause, expected_segments, structure_indices, push_entities(structure_indices)
+    );
 }
 
 TEST_P(MergeUpdateClauseUpdateStrategyMatchAllSegTest, SourceHasValuesOutsideOfTheDataFrame) {
@@ -327,15 +356,17 @@ TEST_P(MergeUpdateClauseUpdateStrategyMatchAllSegTest, SourceHasValuesOutsideOfT
             descriptor_,
             rows_per_segment(),
             cols_per_segment(),
-            iota_view(timestamp{0}, timestamp{3 * rows_per_segment()}),
+            iota_view<timestamp, timestamp>(0, 15),
             std::array<int8_t, 15>{10, 1, 2, 3, 4, 5, 6, 20, 8, 9, 10, 11, 12, 13, 30},
             std::array<unsigned, 15>{100, 1, 2, 3, 4, 5, 6, 200, 8, 9, 10, 11, 12, 13, 300},
-            std::array<bool, 15>{1, 1, 0, 1, 0, 1, 0, 0, 0, 1, 0, 1, 0, 1, 1},
+            std::array{true, true, false, true, false, true, false, false, false, true, false, true, false, true, true},
             std::array<float, 15>{11.1f, 1, 2, 3, 4, 5, 6, 22.2f, 8, 9, 10, 11, 12, 13, 33.3f},
             std::array<timestamp, 15>{1000, 1, 2, 3, 4, 5, 6, 2000, 8, 9, 10, 11, 12, 13, 3000}
     );
     sort_by_rowslice(expected_row_ranges, expected_col_ranges, expected_segments);
-    assert_process_results_match_expected(clause, expected_segments, structure_indices, push_entities());
+    assert_process_results_match_expected(
+            clause, expected_segments, structure_indices, push_entities(structure_indices)
+    );
 }
 
 INSTANTIATE_TEST_SUITE_P(
@@ -418,9 +449,12 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchFirst) {
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][1]].row_range(), RowRange(0, 5));
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][1]].col_range(), ColRange(4, 6));
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities.front().size(), 2);
     const std::vector<EntityId> result_entities = clause.process(std::move(structured_entities[0]));
+    ASSERT_EQ(result_entities.size(), 2);
     auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
             *component_manager_, result_entities
     );
@@ -428,13 +462,14 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchFirst) {
             descriptor_,
             rows_per_segment_,
             cols_per_segment_,
-            iota_view<timestamp, timestamp>(0, 10),
+            iota_view<timestamp, timestamp>(0, 5),
             std::array<int8_t, 5>{0, 1, 2, -2, 4},
             std::array<unsigned, 5>{0, 1, 2, 20, 4},
-            std::array<bool, 5>{0, 1, 0, 0, 0},
+            std::array<bool, 5>{false, true, false, false, false},
             std::array<float, 5>{0.f, 1, 2, -11.f, 4},
             std::array<timestamp, 5>{0, 1, 2, -12, 4}
     );
+    ASSERT_EQ(proc.segments_->size(), 2);
     ASSERT_EQ(*(*proc.segments_)[0], expected_segments[0]);
     ASSERT_EQ(*(*proc.segments_)[1], expected_segments[1]);
     ASSERT_EQ(*(*proc.row_ranges_)[0], RowRange(0, 5));
@@ -462,9 +497,13 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchSecond) {
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][1]].row_range(), RowRange(5, 10));
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][1]].col_range(), ColRange(4, 6));
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
+    ASSERT_EQ(entities.size(), 2);
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities[0].size(), 2);
     const std::vector<EntityId> result_entities = clause.process(std::move(structured_entities[0]));
+    ASSERT_EQ(result_entities.size(), 2);
     auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
             *component_manager_, result_entities
     );
@@ -475,10 +514,13 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchSecond) {
             iota_view<timestamp, timestamp>(5, 10),
             std::array<int8_t, 5>{5, -2, 7, 8, 9},
             std::array<unsigned, 5>{5, 20, 7, 8, 9},
-            std::array<bool, 5>{1, 1, 1, 0, 1},
+            std::array<bool, 5>{true, true, true, false, true},
             std::array<float, 5>{5, -11.f, 7, 8, 9},
             std::array<timestamp, 5>{5, -12, 7, 8, 9}
     );
+    ASSERT_EQ(proc.segments_->size(), 2);
+    ASSERT_EQ(proc.row_ranges_->size(), 2);
+    ASSERT_EQ(proc.col_ranges_->size(), 2);
     ASSERT_EQ(*(*proc.segments_)[0], expected_segments[0]);
     ASSERT_EQ(*(*proc.segments_)[1], expected_segments[1]);
     ASSERT_EQ(*(*proc.row_ranges_)[0], RowRange(5, 10));
@@ -507,9 +549,13 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchThird) {
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][1]].col_range(), ColRange(4, 6));
 
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
+    ASSERT_EQ(entities.size(), 2);
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities.front().size(), 2);
     const std::vector<EntityId> result_entities = clause.process(std::move(structured_entities[0]));
+    ASSERT_EQ(result_entities.size(), 2);
     auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
             *component_manager_, result_entities
     );
@@ -520,9 +566,9 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchThird) {
             iota_view<timestamp, timestamp>(10, 14),
             std::array<int8_t, 4>{-2, 11, 12, 13},
             std::array<unsigned, 4>{20, 11, 12, 13},
-            std::array<bool, 4>{1, 1, 0, 1},
+            std::array<bool, 4>{true, true, false, true},
             std::array<float, 4>{-11.f, 11, 12, 13},
-            std::array<timestamp, 5>{-12, 11, 12, 13}
+            std::array<timestamp, 4>{-12, 11, 12, 13}
     );
     ASSERT_EQ(*(*proc.segments_)[0], expected_segments[0]);
     ASSERT_EQ(*(*proc.segments_)[1], expected_segments[1]);
@@ -556,7 +602,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchFirstAndThird) {
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].row_range(), RowRange(10, 14));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].col_range(), ColRange(4, 6));
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
     const std::vector<EntityId> result_entities_0 = clause.process(std::move(structured_entities[0]));
     auto proc_0 =
@@ -631,7 +677,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchFirstAndSecond) {
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].row_range(), RowRange(5, 10));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].col_range(), ColRange(4, 6));
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
     const std::vector<EntityId> result_entities_0 = clause.process(std::move(structured_entities[0]));
     auto proc_0 =
@@ -706,7 +752,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyMatchSubsetTest, MatchSecondAndThird) {
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].row_range(), RowRange(10, 14));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].col_range(), ColRange(4, 6));
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
     const std::vector<EntityId> result_entities_0 = clause.process(std::move(structured_entities[0]));
     auto proc_0 =
@@ -817,7 +863,7 @@ TEST_F(MergeUpdateClauseOnParameterTest, OneOnColumn_IndexMatchesButColumnDiffer
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[0][1]].col_range(), ColRange(4, 6));
 
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     auto structured = structure_entities(structure_indices, entities);
     const std::vector<EntityId> result = clause.process(std::move(structured[0]));
     ASSERT_TRUE(result.empty());
@@ -844,7 +890,7 @@ TEST_F(MergeUpdateClauseOnParameterTest, OneOnColumn_BothIndexAndColumnMatch) {
     const size_t segments_to_process = row_slices_to_process * column_slices_per_row_slice();
     ASSERT_EQ(ranges_and_keys_.size(), segments_to_process);
 
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     auto structured = structure_entities(structure_indices, entities);
     const auto result = clause.process(std::move(structured[0]));
     auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
@@ -893,9 +939,13 @@ TEST_F(MergeUpdateClauseOnParameterTest, TwoOnColumns_BothMatch) {
     const size_t segments_to_process = row_slices_to_process * column_slices_per_row_slice();
     ASSERT_EQ(segments_to_process, 2);
 
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
+    ASSERT_EQ(entities.size(), 2);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured.size(), 1);
+    ASSERT_EQ(structured.front().size(), 2);
     const auto result = clause.process(std::move(structured[0]));
+    ASSERT_EQ(result.size(), 2);
     auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
             *component_manager_, result
     );
@@ -950,7 +1000,7 @@ TEST_F(MergeUpdateClauseOnParameterTest, OneOnColumn_SourceSpansBothRowSegments)
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][0]].col_range(), ColRange(1, 4));
     ASSERT_EQ(ranges_and_keys_[structure_indices[1][1]].col_range(), ColRange(4, 6));
 
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
 
     auto [expected_segs, expected_col_ranges, expected_row_ranges] = slice_data_into_segments<TimeseriesIndex>(
@@ -1059,7 +1109,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, RequireNonEmptyOn) {
     ASSERT_EQ(row_slices_to_process, 3);
     const size_t segments_to_process = row_slices_to_process * column_slices_per_row_slice();
     ASSERT_EQ(segments_to_process, 6);
-    std::vector<EntityId> entities = push_entities();
+    std::vector<EntityId> entities = push_entities(structure_indices);
     auto structured = structure_entities(structure_indices, entities);
     ASSERT_THROW((void)clause.process(std::move(structured[0])), UserInputException);
 }
@@ -1080,7 +1130,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, NonExistingOnThrows) {
     const size_t segments_to_process = row_slices_to_process * column_slices_per_row_slice();
     ASSERT_EQ(segments_to_process, 6);
     assert_structure_for_processing_result(structure_indices);
-    const std::vector<EntityId> entities = push_entities();
+    const std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
     ASSERT_THROW((void)clause.process(std::move(structured[0])), UserInputException);
 }
@@ -1102,31 +1152,32 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MatchOneColumn_Segment1) {
     ASSERT_EQ(segments_to_process, 6);
     assert_structure_for_processing_result(structure_indices);
 
-    const std::vector<EntityId> entities = push_entities();
+    const std::vector<EntityId> entities = push_entities(structure_indices);
+    ASSERT_EQ(entities.size(), segments_to_process);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured.size(), 3);
+    ASSERT_TRUE(std::ranges::all_of(structured, [](const auto& vec) { return vec.size() == 2; }));
     auto [expected_segs, expected_col_ranges, expected_row_ranges] = slice_data_into_segments<RowCountIndex>(
             non_string_fields_rowcount_index_descriptor(),
             rows_per_segment_,
             cols_per_segment_,
             std::array<int8_t, num_rows_>{9, 2, 12, 33, 33, 33, 33, 33, 33, 33, 33, 6, -9, 0},
             std::array<unsigned, num_rows_>{101, 1, 100, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13},
-            std::array<bool, num_rows_>{
-                    false, true, true, true, false, true, false, true, false, true, false, true, false, true
-            },
-            std::array<float, num_rows_>{
+            std::array{false, true, true, true, false, true, false, true, false, true, false, true, false, true},
+            std::array{
                     1001.f,
-                    1.,
+                    1.f,
                     1000.f,
-                    3.,
-                    4.,
-                    5.,
-                    6.,
-                    7.,
-                    8.,
-                    9.,
-                    10.,
-                    11.,
-                    12.,
+                    3.f,
+                    4.f,
+                    5.f,
+                    6.f,
+                    7.f,
+                    8.f,
+                    9.f,
+                    10.f,
+                    11.f,
+                    12.f,
                     std::numeric_limits<float>::quiet_NaN()
             },
             std::array<timestamp, num_rows_>{2001, 1, 2000, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}
@@ -1173,7 +1224,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MatchOneColumn_ValueInSourceMatc
     ASSERT_EQ(segments_to_process, 6);
     assert_structure_for_processing_result(structure_indices);
 
-    const std::vector<EntityId> entities = push_entities();
+    const std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
     auto [expected_segs, expected_col_ranges, expected_row_ranges] = slice_data_into_segments<RowCountIndex>(
             non_string_fields_rowcount_index_descriptor(),
@@ -1264,7 +1315,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MatchOneColumn_Segment1_Segment3
     ASSERT_EQ(segments_to_process, 6);
     assert_structure_for_processing_result(structure_indices);
 
-    const std::vector<EntityId> entities = push_entities();
+    const std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
     auto [expected_segs, expected_col_ranges, expected_row_ranges] = slice_data_into_segments<RowCountIndex>(
             non_string_fields_rowcount_index_descriptor(),
@@ -1332,7 +1383,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MatchNaN) {
     ASSERT_EQ(segments_to_process, 6);
     assert_structure_for_processing_result(structure_indices);
 
-    const std::vector<EntityId> entities = push_entities();
+    const std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
     auto [expected_segs, expected_col_ranges, expected_row_ranges] = slice_data_into_segments<RowCountIndex>(
             non_string_fields_rowcount_index_descriptor(),
@@ -1388,7 +1439,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MergeOnTwoColumns_Segment1_Segme
     ASSERT_EQ(segments_to_process, 6);
     assert_structure_for_processing_result(structure_indices);
 
-    const std::vector<EntityId> entities = push_entities();
+    const std::vector<EntityId> entities = push_entities(structure_indices);
     std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
     auto [expected_segs, expected_col_ranges, expected_row_ranges] = slice_data_into_segments<RowCountIndex>(
             non_string_fields_rowcount_index_descriptor(),
@@ -1466,10 +1517,11 @@ TEST(IndexValueSpansMultipleSegments, SegmetStartsWithTheSameValueAsAnotherEnds)
     ASSERT_EQ(structure_indices.size(), 2);
     std::vector<EntityId> entities = push_selected_entities(
             *component_manager,
-            ranges_and_keys,
+            structure_indices,
             std::move(target_segments),
             std::move(target_column_ranges),
-            std::move(target_row_ranges)
+            std::move(target_row_ranges),
+            std::move(ranges_and_keys)
     );
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
     auto [expected_segments, expected_col_slices, expected_row_slices] = slice_data_into_segments<TimeseriesIndex>(
@@ -1524,10 +1576,11 @@ TEST(IndexValueSpansMultipleSegments, MultipleSegmentsConsistedOfTheSameValue) {
             ASSERT_EQ(structure_indices.size(), 3);
             std::vector<EntityId> entities = push_selected_entities(
                     *component_manager,
-                    ranges_and_keys,
+                    structure_indices,
                     std::move(target_segments),
                     std::move(target_column_ranges),
-                    std::move(target_row_ranges)
+                    std::move(target_row_ranges),
+                    std::move(ranges_and_keys)
             );
             std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
             ASSERT_EQ(structured_entities.size(), 3);
@@ -1598,12 +1651,1678 @@ TEST(MergeClauseDateRange, SourceMatchesAllIndexRangesButDoesNotMatchAnyRow) {
     const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
     ASSERT_EQ(structure_indices.size(), 3);
     std::vector<EntityId> entities = push_selected_entities(
-            *component_manager, ranges_and_keys, std::move(segments), std::move(cols), std::move(rows)
+            *component_manager,
+            structure_indices,
+            std::move(segments),
+            std::move(cols),
+            std::move(rows),
+            std::move(ranges_and_keys)
     );
     std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
     ASSERT_EQ(structured_entities.size(), 3);
     for (std::vector<EntityId>& structured_entity : structured_entities) {
         const std::vector<EntityId> result = clause.process(std::move(structured_entity));
         ASSERT_TRUE(result.empty());
+    }
+}
+
+struct MergeUpdateClauseInsertAndUpdate : testing::TestWithParam<MergeStrategy> {};
+
+TEST_P(MergeUpdateClauseInsertAndUpdate, InsertBeforeFirstRow) {
+    constexpr static int num_rows = 15;
+    constexpr static int num_cols = non_string_fields.size();
+    constexpr static int rows_per_segment = 5;
+    constexpr static int cols_per_segment = 3;
+    constexpr static int col_slice_count = (num_cols + cols_per_segment - 1) / cols_per_segment;
+
+    MergeStrategy strategy = GetParam();
+    const StreamDescriptor& descriptor = non_string_fields_ts_index_descriptor();
+
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            non_string_fields_ts_index_descriptor(),
+            rows_per_segment,
+            cols_per_segment,
+            iota_view(timestamp{0}, timestamp{num_rows}),
+            iota_view(static_cast<int8_t>(0), static_cast<int8_t>(num_rows)),
+            iota_view(static_cast<unsigned>(0), static_cast<unsigned>(num_rows)),
+            iota_view(0, num_rows) | views::transform([](auto x) -> bool { return x % 2 == 1; }),
+            iota_view(0, num_rows) | views::transform([](auto x) { return static_cast<float>(x); }),
+            iota_view(timestamp{0}, timestamp{num_rows})
+    );
+
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(descriptor, segments, col_ranges, row_ranges);
+    auto component_manager = std::make_shared<ComponentManager>();
+
+    auto [input_frame, input_frame_data_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            descriptor,
+            std::array<timestamp, 3>{-10, -5, -4},
+            std::array<int8_t, 3>{100, 101, 102},
+            std::array<unsigned, 3>{1000, 2000, 3000},
+            std::array<bool, 3>{true, false, true},
+            std::array<float, 3>{500.f, 600.f, 700.f},
+            std::array<timestamp, 3>{111, 222, 333}
+    );
+    MergeUpdateClause clause = create_clause(strategy, component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    // Inserting in the beginning of the DataFrame picks the first row slice
+    ASSERT_EQ(structure_indices.size(), 1);
+    ASSERT_EQ(structure_indices[0].size(), col_slice_count);
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::move(col_ranges),
+            std::move(row_ranges),
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), col_slice_count);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities[0].size(), col_slice_count);
+    auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+            *component_manager, clause.process(std::move(structured_entities[0]))
+    );
+
+    auto [expected_segments, cols, rows] = slice_data_into_segments<TimeseriesIndex>(
+            non_string_fields_ts_index_descriptor(),
+            100000,
+            cols_per_segment,
+            std::array<timestamp, 8>{-10, -5, -4, 0, 1, 2, 3, 4},
+            std::array<int8_t, 8>{100, 101, 102, 0, 1, 2, 3, 4},
+            std::array<unsigned, 8>{1000, 2000, 3000, 0, 1, 2, 3, 4},
+            std::array<bool, 8>{true, false, true, false, true, false, true, false},
+            std::array<float, 8>{500.f, 600.f, 700.f, 0.0f, 1.f, 2.f, 3.f, 4.f},
+            std::array<timestamp, 8>{111, 222, 333, 0, 1, 2, 3, 4}
+    );
+    for (size_t i = 0; i < expected_segments.size(); ++i) {
+        ASSERT_EQ(*proc.segments_->at(i), expected_segments[i]);
+    }
+}
+
+TEST_P(MergeUpdateClauseInsertAndUpdate, InsertAfterLastRow) {
+    constexpr static int num_rows = 15;
+    constexpr static int num_cols = non_string_fields.size();
+    constexpr static int rows_per_segment = 5;
+    constexpr static int cols_per_segment = 3;
+    constexpr static int col_slice_count = (num_cols + cols_per_segment - 1) / cols_per_segment;
+    constexpr static int row_slice_count = (num_rows + rows_per_segment - 1) / rows_per_segment;
+
+    const StreamDescriptor& descriptor = non_string_fields_ts_index_descriptor();
+
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            non_string_fields_ts_index_descriptor(),
+            rows_per_segment,
+            cols_per_segment,
+            iota_view(timestamp{10}, timestamp{10 + num_rows}),
+            iota_view(static_cast<int8_t>(0), static_cast<int8_t>(num_rows)),
+            iota_view(static_cast<unsigned>(0), static_cast<unsigned>(num_rows)),
+            iota_view(0, num_rows) | views::transform([](auto x) -> bool { return x % 2 == 1; }),
+            iota_view(0, num_rows) | views::transform([](auto x) { return static_cast<float>(x); }),
+            iota_view(timestamp{0}, timestamp{num_rows})
+    );
+
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(descriptor, segments, col_ranges, row_ranges);
+    auto component_manager = std::make_shared<ComponentManager>();
+
+    auto [input_frame, input_frame_data_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            descriptor,
+            std::array<timestamp, 3>{100, 101, 102},
+            std::array<int8_t, 3>{100, 101, 102},
+            std::array<unsigned, 3>{1000, 2000, 3000},
+            std::array<bool, 3>{true, false, true},
+            std::array<float, 3>{500.f, 600.f, 700.f},
+            std::array<timestamp, 3>{111, 222, 333}
+    );
+    MergeUpdateClause clause = create_clause(GetParam(), component_manager, std::move(input_frame));
+
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    // Inserting in the beginning of the DataFrame picks the first row slice
+    ASSERT_EQ(structure_indices.size(), 1);
+    ASSERT_EQ(structure_indices[0].size(), col_slice_count);
+
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), col_slice_count);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities[0].size(), col_slice_count);
+    auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+            *component_manager, clause.process(std::move(structured_entities[0]))
+    );
+
+    auto [new_data_segments, cols, rows] = slice_data_into_segments<TimeseriesIndex>(
+            non_string_fields_ts_index_descriptor(),
+            100000,
+            cols_per_segment,
+            std::array<timestamp, 3>{100, 101, 102},
+            std::array<int8_t, 3>{100, 101, 102},
+            std::array<unsigned, 3>{1000, 2000, 3000},
+            std::array<bool, 3>{true, false, true},
+            std::array<float, 3>{500.f, 600.f, 700.f},
+            std::array<timestamp, 3>{111, 222, 333}
+    );
+    sort_by_rowslice(row_ranges, col_ranges, segments);
+    std::span last_row_slice{segments.begin() + (row_slice_count - 1) * col_slice_count, segments.end()};
+    ASSERT_EQ(last_row_slice.size(), new_data_segments.size());
+    for (size_t i = 0; i < new_data_segments.size(); ++i) {
+        last_row_slice[i].append(new_data_segments[i]);
+        ASSERT_EQ(last_row_slice[i], *(*proc.segments_)[i]);
+    }
+}
+
+TEST_P(MergeUpdateClauseInsertAndUpdate, SourceDataEndsBeforeLastSegment) {
+    constexpr static std::array fields{FieldRef({DataType::UINT64, Dimension::Dim0}, "a")};
+    constexpr static size_t rows_per_segment = 5;
+    constexpr static size_t cols_per_segment = 127;
+    constexpr static size_t num_rows = 27;
+    constexpr static size_t num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            iota_view{timestamp{0}, timestamp{num_rows}} | views::transform([](const timestamp x) { return x * 2; }),
+            iota_view{size_t{0}, num_rows}
+    );
+    // Will insert in segments 0, 2, 3
+    // Segments 1, 4, 5 are not processed
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, 3>{1, 21, 33}, std::array<size_t, 3>{100, 200, 300}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    auto component_manager = std::make_shared<ComponentManager>();
+    MergeUpdateClause clause = create_clause(GetParam(), component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_EQ(structure_indices.size(), 3);
+    ASSERT_TRUE(std::ranges::all_of(structure_indices, [](const auto& indices) { return indices.size() == 1; }));
+
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 3);
+    ASSERT_TRUE(std::ranges::all_of(structured_entities, [](const auto& entts) { return entts.size() == 1; }));
+    constexpr static std::array expected_row_ranges = {RowRange{0, 5}, RowRange{10, 15}, RowRange{15, 20}};
+    constexpr static std::array expected_col_ranges = {ColRange{1, 2}, ColRange{1, 2}, ColRange{1, 2}};
+    const std::array expected_segments = {
+            create_dense_segment(
+                    desc, std::array<timestamp, 6>{0, 1, 2, 4, 6, 8}, std::array<size_t, 6>{0, 100, 1, 2, 3, 4}
+            ),
+            create_dense_segment(
+                    desc,
+                    std::array<timestamp, 6>{20, 21, 22, 24, 26, 28},
+                    std::array<size_t, 6>{10, 200, 11, 12, 13, 14}
+            ),
+            create_dense_segment(
+                    desc,
+                    std::array<timestamp, 6>{30, 32, 33, 34, 36, 38},
+                    std::array<size_t, 6>{15, 16, 300, 17, 18, 19}
+            ),
+    };
+    std::array<ProcessingUnit, 3> processing_units;
+    for (size_t i = 0; i < structured_entities.size(); ++i) {
+        processing_units[i] =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[i]))
+                );
+        ASSERT_EQ(processing_units[i].segments_->size(), 1);
+        ASSERT_EQ(processing_units[i].row_ranges_->size(), 1);
+        ASSERT_EQ(processing_units[i].col_ranges_->size(), 1);
+        ASSERT_EQ(*(processing_units[i].row_ranges_->front()), expected_row_ranges[i]);
+        ASSERT_EQ(*(processing_units[i].col_ranges_->front()), expected_col_ranges[i]);
+        ASSERT_EQ(*(processing_units[i].segments_->front()), expected_segments[i]);
+    }
+}
+
+TEST_P(MergeUpdateClauseInsertAndUpdate, SourceDataStartsAfterTheFirstSegment) {
+    constexpr static std::array fields{FieldRef({DataType::UINT64, Dimension::Dim0}, "a")};
+    constexpr static size_t rows_per_segment = 5;
+    constexpr static size_t cols_per_segment = 127;
+    constexpr static size_t num_rows = 27;
+    constexpr static size_t num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            iota_view{timestamp{0}, timestamp{num_rows}} | views::transform([](const timestamp x) { return x * 2; }),
+            iota_view{size_t{0}, num_rows}
+    );
+    // Will insert in segments 2, 3
+    // Segments 0, 1, 4, 5 are not processed
+    constexpr static size_t input_frame_rows = 2;
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, input_frame_rows>{21, 33}, std::array<size_t, input_frame_rows>{100, 200}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    auto component_manager = std::make_shared<ComponentManager>();
+    MergeUpdateClause clause = create_clause(GetParam(), component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    constexpr static size_t expected_segments_to_process = 2;
+    ASSERT_EQ(structure_indices.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structure_indices, [](const auto& indices) { return indices.size() == 1; }));
+
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structured_entities, [](const auto& entts) { return entts.size() == 1; }));
+    constexpr static std::array expected_row_ranges = {RowRange{10, 15}, RowRange{15, 20}};
+    constexpr static std::array expected_col_ranges = {ColRange{1, 2}, ColRange{1, 2}};
+    const std::array expected_segments = {
+            create_dense_segment(
+                    desc,
+                    std::array<timestamp, 6>{20, 21, 22, 24, 26, 28},
+                    std::array<size_t, 6>{10, 100, 11, 12, 13, 14}
+            ),
+            create_dense_segment(
+                    desc,
+                    std::array<timestamp, 6>{30, 32, 33, 34, 36, 38},
+                    std::array<size_t, 6>{15, 16, 200, 17, 18, 19}
+            ),
+    };
+    std::array<ProcessingUnit, expected_segments_to_process> processing_units;
+    for (size_t i = 0; i < structured_entities.size(); ++i) {
+        processing_units[i] =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[i]))
+                );
+        ASSERT_EQ(processing_units[i].segments_->size(), 1);
+        ASSERT_EQ(processing_units[i].row_ranges_->size(), 1);
+        ASSERT_EQ(processing_units[i].col_ranges_->size(), 1);
+        ASSERT_EQ(*(processing_units[i].row_ranges_->front()), expected_row_ranges[i]);
+        ASSERT_EQ(*(processing_units[i].col_ranges_->front()), expected_col_ranges[i]);
+        ASSERT_EQ(*(processing_units[i].segments_->front()), expected_segments[i]);
+    }
+}
+
+TEST_P(MergeUpdateClauseInsertAndUpdate, SkipExpandedSegmentsInsertAtEnd) {
+    constexpr static std::array fields{FieldRef({DataType::UINT64, Dimension::Dim0}, "a")};
+    constexpr static size_t rows_per_segment = 5;
+    constexpr static size_t cols_per_segment = 127;
+    constexpr static size_t num_rows = 27;
+    constexpr static size_t num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            std::array<timestamp, num_rows>{0,  1,  2,  3,  4,  10, 11, 12, 13, 14, 20, 21, 22, 23,
+                                            24, 30, 31, 32, 33, 34, 40, 41, 42, 43, 44, 50, 51},
+            iota_view{size_t{0}, num_rows}
+    );
+    constexpr static size_t input_frame_rows = 3;
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, input_frame_rows>{35, 47}, std::array<size_t, input_frame_rows>{100, 200}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    auto component_manager = std::make_shared<ComponentManager>();
+    MergeUpdateClause clause = create_clause(GetParam(), component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    constexpr static size_t expected_segments_to_process = 2;
+    ASSERT_EQ(structure_indices.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structure_indices, [](const auto& indices) { return indices.size() == 1; }));
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structured_entities, [](const auto& entts) { return entts.size() == 1; }));
+    constexpr static std::array expected_row_ranges = {RowRange{15, 20}, RowRange{20, 25}};
+    constexpr static std::array expected_col_ranges = {ColRange{1, 2}, ColRange{1, 2}};
+    const std::array expected_segments = {
+            create_dense_segment(
+                    desc,
+                    std::array<timestamp, 6>{30, 31, 32, 33, 34, 35},
+                    std::array<size_t, 6>{15, 16, 17, 18, 19, 100}
+            ),
+            create_dense_segment(
+                    desc,
+                    std::array<timestamp, 7>{40, 41, 42, 43, 44, 47},
+                    std::array<size_t, 7>{20, 21, 22, 23, 24, 200}
+            ),
+    };
+    for (size_t i = 0; i < structured_entities.size(); ++i) {
+        const ProcessingUnit& processing_unit =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[i]))
+                );
+        ASSERT_EQ(processing_unit.segments_->size(), 1);
+        ASSERT_EQ(processing_unit.row_ranges_->size(), 1);
+        ASSERT_EQ(processing_unit.col_ranges_->size(), 1);
+        ASSERT_EQ(*(processing_unit.row_ranges_->front()), expected_row_ranges[i]);
+        ASSERT_EQ(*(processing_unit.col_ranges_->front()), expected_col_ranges[i]);
+        ASSERT_EQ(*(processing_unit.segments_->front()), expected_segments[i]);
+    }
+}
+
+TEST_P(MergeUpdateClauseInsertAndUpdate, SkipExpandedSegmentsInsertInMiddle) {
+    constexpr static std::array fields{FieldRef({DataType::UINT64, Dimension::Dim0}, "a")};
+    constexpr static size_t rows_per_segment = 5;
+    constexpr static size_t cols_per_segment = 127;
+    constexpr static size_t num_rows = 27;
+    constexpr static size_t num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            iota_view{timestamp{0}, timestamp{num_rows}} | views::transform([](const timestamp x) { return x * 5; }),
+            iota_view{size_t{0}, num_rows}
+    );
+    constexpr static size_t input_frame_rows = 1;
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, input_frame_rows>{87}, std::array<size_t, input_frame_rows>{100}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    ASSERT_EQ(ranges_and_keys.size(), num_row_slices);
+    auto component_manager = std::make_shared<ComponentManager>();
+    MergeUpdateClause clause = create_clause(GetParam(), component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    constexpr static size_t expected_segments_to_process = 1;
+    ASSERT_EQ(structure_indices.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structure_indices, [](const auto& indices) { return indices.size() == 1; }));
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structured_entities, [](const auto& entts) { return entts.size() == 1; }));
+    constexpr static RowRange expected_row_range{15, 20};
+    constexpr static ColRange expected_col_range{1, 2};
+    const SegmentInMemory expected_segment = create_dense_segment(
+            desc, std::array<timestamp, 6>{75, 80, 85, 87, 90, 95}, std::array<size_t, 6>{15, 16, 17, 100, 18, 19}
+    );
+    const ProcessingUnit& processing_unit =
+            gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                    *component_manager, clause.process(std::move(structured_entities[0]))
+            );
+    ASSERT_EQ(processing_unit.segments_->size(), 1);
+    ASSERT_EQ(processing_unit.row_ranges_->size(), 1);
+    ASSERT_EQ(processing_unit.col_ranges_->size(), 1);
+    ASSERT_EQ(*(processing_unit.row_ranges_->front()), expected_row_range);
+    ASSERT_EQ(*(processing_unit.col_ranges_->front()), expected_col_range);
+    ASSERT_EQ(*(processing_unit.segments_->front()), expected_segment);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        MergeUpdateClauseInsertAndUpdate, MergeUpdateClauseInsertAndUpdate,
+        testing::Values(
+                MergeStrategy{.not_matched_by_target = MergeAction::INSERT},
+                MergeStrategy{.matched = MergeAction::UPDATE, .not_matched_by_target = MergeAction::INSERT}
+        )
+);
+
+struct MergeUpdateClauseUpdateOffByOne : testing::TestWithParam<std::tuple<MergeStrategy, unsigned, int>> {
+    enum { UPDATE_SECOND_TO_LAST = -2, UPDATE_LAST = -1, UPDATE_FIRST = 0, UPDATE_SECOND = 1 };
+    static MergeStrategy strategy() { return std::get<0>(GetParam()); }
+    static unsigned segment_to_update() { return std::get<1>(GetParam()); }
+    static int row_in_segment_to_update() { return std::get<2>(GetParam()); }
+};
+
+/// Tests updating at the edges of row slices with all strategies allowing updates.
+/// Input data consists of 6 segments. For each row slice test updating the first, second, second to last, and last row.
+TEST_P(MergeUpdateClauseUpdateOffByOne, UpdateOffByOne) {
+    constexpr static std::array fields{
+            FieldRef{{DataType::INT64, Dimension::Dim0}, "a"}, FieldRef{{DataType::INT32, Dimension::Dim0}, "b"}
+    };
+    constexpr static int index_step = 5;
+    constexpr static int rows_per_segment = 5;
+    constexpr static int cols_per_segment = 1;
+    constexpr static int num_rows = 27;
+    constexpr static int num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const int row_within_segment = (rows_per_segment + row_in_segment_to_update()) % rows_per_segment;
+    const int row_to_update =
+            segment_to_update() * rows_per_segment + (rows_per_segment + row_in_segment_to_update()) % rows_per_segment;
+    if (row_to_update >= num_rows) {
+        GTEST_SKIP();
+    }
+    const timestamp index_value_to_update{row_to_update * index_step};
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            iota_view{timestamp{0}, timestamp{num_rows}} |
+                    views::transform([](const timestamp x) { return timestamp{x * index_step}; }),
+            iota_view{int64_t{0}, int64_t{num_rows}},
+            iota_view{0, int{num_rows}}
+    );
+    ASSERT_EQ(segments.size(), 12);
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array{index_value_to_update}, std::array{int64_t{100}}, std::array{200}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    ASSERT_EQ(ranges_and_keys.size(), 12);
+    auto component_manager = std::make_shared<ComponentManager>();
+    MergeUpdateClause clause = create_clause(strategy(), component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    constexpr static size_t expected_segments_to_process = 1;
+    ASSERT_EQ(structure_indices.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structure_indices, [](const auto& indices) { return indices.size() == 2; }));
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), expected_segments_to_process);
+    ASSERT_TRUE(std::ranges::all_of(structured_entities, [](const auto& entts) { return entts.size() == 2; }));
+    const RowRange row_range{
+            segment_to_update() * rows_per_segment,
+            std::min(segment_to_update() * rows_per_segment + rows_per_segment, unsigned{num_rows})
+    };
+    const std::array expected_row_ranges{row_range, row_range};
+    constexpr static std::array expected_col_ranges{ColRange{1, 2}, ColRange{2, 3}};
+    const ProcessingUnit& processing_unit =
+            gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                    *component_manager, clause.process(std::move(structured_entities[0]))
+            );
+    ASSERT_EQ(processing_unit.segments_->size(), 2);
+    ASSERT_TRUE(std::ranges::equal(
+            *processing_unit.row_ranges_,
+            expected_row_ranges,
+            [](const std::shared_ptr<RowRange>& left, const RowRange& right) { return *left == right; }
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            *processing_unit.col_ranges_,
+            expected_col_ranges,
+            [](const std::shared_ptr<ColRange>& left, const ColRange& right) { return *left == right; }
+    ));
+    std::vector<int64_t> expected_values_a(row_range.diff());
+    std::iota(expected_values_a.begin(), expected_values_a.end(), row_range.start());
+    expected_values_a[row_within_segment] = 100;
+
+    std::vector<int32_t> expected_values_b(row_range.diff());
+    std::iota(expected_values_b.begin(), expected_values_b.end(), row_range.start());
+    expected_values_b[row_within_segment] = 200;
+
+    auto [expected_segments, _cols, _rows] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            iota_view{row_range.start(), row_range.end()} |
+                    views::transform([](const timestamp x) -> timestamp { return x * index_step; }),
+            std::move(expected_values_a),
+            std::move(expected_values_b)
+    );
+    ASSERT_EQ(expected_segments.size(), 2);
+    for (size_t i = 0; i < expected_segments.size(); ++i) {
+        ASSERT_EQ(*(processing_unit.segments_->at(i)), expected_segments[i]);
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        MergeUpdateClauseUpdateOffByOne, MergeUpdateClauseUpdateOffByOne,
+        testing::Combine(
+                testing::Values(
+                        MergeStrategy{.matched = MergeAction::UPDATE, .not_matched_by_target = MergeAction::DO_NOTHING},
+                        MergeStrategy{.matched = MergeAction::UPDATE, .not_matched_by_target = MergeAction::INSERT}
+                ),
+                testing::Range(0u, 6u),
+                testing::Values(
+                        MergeUpdateClauseUpdateOffByOne::UPDATE_SECOND_TO_LAST,
+                        MergeUpdateClauseUpdateOffByOne::UPDATE_LAST, MergeUpdateClauseUpdateOffByOne::UPDATE_FIRST,
+                        MergeUpdateClauseUpdateOffByOne::UPDATE_SECOND
+                )
+        )
+);
+TEST(MergeUpdateInsertIndexSpansMultipleSegments, LastIndexValueSameAsNextSegmentFirstTwoOverlapingSegments) {
+    constexpr static std::array fields{
+            FieldRef{{DataType::INT64, Dimension::Dim0}, "a"}, FieldRef{{DataType::INT32, Dimension::Dim0}, "b"}
+    };
+    constexpr static int rows_per_segment = 5;
+    constexpr static int cols_per_segment = 1;
+    constexpr static int num_rows = 27;
+    constexpr static int num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    // Assuming segment indexing starts from 0, segment 1 ends with 9 and segment 2 starts with 9
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            std::array<timestamp, num_rows>{1,  2,  3,  4,  5,  6,  7,  8,  9,  9,  9,  9,  10, 11,
+                                            12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24},
+            iota_view{int64_t{0}, int64_t{num_rows}},
+            iota_view{0, int{num_rows}}
+    );
+    ASSERT_EQ(segments.size(), 12);
+    // Will be inserted in segment 2
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, 3>{9, 9, 9}, std::array<int64_t, 3>{10, 8, 120}, std::array{100, 200, 300}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    ASSERT_EQ(ranges_and_keys.size(), 12);
+    auto component_manager = std::make_shared<ComponentManager>();
+    constexpr static MergeStrategy strategy{
+            .matched = MergeAction::UPDATE, .not_matched_by_target = MergeAction::INSERT
+    };
+    MergeUpdateClause clause = create_clause(strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_EQ(structure_indices.size(), 2);
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 2);
+
+    {
+        ASSERT_EQ(structure_indices[0].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{RowRange{5, 10}, RowRange{5, 10}, RowRange{10, 15}, RowRange{10, 15}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{TimestampRange{6, 10}, TimestampRange{6, 10}, TimestampRange{9, 13}, TimestampRange{9, 13}}
+        ));
+
+        ASSERT_EQ(entities.size(), 4);
+        ASSERT_EQ(structured_entities[0].size(), 4);
+        const ProcessingUnit& processing_unit =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[0]))
+                );
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(processing_unit.row_ranges_->size(), 2);
+        ASSERT_EQ(processing_unit.col_ranges_->size(), 2);
+        auto [expected_segments, _c, _r] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                std::numeric_limits<size_t>::max(),
+                cols_per_segment,
+                std::array<timestamp, 8>{6, 7, 8, 9, 9, 9, 9, 9},
+                std::array<int64_t, 8>{5, 6, 7, 8, 9, 10, 11, 120},
+                std::array{5, 6, 7, 200, 9, 100, 11, 300}
+        );
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+    }
+    {
+        ASSERT_EQ(structure_indices[1].size(), 2);
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{RowRange{10, 15}, RowRange{10, 15}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{ColRange{1, 2}, ColRange{2, 3}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{TimestampRange{9, 13}, TimestampRange{9, 13}}
+        ));
+        ASSERT_EQ(structured_entities[1].size(), 2);
+        const ProcessingUnit& processing_unit =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[1]))
+                );
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(processing_unit.row_ranges_->size(), 2);
+        ASSERT_EQ(processing_unit.col_ranges_->size(), 2);
+        auto [expected_segments, _c, _r] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                std::numeric_limits<size_t>::max(),
+                cols_per_segment,
+                std::array<timestamp, 3>{10, 11, 12},
+                std::array<int64_t, 3>{12, 13, 14},
+                std::array{12, 13, 14}
+        );
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+    }
+}
+
+TEST(MergeUpdateInsertIndexSpansMultipleSegments, LastIndexValueSameAsNextSegmentFirstThreeOverlappingSegments) {
+    constexpr static std::array fields{
+            FieldRef{{DataType::INT64, Dimension::Dim0}, "a"}, FieldRef{{DataType::INT32, Dimension::Dim0}, "b"}
+    };
+    constexpr static int rows_per_segment = 5;
+    constexpr static int cols_per_segment = 1;
+    constexpr static int num_rows = 27;
+    constexpr static int num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    // Assuming segment indexing starts from 0, segment 1 ends with 9 and segment 2 starts with 9
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            std::array<timestamp, num_rows>{1, 2, 3, 4,  5,  6,  7,  8,  9,  9,  9,  9,  9, 9,
+                                            9, 9, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19},
+            iota_view{int64_t{0}, int64_t{num_rows}},
+            iota_view{0, int{num_rows}}
+    );
+    ASSERT_EQ(segments.size(), 12);
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc,
+            std::array<timestamp, 7>{8, 9, 9, 9, 9, 10, 11},
+            std::array<int64_t, 7>{100, 10, 8, 120, 15, 17, 100},
+            std::array{100, 200, 300, 400, 500, 600, 700}
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    ASSERT_EQ(ranges_and_keys.size(), 12);
+    auto component_manager = std::make_shared<ComponentManager>();
+    constexpr static MergeStrategy strategy{
+            .matched = MergeAction::UPDATE, .not_matched_by_target = MergeAction::INSERT
+    };
+    MergeUpdateClause clause = create_clause(strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_EQ(structure_indices.size(), 2);
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 6);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 2);
+
+    {
+        ASSERT_EQ(structure_indices[0].size(), 6);
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{
+                        RowRange{5, 10},
+                        RowRange{5, 10},
+                        RowRange{10, 15},
+                        RowRange{10, 15},
+                        RowRange{15, 20},
+                        RowRange{15, 20}
+                }
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{
+                        ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}
+                }
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{
+                        TimestampRange{6, 10},
+                        TimestampRange{6, 10},
+                        TimestampRange{9, 10},
+                        TimestampRange{9, 10},
+                        TimestampRange{9, 13},
+                        TimestampRange{9, 13}
+                }
+        ));
+
+        ASSERT_EQ(structured_entities[0].size(), 6);
+        const ProcessingUnit& processing_unit =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[0]))
+                );
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(processing_unit.row_ranges_->size(), 2);
+        ASSERT_EQ(processing_unit.col_ranges_->size(), 2);
+        const auto expected = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                std::numeric_limits<size_t>::max(), // Slicing is not implemented for insertion
+                cols_per_segment,
+                std::array<timestamp, 14>{6, 7, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
+                std::array<int64_t, 14>{5, 6, 7, 100, 8, 9, 10, 11, 12, 13, 14, 15, 16, 120},
+                std::array{5, 6, 7, 100, 300, 9, 200, 11, 12, 13, 14, 500, 16, 400}
+        );
+        for (size_t i = 0; i < std::get<0>(expected).size(); ++i) {
+            ASSERT_EQ(*(processing_unit.segments_->at(i)), std::get<0>(expected)[i]);
+        }
+    }
+    {
+        ASSERT_EQ(structure_indices[1].size(), 2);
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{RowRange{15, 20}, RowRange{15, 20}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{ColRange{1, 2}, ColRange{2, 3}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{TimestampRange{9, 13}, TimestampRange{9, 13}}
+        ));
+
+        const ProcessingUnit& processing_unit =
+                gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+                        *component_manager, clause.process(std::move(structured_entities[1]))
+                );
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(processing_unit.row_ranges_->size(), 2);
+        ASSERT_EQ(processing_unit.col_ranges_->size(), 2);
+        const auto expected = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                std::numeric_limits<size_t>::max(), // Slicing is not implemented for insertion
+                cols_per_segment,
+                std::array<timestamp, 4>{10, 11, 11, 12},
+                std::array<int64_t, 4>{17, 18, 100, 19},
+                std::array{600, 18, 700, 19}
+        );
+        for (size_t i = 0; i < std::get<0>(expected).size(); ++i) {
+            ASSERT_EQ(*(processing_unit.segments_->at(i)), std::get<0>(expected)[i]);
+        }
+    }
+}
+
+TEST(MergeUpdateInsertIndexSpansMultipleSegments, TwoGroupsOfSegmentsWithMatchingLastIndexValue) {
+    constexpr static std::array fields{
+            FieldRef{{DataType::INT64, Dimension::Dim0}, "a"}, FieldRef{{DataType::INT32, Dimension::Dim0}, "b"}
+    };
+    constexpr static int rows_per_segment = 5;
+    constexpr static int cols_per_segment = 1;
+    constexpr static int num_rows = 27;
+    constexpr static int num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    ASSERT_EQ(num_row_slices, 6);
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    // [1, 2, 3, 4, 5],      -> [1;6)
+    // [6, 7, 8, 9, 9],      -> [6;10)
+    // [9, 9, 9, 9, 9],      -> [9;10)
+    // [9, 9, 10, 10, 10],   -> [9;11)
+    // [10, 10, 10, 11, 12], -> [10;13)
+    // [13, 14]              -> [13;15)
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            rows_per_segment,
+            cols_per_segment,
+            std::array<timestamp, num_rows>{1, 2, 3, 4,  5,  6,  7,  8,  9,  9,  9,  9,  9, 9,
+                                            9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 12, 13, 14},
+            iota_view{int64_t{0}, int64_t{num_rows}},
+            iota_view{0, int{num_rows}}
+    );
+    ASSERT_EQ(segments.size(), 12);
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc,
+            std::array<timestamp, 15>{8, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 11, 11, 13},
+            std::array<int64_t, 15>{100, 11, 16, 13, 100, 8, 200, 19, 100, 17, 20, 300, 400, 23, 500},
+            iota_view{0, 15} | std::views::transform([](const auto x) { return x * 100; })
+    );
+    std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    ASSERT_EQ(ranges_and_keys.size(), 12);
+    auto component_manager = std::make_shared<ComponentManager>();
+    constexpr static MergeStrategy strategy{
+            .matched = MergeAction::UPDATE, .not_matched_by_target = MergeAction::INSERT
+    };
+    MergeUpdateClause clause = create_clause(strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_EQ(structure_indices.size(), 4);
+
+    std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 10);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 4);
+
+    {
+        ASSERT_EQ(structure_indices[0].size(), 6);
+        ASSERT_TRUE(std::ranges::equal(structure_indices[0], std::array{0, 1, 2, 3, 4, 5}));
+        ASSERT_EQ(structured_entities[0].size(), 6);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::array{1, 1, 1, 1, 2, 2}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{
+                        RowRange{5, 10},
+                        RowRange{5, 10},
+                        RowRange{10, 15},
+                        RowRange{10, 15},
+                        RowRange{15, 20},
+                        RowRange{15, 20}
+
+                }
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{
+                        ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}
+                }
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[0] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{
+                        TimestampRange{6, 10},
+                        TimestampRange{6, 10},
+                        TimestampRange{9, 10},
+                        TimestampRange{9, 10},
+                        TimestampRange{9, 11},
+                        TimestampRange{9, 11}
+                }
+        ));
+        const ProcessingUnit& processing_unit = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured_entities[0])));
+        auto [expected_segments, _c, _r] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 15>{6, 7, 8, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9},
+                std::array<int64_t, 15>{5, 6, 7, 100, 8, 9, 10, 11, 12, 13, 14, 15, 16, 100, 200},
+                std::array{5, 6, 7, 0, 500, 9, 10, 100, 12, 300, 14, 15, 200, 400, 600}
+        );
+        ASSERT_EQ(processing_unit.segments_->size(), expected_segments.size());
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+    }
+    {
+        ASSERT_EQ(structure_indices[1].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(structure_indices[1], std::array{4, 5, 6, 7}));
+        ASSERT_EQ(structured_entities[1].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::array{2, 2, 2, 2}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{RowRange{15, 20}, RowRange{15, 20}, RowRange{20, 25}, RowRange{20, 25}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[1] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{TimestampRange{9, 11}, TimestampRange{9, 11}, TimestampRange{10, 13}, TimestampRange{10, 13}}
+        ));
+        const ProcessingUnit& processing_unit = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured_entities[1])));
+        auto [expected_segments, _c, _r] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 8>{10, 10, 10, 10, 10, 10, 10, 10},
+                std::array<int64_t, 8>{17, 18, 19, 20, 21, 22, 100, 300},
+                std::array{900, 18, 700, 1000, 21, 22, 800, 1100}
+        );
+        ASSERT_EQ(processing_unit.segments_->size(), expected_segments.size());
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+    }
+    {
+        ASSERT_EQ(structure_indices[2].size(), 2);
+        ASSERT_TRUE(std::ranges::equal(structure_indices[2], std::array{6, 7}));
+        ASSERT_EQ(structured_entities[2].size(), 2);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[2])), std::array{2, 2}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[2] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{RowRange{20, 25}, RowRange{20, 25}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[2] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{ColRange{1, 2}, ColRange{2, 3}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[2] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{TimestampRange{10, 13}, TimestampRange{10, 13}}
+        ));
+        const ProcessingUnit& processing_unit = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured_entities[2])));
+        auto [expected_segments, _c, _r] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 3>{11, 11, 12},
+                std::array<int64_t, 3>{23, 400, 24},
+                std::array{1300, 1200, 24}
+        );
+        ASSERT_EQ(processing_unit.segments_->size(), expected_segments.size());
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+    }
+    {
+        ASSERT_EQ(structure_indices[3].size(), 2);
+        ASSERT_TRUE(std::ranges::equal(structure_indices[3], std::array{8, 9}));
+        ASSERT_EQ(structured_entities[3].size(), 2);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[3])), std::array{1, 1}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[3] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].row_range(); }),
+                std::array{RowRange{25, 27}, RowRange{25, 27}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[3] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].col_range(); }),
+                std::array{ColRange{1, 2}, ColRange{2, 3}}
+        ));
+        ASSERT_TRUE(std::ranges::equal(
+                structure_indices[3] |
+                        std::views::transform([&](const size_t idx) { return ranges_and_keys[idx].key_.time_range(); }),
+                std::array{TimestampRange{13, 15}, TimestampRange{13, 15}}
+        ));
+        const ProcessingUnit& processing_unit = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured_entities[3])));
+        auto [expected_segments, _c, _r] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 3>{13, 13, 14},
+                std::array<int64_t, 3>{25, 500, 26},
+                std::array{25, 1400, 26}
+        );
+        ASSERT_EQ(processing_unit.segments_->size(), expected_segments.size());
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+    }
+}
+
+struct MergeUpdateInsertIndexSpansMultipleSegmentsChain : testing::Test {
+    MergeUpdateInsertIndexSpansMultipleSegmentsChain() {
+        std::tie(segments, col_ranges, row_ranges) = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                rows_per_segment,
+                cols_per_segment,
+                std::array<timestamp, num_rows>{0,  1,  2,  4,  5,  6,  6,  6,  6,  6, 10,
+                                                11, 11, 13, 15, 15, 16, 17, 17, 19, 20},
+                iota_view{int64_t{0}, int64_t{num_rows}},
+                iota_view{0, int{num_rows}}
+        );
+        ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    }
+
+    void assert_processing_result(
+            const MergeUpdateClause& clause, std::vector<EntityId>&& entities,
+            const std::span<const SegmentInMemory> expected_segments, const std::span<const RowRange> row_ranges
+    ) const {
+        const ProcessingUnit& processing_unit = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(entities)));
+        ASSERT_EQ(processing_unit.segments_->size(), expected_segments.size());
+        ASSERT_EQ(processing_unit.segments_->size(), 2);
+        ASSERT_EQ(*processing_unit.segments_->at(0), expected_segments[0]);
+        ASSERT_EQ(*processing_unit.segments_->at(1), expected_segments[1]);
+        ASSERT_TRUE(std::ranges::equal(
+                (*processing_unit.row_ranges_) | std::views::transform([](const auto& rr) { return *rr; }), row_ranges
+        ));
+    }
+
+    constexpr static int rows_per_segment = 3;
+    constexpr static int cols_per_segment = 1;
+    constexpr static int num_rows = 21;
+    constexpr static int num_row_slices = (num_rows + rows_per_segment - 1) / rows_per_segment;
+    static_assert(num_row_slices == 7, "Number of row slices should be 7");
+    constexpr static std::array fields{
+            FieldRef{{DataType::INT64, Dimension::Dim0}, "a"},
+            FieldRef{{DataType::INT32, Dimension::Dim0}, "b"}
+    };
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor("TestStream", fields);
+    std::shared_ptr<ComponentManager> component_manager = std::make_shared<ComponentManager>();
+    std::vector<SegmentInMemory> segments;
+    std::vector<RowRange> row_ranges;
+    std::vector<ColRange> col_ranges;
+    std::vector<RangesAndKey> ranges_and_keys;
+};
+
+TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice0) {
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, 2>{0, 2}, std::array<int64_t, 2>{0, 10}, std::array{100, 200}
+    );
+    MergeUpdateClause clause =
+            create_clause(update_and_insert_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(structure_indices, std::vector<std::vector<size_t>>{{0, 1}}));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.row_range(); }),
+            std::array{RowRange{0, 3}, RowRange{0, 3}}
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.col_range(); }),
+            std::array{ColRange{1, 2}, ColRange{2, 3}}
+    ));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 2);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities[0].size(), 2);
+    ASSERT_TRUE(std::ranges::equal(
+            std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])), std::array{1, 1}
+    ));
+    auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            100'000,
+            cols_per_segment,
+            std::array<timestamp, 4>{0, 1, 2, 2},
+            std::array<int64_t, 4>{0, 1, 2, 10},
+            std::array{100, 1, 2, 200}
+    );
+    constexpr static std::array expected_row_ranges{RowRange{0, 3}, RowRange{0, 3}};
+    assert_processing_result(clause, std::move(structured_entities[0]), expected_segments, expected_row_ranges);
+}
+
+// Even when the source value does not span multiple segments structure by processing will structure by time slice and
+// load all segments in the time slice of the segment containing the value. This is because the strategy for slicing is
+// selected globally based on the merge strategy. It can be refined so that structure by time slice is used only on
+// subset of the segments, though this will result in more complicated logic for the structuring and processing.
+// Related to Monday 12379148034
+TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice1ValueIsNotInMultipleSegments) {
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array{timestamp{5}}, std::array{int64_t{4}}, std::array{100}
+    );
+    MergeUpdateClause clause =
+            create_clause(update_and_insert_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(structure_indices, std::vector<std::vector<size_t>>{{0, 1, 2, 3, 4, 5}}));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.row_range(); }),
+            std::array{RowRange{3, 6}, RowRange{3, 6}, RowRange{6, 9}, RowRange{6, 9}, RowRange{9, 12}, RowRange{9, 12}}
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.col_range(); }),
+            std::array{ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}, ColRange{1, 2}, ColRange{2, 3}}
+    ));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 6);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities[0].size(), 6);
+    ASSERT_TRUE(std::ranges::equal(
+            std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+            std::array{1, 1, 1, 1, 1, 1}
+    ));
+    auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            100'000,
+            cols_per_segment,
+            std::array<timestamp, 9>{4, 5, 6, 6, 6, 6, 6, 10, 11},
+            std::array<int64_t, 9>{3, 4, 5, 6, 7, 8, 9, 10, 11},
+            std::array{3, 100, 5, 6, 7, 8, 9, 10, 11}
+    );
+    constexpr static std::array expected_row_ranges{RowRange{3, 12}, RowRange{3, 12}};
+    assert_processing_result(clause, std::move(structured_entities[0]), expected_segments, expected_row_ranges);
+}
+
+TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice1ValueIsInMultipleSegments) {
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc,
+            std::array<timestamp, 4>{6, 6, 6, 6},
+            std::array<int64_t, 4>{9, 5, 6, 100},
+            std::array{100, 200, 300, 400}
+    );
+    MergeUpdateClause clause =
+            create_clause(update_and_insert_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(
+            std::ranges::equal(structure_indices, std::vector<std::vector<size_t>>{{0, 1, 2, 3, 4, 5}, {4, 5, 6, 7}})
+    );
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.row_range(); }),
+            std::array{
+                    RowRange{3, 6},
+                    RowRange{3, 6},
+                    RowRange{6, 9},
+                    RowRange{6, 9},
+                    RowRange{9, 12},
+                    RowRange{9, 12},
+                    RowRange{12, 15},
+                    RowRange{12, 15}
+            }
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.col_range(); }),
+            std::array{
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3}
+            }
+    ));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 8);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 2);
+    {
+        ASSERT_EQ(structured_entities[0].size(), 6);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::array{1, 1, 1, 1, 2, 2}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 8>{4, 5, 6, 6, 6, 6, 6, 6},
+                std::array<int64_t, 8>{3, 4, 5, 6, 7, 8, 9, 100},
+                std::array{3, 4, 200, 300, 7, 8, 100, 400}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{3, 10}, RowRange{3, 10}};
+        assert_processing_result(clause, std::move(structured_entities[0]), expected_segments, expected_row_ranges);
+    }
+    {
+        ASSERT_EQ(structured_entities[1].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::array{2, 2, 1, 1}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 5>{10, 11, 11, 13, 15},
+                std::array<int64_t, 5>{10, 11, 12, 13, 14},
+                std::array{10, 11, 12, 13, 14}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{10, 15}, RowRange{10, 15}};
+        assert_processing_result(clause, std::move(structured_entities[1]), expected_segments, expected_row_ranges);
+    }
+}
+
+// This exhibits suboptimal behavior. This is because structure for processing structures by time slice and selects time
+// slices that contain the source value. In this case the source value is contained in 3 time slices and time slices can
+// overlap. So all segments for the first time slice are loaded even though there's nothing to process. Strategy for
+// fixing this is laid out in Monday 12379148034.
+// Note: In the worst case this will load 3 time slices and all segments in those time slices.
+TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice3) {
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array{timestamp{11}}, std::array{int64_t{100}}, std::array{100}
+    );
+    MergeUpdateClause clause =
+            create_clause(update_and_insert_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(
+            structure_indices, std::vector<std::vector<size_t>>{{0, 1, 2, 3, 4, 5}, {4, 5, 6, 7}, {6, 7, 8, 9}}
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.row_range(); }),
+            std::array{
+                    RowRange{3, 6},
+                    RowRange{3, 6},
+                    RowRange{6, 9},
+                    RowRange{6, 9},
+                    RowRange{9, 12},
+                    RowRange{9, 12},
+                    RowRange{12, 15},
+                    RowRange{12, 15},
+                    RowRange{15, 18},
+                    RowRange{15, 18}
+            }
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.col_range(); }),
+            std::array{
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3}
+            }
+    ));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 10);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 3);
+
+    {
+        ASSERT_EQ(structured_entities[0].size(), 6);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::array{1, 1, 1, 1, 2, 2}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 7>{4, 5, 6, 6, 6, 6, 6},
+                std::array<int64_t, 7>{3, 4, 5, 6, 7, 8, 9},
+                std::array{3, 4, 5, 6, 7, 8, 9}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{3, 10}, RowRange{3, 10}};
+        assert_processing_result(clause, std::move(structured_entities[0]), expected_segments, expected_row_ranges);
+    }
+    {
+        ASSERT_EQ(structured_entities[1].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::array{2, 2, 2, 2}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 4>{10, 11, 11, 11},
+                std::array<int64_t, 4>{10, 11, 12, 100},
+                std::array{10, 11, 12, 100}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{10, 13}, RowRange{10, 13}};
+        assert_processing_result(clause, std::move(structured_entities[1]), expected_segments, expected_row_ranges);
+    }
+    {
+        ASSERT_EQ(structured_entities[2].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[2])),
+                std::array{2, 2, 1, 1}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 5>{13, 15, 15, 16, 17},
+                std::array<int64_t, 5>{13, 14, 15, 16, 17},
+                std::array{13, 14, 15, 16, 17}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{13, 18}, RowRange{13, 18}};
+        assert_processing_result(clause, std::move(structured_entities[2]), expected_segments, expected_row_ranges);
+    }
+}
+
+TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice5) {
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array{timestamp{15}}, std::array{int64_t{100}}, std::array{100}
+    );
+    MergeUpdateClause clause =
+            create_clause(update_and_insert_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(
+            structure_indices, std::vector<std::vector<size_t>>{{0, 1, 2, 3}, {2, 3, 4, 5}, {4, 5, 6, 7}}
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.row_range(); }),
+            std::array{
+                    RowRange{9, 12},
+                    RowRange{9, 12},
+                    RowRange{12, 15},
+                    RowRange{12, 15},
+                    RowRange{15, 18},
+                    RowRange{15, 18},
+                    RowRange{18, 21},
+                    RowRange{18, 21}
+            }
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.col_range(); }),
+            std::array{
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3},
+                    ColRange{1, 2},
+                    ColRange{2, 3}
+            }
+    ));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 8);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 3);
+    {
+        ASSERT_EQ(structured_entities[0].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::array{1, 1, 2, 2}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 4>{6, 10, 11, 11},
+                std::array<int64_t, 4>{9, 10, 11, 12},
+                std::array{9, 10, 11, 12}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{9, 13}, RowRange{9, 13}};
+        assert_processing_result(clause, std::move(structured_entities[0]), expected_segments, expected_row_ranges);
+    }
+    {
+        ASSERT_EQ(structured_entities[1].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::array{2, 2, 2, 2}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 4>{13, 15, 15, 15},
+                std::array<int64_t, 4>{13, 14, 15, 100},
+                std::array{13, 14, 15, 100}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{13, 16}, RowRange{13, 16}};
+        assert_processing_result(clause, std::move(structured_entities[1]), expected_segments, expected_row_ranges);
+    }
+    {
+        ASSERT_EQ(structured_entities[2].size(), 4);
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[2])),
+                std::array{2, 2, 1, 1}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc,
+                100'000,
+                cols_per_segment,
+                std::array<timestamp, 5>{16, 17, 17, 19, 20},
+                std::array<int64_t, 5>{16, 17, 18, 19, 20},
+                std::array{16, 17, 18, 19, 20}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{16, 21}, RowRange{16, 21}};
+        assert_processing_result(clause, std::move(structured_entities[2]), expected_segments, expected_row_ranges);
+    }
+}
+
+TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain,
+       InsertInRowSlice3WithoutColumnMatchingDoesNotTriggerGroupingByTimeSlice) {
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array{timestamp{7}}, std::array{int64_t{100}}, std::array{100}
+    );
+    MergeUpdateClause clause = create_clause(update_and_insert_strategy, component_manager, std::move(input_frame));
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(structure_indices, std::vector<std::vector<size_t>>{{0, 1}}));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.row_range(); }),
+            std::array{RowRange{9, 12}, RowRange{9, 12}}
+    ));
+    ASSERT_TRUE(std::ranges::equal(
+            ranges_and_keys | std::views::transform([](const auto& rk) { return rk.col_range(); }),
+            std::array{ColRange{1, 2}, ColRange{2, 3}}
+    ));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    ASSERT_EQ(entities.size(), 2);
+    std::vector<std::vector<EntityId>> structured_entities = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured_entities.size(), 1);
+    ASSERT_EQ(structured_entities[0].size(), 2);
+    ASSERT_TRUE(std::ranges::equal(
+            std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])), std::array{1, 1}
+    ));
+    auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            100'000,
+            cols_per_segment,
+            std::array<timestamp, 4>{6, 7, 10, 11},
+            std::array<int64_t, 4>{9, 100, 10, 11},
+            std::array{9, 100, 10, 11}
+    );
+    constexpr static std::array expected_row_ranges{RowRange{9, 12}, RowRange{9, 12}};
+    assert_processing_result(clause, std::move(structured_entities[0]), expected_segments, expected_row_ranges);
+}
+TEST(MergeUpdateInsertBackSharedGroup, InsertsIntoBackSharedMiddleGroup) {
+    auto component_manager = std::make_shared<ComponentManager>();
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor(
+            "s", std::array{FieldRef{{DataType::INT64, Dimension::Dim0}, "a"}}
+    );
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            2,
+            1,
+            std::array<timestamp, 8>{10, 20, 20, 30, 30, 40, 40, 50},
+            std::array<int64_t, 8>{0, 1, 2, 3, 4, 5, 6, 7}
+    );
+    auto ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
+            desc, std::array<timestamp, 3>{15, 25, 35}, std::array<int64_t, 3>{1000, 1001, 1002}
+    );
+    MergeUpdateClause clause =
+            create_clause(update_and_insert_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(structure_indices, std::vector<std::vector<size_t>>{{0, 1}, {1, 2}, {2, 3}}));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured.size(), 3);
+    {
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc, 100'000, 1, std::array<timestamp, 4>{10, 15, 20, 20}, std::array<int64_t, 4>{0, 1000, 1, 2}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{0, 3}};
+        const ProcessingUnit proc = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured[0])));
+        ASSERT_EQ(proc.segments_->size(), 1);
+        EXPECT_EQ(*proc.segments_->at(0), expected_segments[0]);
+        ASSERT_TRUE(std::ranges::equal(
+                (*proc.row_ranges_) | std::views::transform([](const auto& rr) { return *rr; }), expected_row_ranges
+        ));
+    }
+    {
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc, 100'000, 1, std::array<timestamp, 3>{25, 30, 30}, std::array<int64_t, 3>{1001, 3, 4}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{3, 5}};
+        const ProcessingUnit proc = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured[1])));
+        ASSERT_EQ(proc.segments_->size(), 1);
+        EXPECT_EQ(*proc.segments_->at(0), expected_segments[0]);
+        ASSERT_TRUE(std::ranges::equal(
+                (*proc.row_ranges_) | std::views::transform([](const auto& rr) { return *rr; }), expected_row_ranges
+        ));
+    }
+    {
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc, 100'000, 1, std::array<timestamp, 4>{35, 40, 40, 50}, std::array<int64_t, 4>{1002, 5, 6, 7}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{5, 8}};
+        const ProcessingUnit proc = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured[2])));
+        ASSERT_EQ(proc.segments_->size(), 1);
+        EXPECT_EQ(*proc.segments_->at(0), expected_segments[0]);
+        ASSERT_TRUE(std::ranges::equal(
+                (*proc.row_ranges_) | std::views::transform([](const auto& rr) { return *rr; }), expected_row_ranges
+        ));
+    }
+}
+
+TEST(MergeUpdateInsertOnlySharedSlice, InsertsIntoChainWithSharedBoundaries) {
+    constexpr MergeStrategy insert_only_strategy{.not_matched_by_target = MergeAction::INSERT};
+    auto component_manager = std::make_shared<ComponentManager>();
+    const StreamDescriptor desc = TimeseriesIndex::default_index().create_stream_descriptor(
+            "s", std::array{FieldRef{{DataType::INT64, Dimension::Dim0}, "a"}}
+    );
+    auto [segments, col_ranges, row_ranges] = slice_data_into_segments<TimeseriesIndex>(
+            desc,
+            2,
+            1,
+            std::array<timestamp, 8>{10, 20, 20, 30, 30, 40, 40, 50},
+            std::array<int64_t, 8>{0, 1, 2, 3, 4, 5, 6, 7}
+    );
+    auto ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
+    auto [input_frame, input_frame_owner] =
+            input_frame_from_tensors<TimeseriesIndex>(desc, std::array<timestamp, 1>{25}, std::array<int64_t, 1>{1000});
+    MergeUpdateClause clause = create_clause(insert_only_strategy, component_manager, std::move(input_frame), {"a"});
+    const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
+    ASSERT_TRUE(std::ranges::equal(structure_indices, std::vector<std::vector<size_t>>{{0, 1}, {1, 2}}));
+    const std::vector<EntityId> entities = push_selected_entities(
+            *component_manager,
+            structure_indices,
+            clone_segments(segments),
+            std::vector{col_ranges},
+            std::vector{row_ranges},
+            std::move(ranges_and_keys)
+    );
+    std::vector<std::vector<EntityId>> structured = structure_entities(structure_indices, entities);
+    ASSERT_EQ(structured.size(), 2);
+    {
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured[0])), std::array{1, 2}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc, 100'000, 1, std::array<timestamp, 3>{10, 20, 20}, std::array<int64_t, 3>{0, 1, 2}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{0, 3}};
+        const ProcessingUnit proc = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured[0])));
+        ASSERT_EQ(proc.segments_->size(), 1);
+        EXPECT_EQ(*proc.segments_->at(0), expected_segments[0]);
+        ASSERT_TRUE(std::ranges::equal(
+                (*proc.row_ranges_) | std::views::transform([](const auto& rr) { return *rr; }), expected_row_ranges
+        ));
+    }
+    {
+        ASSERT_TRUE(std::ranges::equal(
+                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured[1])), std::array{2, 1}
+        ));
+        auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
+                desc, 100'000, 1, std::array<timestamp, 4>{25, 30, 30, 40}, std::array<int64_t, 4>{1000, 3, 4, 5}
+        );
+        constexpr static std::array expected_row_ranges{RowRange{3, 6}};
+        const ProcessingUnit proc = gather_entities<
+                std::shared_ptr<SegmentInMemory>,
+                std::shared_ptr<RowRange>,
+                std::shared_ptr<ColRange>,
+                EntityFetchCount>(*component_manager, clause.process(std::move(structured[1])));
+        ASSERT_EQ(proc.segments_->size(), 1);
+        EXPECT_EQ(*proc.segments_->at(0), expected_segments[0]);
+        ASSERT_TRUE(std::ranges::equal(
+                (*proc.row_ranges_) | std::views::transform([](const auto& rr) { return *rr; }), expected_row_ranges
+        ));
     }
 }

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -1829,12 +1829,12 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SourceDataEndsBeforeLastSegment) {
             rows_per_segment,
             cols_per_segment,
             iota_view{timestamp{0}, timestamp{num_rows}} | views::transform([](const timestamp x) { return x * 2; }),
-            iota_view{size_t{0}, num_rows}
+            iota_view{uint64_t{0}, uint64_t{num_rows}}
     );
     // Will insert in segments 0, 2, 3
     // Segments 1, 4, 5 are not processed
     auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
-            desc, std::array<timestamp, 3>{1, 21, 33}, std::array<size_t, 3>{100, 200, 300}
+            desc, std::array<timestamp, 3>{1, 21, 33}, std::array<uint64_t, 3>{100, 200, 300}
     );
     std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
     auto component_manager = std::make_shared<ComponentManager>();
@@ -1858,17 +1858,17 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SourceDataEndsBeforeLastSegment) {
     constexpr static std::array expected_col_ranges = {ColRange{1, 2}, ColRange{1, 2}, ColRange{1, 2}};
     const std::array expected_segments = {
             create_dense_segment(
-                    desc, std::array<timestamp, 6>{0, 1, 2, 4, 6, 8}, std::array<size_t, 6>{0, 100, 1, 2, 3, 4}
+                    desc, std::array<timestamp, 6>{0, 1, 2, 4, 6, 8}, std::array<uint64_t, 6>{0, 100, 1, 2, 3, 4}
             ),
             create_dense_segment(
                     desc,
                     std::array<timestamp, 6>{20, 21, 22, 24, 26, 28},
-                    std::array<size_t, 6>{10, 200, 11, 12, 13, 14}
+                    std::array<uint64_t, 6>{10, 200, 11, 12, 13, 14}
             ),
             create_dense_segment(
                     desc,
                     std::array<timestamp, 6>{30, 32, 33, 34, 36, 38},
-                    std::array<size_t, 6>{15, 16, 300, 17, 18, 19}
+                    std::array<uint64_t, 6>{15, 16, 300, 17, 18, 19}
             ),
     };
     std::array<ProcessingUnit, 3> processing_units;
@@ -1899,13 +1899,13 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SourceDataStartsAfterTheFirstSegment) {
             rows_per_segment,
             cols_per_segment,
             iota_view{timestamp{0}, timestamp{num_rows}} | views::transform([](const timestamp x) { return x * 2; }),
-            iota_view{size_t{0}, num_rows}
+            iota_view{uint64_t{0}, uint64_t{num_rows}}
     );
     // Will insert in segments 2, 3
     // Segments 0, 1, 4, 5 are not processed
     constexpr static size_t input_frame_rows = 2;
     auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
-            desc, std::array<timestamp, input_frame_rows>{21, 33}, std::array<size_t, input_frame_rows>{100, 200}
+            desc, std::array<timestamp, input_frame_rows>{21, 33}, std::array<uint64_t, input_frame_rows>{100, 200}
     );
     std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
     auto component_manager = std::make_shared<ComponentManager>();
@@ -1932,12 +1932,12 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SourceDataStartsAfterTheFirstSegment) {
             create_dense_segment(
                     desc,
                     std::array<timestamp, 6>{20, 21, 22, 24, 26, 28},
-                    std::array<size_t, 6>{10, 100, 11, 12, 13, 14}
+                    std::array<uint64_t, 6>{10, 100, 11, 12, 13, 14}
             ),
             create_dense_segment(
                     desc,
                     std::array<timestamp, 6>{30, 32, 33, 34, 36, 38},
-                    std::array<size_t, 6>{15, 16, 200, 17, 18, 19}
+                    std::array<uint64_t, 6>{15, 16, 200, 17, 18, 19}
             ),
     };
     std::array<ProcessingUnit, expected_segments_to_process> processing_units;
@@ -1969,11 +1969,11 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SkipExpandedSegmentsInsertAtEnd) {
             cols_per_segment,
             std::array<timestamp, num_rows>{0,  1,  2,  3,  4,  10, 11, 12, 13, 14, 20, 21, 22, 23,
                                             24, 30, 31, 32, 33, 34, 40, 41, 42, 43, 44, 50, 51},
-            iota_view{size_t{0}, num_rows}
+            iota_view{uint64_t{0}, uint64_t{num_rows}}
     );
-    constexpr static size_t input_frame_rows = 3;
+    constexpr static size_t input_frame_rows = 2;
     auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
-            desc, std::array<timestamp, input_frame_rows>{35, 47}, std::array<size_t, input_frame_rows>{100, 200}
+            desc, std::array<timestamp, input_frame_rows>{35, 47}, std::array<uint64_t, input_frame_rows>{100, 200}
     );
     std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
     auto component_manager = std::make_shared<ComponentManager>();
@@ -1999,12 +1999,12 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SkipExpandedSegmentsInsertAtEnd) {
             create_dense_segment(
                     desc,
                     std::array<timestamp, 6>{30, 31, 32, 33, 34, 35},
-                    std::array<size_t, 6>{15, 16, 17, 18, 19, 100}
+                    std::array<uint64_t, 6>{15, 16, 17, 18, 19, 100}
             ),
             create_dense_segment(
                     desc,
-                    std::array<timestamp, 7>{40, 41, 42, 43, 44, 47},
-                    std::array<size_t, 7>{20, 21, 22, 23, 24, 200}
+                    std::array<timestamp, 6>{40, 41, 42, 43, 44, 47},
+                    std::array<uint64_t, 6>{20, 21, 22, 23, 24, 200}
             ),
     };
     for (size_t i = 0; i < structured_entities.size(); ++i) {
@@ -2034,11 +2034,11 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SkipExpandedSegmentsInsertInMiddle) {
             rows_per_segment,
             cols_per_segment,
             iota_view{timestamp{0}, timestamp{num_rows}} | views::transform([](const timestamp x) { return x * 5; }),
-            iota_view{size_t{0}, num_rows}
+            iota_view{uint64_t{0}, uint64_t{num_rows}}
     );
     constexpr static size_t input_frame_rows = 1;
     auto [input_frame, input_frame_owner] = input_frame_from_tensors<TimeseriesIndex>(
-            desc, std::array<timestamp, input_frame_rows>{87}, std::array<size_t, input_frame_rows>{100}
+            desc, std::array<timestamp, input_frame_rows>{87}, std::array<uint64_t, input_frame_rows>{100}
     );
     std::vector<RangesAndKey> ranges_and_keys = generate_ranges_and_keys(desc, segments, col_ranges, row_ranges);
     ASSERT_EQ(ranges_and_keys.size(), num_row_slices);
@@ -2062,7 +2062,7 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, SkipExpandedSegmentsInsertInMiddle) {
     constexpr static RowRange expected_row_range{15, 20};
     constexpr static ColRange expected_col_range{1, 2};
     const SegmentInMemory expected_segment = create_dense_segment(
-            desc, std::array<timestamp, 6>{75, 80, 85, 87, 90, 95}, std::array<size_t, 6>{15, 16, 17, 100, 18, 19}
+            desc, std::array<timestamp, 6>{75, 80, 85, 87, 90, 95}, std::array<uint64_t, 6>{15, 16, 17, 100, 18, 19}
     );
     const ProcessingUnit& processing_unit =
             gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -1390,7 +1390,7 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MatchNaN) {
             rows_per_segment_,
             cols_per_segment_,
             std::array<int8_t, num_rows_>{9, 2, 12, 33, 33, 33, 33, 33, 33, 33, 33, 6, -9, 100},
-            std::array<unsigned, num_rows_>{0, 1, 100, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 200},
+            std::array<unsigned, num_rows_>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 200},
             std::array{false, true, false, true, false, true, false, true, false, true, false, true, false, false},
             std::array<float, num_rows_>{
                     0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11., 12., std::numeric_limits<float>::quiet_NaN()
@@ -1445,8 +1445,8 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MergeOnTwoColumns_Segment1_Segme
             non_string_fields_rowcount_index_descriptor(),
             rows_per_segment_,
             cols_per_segment_,
-            std::array<int8_t, num_rows_>{9, 2, 12, 33, 33, 33, 33, 33, 33, 33, 33, 6, -9, 100},
-            std::array<unsigned, num_rows_>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 5},
+            std::array<int8_t, num_rows_>{9, 2, 12, 33, 33, 33, 33, 33, 33, 33, 33, 6, -9, 0},
+            std::array<unsigned, num_rows_>{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13},
             std::array{false, true, false, false, false, true, false, false, false, true, false, true, false, true},
             std::array<float, num_rows_>{
                     0., 1., 2., 1000., 4., 5., 6., 1001., 8., 9., 10., 11., 12., std::numeric_limits<float>::quiet_NaN()
@@ -1653,7 +1653,7 @@ TEST(MergeClauseDateRange, SourceMatchesAllIndexRangesButDoesNotMatchAnyRow) {
     std::vector<EntityId> entities = push_selected_entities(
             *component_manager,
             structure_indices,
-            std::move(segments),
+            clone_segments(segments),
             std::move(cols),
             std::move(rows),
             std::move(ranges_and_keys)
@@ -1776,7 +1776,7 @@ TEST_P(MergeUpdateClauseInsertAndUpdate, InsertAfterLastRow) {
     MergeUpdateClause clause = create_clause(GetParam(), component_manager, std::move(input_frame));
 
     const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys);
-    // Inserting in the beginning of the DataFrame picks the first row slice
+    // Inserting in the end picks the last row slice
     ASSERT_EQ(structure_indices.size(), 1);
     ASSERT_EQ(structure_indices[0].size(), col_slice_count);
 

--- a/cpp/arcticdb/processing/test/test_parallel_processing.cpp
+++ b/cpp/arcticdb/processing/test/test_parallel_processing.cpp
@@ -215,10 +215,6 @@ TEST(Clause, ScheduleClauseProcessingStress) {
         processing_unit_indexes.emplace_back(std::vector<size_t>{idx});
     }
 
-    // Map from index in segment_and_slice_future_splitters to the number of calls to process in the first clause that
-    // will require that segment
-    auto segment_fetch_counts = generate_segment_fetch_counts(processing_unit_indexes, num_segments);
-
     auto processed_entity_ids_fut = schedule_clause_processing(
             component_manager,
             std::move(segment_and_slice_futures),

--- a/cpp/arcticdb/processing/test/test_split_by_time_slice.cpp
+++ b/cpp/arcticdb/processing/test/test_split_by_time_slice.cpp
@@ -1,0 +1,347 @@
+#include <gtest/gtest.h>
+#include <arcticdb/processing/clause.hpp>
+
+#include <random>
+
+using namespace arcticdb;
+using namespace std::ranges;
+namespace {
+std::vector<RangesAndKey> generate_ranges_and_keys(
+        std::span<const TimestampRange> time_ranges, size_t col_slice_count
+) {
+    std::vector<RangesAndKey> res;
+    res.reserve(time_ranges.size() * col_slice_count);
+    RowRange current_row_range{0, 5};
+    ColRange current_col_range{1, 2};
+    for (const TimestampRange& time_range : time_ranges) {
+        for (size_t col_slice_idx = 0; col_slice_idx < col_slice_count; ++col_slice_idx) {
+            res.emplace_back(
+                    current_row_range,
+                    current_col_range,
+                    AtomKeyBuilder()
+                            .start_index(time_range.first)
+                            .end_index(time_range.second)
+                            .build<KeyType::TABLE_DATA>("t")
+            );
+            current_col_range = ColRange{current_col_range.second, current_col_range.second + 1};
+        }
+        current_row_range = RowRange{current_row_range.second, current_row_range.second + 5};
+        current_col_range = ColRange{1, 2};
+    }
+    return res;
+}
+
+} // namespace
+
+class TestSplitByTimeSlice : public testing::Test {
+  protected:
+    TestSplitByTimeSlice() : g(42) {}
+    void shuffle(std::span<RangesAndKey> input) { std::ranges::shuffle(input, g); }
+    std::mt19937 g;
+};
+
+TEST_F(TestSplitByTimeSlice, DisjointTimeRanges_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{20, 30}, TimestampRange{40, 50}, TimestampRange{60, 70}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0}, {1}, {2}, {3}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, DisjointTimeRanges_TwoColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{20, 30}, TimestampRange{40, 50}, TimestampRange{60, 70}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {2, 3}, {4, 5}, {6, 7}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, DisjointTimeRanges_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{20, 30}, TimestampRange{40, 50}, TimestampRange{60, 70}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SingleSharedValueTwoRowSlices_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{15, 20}, TimestampRange{19, 25}, TimestampRange{30, 50}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0}, {1, 2}, {2}, {3}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SingleSharedValueTwoRowSlices_TwoColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{15, 20}, TimestampRange{19, 25}, TimestampRange{30, 50}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {2, 3, 4, 5}, {4, 5}, {6, 7}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SingleSharedValueTwoRowSlices_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{15, 20}, TimestampRange{19, 25}, TimestampRange{30, 50}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1, 2}, {3, 4, 5, 6, 7, 8}, {6, 7, 8}, {9, 10, 11}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SharedValueSpansThreeRowSlices_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{20, 36}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2}, {3}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SharedValueSpansThreeRowSlices_TwoColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{20, 36}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5}, {6, 7}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SharedValueSpansThreeRowSlices_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{20, 36}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5, 6, 7, 8}, {9, 10, 11}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SharedValueSpansFourRowSlices_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{14, 16}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3}, {3}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SharedValueSpansFourRowSlices_TwoColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{14, 16}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5, 6, 7}, {6, 7}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SharedValueSpansFourRowSlices_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{14, 16}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, {9, 10, 11}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, Chain_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 5}, TimestampRange{4, 10}, TimestampRange{9, 15}, TimestampRange{14, 20}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {1, 2}, {2, 3}, {3}}};
+    const std::vector<std::vector<size_t>> result = structure_by_time_slice(input);
+    ASSERT_TRUE(std::ranges::equal(result, expected));
+}
+
+TEST_F(TestSplitByTimeSlice, Chain_TwoColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 5}, TimestampRange{4, 10}, TimestampRange{9, 15}, TimestampRange{14, 20}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1, 2, 3}, {2, 3, 4, 5}, {4, 5, 6, 7}, {6, 7}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, Chain_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 5}, TimestampRange{4, 10}, TimestampRange{9, 15}, TimestampRange{14, 20}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{
+            {{0, 1, 2, 3, 4, 5}, {3, 4, 5, 6, 7, 8}, {6, 7, 8, 9, 10, 11}, {9, 10, 11}}
+    };
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, SingleRowSlice_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{TimestampRange{0, 10}};
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 1> expected{{{0, 1, 2}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, AdjacentTimeRangesShareNoValue_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{TimestampRange{0, 10}, TimestampRange{10, 20}};
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0}, {1}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, TwoSeparateSharedValueGroups_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10}, TimestampRange{9, 15}, TimestampRange{30, 40}, TimestampRange{39, 45}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {1}, {2, 3}, {3}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, MinimalSeamOverlap_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{TimestampRange{0, 5}, TimestampRange{4, 10}};
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 2> expected{{{0, 1}, {1}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, ChainOfFiveRowSlices_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 5},
+            TimestampRange{4, 10},
+            TimestampRange{9, 15},
+            TimestampRange{14, 20},
+            TimestampRange{19, 25}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 5> expected{{{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, IsolatedThenCliqueThenIsolatedThenClique_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 10},
+            TimestampRange{15, 20},
+            TimestampRange{19, 20},
+            TimestampRange{19, 25},
+            TimestampRange{30, 40},
+            TimestampRange{45, 50},
+            TimestampRange{49, 55}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 6> expected{{{0}, {1, 2, 3}, {3}, {4}, {5, 6}, {6}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, CliqueThenChain_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15},
+            TimestampRange{14, 15},
+            TimestampRange{14, 20},
+            TimestampRange{19, 25},
+            TimestampRange{24, 30},
+            TimestampRange{29, 35}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 5> expected{{{0, 1, 2}, {2, 3}, {3, 4}, {4, 5}, {5}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, CliqueThenChain_TwoColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15},
+            TimestampRange{14, 15},
+            TimestampRange{14, 20},
+            TimestampRange{19, 25},
+            TimestampRange{24, 30},
+            TimestampRange{29, 35}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 5> expected{
+            {{0, 1, 2, 3, 4, 5}, {4, 5, 6, 7}, {6, 7, 8, 9}, {8, 9, 10, 11}, {10, 11}}
+    };
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, CliqueThenChain_ThreeColsPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15},
+            TimestampRange{14, 15},
+            TimestampRange{14, 20},
+            TimestampRange{19, 25},
+            TimestampRange{24, 30},
+            TimestampRange{29, 35}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 5> expected{
+            {{0, 1, 2, 3, 4, 5, 6, 7, 8},
+             {6, 7, 8, 9, 10, 11},
+             {9, 10, 11, 12, 13, 14},
+             {12, 13, 14, 15, 16, 17},
+             {15, 16, 17}}
+    };
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, TwoCliquesShareBridgingRowSlice_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{10, 15},
+            TimestampRange{14, 15},
+            TimestampRange{14, 18},
+            TimestampRange{17, 18},
+            TimestampRange{17, 22}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 3> expected{{{0, 1, 2}, {2, 3, 4}, {4}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, ChainInterleavedWithClique_OneColPerRowSlice) {
+    constexpr static std::array time_ranges{
+            TimestampRange{0, 5},
+            TimestampRange{4, 10},
+            TimestampRange{9, 15},
+            TimestampRange{14, 20},
+            TimestampRange{30, 35},
+            TimestampRange{34, 35},
+            TimestampRange{34, 40}
+    };
+    std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
+    shuffle(input);
+    const std::array<std::vector<size_t>, 6> expected{{{0, 1}, {1, 2}, {2, 3}, {3}, {4, 5, 6}, {6}}};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}
+
+TEST_F(TestSplitByTimeSlice, EmptyInput) {
+    std::array<RangesAndKey, 0> input{};
+    constexpr static std::array<std::vector<size_t>, 0> expected{};
+    ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
+}

--- a/cpp/arcticdb/processing/test/test_structure_by_time_slice.cpp
+++ b/cpp/arcticdb/processing/test/test_structure_by_time_slice.cpp
@@ -1,8 +1,6 @@
 #include <gtest/gtest.h>
 #include <arcticdb/processing/clause.hpp>
 
-#include <random>
-
 using namespace arcticdb;
 using namespace std::ranges;
 namespace {
@@ -33,201 +31,177 @@ std::vector<RangesAndKey> generate_ranges_and_keys(
 
 } // namespace
 
-class TestSplitByTimeSlice : public testing::Test {
-  protected:
-    TestSplitByTimeSlice() : g(42) {}
-    void shuffle(std::span<RangesAndKey> input) { std::ranges::shuffle(input, g); }
-    std::mt19937 g;
-};
+class StructureByTimeSlice : public testing::Test {};
 
-TEST_F(TestSplitByTimeSlice, DisjointTimeRanges_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, DisjointTimeRanges_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{20, 30}, TimestampRange{40, 50}, TimestampRange{60, 70}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0}, {1}, {2}, {3}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, DisjointTimeRanges_TwoColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, DisjointTimeRanges_TwoColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{20, 30}, TimestampRange{40, 50}, TimestampRange{60, 70}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {2, 3}, {4, 5}, {6, 7}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, DisjointTimeRanges_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, DisjointTimeRanges_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{20, 30}, TimestampRange{40, 50}, TimestampRange{60, 70}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1, 2}, {3, 4, 5}, {6, 7, 8}, {9, 10, 11}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SingleSharedValueTwoRowSlices_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, SingleSharedValueTwoRowSlices_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{15, 20}, TimestampRange{19, 25}, TimestampRange{30, 50}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0}, {1, 2}, {2}, {3}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SingleSharedValueTwoRowSlices_TwoColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SingleSharedValueTwoRowSlices_TwoColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{15, 20}, TimestampRange{19, 25}, TimestampRange{30, 50}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {2, 3, 4, 5}, {4, 5}, {6, 7}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SingleSharedValueTwoRowSlices_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SingleSharedValueTwoRowSlices_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{15, 20}, TimestampRange{19, 25}, TimestampRange{30, 50}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1, 2}, {3, 4, 5, 6, 7, 8}, {6, 7, 8}, {9, 10, 11}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SharedValueSpansThreeRowSlices_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, SharedValueSpansThreeRowSlices_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{20, 36}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2}, {3}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SharedValueSpansThreeRowSlices_TwoColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SharedValueSpansThreeRowSlices_TwoColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{20, 36}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5}, {6, 7}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SharedValueSpansThreeRowSlices_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SharedValueSpansThreeRowSlices_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{20, 36}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5, 6, 7, 8}, {9, 10, 11}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SharedValueSpansFourRowSlices_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, SharedValueSpansFourRowSlices_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{14, 16}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3}, {3}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SharedValueSpansFourRowSlices_TwoColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SharedValueSpansFourRowSlices_TwoColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{14, 16}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5, 6, 7}, {6, 7}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SharedValueSpansFourRowSlices_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SharedValueSpansFourRowSlices_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15}, TimestampRange{14, 15}, TimestampRange{14, 15}, TimestampRange{14, 16}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}, {9, 10, 11}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, Chain_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, Chain_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 5}, TimestampRange{4, 10}, TimestampRange{9, 15}, TimestampRange{14, 20}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {1, 2}, {2, 3}, {3}}};
     const std::vector<std::vector<size_t>> result = structure_by_time_slice(input);
     ASSERT_TRUE(std::ranges::equal(result, expected));
 }
 
-TEST_F(TestSplitByTimeSlice, Chain_TwoColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, Chain_TwoColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 5}, TimestampRange{4, 10}, TimestampRange{9, 15}, TimestampRange{14, 20}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1, 2, 3}, {2, 3, 4, 5}, {4, 5, 6, 7}, {6, 7}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, Chain_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, Chain_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 5}, TimestampRange{4, 10}, TimestampRange{9, 15}, TimestampRange{14, 20}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{
             {{0, 1, 2, 3, 4, 5}, {3, 4, 5, 6, 7, 8}, {6, 7, 8, 9, 10, 11}, {9, 10, 11}}
     };
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, SingleRowSlice_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, SingleRowSlice_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{TimestampRange{0, 10}};
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 1> expected{{{0, 1, 2}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, AdjacentTimeRangesShareNoValue_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, AdjacentTimeRangesShareNoValue_OneColPerRowSlice) {
     constexpr static std::array time_ranges{TimestampRange{0, 10}, TimestampRange{10, 20}};
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0}, {1}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, TwoSeparateSharedValueGroups_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, TwoSeparateSharedValueGroups_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10}, TimestampRange{9, 15}, TimestampRange{30, 40}, TimestampRange{39, 45}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 4> expected{{{0, 1}, {1}, {2, 3}, {3}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, MinimalSeamOverlap_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, MinimalSeamOverlap_OneColPerRowSlice) {
     constexpr static std::array time_ranges{TimestampRange{0, 5}, TimestampRange{4, 10}};
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 2> expected{{{0, 1}, {1}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, ChainOfFiveRowSlices_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, ChainOfFiveRowSlices_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 5},
             TimestampRange{4, 10},
@@ -236,12 +210,11 @@ TEST_F(TestSplitByTimeSlice, ChainOfFiveRowSlices_OneColPerRowSlice) {
             TimestampRange{19, 25}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 5> expected{{{0, 1}, {1, 2}, {2, 3}, {3, 4}, {4}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, IsolatedThenCliqueThenIsolatedThenClique_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, IsolatedThenCliqueThenIsolatedThenClique_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 10},
             TimestampRange{15, 20},
@@ -252,12 +225,11 @@ TEST_F(TestSplitByTimeSlice, IsolatedThenCliqueThenIsolatedThenClique_OneColPerR
             TimestampRange{49, 55}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 6> expected{{{0}, {1, 2, 3}, {3}, {4}, {5, 6}, {6}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, CliqueThenChain_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, CliqueThenChain_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15},
             TimestampRange{14, 15},
@@ -267,12 +239,11 @@ TEST_F(TestSplitByTimeSlice, CliqueThenChain_OneColPerRowSlice) {
             TimestampRange{29, 35}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 5> expected{{{0, 1, 2}, {2, 3}, {3, 4}, {4, 5}, {5}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, CliqueThenChain_TwoColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, CliqueThenChain_TwoColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15},
             TimestampRange{14, 15},
@@ -282,14 +253,13 @@ TEST_F(TestSplitByTimeSlice, CliqueThenChain_TwoColsPerRowSlice) {
             TimestampRange{29, 35}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 2);
-    shuffle(input);
     const std::array<std::vector<size_t>, 5> expected{
             {{0, 1, 2, 3, 4, 5}, {4, 5, 6, 7}, {6, 7, 8, 9}, {8, 9, 10, 11}, {10, 11}}
     };
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, CliqueThenChain_ThreeColsPerRowSlice) {
+TEST_F(StructureByTimeSlice, CliqueThenChain_ThreeColsPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15},
             TimestampRange{14, 15},
@@ -299,7 +269,6 @@ TEST_F(TestSplitByTimeSlice, CliqueThenChain_ThreeColsPerRowSlice) {
             TimestampRange{29, 35}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 3);
-    shuffle(input);
     const std::array<std::vector<size_t>, 5> expected{
             {{0, 1, 2, 3, 4, 5, 6, 7, 8},
              {6, 7, 8, 9, 10, 11},
@@ -310,7 +279,7 @@ TEST_F(TestSplitByTimeSlice, CliqueThenChain_ThreeColsPerRowSlice) {
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, TwoCliquesShareBridgingRowSlice_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, TwoCliquesShareBridgingRowSlice_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{10, 15},
             TimestampRange{14, 15},
@@ -319,12 +288,11 @@ TEST_F(TestSplitByTimeSlice, TwoCliquesShareBridgingRowSlice_OneColPerRowSlice) 
             TimestampRange{17, 22}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 3> expected{{{0, 1, 2}, {2, 3, 4}, {4}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, ChainInterleavedWithClique_OneColPerRowSlice) {
+TEST_F(StructureByTimeSlice, ChainInterleavedWithClique_OneColPerRowSlice) {
     constexpr static std::array time_ranges{
             TimestampRange{0, 5},
             TimestampRange{4, 10},
@@ -335,12 +303,11 @@ TEST_F(TestSplitByTimeSlice, ChainInterleavedWithClique_OneColPerRowSlice) {
             TimestampRange{34, 40}
     };
     std::vector<RangesAndKey> input = generate_ranges_and_keys(time_ranges, 1);
-    shuffle(input);
     const std::array<std::vector<size_t>, 6> expected{{{0, 1}, {1, 2}, {2, 3}, {3}, {4, 5, 6}, {6}}};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));
 }
 
-TEST_F(TestSplitByTimeSlice, EmptyInput) {
+TEST_F(StructureByTimeSlice, EmptyInput) {
     std::array<RangesAndKey, 0> input{};
     constexpr static std::array<std::vector<size_t>, 0> expected{};
     ASSERT_TRUE(std::ranges::equal(structure_by_time_slice(input), expected));

--- a/cpp/arcticdb/util/buffer.hpp
+++ b/cpp/arcticdb/util/buffer.hpp
@@ -220,6 +220,8 @@ struct Buffer : public BaseBuffer<Buffer, true> {
 
     [[nodiscard]] size_t available() const { return capacity_ >= preamble_bytes_ ? capacity_ - preamble_bytes_ : 0; }
 
+    void clear() { deallocate(); }
+
   private:
     inline void resize(size_t alloc_bytes) {
         const size_t bytes = alloc_bytes - preamble_bytes_;

--- a/cpp/arcticdb/util/error_code.hpp
+++ b/cpp/arcticdb/util/error_code.hpp
@@ -60,6 +60,7 @@ inline std::unordered_map<ErrorCategory, const char*> get_error_category_names()
     ERROR_CODE(1003, E_RUNTIME_ERROR)                                                                                  \
     ERROR_CODE(1004, E_STORED_CONFIG_ERROR)                                                                            \
     ERROR_CODE(1005, E_NOT_SUPPORTED)                                                                                  \
+    ERROR_CODE(1006, E_NOT_IMPLEMENTED)                                                                                \
     ERROR_CODE(2000, E_INCOMPATIBLE_OBJECTS)                                                                           \
     ERROR_CODE(2001, E_UNIMPLEMENTED_INPUT_TYPE)                                                                       \
     ERROR_CODE(2002, E_UPDATE_NOT_SUPPORTED)                                                                           \

--- a/cpp/arcticdb/util/flatten_utils.hpp
+++ b/cpp/arcticdb/util/flatten_utils.hpp
@@ -20,7 +20,7 @@ namespace arcticdb::util {
 using namespace arcticdb::entity;
 
 template<class T, template<class> class Tensor>
-inline bool has_funky_strides(Tensor<T>& a) {
+bool has_funky_strides(Tensor<T>& a) {
     for (ssize_t i = 0; i < a.ndim(); ++i) {
         if (a.strides(i) < 0 || a.strides(i) % a.itemsize() != 0)
             return true;
@@ -29,7 +29,7 @@ inline bool has_funky_strides(Tensor<T>& a) {
 }
 
 template<class T>
-inline bool has_funky_strides(py::array_t<T>& a) {
+bool has_funky_strides(py::array_t<T>& a) {
     for (ssize_t i = 0; i < a.ndim(); ++i) {
         if (a.strides(i) < 0 || a.strides(i) % a.itemsize() != 0)
             return true;
@@ -38,7 +38,7 @@ inline bool has_funky_strides(py::array_t<T>& a) {
 }
 
 template<typename RawType, typename TensorType>
-inline bool is_cstyle_array(const TensorType& tensor) {
+bool is_cstyle_array(const TensorType& tensor) {
     return tensor.size() == 0 || tensor.strides(tensor.ndim() - 1) == sizeof(RawType);
 }
 

--- a/cpp/arcticdb/util/test/segment_generation_utils.hpp
+++ b/cpp/arcticdb/util/test/segment_generation_utils.hpp
@@ -223,6 +223,7 @@ void slice_data_into_segments_helper(
 }
 
 template<pipelines::ValidIndex index, std::ranges::sized_range... Data>
+requires(sizeof...(Data) > 0)
 std::tuple<std::vector<SegmentInMemory>, std::vector<pipelines::ColRange>, std::vector<pipelines::RowRange>>
 slice_data_into_segments(
         const StreamDescriptor& descriptor, const size_t rows_per_segment, const size_t cols_per_segment, Data&&... data
@@ -231,6 +232,14 @@ slice_data_into_segments(
     std::vector<SegmentInMemory> segments;
     std::vector<pipelines::ColRange> col_ranges;
     std::vector<pipelines::RowRange> row_ranges;
+
+    util::check(
+            []<typename T1, typename... Ts>(const T1& head, const Ts&... tail) {
+                const size_t sz = head.size();
+                return ((tail.size() == sz) && ...);
+            }(data...),
+            "All input data must be of the same size"
+    );
 
     auto [index_columns, data_columns] = split_pack<index::field_count()>(std::forward<Data>(data)...);
     static_assert(
@@ -262,4 +271,5 @@ slice_data_into_segments(
     );
     return std::make_tuple(std::move(segments), std::move(col_ranges), std::move(row_ranges));
 }
+
 } // namespace arcticdb

--- a/cpp/arcticdb/util/type_traits.hpp
+++ b/cpp/arcticdb/util/type_traits.hpp
@@ -27,4 +27,31 @@ concept instantiation_of = is_instantiation_of_v<T, TT>;
 
 template<typename T, typename... U>
 concept any_of = std::disjunction_v<std::is_same<T, U>...>;
+
+template<typename T>
+concept type_descriptor_tag = instantiation_of<T, entity::TypeDescriptorTag>;
+
+template<typename T>
+struct function_arg_types : function_arg_types<decltype(&std::decay_t<T>::operator())> {};
+
+// Free function
+template<typename ReturnType, typename... Args>
+struct function_arg_types<ReturnType (*)(Args...)> {
+    using args_t = std::tuple<Args...>;
+    using return_t = ReturnType;
+};
+
+// Member method
+template<typename ClassType, typename ReturnType, typename... Args>
+struct function_arg_types<ReturnType (ClassType::*)(Args...)> {
+    using args_t = std::tuple<Args...>;
+    using return_t = ReturnType;
+};
+
+template<typename ClassType, typename ReturnType, typename... Args>
+struct function_arg_types<ReturnType (ClassType::*)(Args...) const> {
+    using args_t = std::tuple<Args...>;
+    using return_t = ReturnType;
+};
+
 } // namespace arcticdb::util

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -2475,13 +2475,14 @@ VersionedItem LocalVersionedEngine::merge_internal(
         const ReadOptions read_options;
         VersionedItem versioned_item = merge_update_impl(
                                                store(),
-                                               VersionedItem{*update_info.previous_index_key_},
+                                               update_info,
                                                read_options,
                                                write_options_,
                                                IndexPartialKey{stream_id, update_info.next_version_id_},
                                                std::move(on),
                                                strategy,
-                                               std::move(source)
+                                               std::move(source),
+                                               get_de_dup_map(stream_id, update_info.previous_index_key_, write_options)
         )
                                                .get();
         write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -2473,18 +2473,19 @@ VersionedItem LocalVersionedEngine::merge_internal(
             return VersionedItem{*std::move(update_info.previous_index_key_)};
         }
         const ReadOptions read_options;
-        VersionedItem versioned_item = merge_update_impl(
-                                               store(),
-                                               update_info,
-                                               read_options,
-                                               write_options_,
-                                               IndexPartialKey{stream_id, update_info.next_version_id_},
-                                               std::move(on),
-                                               strategy,
-                                               std::move(source),
-                                               get_de_dup_map(stream_id, update_info.previous_index_key_, write_options)
-        )
-                                               .get();
+        VersionedItem versioned_item =
+                merge_update_impl(
+                        store(),
+                        update_info,
+                        read_options,
+                        write_options_,
+                        IndexPartialKey{.id = stream_id, .version_id = update_info.next_version_id_},
+                        std::move(on),
+                        strategy,
+                        std::move(source),
+                        get_de_dup_map(stream_id, update_info, write_options_)
+                )
+                        .get();
         write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
         return versioned_item;
     } else if (upsert) {

--- a/cpp/arcticdb/version/merge_options.cpp
+++ b/cpp/arcticdb/version/merge_options.cpp
@@ -16,4 +16,8 @@ bool MergeStrategy::update_only() const {
 bool MergeStrategy::insert_only() const {
     return matched == MergeAction::DO_NOTHING && not_matched_by_target == MergeAction::INSERT;
 }
+
+bool MergeStrategy::insert() const { return not_matched_by_target == MergeAction::INSERT; }
+
+bool MergeStrategy::update() const { return matched == MergeAction::UPDATE; }
 } // namespace arcticdb

--- a/cpp/arcticdb/version/merge_options.hpp
+++ b/cpp/arcticdb/version/merge_options.hpp
@@ -12,11 +12,13 @@
 namespace arcticdb {
 enum class MergeAction : uint8_t { DO_NOTHING, UPDATE, INSERT };
 struct MergeStrategy {
-    MergeAction matched;
-    MergeAction not_matched_by_target;
+    MergeAction matched = MergeAction::DO_NOTHING;
+    MergeAction not_matched_by_target = MergeAction::DO_NOTHING;
     bool operator==(const MergeStrategy&) const = default;
     bool update_only() const;
     bool insert_only() const;
+    bool insert() const;
+    bool update() const;
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -401,7 +401,7 @@ std::vector<SliceAndKey> merge_slices_and_keys(
                 ++old_slice_and_key_it;
             } else {
                 const RowRange new_row_range = new_slice_and_key_it->slice().row_range;
-                const size_t inserted_rows = inserted_rows_per_row_range[new_row_range];
+                const size_t inserted_rows = inserted_rows_per_row_range.at(new_row_range);
                 new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
                 new_slice_and_key_it->slice().row_range.second += total_inserted_rows + inserted_rows;
                 total_inserted_rows += inserted_rows;
@@ -3024,7 +3024,8 @@ folly::Future<ReadVersionOutput> read_frame_for_version(
 folly::Future<std::vector<SliceAndKey>> read_modify_write_data_keys(
         const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
         const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
-        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<DeDupMap> de_dup_map
+        std::shared_ptr<ComponentManager> component_manager = std::make_shared<ComponentManager>(),
+        std::shared_ptr<DeDupMap> de_dup_map = std::make_shared<DeDupMap>()
 ) {
     auto write_clause_processing_structure = read_query->clauses_.empty()
                                                      ? ProcessingStructure::ROW_SLICE
@@ -3061,15 +3062,7 @@ folly::Future<VersionedItem> read_modify_write_impl(
         const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
         std::optional<proto::descriptors::UserDefinedMetadata>&& user_meta_proto
 ) {
-    return read_modify_write_data_keys(
-                   store,
-                   read_query,
-                   read_options,
-                   target_partial_index_key,
-                   pipeline_context,
-                   std::make_shared<ComponentManager>(),
-                   std::make_shared<DeDupMap>()
-    )
+    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
             .thenValue([&](std::vector<SliceAndKey>&& data_keys_and_slices) {
                 ARCTICDB_DEBUG_CHECK(
                         ErrorCode::E_ASSERTION_FAILURE,
@@ -3125,13 +3118,14 @@ folly::Future<VersionedItem> merge_update_impl(
     // The target is empty.
     if (pipeline_context->rows_ == 0) {
         if (strategy.insert()) {
-            return write_dataframe_impl(store, update_info.next_version_id_, source, write_options, de_dup_map);
+            return async_write_dataframe_impl(store, update_info.next_version_id_, source, write_options, de_dup_map)
+                    .get();
         } else if (strategy.update_only()) {
             const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                     0,
                     pipeline_context->descriptor(),
                     pipeline_context->release_normalization(),
-                    pipeline_context->release_opt_user_defined_metadata(),
+                    std::move(source->user_meta),
                     std::nullopt,
                     write_options.bucketize_dynamic
             );
@@ -3155,7 +3149,7 @@ folly::Future<VersionedItem> merge_update_impl(
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !write_options.dynamic_schema, "Cannot merge update with dynamic schema"
     );
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
             strategy.not_matched_by_target != MergeAction::INSERT ||
                     pipeline_context->descriptor().index().type() == IndexDescriptor::Type::TIMESTAMP,
             "Merge update with INSERT strategy is not implemented for ROWRANGE indexes yet."
@@ -3189,7 +3183,7 @@ folly::Future<VersionedItem> merge_update_impl(
                 ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
                 component_manager->process_entities([&](const MergeUpdateInsertedRowsEntity& inserted_rows,
                                                         const std::shared_ptr<RowRange>& row_range) {
-                    inserted_rows_per_row_range.emplace(*row_range, inserted_rows.inserted_rows);
+                    inserted_rows_per_row_range.emplace(*row_range, inserted_rows);
                 });
                 std::vector<SliceAndKey> merged_ranges_and_keys = merge_slices_and_keys(
                         std::move(pipeline_context->slice_and_keys_),
@@ -3456,13 +3450,7 @@ folly::Future<std::optional<VersionedItem>> compact_data_impl(
                 ReadOptions read_options;
                 read_options.set_dynamic_schema(dynamic_schema);
                 return read_modify_write_data_keys(
-                               store,
-                               read_query,
-                               read_options,
-                               target_partial_index_key,
-                               pipeline_context,
-                               std::make_shared<ComponentManager>(),
-                               std::make_shared<DeDupMap>()
+                               store, read_query, read_options, target_partial_index_key, pipeline_context
                 )
                         .thenValue(
                                 [pipeline_context = std::move(pipeline_context),

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -380,6 +380,49 @@ bool is_fake_index_name(const arcticc::pb2::descriptors_pb2::NormalizationMetada
     return is_fake_datetime_index_name || is_fake_mutliindex_name;
 }
 
+std::vector<SliceAndKey> merge_slices_and_keys(
+        std::vector<SliceAndKey>&& old_slices, std::vector<SliceAndKey>&& new_slices,
+        ankerl::unordered_dense::map<RowRange, size_t>&& inserted_rows_per_row_range
+) {
+    ranges::sort(new_slices);
+    std::vector<SliceAndKey> merged_ranges_and_keys;
+    auto new_slice_and_key_it = new_slices.begin();
+    auto old_slice_and_key_it = old_slices.begin();
+    while (old_slice_and_key_it != old_slices.end()) {
+        size_t total_inserted_rows{};
+        ColRange current_col_range = old_slice_and_key_it->slice().col_range;
+        while (old_slice_and_key_it != old_slices.end() && current_col_range == old_slice_and_key_it->slice().col_range
+        ) {
+            if (new_slice_and_key_it == new_slices.end() ||
+                old_slice_and_key_it->slice() < new_slice_and_key_it->slice()) {
+                old_slice_and_key_it->slice().row_range.first += total_inserted_rows;
+                old_slice_and_key_it->slice().row_range.second += total_inserted_rows;
+                merged_ranges_and_keys.emplace_back(std::move(*old_slice_and_key_it));
+                ++old_slice_and_key_it;
+            } else {
+                const RowRange new_row_range = new_slice_and_key_it->slice().row_range;
+                const size_t inserted_rows = inserted_rows_per_row_range[new_row_range];
+                new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
+                new_slice_and_key_it->slice().row_range.second += total_inserted_rows + inserted_rows;
+                total_inserted_rows += inserted_rows;
+                merged_ranges_and_keys.emplace_back(std::move(*new_slice_and_key_it));
+                ++new_slice_and_key_it;
+                while (old_slice_and_key_it != old_slices.end() &&
+                       old_slice_and_key_it->slice().col_range == current_col_range &&
+                       old_slice_and_key_it->slice().row_range.first < new_row_range.second) {
+                    ++old_slice_and_key_it;
+                }
+            }
+        }
+    }
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            new_slice_and_key_it == new_slices.end(), "Not all new slices were merged"
+    );
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            old_slice_and_key_it == old_slices.end(), "Not all old slices were merged"
+    );
+    return merged_ranges_and_keys;
+}
 } // namespace
 
 VersionedItem delete_range_impl(
@@ -2980,18 +3023,18 @@ folly::Future<ReadVersionOutput> read_frame_for_version(
 
 folly::Future<std::vector<SliceAndKey>> read_modify_write_data_keys(
         const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
-        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context
+        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
+        std::shared_ptr<ComponentManager> component_manager, std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto write_clause_processing_structure = read_query->clauses_.empty()
                                                      ? ProcessingStructure::ROW_SLICE
                                                      : read_query->clauses_.back()->clause_info().output_structure_;
-    read_query->clauses_.push_back(std::make_shared<Clause>(WriteClause(
-            target_partial_index_key, std::make_shared<DeDupMap>(), store, write_clause_processing_structure
-    )));
+    read_query->clauses_.push_back(std::make_shared<Clause>(
+            WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
+    ));
 
-    auto component_manager = std::make_shared<ComponentManager>();
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
-            .thenValue([component_manager,
+            .thenValue([component_manager = std::move(component_manager),
                         pipeline_context,
                         read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
                 generate_output_schema_and_save_to_pipeline(*pipeline_context, *read_query);
@@ -3018,7 +3061,15 @@ folly::Future<VersionedItem> read_modify_write_impl(
         const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
         std::optional<proto::descriptors::UserDefinedMetadata>&& user_meta_proto
 ) {
-    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
+    return read_modify_write_data_keys(
+                   store,
+                   read_query,
+                   read_options,
+                   target_partial_index_key,
+                   pipeline_context,
+                   std::make_shared<ComponentManager>(),
+                   std::make_shared<DeDupMap>()
+    )
             .thenValue([&](std::vector<SliceAndKey>&& data_keys_and_slices) {
                 ARCTICDB_DEBUG_CHECK(
                         ErrorCode::E_ASSERTION_FAILURE,
@@ -3055,21 +3106,44 @@ folly::Future<VersionedItem> read_modify_write_impl(
 }
 
 folly::Future<VersionedItem> merge_update_impl(
-        const std::shared_ptr<Store>& store, const VersionIdentifier& version_info, const ReadOptions& read_options,
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
-        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source
+        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
+        std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto read_query = std::make_shared<ReadQuery>();
     const StreamDescriptor& source_descriptor = source->desc();
     auto merge_update_clause = std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source));
     read_query->clauses_.push_back(merge_update_clause);
-    VersionIdentifier resolved = version_info;
+    VersionIdentifier resolved = VersionedItem{*update_info.previous_index_key_};
     if (auto* vi = std::get_if<VersionedItem>(&resolved)) {
         // TODO: Swap this out for the async version and chain futures from it
         resolved = std::make_shared<IndexInformation>(read_index_key_without_column_stats_sync(store, vi->key_));
     }
     std::shared_ptr<PipelineContext> pipeline_context =
             setup_pipeline_context(store, std::move(resolved), *read_query, read_options);
+    // The target is empty.
+    if (pipeline_context->rows_ == 0) {
+        if (strategy.insert()) {
+            return write_dataframe_impl(store, update_info.next_version_id_, source, write_options, de_dup_map);
+        } else if (strategy.update_only()) {
+            const TimeseriesDescriptor tsd = make_timeseries_descriptor(
+                    0,
+                    pipeline_context->descriptor(),
+                    pipeline_context->release_normalization(),
+                    pipeline_context->release_opt_user_defined_metadata(),
+                    std::nullopt,
+                    write_options.bucketize_dynamic
+            );
+            return index::write_index(
+                    index_type_from_descriptor(pipeline_context->descriptor()),
+                    tsd,
+                    std::vector<SliceAndKey>{},
+                    target_partial_index_key,
+                    store
+            );
+        }
+    }
     // TODO: Rely on modify_schema for this https://man312219.monday.com/boards/7852509418/pulses/10997979275
     schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
             columns_match(pipeline_context->descriptor(), source_descriptor),
@@ -3081,6 +3155,11 @@ folly::Future<VersionedItem> merge_update_impl(
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !write_options.dynamic_schema, "Cannot merge update with dynamic schema"
     );
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            strategy.not_matched_by_target != MergeAction::INSERT ||
+                    pipeline_context->descriptor().index().type() == IndexDescriptor::Type::TIMESTAMP,
+            "Merge update with INSERT strategy is not implemented for ROWRANGE indexes yet."
+    );
     const IndexDescriptor::Type index_type = pipeline_context->descriptor().index().type();
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             (index_type == IndexDescriptor::Type::TIMESTAMP &&
@@ -3091,25 +3170,32 @@ folly::Future<VersionedItem> merge_update_impl(
     );
     folly::poly_cast<MergeUpdateClause>(*merge_update_clause).fake_index_name_ =
             index_type == IndexDescriptor::Type::TIMESTAMP && is_fake_index_name(pipeline_context->normalization());
-    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
+    auto component_manager = std::make_shared<ComponentManager>();
+    return read_modify_write_data_keys(
+                   store,
+                   read_query,
+                   read_options,
+                   target_partial_index_key,
+                   pipeline_context,
+                   component_manager,
+                   std::move(de_dup_map)
+    )
             .thenValue([pipeline_context = std::move(pipeline_context),
+                        component_manager = std::move(component_manager),
                         store,
                         write_options,
                         source = std::move(source),
                         target_partial_index_key](std::vector<SliceAndKey>&& data_keys_and_slices) {
-                // TODO: This needs to be changed to account for the INSERT option of merge update. Insert can
-                // create new segments and shift row slices.
-                ranges::sort(data_keys_and_slices);
-                std::vector<SliceAndKey> merged_ranges_and_keys;
-                auto new_slice = data_keys_and_slices.begin();
-                for (SliceAndKey& slice : pipeline_context->slice_and_keys_) {
-                    if (new_slice != data_keys_and_slices.end() && new_slice->slice_ == slice.slice_) {
-                        merged_ranges_and_keys.push_back(std::move(*new_slice));
-                        ++new_slice;
-                    } else {
-                        merged_ranges_and_keys.push_back(std::move(slice));
-                    }
-                }
+                ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
+                component_manager->process_entities([&](const MergeUpdateInsertedRowsEntity& inserted_rows,
+                                                        const std::shared_ptr<RowRange>& row_range) {
+                    inserted_rows_per_row_range.emplace(*row_range, inserted_rows.inserted_rows);
+                });
+                std::vector<SliceAndKey> merged_ranges_and_keys = merge_slices_and_keys(
+                        std::move(pipeline_context->slice_and_keys_),
+                        std::move(data_keys_and_slices),
+                        std::move(inserted_rows_per_row_range)
+                );
                 pipeline_context->slice_and_keys_.clear();
                 const size_t row_count = merged_ranges_and_keys.empty()
                                                  ? 0
@@ -3370,7 +3456,13 @@ folly::Future<std::optional<VersionedItem>> compact_data_impl(
                 ReadOptions read_options;
                 read_options.set_dynamic_schema(dynamic_schema);
                 return read_modify_write_data_keys(
-                               store, read_query, read_options, target_partial_index_key, pipeline_context
+                               store,
+                               read_query,
+                               read_options,
+                               target_partial_index_key,
+                               pipeline_context,
+                               std::make_shared<ComponentManager>(),
+                               std::make_shared<DeDupMap>()
                 )
                         .thenValue(
                                 [pipeline_context = std::move(pipeline_context),

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -188,9 +188,10 @@ folly::Future<VersionedItem> read_modify_write_impl(
 );
 
 folly::Future<VersionedItem> merge_update_impl(
-        const std::shared_ptr<Store>& store, const VersionIdentifier& version_info, const ReadOptions& read_options,
+        const std::shared_ptr<Store>& store, const UpdateInfo& version_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
-        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source
+        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
+        std::shared_ptr<DeDupMap> de_dup_map
 );
 
 folly::Future<CompactDataInfo> compact_data_explain_plan_impl(

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -188,7 +188,7 @@ folly::Future<VersionedItem> read_modify_write_impl(
 );
 
 folly::Future<VersionedItem> merge_update_impl(
-        const std::shared_ptr<Store>& store, const UpdateInfo& version_info, const ReadOptions& read_options,
+        const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
         std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
         std::shared_ptr<DeDupMap> de_dup_map

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -1173,6 +1173,110 @@
   },
   {
    "cell_type": "markdown",
+   "id": "k9v2insert1",
+   "metadata": {},
+   "source": [
+    "#### Insert Only: `matched=\"do_nothing\"`, `not_matched_by_target=\"insert\"`\n",
+    "\n",
+    "This strategy inserts rows from `source` that do not have a matching row in `target`, while leaving all existing rows unchanged. This is useful when you want to add new data points without modifying any existing entries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8v2insert2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Target: existing daily prices\n",
+    "target_data = pd.DataFrame(\n",
+    "    {\"Price\": [100.0, 110.0, 120.0]},\n",
+    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-01\"), pd.Timestamp(\"2025-01-02\"), pd.Timestamp(\"2025-01-03\")])\n",
+    ")\n",
+    "lib.write(\"insert_only_example\", target_data)\n",
+    "print(\"Original data\")\n",
+    "display(lib.read(\"insert_only_example\").data)\n",
+    "\n",
+    "# Source: one matching row (2025-01-02) and two new rows (2025-01-01 12:00, 2025-01-04)\n",
+    "source_data = pd.DataFrame(\n",
+    "    {\"Price\": [999.0, 105.0, 130.0]},\n",
+    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-02\"), pd.Timestamp(\"2025-01-01 12:00\"), pd.Timestamp(\"2025-01-04\")])\n",
+    ")\n",
+    "print(\"Source data\")\n",
+    "display(source_data)\n",
+    "\n",
+    "# Insert only — the matching row (2025-01-02) is ignored, new rows are inserted\n",
+    "lib.merge_experimental(\n",
+    "    \"insert_only_example\",\n",
+    "    source_data,\n",
+    "    strategy=MergeStrategy(matched=\"do_nothing\", not_matched_by_target=\"insert\")\n",
+    ")\n",
+    "print(\"Data after merge — new rows inserted, existing rows unchanged\")\n",
+    "display(lib.read(\"insert_only_example\").data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m3v2insert3",
+   "metadata": {},
+   "source": [
+    "The row at `2025-01-02` already existed in `target`, so the source value of `999.0` was ignored. The two new rows (`2025-01-01 12:00` and `2025-01-04`) were inserted in sorted order. The existing data remains untouched."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "k4v2insert4",
+   "metadata": {},
+   "source": [
+    "#### Update and Insert: `matched=\"update\"`, `not_matched_by_target=\"insert\"`\n",
+    "\n",
+    "This strategy combines both behaviors: matching rows in `target` are updated with source values, and unmatched rows from `source` are inserted. This is the default strategy and is useful when you want to apply a complete set of corrections that may include both modifications to existing data and entirely new entries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5v2insert5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Target: existing daily prices\n",
+    "target_data = pd.DataFrame(\n",
+    "    {\"Price\": [100.0, 110.0, 120.0]},\n",
+    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-01\"), pd.Timestamp(\"2025-01-02\"), pd.Timestamp(\"2025-01-03\")])\n",
+    ")\n",
+    "lib.write(\"upsert_example\", target_data)\n",
+    "print(\"Original data\")\n",
+    "display(lib.read(\"upsert_example\").data)\n",
+    "\n",
+    "# Source: one correction for an existing row and one brand new row\n",
+    "source_data = pd.DataFrame(\n",
+    "    {\"Price\": [999.0, 130.0]},\n",
+    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-02\"), pd.Timestamp(\"2025-01-04\")])\n",
+    ")\n",
+    "print(\"Source data\")\n",
+    "display(source_data)\n",
+    "\n",
+    "# Update and insert — the matching row is updated, the new row is inserted\n",
+    "lib.merge_experimental(\n",
+    "    \"upsert_example\",\n",
+    "    source_data,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"insert\")\n",
+    ")\n",
+    "print(\"Data after merge — existing row updated, new row inserted\")\n",
+    "display(lib.read(\"upsert_example\").data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "m6v2insert6",
+   "metadata": {},
+   "source": [
+    "The row at `2025-01-02` was updated from `110.0` to `999.0`, and the new row at `2025-01-04` was inserted in the correct sorted position. This is essentially an \"upsert\" operation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "zun7ba30n4",
    "metadata": {},
    "source": [
@@ -2101,8 +2205,8 @@
     "\n",
     "1. Both `target` and `source` must have a sorted index when using `pd.DatetimeIndex` or a `pd.MultiIndex` with a datetime first level.\n",
     "2. The library must use a static schema, and both `source` and `target` must share the same schema.\n",
-    "3. The only supported strategy is `MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\")`.\n",
-    "4. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses row-range matching (requires the `on` parameter)."
+    "3. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses row-range matching (requires the `on` parameter).\n",
+    "4. For strategies with `not_matched_by_target=\"insert\"`, only datetime-indexed data is supported (including `pd.MultiIndex` with a datetime first level)."
    ]
   },
   {

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -282,7 +282,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=2, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1771501596070866899)"
+       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=8, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1784913472050154303)"
       ]
      },
      "execution_count": 4,
@@ -1183,10 +1183,195 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "c8v2insert2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>110.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-03</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Price\n",
+       "2025-01-01  100.0\n",
+       "2025-01-02  110.0\n",
+       "2025-01-03  120.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01 12:00:00</th>\n",
+       "      <td>105.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02 00:00:00</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-04 00:00:00</th>\n",
+       "      <td>130.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Price\n",
+       "2025-01-01 12:00:00  105.0\n",
+       "2025-01-02 00:00:00  999.0\n",
+       "2025-01-04 00:00:00  130.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge — new rows inserted, existing rows unchanged\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01 00:00:00</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01 12:00:00</th>\n",
+       "      <td>105.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02 00:00:00</th>\n",
+       "      <td>110.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-03 00:00:00</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-04 00:00:00</th>\n",
+       "      <td>130.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Price\n",
+       "2025-01-01 00:00:00  100.0\n",
+       "2025-01-01 12:00:00  105.0\n",
+       "2025-01-02 00:00:00  110.0\n",
+       "2025-01-03 00:00:00  120.0\n",
+       "2025-01-04 00:00:00  130.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Target: existing daily prices\n",
     "target_data = pd.DataFrame(\n",
@@ -1197,10 +1382,10 @@
     "print(\"Original data\")\n",
     "display(lib.read(\"insert_only_example\").data)\n",
     "\n",
-    "# Source: one matching row (2025-01-02) and two new rows (2025-01-01 12:00, 2025-01-04)\n",
+    "# Source: a new row (2025-01-01 12:00), a matching row (2025-01-02), and a new row (2025-01-04)\n",
     "source_data = pd.DataFrame(\n",
-    "    {\"Price\": [999.0, 105.0, 130.0]},\n",
-    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-02\"), pd.Timestamp(\"2025-01-01 12:00\"), pd.Timestamp(\"2025-01-04\")])\n",
+    "    {\"Price\": [105.0, 999.0, 130.0]},\n",
+    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-01 12:00\"), pd.Timestamp(\"2025-01-02\"), pd.Timestamp(\"2025-01-04\")])\n",
     ")\n",
     "print(\"Source data\")\n",
     "display(source_data)\n",
@@ -1235,10 +1420,185 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "c5v2insert5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>110.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-03</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Price\n",
+       "2025-01-01  100.0\n",
+       "2025-01-02  110.0\n",
+       "2025-01-03  120.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-04</th>\n",
+       "      <td>130.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Price\n",
+       "2025-01-02  999.0\n",
+       "2025-01-04  130.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge — existing row updated, new row inserted\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-03</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-04</th>\n",
+       "      <td>130.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Price\n",
+       "2025-01-01  100.0\n",
+       "2025-01-02  999.0\n",
+       "2025-01-03  120.0\n",
+       "2025-01-04  130.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Target: existing daily prices\n",
     "target_data = pd.DataFrame(\n",
@@ -1293,7 +1653,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "mh15e0vkis",
    "metadata": {},
    "outputs": [
@@ -1549,7 +1909,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "yk1s8gl62dk",
    "metadata": {},
    "outputs": [
@@ -1794,7 +2154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "ol0vob2k2ao",
    "metadata": {},
    "outputs": [
@@ -1927,7 +2287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260219 13:46:36.494286 1173784 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260724 20:17:52.543535 4443 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {
@@ -1958,7 +2318,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2025-01-01</th>\n",
-       "      <td>None</td>\n",
+       "      <td>NaN</td>\n",
        "      <td>999.0</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -1982,7 +2342,7 @@
       ],
       "text/plain": [
        "           Exchange  Price\n",
-       "2025-01-01     None  999.0\n",
+       "2025-01-01      NaN  999.0\n",
        "2025-01-01      LSE  200.0\n",
        "2025-01-02     None  300.0\n",
        "2025-01-02      LSE  400.0"
@@ -2059,10 +2419,233 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "n7oi7kz5fwk",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data (MultiIndex with datetime first level)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-01</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-02</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>110.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>210.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-03</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>220.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Price\n",
+       "Date       Exchange       \n",
+       "2025-01-01 NYSE      100.0\n",
+       "           LSE       200.0\n",
+       "2025-01-02 NYSE      110.0\n",
+       "           LSE       210.0\n",
+       "2025-01-03 NYSE      120.0\n",
+       "           LSE       220.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correction data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <th>CORRECTED</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      Price\n",
+       "Date       Exchange        \n",
+       "2025-01-02 CORRECTED  999.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge — both rows at 2025-01-02 updated\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-01</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-02</th>\n",
+       "      <th>CORRECTED</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>CORRECTED</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-03</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>220.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                      Price\n",
+       "Date       Exchange        \n",
+       "2025-01-01 NYSE       100.0\n",
+       "           LSE        200.0\n",
+       "2025-01-02 CORRECTED  999.0\n",
+       "           CORRECTED  999.0\n",
+       "2025-01-03 NYSE       120.0\n",
+       "           LSE        220.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Target: daily prices with a MultiIndex of (date, exchange)\n",
     "dates = pd.to_datetime([\"2025-01-01\", \"2025-01-01\", \"2025-01-02\", \"2025-01-02\", \"2025-01-03\", \"2025-01-03\"])\n",
@@ -2077,23 +2660,23 @@
     "print(\"Original data (MultiIndex with datetime first level)\")\n",
     "display(lib.read(\"multi_datetime\").data)\n",
     "\n",
-    "# Source: corrections for 2025-01-02 — updates both NYSE and LSE rows at that date\n",
-    "source_dates = pd.to_datetime([\"2025-01-02\", \"2025-01-02\"])\n",
+    "# Source: a single correction for 2025-01-02. Matching uses only the datetime (the first\n",
+    "# index level), so this one row matches BOTH rows sharing that date.\n",
     "source_idx = pd.MultiIndex.from_arrays(\n",
-    "    [source_dates, [\"CORRECTED_NYSE\", \"CORRECTED_LSE\"]],\n",
+    "    [pd.to_datetime([\"2025-01-02\"]), [\"CORRECTED\"]],\n",
     "    names=[\"Date\", \"Exchange\"]\n",
     ")\n",
-    "source_correction = pd.DataFrame({\"Price\": [999.0, 888.0]}, index=source_idx)\n",
+    "source_correction = pd.DataFrame({\"Price\": [999.0]}, index=source_idx)\n",
     "print(\"Correction data\")\n",
     "display(source_correction)\n",
     "\n",
-    "# Merge: matches on datetime (first level), updates Exchange and Price\n",
+    "# Merge: matches on datetime (first level), updates the Exchange level and Price\n",
     "lib.merge_experimental(\n",
     "    \"multi_datetime\",\n",
     "    source_correction,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\")\n",
     ")\n",
-    "print(\"Data after merge — only 2025-01-02 rows updated\")\n",
+    "print(\"Data after merge — both rows at 2025-01-02 updated\")\n",
     "display(lib.read(\"multi_datetime\").data)"
    ]
   },
@@ -2102,17 +2685,240 @@
    "id": "77debvhorr8",
    "metadata": {},
    "source": [
-    "Both rows at `2025-01-02` were updated because they share the same datetime. The `Exchange` level — which is the second index level — was also updated to the new values from `source`. Rows at other dates remain unchanged.\n",
+    "Because matching uses only the datetime (the first index level), the single correction at `2025-01-02` matched **both** rows sharing that date. Both had their `Exchange` level — the second index level — and `Price` updated to the source values, producing two identical rows. Rows at other dates remain unchanged.\n",
     "\n",
-    "To update only a specific exchange at a given date, use the `on` parameter with the second index level name. Note that since `Exchange` is a non-first index level, it is treated as a regular column internally and can be used in `on`."
+    "With datetime-only matching you cannot give the two rows at the same date *different* corrections: a source containing two rows at `2025-01-02` would match each target row twice and raise an ambiguity error. To target a specific row, add the distinguishing level to `on`, as shown next."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "k5hu3rkcs8k",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-01</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-02</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>110.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>210.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-03</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>220.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Price\n",
+       "Date       Exchange       \n",
+       "2025-01-01 NYSE      100.0\n",
+       "           LSE       200.0\n",
+       "2025-01-02 NYSE      110.0\n",
+       "           LSE       210.0\n",
+       "2025-01-03 NYSE      120.0\n",
+       "           LSE       220.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correction data (NYSE only)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Price\n",
+       "Date       Exchange       \n",
+       "2025-01-02 NYSE      999.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge with on=['Exchange'] — only NYSE at 2025-01-02 updated\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-01</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-02</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>210.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">2025-01-03</th>\n",
+       "      <th>NYSE</th>\n",
+       "      <td>120.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>LSE</th>\n",
+       "      <td>220.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Price\n",
+       "Date       Exchange       \n",
+       "2025-01-01 NYSE      100.0\n",
+       "           LSE       200.0\n",
+       "2025-01-02 NYSE      999.0\n",
+       "           LSE       210.0\n",
+       "2025-01-03 NYSE      120.0\n",
+       "           LSE       220.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Reset to original data\n",
     "lib.write(\"multi_datetime_on\", multi_target)\n",
@@ -2151,10 +2957,227 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "854s59ew9gj",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data (MultiIndex with non-datetime first level)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Category</th>\n",
+       "      <th>ProductID</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">Electronics</th>\n",
+       "      <th>101</th>\n",
+       "      <td>Laptop</td>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>102</th>\n",
+       "      <td>Phone</td>\n",
+       "      <td>499.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">Clothing</th>\n",
+       "      <th>201</th>\n",
+       "      <td>Jacket</td>\n",
+       "      <td>150.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>202</th>\n",
+       "      <td>Shoes</td>\n",
+       "      <td>89.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         Name  Price\n",
+       "Category    ProductID               \n",
+       "Electronics 101        Laptop  999.0\n",
+       "            102         Phone  499.0\n",
+       "Clothing    201        Jacket  150.0\n",
+       "            202         Shoes   89.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correction data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Category</th>\n",
+       "      <th>ProductID</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>UPDATED</th>\n",
+       "      <th>999</th>\n",
+       "      <td>Phone</td>\n",
+       "      <td>399.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     Name  Price\n",
+       "Category ProductID              \n",
+       "UPDATED  999        Phone  399.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge with on=['Name'] — Phone row updated\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th>Name</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Category</th>\n",
+       "      <th>ProductID</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Electronics</th>\n",
+       "      <th>101</th>\n",
+       "      <td>Laptop</td>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>UPDATED</th>\n",
+       "      <th>999</th>\n",
+       "      <td>Phone</td>\n",
+       "      <td>399.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th rowspan=\"2\" valign=\"top\">Clothing</th>\n",
+       "      <th>201</th>\n",
+       "      <td>Jacket</td>\n",
+       "      <td>150.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>202</th>\n",
+       "      <td>Shoes</td>\n",
+       "      <td>89.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                         Name  Price\n",
+       "Category    ProductID               \n",
+       "Electronics 101        Laptop  999.0\n",
+       "UPDATED     999         Phone  399.0\n",
+       "Clothing    201        Jacket  150.0\n",
+       "            202         Shoes   89.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Target: product catalog with a MultiIndex of (Category, ProductID)\n",
     "idx = pd.MultiIndex.from_arrays(\n",
@@ -2206,7 +3229,7 @@
     "1. Both `target` and `source` must have a sorted index when using `pd.DatetimeIndex` or a `pd.MultiIndex` with a datetime first level.\n",
     "2. The library must use a static schema, and both `source` and `target` must share the same schema.\n",
     "3. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses row-range matching (requires the `on` parameter).\n",
-    "4. For strategies with `not_matched_by_target=\"insert\"`, only datetime-indexed data is supported (including `pd.MultiIndex` with a datetime first level)."
+    "4. For strategies with `not_matched_by_target=\"insert\"`, only datetime-indexed data is supported."
    ]
   },
   {

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -156,10 +156,8 @@ def dataframe_dump_to_log(label_for_df, df: pd.DataFrame):
     we could use to reproduce something or further analyze failures caused by
     a problems in test code or arctic
     """
-    print("-" * 80)
-    if SHORTER_LOGS:
-        print("No full dataframes dumps when shorter logs is activated")
-    else:
+    if not SHORTER_LOGS:
+        print("-" * 80)
         if isinstance(df, pd.DataFrame):
             print("dataframe : , ", label_for_df)
             print(df.to_csv())

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -156,17 +156,18 @@ def dataframe_dump_to_log(label_for_df, df: pd.DataFrame):
     we could use to reproduce something or further analyze failures caused by
     a problems in test code or arctic
     """
-    if not SHORTER_LOGS:
-        print("-" * 80)
-        if isinstance(df, pd.DataFrame):
-            print("dataframe : , ", label_for_df)
-            print(df.to_csv())
-            print("column definitions : ")
-            print(df.dtypes)
-        else:
-            print(f"Not a dataframe passed : {type(df)}")
-            print(df)
-        print("-" * 80)
+    if SHORTER_LOGS:
+        return
+    print("-" * 80)
+    if isinstance(df, pd.DataFrame):
+        print("dataframe : , ", label_for_df)
+        print(df.to_csv())
+        print("column definitions : ")
+        print(df.dtypes)
+    else:
+        print(f"Not a dataframe passed : {type(df)}")
+        print(df)
+    print("-" * 80)
 
 
 def dataframe_single_column_string(length=1000, column_label="string_short", seed=0, string_len=1):

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4298,8 +4298,6 @@ class NativeVersionStore:
         source : pandas.DataFrame or pandas.Series
             The new data to merge. In the case of timeseries, the index must be sorted.
         strategy : Optional[MergeStrategy], default=MergeStrategy(matched="update", not_matched_by_target="insert")
-            !!! warning
-                Only `MergeStrategy(matched="update", not_matched_by_target="do_nothing")` is implemented
 
             Determines how to handle matched and unmatched rows. Accepted strategies are:
                 - MergeStrategy(matched="update", not_matched_by_target="do_nothing"): Update matched rows, leave others unchanged.

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4298,6 +4298,8 @@ class NativeVersionStore:
         source : pandas.DataFrame or pandas.Series
             The new data to merge. In the case of timeseries, the index must be sorted.
         strategy : Optional[MergeStrategy], default=MergeStrategy(matched="update", not_matched_by_target="insert")
+            !!! warning
+                Strategies using insertion are implemented only for DatetimeIndex
 
             Determines how to handle matched and unmatched rows. Accepted strategies are:
                 - MergeStrategy(matched="update", not_matched_by_target="do_nothing"): Update matched rows, leave others unchanged.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3438,8 +3438,6 @@ class Library:
         source : pandas.DataFrame or pandas.Series
             The new data to merge. In the case of timeseries, the index must be sorted.
         strategy : Optional[MergeStrategy], default=MergeStrategy(matched="update", not_matched_by_target="insert")
-            !!! warning
-                Only `MergeStrategy(matched="update", not_matched_by_target="do_nothing")` is implemented
 
             Determines how to handle matched and unmatched rows. Accepted strategies are:
                 - MergeStrategy(matched="update", not_matched_by_target="do_nothing"): Update matched rows, leave others unchanged.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3438,6 +3438,8 @@ class Library:
         source : pandas.DataFrame or pandas.Series
             The new data to merge. In the case of timeseries, the index must be sorted.
         strategy : Optional[MergeStrategy], default=MergeStrategy(matched="update", not_matched_by_target="insert")
+            !!! warning
+                Strategies using insertion are implemented only for DatetimeIndex
 
             Determines how to handle matched and unmatched rows. Accepted strategies are:
                 - MergeStrategy(matched="update", not_matched_by_target="do_nothing"): Update matched rows, leave others unchanged.

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -1,3 +1,5 @@
+from collections import Counter
+
 import pandas as pd
 import numpy as np
 import pytest
@@ -14,6 +16,8 @@ from typing import List, Tuple, Optional
 
 from arcticdb.util.test import assert_frame_equal, merge
 from tests.util.mark import MACOS, WINDOWS
+
+from arcticdb.options import LibraryOptions
 
 pytestmark = pytest.mark.merge_update
 
@@ -183,4 +187,164 @@ def test_rowrange_merge_update(s3_version_store_v1, merge_args):
         return
     result = lib.read(symbol).data
     expected = merge(target[0], source, strategy=strategy, on=on)
+    assert_frame_equal(result, expected)
+
+
+########################################################################################
+##################################### MERGE INSERT #####################################
+########################################################################################
+
+# Writing an oracle function for merge insert is actually complicated. The hypothesis strategy takes a different
+# approach, starting from the end result and working backwards to generate the target and source dataframes. The steps
+# are as follows:
+# 1. Generate the end result first
+# 2. Select random rows from the end result. These rows will be the rows that will be inserted in in the target.
+# 2.1. The selected rows might appear more than once in the end result. Find all rows in the the dataframe that match
+#      on the set of on columns
+# 2.2 Remove all such rows from the end result
+# 2.3 Add the removed rows to the source dataframe
+# 3. Chose random rows from the datafrme computed on the previous step. These rows will be the rows to be updated
+# 3.1 Find all rows that match on the set of on columns and place random values in the rest of the columns. This will
+#     be the target.
+# 3.2 Place the set of selected rows in the source dataframe
+# 4. Now we have the end result, the target and the source.
+
+# Single sentinel used only when building match keys: None/NaN/NaT collapse to it so they compare equal, mirroring the
+# way the merge treats missing values (a source None matches a target NaN and vice versa). It is never written into the
+# data - target/source/expected are slices/reorders of the generated frame, so the real None/NaN values are preserved.
+_MISSING = object()
+
+
+def _row_keys(frame, on):
+    return [
+        (index, *[_MISSING if pd.isna(frame[col].iat[pos]) else frame[col].iat[pos] for col in on])
+        for pos, index in enumerate(frame.index)
+    ]
+
+
+@st.composite
+def merge_insert_dataframes(draw, column_names, column_dtypes, min_date, max_date, on):
+    merged_dataframe = draw(dataframe(column_names, column_dtypes, min_date, max_date))
+    merged_dataframe.sort_index(inplace=True)
+    inserted_row_indexes = sorted(draw(st.lists(st.integers(0, len(merged_dataframe) - 1), unique=True)))
+    keys = pd.Series(_row_keys(merged_dataframe, on), index=merged_dataframe.index)
+    inserted_keys = list(set(keys.iloc[inserted_row_indexes]))
+    # A row is a source (inserted) row if it shares an (index, on) key with a selected row. This pulls in every row with
+    # a matching key - e.g. a None and a NaN at the same index - because the merge would treat them as equal.
+    is_source = keys.isin(inserted_keys).to_numpy()
+    target_dataframe = merged_dataframe[~is_source]
+    source = merged_dataframe[is_source]
+    # Reconstruct expected the way the merge places rows: within each timestamp the target rows come first, then the
+    # inserted rows. Reorder by position (iloc) rather than pd.concat, which would collapse an object column's NaN to
+    # None; iloc preserves the exact None/NaN values.
+    order = sorted(range(len(merged_dataframe)), key=lambda i: (merged_dataframe.index[i], bool(is_source[i])))
+    expected = merged_dataframe.iloc[order]
+    return target_dataframe, source, expected
+
+
+@st.composite
+def merge_insert_arguments(draw):
+    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True))
+    target, source, expected = draw(merge_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on))
+    rows_per_segment = draw(st.integers(1, len(expected)))
+    cols_per_segment = draw(st.integers(1, len(COL_NAMES)))
+    return target, source, expected, on, cols_per_segment, rows_per_segment
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@given(merge_args=merge_insert_arguments())
+@settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
+def test_datetime_insert(s3_storage, merge_args):
+    target, source, expected, on, cols_per_segment, rows_per_segment = merge_args
+    # A fresh library per hypothesis example: the drawn rows/columns_per_segment are library-level options, and the
+    # function-scoped fixture is not reset between examples, so recreate the library each time.
+    ac = s3_storage.create_arctic()
+    name = "test_datetime_insert"
+    if name in ac.list_libraries():
+        ac.delete_library(name)
+    lib = ac.create_library(
+        name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
+    )
+    lib.write("symbol", target)
+    lib.merge_experimental(
+        "symbol", source, strategy=MergeStrategy(matched="do_nothing", not_matched_by_target="insert"), on=on
+    )
+    result = lib.read("symbol").data
+    assert_frame_equal(result, expected)
+
+
+@st.composite
+def merge_update_insert_dataframes(draw, column_names, column_dtypes, min_date, max_date, on):
+    merged_dataframe = draw(dataframe(column_names, column_dtypes, min_date, max_date))
+    merged_dataframe.sort_index(inplace=True)
+    keys = pd.Series(_row_keys(merged_dataframe, on), index=merged_dataframe.index)
+
+    # Rows to insert (same rule as the insert-only case): any row sharing a selected key is a source-only row.
+    inserted_row_indexes = sorted(draw(st.lists(st.integers(0, len(merged_dataframe) - 1), unique=True)))
+    inserted_keys = list(set(keys.iloc[inserted_row_indexes]))
+    is_inserted = keys.isin(inserted_keys).to_numpy()
+
+    # Rows to update: chosen from the non-inserted rows whose (index, on) key is unique among the non-inserted rows, so
+    # each update source row matches exactly one target row. An updated row stays in the target (with fresh random
+    # values in its non-"on" columns) and a copy carrying the expected values is added to the source, so the merge's
+    # update restores it to the expected values.
+    non_inserted_positions = [i for i in range(len(merged_dataframe)) if not is_inserted[i]]
+    non_inserted_keys = [keys.iloc[i] for i in non_inserted_positions]
+    key_counts = Counter(non_inserted_keys)
+    updatable_positions = [i for i, key in zip(non_inserted_positions, non_inserted_keys) if key_counts[key] == 1]
+    is_updated = np.zeros(len(merged_dataframe), dtype=bool)
+    for position in draw(st.lists(st.sampled_from(updatable_positions), unique=True)) if updatable_positions else []:
+        is_updated[position] = True
+
+    # source = inserted rows + copies of the updated rows, all carrying the expected values. A single boolean slice (no
+    # pd.concat) keeps the exact None/NaN values, and it is index-sorted because merged_dataframe is sorted.
+    source = merged_dataframe[is_inserted | is_updated]
+
+    # target = the non-inserted rows; the updated rows get fresh random values in their non-"on" columns.
+    target = merged_dataframe[~is_inserted].copy(deep=True)
+    non_on_columns = [col for col in target.columns if col not in on]
+    updated_positions_in_target = np.flatnonzero(is_updated[~is_inserted])
+    if len(updated_positions_in_target) > 0 and non_on_columns:
+        replacement = draw(dataframe(column_names, column_dtypes, min_date, max_date))
+        picks = [draw(st.integers(0, len(replacement) - 1)) for _ in updated_positions_in_target]
+        for col in non_on_columns:
+            target.iloc[updated_positions_in_target, target.columns.get_loc(col)] = replacement.iloc[picks][
+                col
+            ].to_numpy()
+            # Restore the dtype in case the positional assignment upcast it (object columns keep None/NaN as-is).
+            if merged_dataframe[col].dtype != object:
+                target[col] = target[col].astype(merged_dataframe[col].dtype)
+
+    # expected = merged reordered so inserted rows follow the target rows at the same timestamp; updates stay in place.
+    order = sorted(range(len(merged_dataframe)), key=lambda i: (merged_dataframe.index[i], bool(is_inserted[i])))
+    expected = merged_dataframe.iloc[order]
+    return target, source, expected
+
+
+@st.composite
+def merge_update_insert_arguments(draw):
+    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True))
+    target, source, expected = draw(merge_update_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on))
+    rows_per_segment = draw(st.integers(1, len(expected)))
+    cols_per_segment = draw(st.integers(1, len(COL_NAMES)))
+    return target, source, expected, on, cols_per_segment, rows_per_segment
+
+
+@use_of_function_scoped_fixtures_in_hypothesis_checked
+@given(merge_args=merge_update_insert_arguments())
+@settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
+def test_datetime_update_insert(s3_storage, merge_args):
+    target, source, expected, on, cols_per_segment, rows_per_segment = merge_args
+    ac = s3_storage.create_arctic()
+    name = "test_datetime_update_insert"
+    if name in ac.list_libraries():
+        ac.delete_library(name)
+    lib = ac.create_library(
+        name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
+    )
+    lib.write("symbol", target)
+    lib.merge_experimental(
+        "symbol", source, strategy=MergeStrategy(matched="update", not_matched_by_target="insert"), on=on
+    )
+    result = lib.read("symbol").data
     assert_frame_equal(result, expected)

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -1,5 +1,3 @@
-from collections import Counter
-
 import pandas as pd
 import numpy as np
 import pytest
@@ -10,11 +8,11 @@ from arcticdb.util.hypothesis import (
     DataframeStrategyIndexType,
 )
 from arcticdb.exceptions import DuplicateKeyException, UserInputException
-from arcticdb.version_store._store import MergeStrategy
+from arcticdb.version_store._store import MergeStrategy, MergeAction, normalize_merge_action
 from hypothesis import assume, strategies as st, given, settings, HealthCheck
 from typing import List, Tuple, Optional
 
-from arcticdb.util.test import assert_frame_equal, merge
+from arcticdb.util.test import assert_frame_equal, merge, random_strings_of_length_with_nan
 from tests.util.mark import MACOS, WINDOWS
 
 from arcticdb.options import LibraryOptions
@@ -195,19 +193,29 @@ def test_rowrange_merge_update(s3_version_store_v1, merge_args):
 ########################################################################################
 
 # Writing an oracle function for merge insert is actually complicated. The hypothesis strategy takes a different
-# approach, starting from the end result and working backwards to generate the target and source dataframes. The steps
-# are as follows:
-# 1. Generate the end result first
-# 2. Select random rows from the end result. These rows will be the rows that will be inserted in in the target.
-# 2.1. The selected rows might appear more than once in the end result. Find all rows in the the dataframe that match
-#      on the set of on columns
-# 2.2 Remove all such rows from the end result
-# 2.3 Add the removed rows to the source dataframe
-# 3. Chose random rows from the datafrme computed on the previous step. These rows will be the rows to be updated
-# 3.1 Find all rows that match on the set of on columns and place random values in the rest of the columns. This will
-#     be the target.
-# 3.2 Place the set of selected rows in the source dataframe
-# 4. Now we have the end result, the target and the source.
+# approach, starting from the end result and working backwards to generate the target and source dataframes. The
+# steps are as follows:
+# 1. Generate the end result first.
+# 2. Select random rows from the end result. These rows will be the rows inserted into the target.
+# 2.1 The selected rows might appear more than once in the end result. Find and remove all rows in the dataframe
+#     that match on the index and the set of on columns as any of the selected rows — not just the selected rows
+#     themselves, so the removed set can contain multiple rows sharing an identical key.
+# 2.2 Add all of the removed rows to the source dataframe. None of them remain in the target, so the merge treats
+#     every one as unmatched: if several removed rows share a key, all of them get inserted into the target, not
+#     just one.
+# 3. Choose random rows from the remaining rows whose match key (index and on columns) is unique among them, so
+#    each source row matches at most one target row. These are the matched rows. Put copies of these rows,
+#    unchanged, into both the target and the source — so at this point target and source agree on every matched
+#    row, and the end result is already the expected outcome of the merge regardless of strategy.
+# 4. Only one of target/source gets its matched rows' non-on columns overwritten with random values, and which one
+#    depends on the strategy — the other keeps the end result's original (and therefore expected) values:
+# 4.1 If the strategy updates on matched: the merge overwrites the target with the source on a match, so the
+#     target's matched rows are randomized (proving the merge corrects them) while the source keeps the expected
+#     values.
+# 4.2 If the strategy does not update on matched: the merge ignores the source on a match, so the source's matched
+#     rows are randomized (proving the merge ignores them) while the target keeps the expected values.
+# In both cases the expected result is simply the end result from step 1, reordered so inserted rows follow the
+# target rows sharing their timestamp.
 
 # Single sentinel used only when building match keys: None/NaN/NaT collapse to it so they compare equal, mirroring the
 # way the merge treats missing values (a source None matches a target NaN and vice versa). It is never written into the
@@ -215,49 +223,95 @@ def test_rowrange_merge_update(s3_version_store_v1, merge_args):
 _MISSING = object()
 
 
-def _row_keys(frame, on):
-    return [
-        (index, *[_MISSING if pd.isna(frame[col].iat[pos]) else frame[col].iat[pos] for col in on])
-        for pos, index in enumerate(frame.index)
-    ]
+def match_keys(frame, on):
+    columns = [frame[col] for col in on]
+    return pd.Series(
+        [
+            (index, *(_MISSING if pd.isna(col.iat[pos]) else col.iat[pos] for col in columns))
+            for pos, index in enumerate(frame.index)
+        ]
+    )
+
+
+def generate_rows_to_insert(draw, keys):
+    seed = draw(st.lists(st.integers(0, len(keys) - 1), unique=True))
+    inserted_keys = set(keys.iloc[seed])
+    return keys.isin(inserted_keys).to_numpy()
+
+
+def generate_matched_rows(draw, keys, is_inserted):
+    remaining = np.flatnonzero(~is_inserted)
+    matchable = remaining[~keys.iloc[remaining].duplicated(keep=False).to_numpy()]
+    positions = draw(st.lists(st.sampled_from(matchable), unique=True)) if len(matchable) else []
+    is_matched = np.zeros(len(is_inserted), dtype=bool)
+    is_matched[positions] = True
+    return is_matched
+
+
+def random_values_for_dtype(dtype, count):
+    dtype = np.dtype(dtype)
+    if dtype == object:
+        return random_strings_of_length_with_nan(count, 10)
+    if np.issubdtype(dtype, np.integer):
+        info = np.iinfo(dtype)
+        return np.random.randint(info.min, info.max, size=count, dtype=dtype)
+    if np.issubdtype(dtype, np.floating):
+        return np.random.random(count).astype(dtype)
+    if np.issubdtype(dtype, np.bool_):
+        return np.random.random(count) < 0.5
+    # datetime64[ns] stored as int64
+    info = np.iinfo(np.int64)
+    return np.random.randint(info.min, info.max, size=count).astype(dtype)
+
+
+def randomize_values(frame, positions, columns):
+    if not len(positions) or not columns:
+        return
+    for col in columns:
+        dtype = frame[col].dtype
+        frame.iloc[positions, frame.columns.get_loc(col)] = random_values_for_dtype(dtype, len(positions))
+        if dtype != object:
+            frame[col] = frame[col].astype(dtype)
 
 
 @st.composite
-def merge_insert_dataframes(draw, column_names, column_dtypes, min_date, max_date, on):
-    merged_dataframe = draw(dataframe(column_names, column_dtypes, min_date, max_date))
-    merged_dataframe.sort_index(inplace=True)
-    inserted_row_indexes = sorted(draw(st.lists(st.integers(0, len(merged_dataframe) - 1), unique=True)))
-    keys = pd.Series(_row_keys(merged_dataframe, on), index=merged_dataframe.index)
-    inserted_keys = list(set(keys.iloc[inserted_row_indexes]))
-    # A row is a source (inserted) row if it shares an (index, on) key with a selected row. This pulls in every row with
-    # a matching key - e.g. a None and a NaN at the same index - because the merge would treat them as equal.
-    is_source = keys.isin(inserted_keys).to_numpy()
-    target_dataframe = merged_dataframe[~is_source]
-    source = merged_dataframe[is_source]
-    # Reconstruct expected the way the merge places rows: within each timestamp the target rows come first, then the
-    # inserted rows. Reorder by position (iloc) rather than pd.concat, which would collapse an object column's NaN to
-    # None; iloc preserves the exact None/NaN values.
-    order = sorted(range(len(merged_dataframe)), key=lambda i: (merged_dataframe.index[i], bool(is_source[i])))
-    expected = merged_dataframe.iloc[order]
-    return target_dataframe, source, expected
+def merge_insert_dataframes(draw, column_names, column_dtypes, min_date, max_date, on, strategy):
+    merged = draw(dataframe(column_names, column_dtypes, min_date, max_date)).sort_index()
+    keys = match_keys(merged, on)
+    is_inserted = generate_rows_to_insert(draw, keys)
+    is_matched = generate_matched_rows(draw, keys, is_inserted)
+    is_source = is_inserted | is_matched
+    target = merged[~is_inserted].copy(deep=True)
+    source = merged[is_source].copy(deep=True)
+    non_on_columns = [col for col in merged.columns if col not in on]
+    if normalize_merge_action(strategy.matched) == MergeAction.UPDATE:
+        # merge overwrites target with source, so randomize target to prove the merge actually updates it.
+        randomize_values(target, np.flatnonzero(is_matched[~is_inserted]), non_on_columns)
+    else:
+        # matched=do_nothing: merge ignores source, so randomize source to prove the merge doesn't use it.
+        randomize_values(source, np.flatnonzero(is_matched[is_source]), non_on_columns)
+
+    # Reorder so inserted rows follow the target rows sharing their timestamp
+    order = sorted(range(len(merged)), key=lambda i: (merged.index[i], bool(is_inserted[i])))
+    expected = merged.iloc[order]
+
+    return target, source, expected
 
 
 @st.composite
-def merge_insert_arguments(draw):
+def merge_insert_arguments(draw, strategy):
     on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True))
-    target, source, expected = draw(merge_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on))
+    target, source, expected = draw(merge_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on, strategy))
     rows_per_segment = draw(st.integers(1, len(expected)))
     cols_per_segment = draw(st.integers(1, len(COL_NAMES)))
-    return target, source, expected, on, cols_per_segment, rows_per_segment
+    return target, source, expected, strategy, on, cols_per_segment, rows_per_segment
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
-@given(merge_args=merge_insert_arguments())
+@given(merge_args=merge_insert_arguments(MergeStrategy(matched="do_nothing", not_matched_by_target="insert")))
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
 def test_datetime_insert(s3_storage, merge_args):
-    target, source, expected, on, cols_per_segment, rows_per_segment = merge_args
-    # A fresh library per hypothesis example: the drawn rows/columns_per_segment are library-level options, and the
-    # function-scoped fixture is not reset between examples, so recreate the library each time.
+    target, source, expected, strategy, on, cols_per_segment, rows_per_segment = merge_args
     ac = s3_storage.create_arctic()
     name = "test_datetime_insert"
     if name in ac.list_libraries():
@@ -266,75 +320,16 @@ def test_datetime_insert(s3_storage, merge_args):
         name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
     )
     lib.write("symbol", target)
-    lib.merge_experimental(
-        "symbol", source, strategy=MergeStrategy(matched="do_nothing", not_matched_by_target="insert"), on=on
-    )
+    lib.merge_experimental("symbol", source, strategy=strategy, on=on)
     result = lib.read("symbol").data
     assert_frame_equal(result, expected)
 
 
-@st.composite
-def merge_update_insert_dataframes(draw, column_names, column_dtypes, min_date, max_date, on):
-    merged_dataframe = draw(dataframe(column_names, column_dtypes, min_date, max_date))
-    merged_dataframe.sort_index(inplace=True)
-    keys = pd.Series(_row_keys(merged_dataframe, on), index=merged_dataframe.index)
-
-    # Rows to insert (same rule as the insert-only case): any row sharing a selected key is a source-only row.
-    inserted_row_indexes = sorted(draw(st.lists(st.integers(0, len(merged_dataframe) - 1), unique=True)))
-    inserted_keys = list(set(keys.iloc[inserted_row_indexes]))
-    is_inserted = keys.isin(inserted_keys).to_numpy()
-
-    # Rows to update: chosen from the non-inserted rows whose (index, on) key is unique among the non-inserted rows, so
-    # each update source row matches exactly one target row. An updated row stays in the target (with fresh random
-    # values in its non-"on" columns) and a copy carrying the expected values is added to the source, so the merge's
-    # update restores it to the expected values.
-    non_inserted_positions = [i for i in range(len(merged_dataframe)) if not is_inserted[i]]
-    non_inserted_keys = [keys.iloc[i] for i in non_inserted_positions]
-    key_counts = Counter(non_inserted_keys)
-    updatable_positions = [i for i, key in zip(non_inserted_positions, non_inserted_keys) if key_counts[key] == 1]
-    is_updated = np.zeros(len(merged_dataframe), dtype=bool)
-    for position in draw(st.lists(st.sampled_from(updatable_positions), unique=True)) if updatable_positions else []:
-        is_updated[position] = True
-
-    # source = inserted rows + copies of the updated rows, all carrying the expected values. A single boolean slice (no
-    # pd.concat) keeps the exact None/NaN values, and it is index-sorted because merged_dataframe is sorted.
-    source = merged_dataframe[is_inserted | is_updated]
-
-    # target = the non-inserted rows; the updated rows get fresh random values in their non-"on" columns.
-    target = merged_dataframe[~is_inserted].copy(deep=True)
-    non_on_columns = [col for col in target.columns if col not in on]
-    updated_positions_in_target = np.flatnonzero(is_updated[~is_inserted])
-    if len(updated_positions_in_target) > 0 and non_on_columns:
-        replacement = draw(dataframe(column_names, column_dtypes, min_date, max_date))
-        picks = [draw(st.integers(0, len(replacement) - 1)) for _ in updated_positions_in_target]
-        for col in non_on_columns:
-            target.iloc[updated_positions_in_target, target.columns.get_loc(col)] = replacement.iloc[picks][
-                col
-            ].to_numpy()
-            # Restore the dtype in case the positional assignment upcast it (object columns keep None/NaN as-is).
-            if merged_dataframe[col].dtype != object:
-                target[col] = target[col].astype(merged_dataframe[col].dtype)
-
-    # expected = merged reordered so inserted rows follow the target rows at the same timestamp; updates stay in place.
-    order = sorted(range(len(merged_dataframe)), key=lambda i: (merged_dataframe.index[i], bool(is_inserted[i])))
-    expected = merged_dataframe.iloc[order]
-    return target, source, expected
-
-
-@st.composite
-def merge_update_insert_arguments(draw):
-    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True))
-    target, source, expected = draw(merge_update_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on))
-    rows_per_segment = draw(st.integers(1, len(expected)))
-    cols_per_segment = draw(st.integers(1, len(COL_NAMES)))
-    return target, source, expected, on, cols_per_segment, rows_per_segment
-
-
 @use_of_function_scoped_fixtures_in_hypothesis_checked
-@given(merge_args=merge_update_insert_arguments())
+@given(merge_args=merge_insert_arguments(MergeStrategy(matched="update", not_matched_by_target="insert")))
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
 def test_datetime_update_insert(s3_storage, merge_args):
-    target, source, expected, on, cols_per_segment, rows_per_segment = merge_args
+    target, source, expected, strategy, on, cols_per_segment, rows_per_segment = merge_args
     ac = s3_storage.create_arctic()
     name = "test_datetime_update_insert"
     if name in ac.list_libraries():
@@ -343,8 +338,6 @@ def test_datetime_update_insert(s3_storage, merge_args):
         name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
     )
     lib.write("symbol", target)
-    lib.merge_experimental(
-        "symbol", source, strategy=MergeStrategy(matched="update", not_matched_by_target="insert"), on=on
-    )
+    lib.merge_experimental("symbol", source, strategy=strategy, on=on)
     result = lib.read("symbol").data
     assert_frame_equal(result, expected)

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -259,9 +259,10 @@ def random_values_for_dtype(dtype, count):
         return np.random.random(count).astype(dtype)
     if np.issubdtype(dtype, np.bool_):
         return np.random.random(count) < 0.5
-    # datetime64[ns] stored as int64
-    info = np.iinfo(np.int64)
-    return np.random.randint(info.min, info.max, size=count).astype(dtype)
+    # datetime64[ns] stored as int64. dtype must be passed explicitly, otherwise numpy uses the platform default
+    # integer, which is int32 on Windows, and the bounds below are then out of range.
+    low, high = (d.astype("datetime64[ns]").astype(np.int64) for d in (MIN_DATE, MAX_DATE))
+    return np.random.randint(low, high, size=count, dtype=np.int64).astype(dtype)
 
 
 def randomize_values(frame, positions, columns):

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -8,16 +8,14 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import pytest
 import pandas as pd
-from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data, merge
+from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data, merge, query_stats_operation_count
 import arcticdb
 from arcticdb.version_store import VersionedItem
 from arcticdb_ext.exceptions import SchemaException
 from arcticdb_ext.storage import KeyType
 import numpy as np
 from arcticdb.exceptions import (
-    StreamDescriptorMismatch,
     UserInputException,
-    SortingException,
     UnsortedDataException,
     StorageException,
     ArcticException,
@@ -25,6 +23,7 @@ from arcticdb.exceptions import (
 from arcticdb.version_store.library import MergeAction, MergeStrategy
 from arcticdb.version_store._store import normalize_merge_action
 from typing import Union, List, Optional
+import arcticdb.toolbox.query_stats as qs
 
 pytestmark = pytest.mark.merge_update
 
@@ -537,22 +536,19 @@ class TestMergeTimeseriesUpdate:
             lib.merge_experimental("sym", source, strategy=self.strategy)
 
     @pytest.mark.parametrize("merge_metadata", (None, "meta"))
+    @pytest.mark.xfail(reason="Monday: 12518592426")
     def test_target_is_empty(self, lmdb_library, merge_metadata):
         lib = lmdb_library
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
         lib.write("sym", target)
 
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        # NOTE: detecting that nothing will be changed is easier when the target is empty. It will be easy to not
-        # increase the version number. However, this will create two different behaviors because we currently increase
-        # the version if nothing is updated. I think having too many different behaviors will be confusing. IMO this
-        # must have the same behavior as test_merge_update_writes_new_version_even_if_nothing_is_changed.
         merge_vit = lib.merge_experimental(
             "sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING), metadata=merge_metadata
         )
         expected = target
         read_vit = lib.read("sym")
-        assert_vit_equals_except_data(merge_vit, read_vit)
+        assert read_vit.metadata is None if merge_metadata is None else read_vit.metadata == merge_metadata
         assert_frame_equal(read_vit.data, expected)
 
     @pytest.mark.parametrize(
@@ -1037,13 +1033,60 @@ class TestMergeTimeseriesUpdate:
         with pytest.raises(UserInputException, match="E_DUPLICATE_COLUMN") as exc_info:
             lib.merge_experimental("sym", source, strategy=self.strategy, on=["my_duplicated_column"])
 
+    def test_on_colum_reorders_matched_rows(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 0, 0, 1, 1], "b": [1, 2, 3, 4, 5], "c": ["a", "b", "c", "d", "e"]},
+            index=pd.DatetimeIndex([pd.Timestamp(0)] * 5),
+        )
+        # The test matches on column "a". Note the order of the columns of a. This means that
+        # source[0]: updates target [1, 2]
+        # source[1]: updates target []
+        # source[2]: updates target [0, 3, 4]
+        # Meaning that flatten(rows_to_be_updated) is not a sorted list
+        source = pd.DataFrame(
+            {"a": [0, 2, 1], "b": [100, 200, 300], "c": ["A", "B", "C"]}, index=pd.DatetimeIndex([pd.Timestamp(0)] * 3)
+        )
+        expected = pd.DataFrame(
+            {"a": [1, 0, 0, 1, 1], "b": [300, 100, 100, 300, 300], "c": ["C", "A", "A", "C", "C"]},
+            index=pd.DatetimeIndex([pd.Timestamp(0)] * 5),
+        )
+        generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a"])
+
 
 class TestMergeTimeseriesInsert:
+
+    def setup_method(self):
+        self.strategy = MergeStrategy("do_nothing", "insert")
+
+    def test_insert_past_row_slice_boundary_is_not_dropped(self, lmdb_library_factory):
+        # Regression test: an unmatched insert row that falls in the gap between two row slices used to be dropped.
+        # With rows_per_segment=2 the target [10, 20, 30] is sliced into [10, 20] and [30]; inserting the unmatched
+        # rows at 15 and 25 must keep both (25 previously landed past the first slice's end and was lost).
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=2))
+        target = pd.DataFrame(
+            {"a": [0, 1, 2]},
+            index=pd.DatetimeIndex([pd.Timestamp(10), pd.Timestamp(20), pd.Timestamp(30)]),
+        )
+        lib.write("sym", target)
+        source = pd.DataFrame(
+            {"a": [100, 101]},
+            index=pd.DatetimeIndex([pd.Timestamp(15), pd.Timestamp(25)]),
+        )
+        lib.merge_experimental("sym", source, strategy=self.strategy)
+        expected = pd.DataFrame(
+            {"a": [0, 100, 1, 101, 2]},
+            index=pd.DatetimeIndex(
+                [pd.Timestamp(10), pd.Timestamp(15), pd.Timestamp(20), pd.Timestamp(25), pd.Timestamp(30)]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
     @pytest.mark.parametrize(
         "strategy",
         (MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), MergeStrategy("do_nothing", "insert")),
     )
-    def test_basic(self, lmdb_library, monkeypatch, strategy):
+    def test_basic(self, lmdb_library, strategy):
         lib = lmdb_library
 
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
@@ -1052,20 +1095,6 @@ class TestMergeTimeseriesInsert:
         source = pd.DataFrame(
             {"a": [-1, -2, -3], "b": [-1.0, -2.0, -3.0]},
             index=pd.DatetimeIndex(["2023-01-01", "2024-01-01 10:00:00", "2025-01-04"]),
-        )
-        monkeypatch.setattr(
-            lib.__class__,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=1,
-                metadata=write_vit.metadata,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
         )
 
         merge_vit = lib.merge_experimental("sym", source, strategy=strategy)
@@ -1077,7 +1106,6 @@ class TestMergeTimeseriesInsert:
         assert merge_vit.data is None
 
         expected = pd.concat([target, source]).sort_index()
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 1))
         assert_frame_equal(lib.read("sym").data, expected)
 
     @pytest.mark.parametrize(
@@ -1118,24 +1146,10 @@ class TestMergeTimeseriesInsert:
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
-    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library, monkeypatch):
+    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
-        write_vit = lib.write("sym", target)
-        monkeypatch.setattr(
-            lib,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=write_vit.version + 1,
-                metadata=write_vit.metadata,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
-        )
+        lib.write("sym", target)
         source = pd.DataFrame(
             {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]}, index=pd.date_range("2024-01-01", periods=3)
         )
@@ -1144,34 +1158,16 @@ class TestMergeTimeseriesInsert:
         )
         assert merge_vit.version == 1
 
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=target,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(read_vit, merge_vit)
         assert_frame_equal(read_vit.data, target)
 
         lt = lib._dev_tools.library_tool()
-        monkeypatch.setattr(
-            lt,
-            "find_keys_for_symbol",
-            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 1, KeyType.TABLE_INDEX: 1, KeyType.VERSION: 2}),
-        )
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
-    def test_index_and_column(self, lmdb_library, monkeypatch):
+    def test_index_and_column(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target)
@@ -1187,7 +1183,6 @@ class TestMergeTimeseriesInsert:
                 ]
             ),
         )
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
         lib.merge_experimental(
             "sym", source, on=["a"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
         )
@@ -1195,11 +1190,10 @@ class TestMergeTimeseriesInsert:
         # The first row is matched, but the strategy for matched rows is DO_NOTHING, so no update
         # the rest rows are inserted
         expected = pd.concat([target, source.tail(len(source) - 1)]).sort_index()
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_on_multiple_columns(self, lmdb_library, monkeypatch):
+    def test_on_multiple_columns(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame(
             {
@@ -1232,89 +1226,406 @@ class TestMergeTimeseriesInsert:
             ),
         )
 
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
         lib.merge_experimental(
             "sym", source, on=["b", "d", "e"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
         )
         expected = pd.concat([target, source.tail(len(source) - 1)]).sort_index()
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_does_not_throw_when_target_row_is_matched_more_than_once_when_matched_is_do_nothing(
-        self, lmdb_library, monkeypatch
-    ):
+    def test_does_not_throw_when_target_row_is_matched_more_than_once_when_matched_is_do_nothing(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target)
 
         source = pd.DataFrame(
-            {"a": [1, 2, 4], "b": [1.0, 2.0, 4.0]},
+            {"a": [1, 2, 40], "b": [1.0, 2.0, 40.0]},
             index=pd.DatetimeIndex(
                 [
                     pd.Timestamp("2024-01-01"),  # Matches first row of target
                     pd.Timestamp("2024-01-01"),  # Also matches first row of target
-                    pd.Timestamp("2024-01-04"),
+                    pd.Timestamp("2024-01-02 00:00:01"),
                 ]
             ),
         )
 
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
         lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
         expected = pd.DataFrame(
-            {"a": [1, 2, 3, 4], "b": [1.0, 2.0, 3.0, 4.0]}, index=pd.date_range("2024-01-01", periods=4)
+            {
+                "a": [
+                    1,
+                    2,
+                    40,
+                    3,
+                ],
+                "b": [1.0, 2.0, 40.0, 3.0],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),
+                    pd.Timestamp("2024-01-02"),
+                    pd.Timestamp("2024-01-02 00:00:01"),
+                    pd.Timestamp("2024-01-03"),
+                ]
+            ),
         )
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_target_is_empty(self, lmdb_library, monkeypatch):
+    def test_target_is_empty(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
-        write_vit = lib.write("sym", target)
-
+        write_vit = lib.write("sym", target, metadata={"meta": "data"})
+        assert write_vit.version == 0
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        monkeypatch.setattr(
-            lib.__class__,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=1,
-                metadata=None,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
+        merge_vit = lib.merge_experimental(
+            "sym", source, strategy=MergeStrategy("do_nothing", "insert"), metadata={"new_meta": "new_data"}
         )
-        merge_vit = lib.merge_experimental("sym", source, strategy=MergeStrategy("do_nothing", "insert"))
+        assert merge_vit.version == 1
         expected = source
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=expected,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
         read_vit = lib.read("sym")
+        assert read_vit.metadata == {"new_meta": "new_data"}
         assert_vit_equals_except_data(merge_vit, read_vit)
         assert_frame_equal(read_vit.data, expected)
 
+    def test_insert_within_single_segment(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", target)
+        source = pd.DataFrame(
+            {"a": [100, 200, 300, 400], "b": [100.0, 200.0, 300.0, 400.0]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(2),
+                    pd.Timestamp(2),
+                    pd.Timestamp(6),
+                    pd.Timestamp(9),
+                ]
+            ),
+        )
+        lib.merge_experimental("sym", source, self.strategy)
+        expected = pd.concat([target, source]).sort_index()
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 1, 100], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 2, 3, 4, 5, 100, 6], "b": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 300.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_first_equal_run_Insert_in_second_equal_run.",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 3], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 100, 2, 3, 4, 5, 6], "b": [0.0, 1.0, 200, 2.0, 3.0, 4.0, 5.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_second_equal_run_Insert_in_first.",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 1, 2, 5, 200, 4, 3], "b": [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                        ]
+                    ),
+                ),
+                pd.DataFrame(
+                    {
+                        "a": [0, 1, 100, 2, 3, 4, 5, 200, 6],
+                        "b": [0.0, 1.0, 200.0, 2.0, 3.0, 4.0, 5.0, 600.0, 6.0],
+                    },
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_both_equal_index_runs_and_insert_in_both.",
+            ),
+        ],
+    )
+    def test_within_single_segment_match_on_column(self, lmdb_library, source, expected):
+        lib = lmdb_library
+        index = pd.DatetimeIndex(
+            [
+                pd.Timestamp(0),
+                pd.Timestamp(0),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(6),
+            ]
+        )
+        target = pd.DataFrame({"a": range(len(index)), "b": np.linspace(0, len(index) - 1, len(index))}, index=index)
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pd.DataFrame({"a": [10], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp(0)])),
+            pd.DataFrame({"a": [10], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp(5)])),
+            pd.DataFrame({"a": [10], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp(10)])),
+            pd.DataFrame(
+                {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])
+            ),
+            pd.DataFrame(
+                {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(10)])
+            ),
+            pd.DataFrame(
+                {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(5), pd.Timestamp(10)])
+            ),
+            pd.DataFrame(
+                {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]},
+                index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+            ),
+        ],
+    )
+    def test_within_single_segment_matched_rows_stay_the_same(self, lmdb_library, source):
+        lib = lmdb_library
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, self.strategy)
+        assert_frame_equal(lib.read("sym").data, target)
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                pd.DataFrame({"a": [10], "b": [20.0], "c": [True]}, index=pd.DatetimeIndex([pd.Timestamp(2)])),
+                id="Insert_single_row_in_first_segment",
+            ),
+            pytest.param(
+                pd.DataFrame({"a": [10], "b": [20.0], "c": [True]}, index=pd.DatetimeIndex([pd.Timestamp(21)])),
+                id="Insert_single_row_in_second_segment",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [10, 100], "b": [20.0, 200.0], "c": [False, True]},
+                    index=pd.DatetimeIndex([pd.Timestamp(6), pd.Timestamp(26)]),
+                ),
+                id="Insert_single_value_in_both_segments",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {
+                        "a": [10, 20, 30, 40, 50, 1000, 2000],
+                        "b": [60.0, 70.0, 80.0, 90.0, 100.0, 3000, 4000],
+                        "c": [True, False, False, True, True, True, False],
+                    },
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(1),
+                            pd.Timestamp(2),
+                            pd.Timestamp(3),
+                            pd.Timestamp(7),
+                            pd.Timestamp(9),
+                            pd.Timestamp(21),
+                            pd.Timestamp(26),
+                        ]
+                    ),
+                ),
+                id="Insert_multiple_values_in_both_segments",
+            ),
+        ],
+    )
+    def test_within_two_segments(self, lmdb_library, source):
+        lib = lmdb_library
+        seg0 = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": [True, False, True]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", seg0)
+        seg1 = pd.DataFrame(
+            {"a": [4, 5, 6], "b": [4.0, 5.0, 6.0], "c": [False, True, False]},
+            index=pd.DatetimeIndex([pd.Timestamp(20), pd.Timestamp(25), pd.Timestamp(30)]),
+        )
+        lib.append("sym", seg1)
+        expected = pd.concat([seg0, seg1, source]).sort_index()
+        lib.merge_experimental("sym", source, self.strategy)
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            [pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp(5)]))],
+            [
+                pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp(5)])),
+                pd.DataFrame({"a": [10]}, index=pd.DatetimeIndex([pd.Timestamp(10)])),
+            ],
+        ],
+    )
+    def test_insert_before_first_segment_start(self, in_memory_store_factory, target):
+        lib = in_memory_store_factory()
+        for tgt in target:
+            lib.append("sym", tgt)
+        source = pd.DataFrame(
+            {"a": [100, 200, 300]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(1)])
+        )
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, self.strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        index_key = lib.read_index("sym")
+        assert index_key.index[0] == source.index[0]
+        assert index_key["end_index"][0] == pd.Timestamp(6)
+        assert_frame_equal(lib.read("sym").data, pd.concat(target + [source]).sort_index())
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            [pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp(5)]))],
+            [
+                pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp(5)])),
+                pd.DataFrame({"a": [10]}, index=pd.DatetimeIndex([pd.Timestamp(10)])),
+            ],
+        ],
+    )
+    def test_insert_after_last_segment_end(self, in_memory_store_factory, target):
+        lib = in_memory_store_factory()
+        for tgt in target:
+            lib.append("sym", tgt)
+        source = pd.DataFrame(
+            {"a": [100, 200, 300]}, index=pd.DatetimeIndex([pd.Timestamp(15), pd.Timestamp(15), pd.Timestamp(16)])
+        )
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, self.strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        index_key = lib.read_index("sym")
+        assert index_key.index[-1] == target[-1].index[0]
+        assert index_key["end_index"][-1] == pd.Timestamp(17)
+        assert_frame_equal(lib.read("sym").data, pd.concat(target + [source]).sort_index())
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            [pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp(5)]))],
+            [
+                pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp(5)])),
+                pd.DataFrame({"a": [10]}, index=pd.DatetimeIndex([pd.Timestamp(10)])),
+            ],
+        ],
+    )
+    def test_insert_before_first_segment_start_and_after_last_segment_end(self, lmdb_library, target):
+        lib = lmdb_library
+        for tgt in target:
+            lib.append("sym", tgt)
+        source = pd.DataFrame(
+            {"a": [100, 200, 300, 400, 500, 600]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(0),
+                    pd.Timestamp(0),
+                    pd.Timestamp(1),
+                    pd.Timestamp(15),
+                    pd.Timestamp(15),
+                    pd.Timestamp(16),
+                ]
+            ),
+        )
+        lib.merge_experimental("sym", source, self.strategy)
+        assert_frame_equal(lib.read("sym").data, pd.concat(target + [source]).sort_index())
+
+    def test_insert_between_two_segments_appends_to_first(self, in_memory_store_factory):
+        lib = in_memory_store_factory()
+        seg0 = pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)]))
+        lib.write("sym", seg0)
+        seg1 = pd.DataFrame({"a": [3, 4]}, index=pd.DatetimeIndex([pd.Timestamp(10), pd.Timestamp(15)]))
+        lib.append("sym", seg1)
+        source = pd.DataFrame({"a": [100, 200]}, index=pd.DatetimeIndex([pd.Timestamp(6), pd.Timestamp(7)]))
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, self.strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        assert_frame_equal(lib.read("sym").data, pd.concat([seg0, seg1, source]).sort_index())
+        lt = lib.library_tool()
+        segments = [lt.read_to_dataframe(key) for key in lt.dataframe_to_keys(lt.read_index("sym"), "sym")]
+        segments[0].index.name = None
+        segments[1].index.name = None
+        assert_frame_equal(segments[0], pd.concat([seg0, source]).sort_index())
+        assert_frame_equal(segments[1], seg1)
+
 
 class TestMergeTimeseriesUpdateAndInsert:
+
+    def setup_method(self):
+        self.strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
 
     @pytest.mark.parametrize(
         "strategy",
         (None, MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), MergeStrategy("update", "insert")),
     )
-    def test_basic(self, lmdb_library, monkeypatch, strategy):
+    def test_basic(self, lmdb_library, strategy):
         lib = lmdb_library
         target = pd.DataFrame(
             {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]}, index=pd.date_range("2024-01-01", periods=3)
@@ -1326,21 +1637,6 @@ class TestMergeTimeseriesUpdateAndInsert:
             index=pd.DatetimeIndex(
                 [pd.Timestamp("2024-01-01 15:00:00"), pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-02 01:00:00")]
             ),
-        )
-
-        monkeypatch.setattr(
-            lib.__class__,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=1,
-                metadata=write_vit.metadata,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
         )
 
         merge_vit = (
@@ -1368,30 +1664,11 @@ class TestMergeTimeseriesUpdateAndInsert:
             ),
         )
 
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=expected,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
-
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(read_vit, merge_vit)
         assert_frame_equal(read_vit.data, expected)
 
         lt = lib._dev_tools.library_tool()
-        monkeypatch.setattr(
-            lt,
-            "find_keys_for_symbol",
-            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 2, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}),
-        )
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
@@ -1507,7 +1784,7 @@ class TestMergeTimeseriesUpdateAndInsert:
             assert_vit_equals_except_data(merge_vit, read_vit)
             assert_frame_equal(read_vit.data, expected)
 
-    def test_on_index_and_column(self, lmdb_library, monkeypatch):
+    def test_on_index_and_column(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame(
             {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]}, index=pd.date_range("2024-01-01", periods=3)
@@ -1525,7 +1802,6 @@ class TestMergeTimeseriesUpdateAndInsert:
                 ]
             ),
         )
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
         lib.merge_experimental("sym", source, on=["a"])
 
         expected = pd.DataFrame(
@@ -1541,12 +1817,11 @@ class TestMergeTimeseriesUpdateAndInsert:
                 ]
             ),
         )
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
         received = lib.read("sym").data
 
         assert_frame_equal(received, expected)
 
-    def test_on_multiple_columns(self, lmdb_library, monkeypatch):
+    def test_on_multiple_columns(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame(
             {
@@ -1579,10 +1854,7 @@ class TestMergeTimeseriesUpdateAndInsert:
             ),
         )
 
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
-        lib.merge_experimental(
-            "sym", source, on=["b", "d", "e"], strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING)
-        )
+        lib.merge_experimental("sym", source, on=["b", "d", "e"])
         expected = pd.DataFrame(
             {
                 "a": [10, 2, 20, 3, 30, 4, 40, 50],
@@ -1604,69 +1876,779 @@ class TestMergeTimeseriesUpdateAndInsert:
                 ]
             ),
         )
-
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
 
-    def test_target_is_empty(self, lmdb_library, monkeypatch):
+    def test_target_is_empty(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
         write_vit = lib.write("sym", target)
-
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        monkeypatch.setattr(
-            lib.__class__,
-            "merge_experimental",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=write_vit.symbol,
-                library=write_vit.library,
-                data=None,
-                version=1,
-                metadata=None,
-                host=write_vit.host,
-                timestamp=write_vit.timestamp + 1,
-            ),
-            raising=False,
-        )
         merge_vit = lib.merge_experimental("sym", source)
         expected = source
-        monkeypatch.setattr(
-            lib,
-            "read",
-            lambda *args, **kwargs: VersionedItem(
-                symbol=merge_vit.symbol,
-                library=merge_vit.library,
-                data=expected,
-                version=merge_vit.version,
-                metadata=merge_vit.metadata,
-                host=merge_vit.host,
-                timestamp=merge_vit.timestamp,
-            ),
-        )
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(merge_vit, read_vit)
         assert_frame_equal(read_vit.data, expected)
 
-    @pytest.mark.skip(reason="Not implemented yet")
-    def test_throws_when_target_row_is_matched_more_than_once(self, lmdb_library):
+    @pytest.mark.parametrize(
+        "source",
+        [
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [10, 20], "b": [10.0, 20.0]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0)])
+                ),
+                id="No_unmatched",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(2)]),
+                ),
+                id="Contains_unmatched",
+            ),
+        ],
+    )
+    def test_throws_when_target_row_is_matched_more_than_once(self, lmdb_library, source):
         lib = lmdb_library
-        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
-        lib.write("sym", target)
-
-        source = pd.DataFrame(
+        target = pd.DataFrame(
             {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        lib.write("sym", target)
+        with pytest.raises(UserInputException):
+            lib.merge_experimental("sym", source, strategy=self.strategy)
+
+    @pytest.mark.parametrize(
+        "source,expected",
+        [
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 1, 100], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 2, 3, 4, 5, 100, 6], "b": [100.0, 200.0, 2.0, 3.0, 4.0, 5.0, 300.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_first_equal_run_Insert_in_second_equal_run",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 3], "b": [100.0, 200.0, 300.0]},
+                    index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+                ),
+                pd.DataFrame(
+                    {"a": [0, 1, 100, 2, 3, 4, 5, 6], "b": [100.0, 1.0, 200, 2.0, 300.0, 4.0, 5.0, 6.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_second_equal_run_Insert_in_first",
+            ),
+            pytest.param(
+                pd.DataFrame(
+                    {"a": [0, 100, 1, 2, 5, 200, 4, 3], "b": [100.0, 200.0, 300.0, 400.0, 500.0, 600.0, 700.0, 800.0]},
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                        ]
+                    ),
+                ),
+                pd.DataFrame(
+                    {
+                        "a": [0, 1, 100, 2, 3, 4, 5, 200, 6],
+                        "b": [100.0, 300.0, 200.0, 400.0, 800.0, 700.0, 500.0, 600.0, 6.0],
+                    },
+                    index=pd.DatetimeIndex(
+                        [
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(0),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(5),
+                            pd.Timestamp(6),
+                        ]
+                    ),
+                ),
+                id="Match_in_both_equal_index_runs_and_insert_in_both",
+            ),
+        ],
+    )
+    def test_within_single_segment_match_on_column(self, lmdb_library, source, expected):
+        lib = lmdb_library
+        index = pd.DatetimeIndex(
+            [
+                pd.Timestamp(0),
+                pd.Timestamp(0),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(5),
+                pd.Timestamp(6),
+            ]
+        )
+        target = pd.DataFrame({"a": range(len(index)), "b": np.linspace(0, len(index) - 1, len(index))}, index=index)
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_insert_before_first_segment_start_and_update_first_value(self, lmdb_library):
+        lib = lmdb_library
+        lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
+        source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0)]))
+        lib.merge_experimental("sym", source, self.strategy)
+        expected = pd.DataFrame(
+            {"a": [10, 20, 2]}, index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0), pd.Timestamp(5)])
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_insert_before_first_segment_start_and_update_first_value_on(self, lmdb_library):
+        lib = lmdb_library
+        lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
+        source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0)]))
+        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        expected = pd.DataFrame(
+            {"a": [10, 1, 20, 2]},
+            index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_insert_after_last_and_match_last(self, lmdb_library):
+        lib = lmdb_library
+        lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
+        source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(5), pd.Timestamp(10)]))
+        lib.merge_experimental("sym", source, self.strategy)
+        expected = pd.DataFrame(
+            {"a": [1, 10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)])
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_insert_after_last_and_match_last_on(self, lmdb_library):
+        lib = lmdb_library
+        lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
+        source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(5), pd.Timestamp(10)]))
+        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        expected = pd.DataFrame(
+            {"a": [1, 2, 10, 20]},
+            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(5), pd.Timestamp(10)]),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+
+class TestMergeUpdateInsertIndexSpansMultipleSegments:
+    """End-to-end translation of the C++ fixture ``MergeUpdateInsertIndexSpansMultipleSegments``
+    (cpp/arcticdb/processing/test/test_merge_update.cpp): a single index value spans a segment boundary. The C++ tests
+    assert on the internal processing-unit output; here we only check the final read result of an update+insert merge.
+    The fixture's layout is reproduced with rows_per_segment=5 and columns_per_segment=1 (matching cols_per_segment=1).
+    """
+
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
+
+    def _run(self, lmdb_library_factory, target, source, expected, on):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=5, columns_per_segment=1))
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_last_index_value_same_as_next_segment_first_two_overlapping_segments(self, lmdb_library_factory):
+        target = pd.DataFrame(
+            {"a": np.arange(27, dtype=np.int64), "b": np.arange(27, dtype=np.int32)},
             index=pd.DatetimeIndex(
                 [
-                    pd.Timestamp("2024-01-01"),  # Matches first row of target
-                    pd.Timestamp("2024-01-01"),  # Also matches first row of target
-                    pd.Timestamp("2024-01-03"),
+                    pd.Timestamp(v)
+                    for v in [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        9,
+                        9,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                    ]
                 ]
             ),
         )
-        strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
-        with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=strategy)
+        source = pd.DataFrame(
+            {"a": np.array([10, 8, 120], dtype=np.int64), "b": np.array([100, 200, 300], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in [9, 9, 9]]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        10,
+                        11,
+                        120,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26,
+                    ],
+                    dtype=np.int64,
+                ),
+                "b": np.array(
+                    [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        200,
+                        9,
+                        100,
+                        11,
+                        300,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26,
+                    ],
+                    dtype=np.int32,
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                    ]
+                ]
+            ),
+        )
+        self._run(lmdb_library_factory, target, source, expected, on=["a"])
+
+    def test_last_index_value_same_as_next_segment_first_three_overlapping_segments(self, lmdb_library_factory):
+        target = pd.DataFrame(
+            {"a": np.arange(27, dtype=np.int64), "b": np.arange(27, dtype=np.int32)},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
+                ]
+            ),
+        )
+        source = pd.DataFrame(
+            {
+                "a": np.array([100, 10, 8, 120, 15, 17, 100], dtype=np.int64),
+                "b": np.array([100, 200, 300, 400, 500, 600, 700], dtype=np.int32),
+            },
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in [8, 9, 9, 9, 9, 10, 11]]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        100,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        120,
+                        17,
+                        18,
+                        100,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26,
+                    ],
+                    dtype=np.int64,
+                ),
+                "b": np.array(
+                    [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        100,
+                        300,
+                        9,
+                        200,
+                        11,
+                        12,
+                        13,
+                        14,
+                        500,
+                        16,
+                        400,
+                        600,
+                        18,
+                        700,
+                        19,
+                        20,
+                        21,
+                        22,
+                        23,
+                        24,
+                        25,
+                        26,
+                    ],
+                    dtype=np.int32,
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        8,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        10,
+                        11,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        17,
+                        18,
+                        19,
+                    ]
+                ]
+            ),
+        )
+        self._run(lmdb_library_factory, target, source, expected, on=["a"])
+
+    def test_two_groups_of_segments_with_matching_last_index_value(self, lmdb_library_factory):
+        target = pd.DataFrame(
+            {"a": np.arange(27, dtype=np.int64), "b": np.arange(27, dtype=np.int32)},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 10, 11, 12, 13, 14]
+                ]
+            ),
+        )
+        source = pd.DataFrame(
+            {
+                "a": np.array([100, 11, 16, 13, 100, 8, 200, 19, 100, 17, 20, 300, 400, 23, 500], dtype=np.int64),
+                "b": np.array([i * 100 for i in range(15)], dtype=np.int32),
+            },
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in [8, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10, 10, 11, 11, 13]]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        100,
+                        8,
+                        9,
+                        10,
+                        11,
+                        12,
+                        13,
+                        14,
+                        15,
+                        16,
+                        100,
+                        200,
+                        17,
+                        18,
+                        19,
+                        20,
+                        21,
+                        22,
+                        100,
+                        300,
+                        23,
+                        400,
+                        24,
+                        25,
+                        500,
+                        26,
+                    ],
+                    dtype=np.int64,
+                ),
+                "b": np.array(
+                    [
+                        0,
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        0,
+                        500,
+                        9,
+                        10,
+                        100,
+                        12,
+                        300,
+                        14,
+                        15,
+                        200,
+                        400,
+                        600,
+                        900,
+                        18,
+                        700,
+                        1000,
+                        21,
+                        22,
+                        800,
+                        1100,
+                        1300,
+                        1200,
+                        24,
+                        25,
+                        1400,
+                        26,
+                    ],
+                    dtype=np.int32,
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [
+                        1,
+                        2,
+                        3,
+                        4,
+                        5,
+                        6,
+                        7,
+                        8,
+                        8,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        9,
+                        10,
+                        10,
+                        10,
+                        10,
+                        10,
+                        10,
+                        10,
+                        10,
+                        11,
+                        11,
+                        12,
+                        13,
+                        13,
+                        14,
+                    ]
+                ]
+            ),
+        )
+        self._run(lmdb_library_factory, target, source, expected, on=["a"])
+
+
+class TestMergeUpdateInsertIndexSpansMultipleSegmentsChain:
+    """End-to-end translation of the C++ fixture ``MergeUpdateInsertIndexSpansMultipleSegmentsChain``
+    (cpp/arcticdb/processing/test/test_merge_update.cpp): the same index value chains across several segments. The C++
+    tests assert on the internal processing-unit output; here we only check the final read result of an update+insert
+    merge. The fixture's layout is reproduced with rows_per_segment=3 and columns_per_segment=1 (matching
+    cols_per_segment=1). Shared target index [0,1,2,4,5,6,6,6,6,6,10,11,11,13,15,15,16,17,17,19,20], a=b=0..20.
+    """
+
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
+
+    _CHAIN_INDEX = [0, 1, 2, 4, 5, 6, 6, 6, 6, 6, 10, 11, 11, 13, 15, 15, 16, 17, 17, 19, 20]
+
+    def _chain_target(self):
+        return pd.DataFrame(
+            {"a": np.arange(21, dtype=np.int64), "b": np.arange(21, dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in self._CHAIN_INDEX]),
+        )
+
+    def _run(self, lmdb_library_factory, source, expected, on):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, columns_per_segment=1))
+        lib.write("sym", self._chain_target())
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_source_in_row_slice_0(self, lmdb_library_factory):
+        source = pd.DataFrame(
+            {"a": np.array([0, 10], dtype=np.int64), "b": np.array([100, 200], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in [0, 2]]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [0, 1, 2, 10, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int64
+                ),
+                "b": np.array(
+                    [100, 1, 2, 200, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int32
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [pd.Timestamp(v) for v in [0, 1, 2, 2, 4, 5, 6, 6, 6, 6, 6, 10, 11, 11, 13, 15, 15, 16, 17, 17, 19, 20]]
+            ),
+        )
+        self._run(lmdb_library_factory, source, expected, on=["a"])
+
+    def test_source_in_row_slice_1_value_is_not_in_multiple_segments(self, lmdb_library_factory):
+        source = pd.DataFrame(
+            {"a": np.array([4], dtype=np.int64), "b": np.array([100], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(5)]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.arange(21, dtype=np.int64),
+                "b": np.array(
+                    [0, 1, 2, 3, 100, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int32
+                ),
+            },
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in self._CHAIN_INDEX]),
+        )
+        self._run(lmdb_library_factory, source, expected, on=["a"])
+
+    def test_source_in_row_slice_1_value_is_in_multiple_segments(self, lmdb_library_factory):
+        source = pd.DataFrame(
+            {"a": np.array([9, 5, 6, 100], dtype=np.int64), "b": np.array([100, 200, 300, 400], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(v) for v in [6, 6, 6, 6]]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int64
+                ),
+                "b": np.array(
+                    [0, 1, 2, 3, 4, 200, 300, 7, 8, 100, 400, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20],
+                    dtype=np.int32,
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [pd.Timestamp(v) for v in [0, 1, 2, 4, 5, 6, 6, 6, 6, 6, 6, 10, 11, 11, 13, 15, 15, 16, 17, 17, 19, 20]]
+            ),
+        )
+        self._run(lmdb_library_factory, source, expected, on=["a"])
+
+    def test_source_in_row_slice_3(self, lmdb_library_factory):
+        source = pd.DataFrame(
+            {"a": np.array([100], dtype=np.int64), "b": np.array([100], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(11)]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 100, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int64
+                ),
+                "b": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 100, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int32
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [0, 1, 2, 4, 5, 6, 6, 6, 6, 6, 10, 11, 11, 11, 13, 15, 15, 16, 17, 17, 19, 20]
+                ]
+            ),
+        )
+        self._run(lmdb_library_factory, source, expected, on=["a"])
+
+    def test_source_in_row_slice_5(self, lmdb_library_factory):
+        source = pd.DataFrame(
+            {"a": np.array([100], dtype=np.int64), "b": np.array([100], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(15)]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 100, 16, 17, 18, 19, 20], dtype=np.int64
+                ),
+                "b": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 100, 16, 17, 18, 19, 20], dtype=np.int32
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp(v)
+                    for v in [0, 1, 2, 4, 5, 6, 6, 6, 6, 6, 10, 11, 11, 13, 15, 15, 15, 16, 17, 17, 19, 20]
+                ]
+            ),
+        )
+        self._run(lmdb_library_factory, source, expected, on=["a"])
+
+    def test_insert_in_row_slice_3_without_column_matching(self, lmdb_library_factory):
+        # on=None matches on the index only; index 7 is absent from the target so the row is inserted.
+        source = pd.DataFrame(
+            {"a": np.array([100], dtype=np.int64), "b": np.array([100], dtype=np.int32)},
+            index=pd.DatetimeIndex([pd.Timestamp(7)]),
+        )
+        expected = pd.DataFrame(
+            {
+                "a": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int64
+                ),
+                "b": np.array(
+                    [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20], dtype=np.int32
+                ),
+            },
+            index=pd.DatetimeIndex(
+                [pd.Timestamp(v) for v in [0, 1, 2, 4, 5, 6, 6, 6, 6, 6, 7, 10, 11, 11, 13, 15, 15, 16, 17, 17, 19, 20]]
+            ),
+        )
+        self._run(lmdb_library_factory, source, expected, on=None)
 
 
 @pytest.mark.parametrize(
@@ -2583,3 +3565,110 @@ class TestMergeMultiindexUpdate:
         lib.write("sym", target)
         with pytest.raises(TypeError):
             lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+
+
+@pytest.mark.parametrize(
+    "target_segments, source, expected",
+    [
+        pytest.param(
+            [
+                pd.DataFrame({"a": [0]}, index=pd.DatetimeIndex([10])),
+                pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([10, 10, 30])),
+                pd.DataFrame({"a": [4, 5]}, index=pd.DatetimeIndex([30, 30])),
+            ],
+            pd.DataFrame({"a": [1000, 1001, 1002, 1003]}, index=pd.DatetimeIndex([30, 40, 50, 60])),
+            pd.DataFrame(
+                {"a": [0, 1, 2, 3, 4, 5, 1000, 1001, 1002, 1003]},
+                index=pd.DatetimeIndex([10, 10, 10, 30, 30, 30, 30, 40, 50, 60]),
+            ),
+            id="end_trailing",
+        ),
+        pytest.param(
+            [
+                pd.DataFrame({"a": [0]}, index=pd.DatetimeIndex([10])),
+                pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([10, 10, 30])),
+                pd.DataFrame({"a": [4, 5]}, index=pd.DatetimeIndex([30, 30])),
+                pd.DataFrame({"a": [6]}, index=pd.DatetimeIndex([100])),
+            ],
+            pd.DataFrame({"a": [1000, 1001, 1002]}, index=pd.DatetimeIndex([30, 40, 50])),
+            pd.DataFrame(
+                {"a": [0, 1, 2, 3, 4, 5, 1000, 1001, 1002, 6]},
+                index=pd.DatetimeIndex([10, 10, 10, 30, 30, 30, 30, 40, 50, 100]),
+            ),
+            id="middle_gap",
+        ),
+        pytest.param(
+            [
+                pd.DataFrame({"a": [0]}, index=pd.DatetimeIndex([10])),
+                pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([10, 10, 30])),
+                pd.DataFrame({"a": [4, 5]}, index=pd.DatetimeIndex([30, 30])),
+            ],
+            pd.DataFrame({"a": [1000, 1001, 1002]}, index=pd.DatetimeIndex([1, 2, 30])),
+            pd.DataFrame(
+                {"a": [1000, 1001, 0, 1, 2, 3, 4, 5, 1002]},
+                index=pd.DatetimeIndex([1, 2, 10, 10, 10, 30, 30, 30, 30]),
+            ),
+            id="beginning_prepend",
+        ),
+        pytest.param(
+            [
+                pd.DataFrame({"a": [0]}, index=pd.DatetimeIndex([10])),
+                pd.DataFrame({"a": [1, 2, 3]}, index=pd.DatetimeIndex([10, 10, 30])),
+                pd.DataFrame({"a": [4, 5]}, index=pd.DatetimeIndex([30, 30])),
+            ],
+            pd.DataFrame({"a": [1000, 1001]}, index=pd.DatetimeIndex([20, 30])),
+            pd.DataFrame(
+                {"a": [0, 1, 2, 1000, 3, 4, 5, 1001]},
+                index=pd.DatetimeIndex([10, 10, 10, 20, 30, 30, 30, 30]),
+            ),
+            id="within_span",
+        ),
+    ],
+)
+def test_merge_insert_with_repeated_boundary_timestamps(lmdb_library, target_segments, source, expected):
+    lib = lmdb_library
+    lib.write("sym", target_segments[0])
+    for segment in target_segments[1:]:
+        lib.append("sym", segment)
+
+    lt = lib._dev_tools.library_tool()
+    assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == len(target_segments)
+
+    lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), on=["a"])
+    assert_frame_equal(lib.read("sym").data, expected)
+
+
+def test_merge_insert_into_back_shared_middle_group(lmdb_library):
+    lib = lmdb_library
+    lib.write("sym", pd.DataFrame({"a": [0, 1]}, index=pd.DatetimeIndex([10, 20])))
+    lib.append("sym", pd.DataFrame({"a": [2, 3]}, index=pd.DatetimeIndex([20, 30])))
+    lib.append("sym", pd.DataFrame({"a": [4, 5]}, index=pd.DatetimeIndex([30, 40])))
+    lib.append("sym", pd.DataFrame({"a": [6, 7]}, index=pd.DatetimeIndex([40, 50])))
+    assert len(lib._dev_tools.library_tool().find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
+
+    source = pd.DataFrame({"a": [1000, 1001, 1002]}, index=pd.DatetimeIndex([15, 25, 35]))
+    lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), on=["a"])
+
+    expected = pd.DataFrame(
+        {"a": [0, 1000, 1, 2, 1001, 3, 4, 1002, 5, 6, 7]},
+        index=pd.DatetimeIndex([10, 15, 20, 20, 25, 30, 30, 35, 40, 40, 50]),
+    )
+    assert_frame_equal(lib.read("sym").data, expected)
+
+
+def test_merge_insert_only_into_chain_with_shared_boundaries(lmdb_library):
+    lib = lmdb_library
+    lib.write("sym", pd.DataFrame({"a": [0, 1]}, index=pd.DatetimeIndex([10, 20])))
+    lib.append("sym", pd.DataFrame({"a": [2, 3]}, index=pd.DatetimeIndex([20, 30])))
+    lib.append("sym", pd.DataFrame({"a": [4, 5]}, index=pd.DatetimeIndex([30, 40])))
+    lib.append("sym", pd.DataFrame({"a": [6, 7]}, index=pd.DatetimeIndex([40, 50])))
+    assert len(lib._dev_tools.library_tool().find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
+
+    source = pd.DataFrame({"a": [1000]}, index=pd.DatetimeIndex([25]))
+    lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), on=["a"])
+
+    expected = pd.DataFrame(
+        {"a": [0, 1, 2, 1000, 3, 4, 5, 6, 7]},
+        index=pd.DatetimeIndex([10, 20, 20, 25, 30, 30, 40, 40, 50]),
+    )
+    assert_frame_equal(lib.read("sym").data, expected)

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -335,6 +335,49 @@ class TestMergeTimeseriesUpdate:
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
+    def test_dedup_map_deduplicates_unchanged_column_slice(self, lmdb_library_factory):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(columns_per_segment=2, dedup=True))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": [10, 20, 30], "d": [100.0, 200.0, 300.0]},
+            index=pd.date_range("2024-01-01", periods=3),
+        )
+        lib.write("sym", target)
+        source = pd.DataFrame(
+            {"a": [20, 30], "b": [20.0, 30.0], "c": [20, 30], "d": [200.0, 300.0]},
+            index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")]),
+        )
+        lib.merge_experimental("sym", source, strategy=self.strategy)
+        expected = pd.DataFrame(
+            {"a": [1, 20, 30], "b": [1.0, 20.0, 30.0], "c": [10, 20, 30], "d": [100.0, 200.0, 300.0]},
+            index=pd.date_range("2024-01-01", periods=3),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+        lt = lib._dev_tools.library_tool()
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 3
+        keys_v0 = lt.dataframe_to_keys(lt.read_index("sym", as_of=0), "sym")
+        keys_v1 = lt.dataframe_to_keys(lt.read_index("sym", as_of=1), "sym")
+        assert keys_v0[-1] == keys_v1[-1]
+
+    @pytest.mark.parametrize("de_duplication", [False, True])
+    def test_skips_writing_row_slice_left_unchanged_by_on_mismatch(self, in_memory_store_factory, de_duplication):
+        # A row slice whose index matches but whose "on" column does not match is not re-emitted,
+        # so no data segment is written regardless of whether dedup is enabled.
+        lib = in_memory_store_factory(segment_row_size=2, de_duplication=de_duplication)
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},
+            index=pd.date_range("2024-01-01", periods=6),
+        )
+        lib.write("sym", target)
+        source = pd.DataFrame({"a": [999], "b": [99.0]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-03")]))
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 0
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        assert_frame_equal(lib.read("sym").data, target)
+
     @pytest.mark.parametrize(
         "slicing_policy",
         [
@@ -1146,8 +1189,10 @@ class TestMergeTimeseriesInsert:
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
-    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library):
-        lib = lmdb_library
+    # The row slice is not re-emitted when unchanged, so no second data key is written regardless of dedup.
+    @pytest.mark.parametrize("dedup, expected_data_keys", [(False, 1), (True, 1)])
+    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library_factory, dedup, expected_data_keys):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(dedup=dedup))
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target)
         source = pd.DataFrame(
@@ -1163,7 +1208,7 @@ class TestMergeTimeseriesInsert:
         assert_frame_equal(read_vit.data, target)
 
         lt = lib._dev_tools.library_tool()
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == expected_data_keys
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
@@ -2896,8 +2941,10 @@ class TestMergeRowrangeUpdate:
         with pytest.raises(StorageException):
             lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
 
-    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library):
-        lib = lmdb_library
+    # The row slice is not re-emitted when unchanged, so no second data key is written regardless of dedup.
+    @pytest.mark.parametrize("dedup, expected_data_keys", [(False, 1), (True, 1)])
+    def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library_factory, dedup, expected_data_keys):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(dedup=dedup))
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         lib.write("sym", target)
         source = pd.DataFrame({"a": [10, 20], "b": [10.0, 20.0]})
@@ -2909,7 +2956,7 @@ class TestMergeRowrangeUpdate:
         assert_frame_equal(read_vit.data, target)
 
         lt = lib._dev_tools.library_tool()
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == expected_data_keys
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 


### PR DESCRIPTION
# Merge update - Insert
## High level overview
This PR implements both strategies `MergeStrategy("do_nothing", "insert")` and `MergeStrategy("update", "insert")`. Both the source and the target must be DateTime-indexed and ordered. Insertion is stable, meaning that new values will come after values already in the target.
## Implementation details
### Structure by time slice
Only source rows that are not matched by anything in the target are inserted. This means that if an index value appears in more than one segment all segments containing that index value must be loaded by the processing unit. This is implemented in `structure_by_time_slice`. This function structures together all segments that contain the same index values. With this change one segment can appear in multiple groups. Example
```
[[1, 2, 3],[4, 4, 4], [4, 5, 5], [5, 5, 5], [5, 6, 7], [7, 8, 9]]
```
Will produce the following groups:
```
[[[1, 2, 3]], [[4, 4, 4], [4, 5, 5]], [[4, 5, 5], [5, 5, 5], [5, 6, 7]], [[5, 6, 7], [7, 8, 9]]]
```
With corresponding time ranges
```
[[1, 4), [4, 5), [4, 8), [7, 10)]
```
**Note 1**. that the procedure intentionally splits the groups so that when segments are chained like so `[a, b] [b, c] [c, d], [d, e]` not all segments are loaded in the same processing unit.
**Note 2.** With this approach different processing unit not only can have overlapping index ranges. Two different processing units can have the same index range. Example:
```
[[10], [10, 10, 30], [30, 30]]
```
Will create two groups
```
[[[10], [10, 10, 30]], [[10, 10, 30], [30, 30]]]
```
Both groups span the same index range `[10;31)`
**Note 3.** Only the first and last row slice of a group can be requested by more than one processing unit
**Note 4.** Two processing units will never operate on the same set of data (see `get_target_start_end`). If the first row slice of a group has entity fetch count > 1 this means that it's the last row slice of a previous group. This means that the first index value of this row slice was repeated in the previous group. That group will handle this index value. This processing unit must skip the repeated index value. Analogous if the last segment has entity fetch count > 1, it must be cut at the end. Using the example above. 
```
[[4, 5, 5], [5, 5, 5], [5, 6, 7]] // [5, 6, 7] has entity fetch count > 1. The processing unit will process all vaues in range [4;6)
[[5, 6, 7], [7, 8, 9]] // [5, 6, 7] has entity fetch count > 1. The processing unit will process all values in range [6; 10)
```
#### Performance consideration
Structure for processing still marks all segments in a time sliced group for loading if there's an index value appearing in the time range of the index group. When this is the value that spans multiple segments this will create more work, as some segments that are not matched will be loaded. Using the example above if the source contains the value `5` we'll end up with the following processing units
```
[4, 4, 4], [4, 5, 5]
[4, 5, 5], [5, 5, 5], [5, 6, 7]
[5, 6, 7], [7, 8, 9]
```
Clearly only the one in the middle needs actual work.
## Merge
The `merge` function performs both inserting new data and updating matched rows. It produces **a single one** column. Essentially it is merging of two sorted lists, with the caveat that the target is actually list of lists, not a single list. However all values in `concatenate(target_index)` are sorted. The nuisance is that there's additional bookkeeping of which is the current target list.
Since the target rows to be updated can be in arbitrary order updating happens in two steps
1. Write all data values corresponding to index value `x` (including new values)
2. Iterate over the rows to update and overwrite with the new value
	1. This must keep track of how many values were inserted up to now in order to get the proper offset
	2. This makes strings sub-optimal. It first adds all strings in the global merged pool but overwriting might orphan some string values. The pool needs rebuilding at the end.
Merge will also truncate columns so that the output contains only values for which the processing unit is responsible. Using the the example above if the source contains value `5` the processing units will be
```
[4, 4, 4], [4, 5, 5]
[4, 5, 5], [5, 5, 5], [5, 6, 7]
[5, 6, 7], [7, 8, 9]
```
assuming no insertion the output will be
```
[4, 4, 4, 4]
[5, 5, 5, 5, 5, 5]
[6, 7, 7, 8, 9]
```
### Further work
Currently merging uses the same algorithm for the index and the data columns. A better approach would be to run the current algorithm for the index once and make it produce a recipe of the sort:
```c++
enum DataSource {SOURCE, TARGET};
struct Entry {
	DataSource src;
	size_t offset_from_source_start;
	size_t count;
};
std::vector<Entry> merge_recipe;
```
and apply this to all columns.
## Index reconstruction
The reconstruction of the index key has changed a bit. Up to now there was a `1:1` mapping in the slices and keys of the old keys and the new keys because update did not create new data. Now the processing unit will emit different row ranges. The new row ranges will represent the combined row range of the whole group of row slices processed by the segment, it will **not** account the added rows. The added rows are reported separately in the `MergeUpdateInsertedRowsEntity` structure fetched from the component manager.
## MatchRecord
Helper structure to handle all the matching logic together and encapsulated. The biggest change is that the structure of matched rows is no longer a list of lists (for every source row all target rows that match it). It's list of list of lists. For each row slice for each source source row all target rows that match it.