### PR TITLE
Rename compact_data_inline -> compact_data

### DIFF
--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -113,7 +113,7 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     VersionId version_id_ = 0;
     size_t total_rows_ = 0;
     size_t rows_ = 0;
-    // Used in appends with compact_data_inline to check the data can be appended
+    // Used in appends with compact_data to check the data can be appended
     std::optional<IndexValue> last_existing_index_value_;
     std::vector<SliceAndKey> slice_and_keys_;
     util::BitSet fetch_index_;

--- a/cpp/arcticdb/processing/clause_compact_data.cpp
+++ b/cpp/arcticdb/processing/clause_compact_data.cpp
@@ -110,10 +110,10 @@ std::vector<std::vector<size_t>> CompactDataClause::structure_for_processing(std
         row_ranges.insert(range_and_key.row_range());
     }
     if (frame_) {
-        // frame_ is non null when we have arrived here via the compact_data_inline argument to append[_batch]
+        // frame_ is non null when we have arrived here via the compact_data argument to append[_batch]
         // In this case, we treat the frame being appended as if it is ONE row-slice (even if it is larger than the
         // library's default slicing policy). A consequence of this is that the resulting structure on-disk may not be
-        // identical to calling append with compact_data_inline=false, followed by an explicit compact_data call.
+        // identical to calling append with compact_data=false, followed by an explicit compact_data call.
         // However, the invariant that all row-slices will have rows_per_segments+-33% will be maintained in both cases
         util::check(
                 frame_->offset == (row_ranges.empty() ? 0 : row_ranges.rbegin()->second),

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1857,12 +1857,12 @@ VersionedItem LocalVersionedEngine::append_internal(
     py::gil_scoped_release release_gil;
     auto update_info = get_latest_undeleted_version_and_next_version_id(store(), version_map(), stream_id);
 
-    // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data_inline is true,
+    // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data is true,
     // but also when it isn't. However, the read-modify-write pipeline is all built around the PipelineContext class
     // which assumes an existing version. Better if we just make the FixedSlicer smarter so that its logic is more like
     // ReslicingInfo
     if (update_info.previous_index_key_.has_value()) {
-        if (append_options.compact_data_inline) {
+        if (append_options.compact_data) {
             auto compact_data_frame = std::make_optional<CompactDataFrame>(
                     frame, append_options.validate_index, cfg().write_options().empty_types()
             );

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1375,7 +1375,7 @@ void check_can_perform_processing(
              std::holds_alternative<std::monostate>(read_query.row_filter) && read_query.clauses_.empty());
     const bool is_numpy_array = pipeline_context->has_normalization() && pipeline_context->normalization().has_np();
     // We do not support processing over numpy arrays in general, but compact_data (either directly, or via the
-    // compact_data_inline argument to append) must work with numpy arrays as well as Series/DataFrames
+    // compact_data argument to append) must work with numpy arrays as well as Series/DataFrames
     const bool is_compaction =
             !read_query.clauses_.empty() && folly::poly_type(*read_query.clauses_.front()) == typeid(CompactDataClause);
     if (!is_query_empty) {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -829,13 +829,13 @@ VersionedItem PythonVersionStore::test_write_versioned_segment(
 
 VersionedItem PythonVersionStore::append(
         const StreamId& stream_id, const convert::InputItem& item, const py::object& norm, const py::object& user_meta,
-        bool upsert, bool prune_previous_versions, bool validate_index, bool compact_data_inline
+        bool upsert, bool prune_previous_versions, bool validate_index, bool compact_data
 ) {
     AppendOptions append_options{
             .upsert = upsert,
             .prune_previous_versions = prune_previous_versions,
             .validate_index = validate_index,
-            .compact_data_inline = compact_data_inline
+            .compact_data = compact_data
     };
     return append_internal(
             stream_id,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -73,7 +73,7 @@ class PythonVersionStore : public LocalVersionedEngine {
     VersionedItem append(
             const StreamId& stream_id, const convert::InputItem& item, const py::object& norm,
             const py::object& user_meta, bool upsert, bool prune_previous_versions, bool validate_index,
-            bool compact_data_inline
+            bool compact_data
     );
 
     VersionedItem update(

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -36,7 +36,7 @@ struct AppendOptions {
     bool upsert = false;
     bool prune_previous_versions = false;
     bool validate_index = false;
-    bool compact_data_inline = false;
+    bool compact_data = false;
 };
 
 enum class Slicing { NoSlicing, RowSlicing };

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -955,7 +955,7 @@ class NativeVersionStore:
         prune_previous_version: Optional[bool] = None,
         validate_index: bool = False,
         index_column: bool = False,
-        compact_data_inline: bool = False,
+        compact_data: bool = False,
         **kwargs,
     ) -> Optional[VersionedItem]:
         # FUTURE: use @overload and Literal for the existence of the return value once we ditch Python 3.6
@@ -985,7 +985,7 @@ class NativeVersionStore:
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
-        compact_data_inline: bool, default=False
+        compact_data: bool, default=False
             If False, the data being appended will be sliced and written to disk without consideration for how
             fragmented this may make the data.
             If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
@@ -1088,7 +1088,7 @@ class NativeVersionStore:
                         write_if_missing,
                         prune_previous_version,
                         validate_index,
-                        compact_data_inline,
+                        compact_data,
                     )
                     # This is a heuristic to check for the case of using append call to write an empty dataframe in that
                     # case we want to warn users that the processing pipeline might not work as expected. There are two

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1366,7 +1366,7 @@ class Library:
         prune_previous_versions: bool = False,
         validate_index: bool = True,
         index_column: bool = False,
-        compact_data_inline: bool = False,
+        compact_data: bool = False,
     ) -> VersionedItem:
         """
         Appends the given data to the existing, stored data. Append always appends along the index. A new version will
@@ -1400,7 +1400,7 @@ class Library:
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
-        compact_data_inline: bool, default=False
+        compact_data: bool, default=False
             If False, the data being appended will be sliced and written to disk without consideration for how
             fragmented this may make the data.
             If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
@@ -1463,7 +1463,7 @@ class Library:
             prune_previous_version=prune_previous_versions,
             validate_index=validate_index,
             index_column=index_column,
-            compact_data_inline=compact_data_inline,
+            compact_data=compact_data,
         )
 
     def append_batch(

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -221,11 +221,11 @@ def test_append_with_defragmentation(
         )
 
 
-@pytest.mark.parametrize("compact_data_inline", [True, False])
+@pytest.mark.parametrize("compact_data", [True, False])
 class TestAppendHypothesis:
     @pytest.mark.parametrize("colnum,periods,rownum,cols,tsbounds,append_point", gen_params_append())
     def test_append_partial_read(
-        self, version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point, compact_data_inline
+        self, version_store_factory, colnum, periods, rownum, cols, tsbounds, append_point, compact_data
     ):
         tz = "America/New_York"
         version_store = version_store_factory(col_per_group=colnum, row_per_segment=rownum)
@@ -238,7 +238,7 @@ class TestAppendHypothesis:
         sid = "XXX"
         version_store.write(sid, tf1)
         tf2 = tf.tsloc[c2:]
-        version_store.append(sid, tf2, compact_data_inline=compact_data_inline)
+        version_store.append(sid, tf2, compact_data=compact_data)
 
         dtr = (dtidx[tsbounds[0]], dtidx[tsbounds[1]])
         vit = version_store.read(sid, date_range=dtr, columns=list(cols))
@@ -271,7 +271,7 @@ class TestAppendHypothesis:
         match,
         swap,
         lmdb_version_store: NativeVersionStore,
-        compact_data_inline,
+        compact_data,
     ):
         lib = lmdb_version_store
         if swap:
@@ -281,12 +281,10 @@ class TestAppendHypothesis:
 
         to_append, _ = append.make(abs(next_start), 1)
         with pytest.raises(NormalizationException) as e:
-            lib.append("s", to_append, compact_data_inline=compact_data_inline)
+            lib.append("s", to_append, compact_data=compact_data)
         assert match in str(e.value)
 
-    def test_regular_append_dynamic_schema_named_index(
-        self, lmdb_version_store_tiny_segment_dynamic, compact_data_inline
-    ):
+    def test_regular_append_dynamic_schema_named_index(self, lmdb_version_store_tiny_segment_dynamic, compact_data):
         lib = lmdb_version_store_tiny_segment_dynamic
         sym = "test_parallel_append_dynamic_schema_named_index"
         df_0 = pd.DataFrame({"col_0": [0], "col_1": [0.5]}, index=pd.date_range("2024-01-01", periods=1))
@@ -294,14 +292,14 @@ class TestAppendHypothesis:
         df_1 = pd.DataFrame({"col_0": [1]}, index=pd.date_range("2024-01-02", periods=1))
         lib.write(sym, df_0)
         with pytest.raises(StreamDescriptorMismatch) as exception_info:
-            lib.append(sym, df_1, compact_data_inline=compact_data_inline)
+            lib.append(sym, df_1, compact_data=compact_data)
 
         assert "date" in str(exception_info.value)
 
     @pytest.mark.parametrize(
         "idx", [pd.date_range(pd.Timestamp("2020-01-01"), periods=3), pd.RangeIndex(start=0, stop=3, step=1)]
     )
-    def test_append_bool_named_col(self, lmdb_version_store_dynamic_schema, idx, compact_data_inline):
+    def test_append_bool_named_col(self, lmdb_version_store_dynamic_schema, idx, compact_data):
         symbol = "bad_append"
 
         initial = pd.DataFrame({"col": [1, 2, 3]}, index=idx)
@@ -311,6 +309,6 @@ class TestAppendHypothesis:
 
         # The normalization exception is getting reraised as an ArcticNativeException so we check for that
         with pytest.raises(ArcticNativeException):
-            lmdb_version_store_dynamic_schema.append(symbol, bad_df, compact_data_inline=compact_data_inline)
+            lmdb_version_store_dynamic_schema.append(symbol, bad_df, compact_data=compact_data)
 
         assert_frame_equal(lmdb_version_store_dynamic_schema.read(symbol).data, initial)

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -441,7 +441,7 @@ def test_prune_previous_defragment_symbol_data(version_store_factory, monkeypatc
 @pytest.mark.parametrize("lib_config", (True, False))
 @pytest.mark.parametrize("env_var", (True, False))
 @pytest.mark.parametrize("arg", (True, False, None))
-def test_prune_previous_append_compact_data_inline(version_store_factory, monkeypatch, lib_config, env_var, arg):
+def test_prune_previous_append_compact_data(version_store_factory, monkeypatch, lib_config, env_var, arg):
     lib = version_store_factory(prune_previous_version=lib_config, use_tombstones=True)
     should_be_pruned = lib_config
     if env_var:
@@ -451,12 +451,12 @@ def test_prune_previous_append_compact_data_inline(version_store_factory, monkey
         should_be_pruned = arg
 
     lt = lib.library_tool()
-    sym = f"test_prune_previous_append_compact_data_inline"
+    sym = f"test_prune_previous_append_compact_data"
     df_0 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-01", periods=10))
     lib.write(sym, df_0)
 
     df_1 = pd.DataFrame({"col": np.arange(10)}, index=pd.date_range("2024-01-11", periods=10))
-    lib.append(sym, df_1, prune_previous_version=arg, compact_data_inline=True)
+    lib.append(sym, df_1, prune_previous_version=arg, compact_data=True)
 
     assert len(lt.find_keys(KeyType.TABLE_INDEX)) == (1 if should_be_pruned else 2)
 

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -84,7 +84,7 @@ def test_read_incomplete_no_warning(s3_store_factory, sym, get_stderr):
         set_log_level()
 
 
-# sort_index assumes segments are internally sorted, which is not the case when appending with compact_data_inline=True
+# sort_index assumes segments are internally sorted, which is not the case when appending with compact_data=True
 @pytest.mark.parametrize("prune_previous_versions", [True, False])
 def test_append_out_of_order_and_sort(lmdb_version_store_ignore_order, prune_previous_versions):
     symbol = "out_of_order"
@@ -210,9 +210,9 @@ def test_defragment_no_work_to_do(sym, lmdb_version_store):
         lmdb_version_store.defragment_symbol_data(sym)
 
 
-@pytest.mark.parametrize("compact_data_inline", [True, False])
+@pytest.mark.parametrize("compact_data", [True, False])
 class TestAppend:
-    def test_append_simple(self, lmdb_version_store, compact_data_inline):
+    def test_append_simple(self, lmdb_version_store, compact_data):
         symbol = "test_append_simple"
         df1 = pd.DataFrame({"x": np.arange(1, 10, dtype=np.int64)})
         lmdb_version_store.write(symbol, df1)
@@ -220,14 +220,14 @@ class TestAppend:
         assert_frame_equal(vit.data, df1)
 
         df2 = pd.DataFrame({"x": np.arange(11, 20, dtype=np.int64)})
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         vit = lmdb_version_store.read(symbol)
         expected = pd.concat([df1, df2], ignore_index=True)
         assert_frame_equal(vit.data, expected)
 
     @pytest.mark.parametrize("empty_types", (True, False))
     @pytest.mark.parametrize("dynamic_schema", (True, False))
-    def test_append_range_index(self, version_store_factory, empty_types, dynamic_schema, compact_data_inline):
+    def test_append_range_index(self, version_store_factory, empty_types, dynamic_schema, compact_data):
         lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
         sym = "test_append_range_index"
         df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(0, 4, 2))
@@ -235,7 +235,7 @@ class TestAppend:
 
         # Appending another range index following on from what is there should work
         df_1 = pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(4, 8, 2))
-        lib.append(sym, df_1, compact_data_inline=compact_data_inline)
+        lib.append(sym, df_1, compact_data=compact_data)
         expected = pd.concat([df_0, df_1])
         received = lib.read(sym).data
         assert_frame_equal(expected, received)
@@ -247,13 +247,11 @@ class TestAppend:
             pd.RangeIndex(8, 14, 3),
         ]:
             with pytest.raises(NormalizationException):
-                lib.append(sym, pd.DataFrame({"col": [4, 5]}, index=idx), compact_data_inline=compact_data_inline)
+                lib.append(sym, pd.DataFrame({"col": [4, 5]}, index=idx), compact_data=compact_data)
 
     @pytest.mark.parametrize("empty_types", (True, False))
     @pytest.mark.parametrize("dynamic_schema", (True, False))
-    def test_append_range_index_from_zero(
-        self, version_store_factory, empty_types, dynamic_schema, compact_data_inline
-    ):
+    def test_append_range_index_from_zero(self, version_store_factory, empty_types, dynamic_schema, compact_data):
         lib = version_store_factory(empty_types=empty_types, dynamic_schema=dynamic_schema)
         sym = "test_append_range_index_from_zero"
         df_0 = pd.DataFrame({"col": [0, 1]}, index=pd.RangeIndex(-6, -2, 2))
@@ -263,10 +261,10 @@ class TestAppend:
             lib.append(
                 sym,
                 pd.DataFrame({"col": [2, 3]}, index=pd.RangeIndex(0, 4, 2)),
-                compact_data_inline=compact_data_inline,
+                compact_data=compact_data,
             )
 
-    def test_append_indexed(self, s3_version_store, compact_data_inline):
+    def test_append_indexed(self, s3_version_store, compact_data):
         symbol = "test_append_simple"
         idx1 = np.arange(0, 10)
         d1 = {"x": np.arange(10, 20, dtype=np.int64)}
@@ -278,12 +276,12 @@ class TestAppend:
         idx2 = np.arange(10, 20)
         d2 = {"x": np.arange(20, 30, dtype=np.int64)}
         df2 = pd.DataFrame(data=d2, index=idx2)
-        s3_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        s3_version_store.append(symbol, df2, compact_data=compact_data)
         vit = s3_version_store.read(symbol)
         expected = pd.concat([df1, df2])
         assert_frame_equal(vit.data, expected)
 
-    def test_append_string_of_different_sizes(self, lmdb_version_store, compact_data_inline):
+    def test_append_string_of_different_sizes(self, lmdb_version_store, compact_data):
         symbol = "test_append_simple"
         df1 = pd.DataFrame(data={"x": ["cat", "dog"]}, index=np.arange(0, 2))
         lmdb_version_store.write(symbol, df1)
@@ -294,25 +292,25 @@ class TestAppend:
             data={"x": ["catandsomethingelse", "dogandsomethingevenlonger"]},
             index=np.arange(2, 4),
         )
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         vit = lmdb_version_store.read(symbol)
         expected = pd.concat([df1, df2])
         assert_frame_equal(vit.data, expected)
 
-    def test_append_dynamic_schema_add_column(self, lmdb_version_store_dynamic_schema, compact_data_inline):
+    def test_append_dynamic_schema_add_column(self, lmdb_version_store_dynamic_schema, compact_data):
         symbol = "symbol"
         lib = lmdb_version_store_dynamic_schema
         df_1 = pd.DataFrame(data={"a": [1.0, 2.0]}, index=pd.date_range("2018-01-01", periods=2))
         df_2 = pd.DataFrame(data={"b": [3.0, 4.0]}, index=pd.date_range("2018-01-03", periods=2))
 
         lib.write(symbol, df_1)
-        lib.append(symbol, df_2, compact_data_inline=compact_data_inline)
+        lib.append(symbol, df_2, compact_data=compact_data)
 
         expected_df = pd.concat([df_1, df_2])
         result_df = lib.read(symbol).data
         assert_frame_equal(result_df, expected_df)
 
-    def test_append_snapshot_delete(self, lmdb_version_store, compact_data_inline):
+    def test_append_snapshot_delete(self, lmdb_version_store, compact_data):
         symbol = "test_append_snapshot_delete"
         if sys.platform == "win32":
             # Keep it smaller on Windows due to restricted LMDB size
@@ -331,7 +329,7 @@ class TestAppend:
         idx2 = np.arange(row_count, 2 * row_count)
         d2 = {"x": np.arange(2 * row_count, 3 * row_count, dtype=np.int64)}
         df2 = pd.DataFrame(data=d2, index=idx2)
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         vit = lmdb_version_store.read(symbol)
         expected = pd.concat([df1, df2])
         assert_frame_equal(vit.data, expected)
@@ -345,17 +343,17 @@ class TestAppend:
 
         assert_frame_equal(lmdb_version_store.read(symbol, as_of="my_snap").data, df1)
 
-    def test_append_out_of_order_throws(self, lmdb_version_store, compact_data_inline):
+    def test_append_out_of_order_throws(self, lmdb_version_store, compact_data):
         lib: NativeVersionStore = lmdb_version_store
         lib.write("a", pd.DataFrame({"c": [1, 2, 3]}, index=pd.date_range(0, periods=3)))
         with pytest.raises(Exception, match="1970-01-03"):
             lib.append(
                 "a",
                 pd.DataFrame({"c": [4]}, index=pd.date_range(1, periods=1)),
-                compact_data_inline=compact_data_inline,
+                compact_data=compact_data,
             )
 
-    def test_upsert_with_delete(self, lmdb_version_store_big_map, compact_data_inline):
+    def test_upsert_with_delete(self, lmdb_version_store_big_map, compact_data):
         lib = lmdb_version_store_big_map
         symbol = "upsert_with_delete"
         lib.version_store.remove_incomplete(symbol)
@@ -377,7 +375,7 @@ class TestAppend:
             if idx % 3 == 0:
                 lib.delete(symbol)
 
-            lib.append(symbol, df, write_if_missing=True, compact_data_inline=compact_data_inline)
+            lib.append(symbol, df, write_if_missing=True, compact_data=compact_data)
 
         first = list_df[len(list_df) - 3]
         second = list_df[len(list_df) - 2]
@@ -391,24 +389,24 @@ class TestAppend:
         condition=WINDOWS, raises=arcticdb.exceptions.ArcticDbNotYetImplemented, reason="Not implemented on Windows"
     )
     @pytest.mark.parametrize("dtype", supported_types_list)
-    def test_append_numpy_array(self, lmdb_version_store, dtype, compact_data_inline):
+    def test_append_numpy_array(self, lmdb_version_store, dtype, compact_data):
         """Tests append with all supported by arctic data types"""
         sym = f"test_append_numpy_array"
         np1 = generate_random_numpy_array(10, dtype)
         lmdb_version_store.write(sym, np1)
         np2 = generate_random_numpy_array(10, dtype)
-        lmdb_version_store.append(sym, np2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(sym, np2, compact_data=compact_data)
         expected = np.concatenate((np1, np2))
         assert_array_equal(lmdb_version_store.read(sym).data, expected)
 
-    def test_append_pickled_symbol(self, lmdb_version_store, compact_data_inline):
+    def test_append_pickled_symbol(self, lmdb_version_store, compact_data):
         symbol = "test_append_pickled_symbol"
         lmdb_version_store.write(symbol, np.arange(100).tolist())
         assert lmdb_version_store.is_symbol_pickled(symbol)
         with pytest.raises(InternalException):
-            _ = lmdb_version_store.append(symbol, np.arange(100).tolist(), compact_data_inline=compact_data_inline)
+            _ = lmdb_version_store.append(symbol, np.arange(100).tolist(), compact_data=compact_data)
 
-    def test_append_not_sorted_exception(self, lmdb_version_store, compact_data_inline):
+    def test_append_not_sorted_exception(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -428,23 +426,23 @@ class TestAppend:
         assert df2.index.is_monotonic_increasing == False
 
         with pytest.raises(UnsortedDataException):
-            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data=compact_data)
 
     @pytest.mark.parametrize("validate_index", (True, False))
-    def test_append_same_index_value(self, lmdb_version_store_v1, validate_index, compact_data_inline):
+    def test_append_same_index_value(self, lmdb_version_store_v1, validate_index, compact_data):
         lib = lmdb_version_store_v1
         sym = "test_append_same_index_value"
         df_0 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
         lib.write(sym, df_0)
 
         df_1 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range(df_0.index[-1], periods=2))
-        lib.append(sym, df_1, validate_index=validate_index, compact_data_inline=compact_data_inline)
+        lib.append(sym, df_1, validate_index=validate_index, compact_data=compact_data)
         expected = pd.concat([df_0, df_1])
         received = lib.read(sym).data
         assert_frame_equal(expected, received)
         assert lib.get_info(sym)["sorted"] == "ASCENDING"
 
-    def test_append_existing_not_sorted_exception(self, lmdb_version_store, compact_data_inline):
+    def test_append_existing_not_sorted_exception(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -464,9 +462,9 @@ class TestAppend:
         assert df2.index.is_monotonic_increasing == True
 
         with pytest.raises(UnsortedDataException):
-            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data=compact_data)
 
-    def test_append_not_sorted_non_validate_index(self, lmdb_version_store, compact_data_inline):
+    def test_append_not_sorted_non_validate_index(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -484,9 +482,9 @@ class TestAppend:
         dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_increasing == False
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
 
-    def test_append_not_sorted_multi_index_exception(self, lmdb_version_store, compact_data_inline):
+    def test_append_not_sorted_multi_index_exception(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -516,9 +514,9 @@ class TestAppend:
         assert isinstance(df.index, MultiIndex) == True
 
         with pytest.raises(UnsortedDataException):
-            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+            lmdb_version_store.append(symbol, df2, validate_index=True, compact_data=compact_data)
 
-    def test_append_not_sorted_range_index_non_exception(self, lmdb_version_store, compact_data_inline):
+    def test_append_not_sorted_range_index_non_exception(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -535,9 +533,9 @@ class TestAppend:
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_increasing == False
         with pytest.raises(NormalizationException):
-            lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+            lmdb_version_store.append(symbol, df2, compact_data=compact_data)
 
-    def test_append_mix_ascending_not_sorted(self, lmdb_version_store, compact_data_inline):
+    def test_append_mix_ascending_not_sorted(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -555,7 +553,7 @@ class TestAppend:
         dtidx = pd.date_range(initial_timestamp, periods=num_rows)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_increasing == True
-        lmdb_version_store.append(symbol, df2, validate_index=True, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, validate_index=True, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "ASCENDING"
 
@@ -564,7 +562,7 @@ class TestAppend:
         dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_increasing == False
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "UNSORTED"
 
@@ -573,11 +571,11 @@ class TestAppend:
         dtidx = pd.date_range(initial_timestamp, periods=num_rows)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_increasing == True
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "UNSORTED"
 
-    def test_append_mix_descending_not_sorted(self, lmdb_version_store, compact_data_inline):
+    def test_append_mix_descending_not_sorted(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -595,7 +593,7 @@ class TestAppend:
         dtidx = pd.date_range(initial_timestamp, periods=num_rows)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
         assert df2.index.is_monotonic_decreasing == True
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "DESCENDING"
 
@@ -604,7 +602,7 @@ class TestAppend:
         dtidx = np.roll(pd.date_range(initial_timestamp, periods=num_rows), 3)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_decreasing == False
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "UNSORTED"
 
@@ -613,11 +611,11 @@ class TestAppend:
         dtidx = pd.date_range(initial_timestamp, periods=num_rows)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
         assert df2.index.is_monotonic_decreasing == True
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "UNSORTED"
 
-    def test_append_mix_ascending_descending(self, lmdb_version_store, compact_data_inline):
+    def test_append_mix_ascending_descending(self, lmdb_version_store, compact_data):
         symbol = "bad_append"
 
         num_initial_rows = 20
@@ -635,7 +633,7 @@ class TestAppend:
         dtidx = pd.date_range(initial_timestamp, periods=num_rows)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=dtidx)
         assert df2.index.is_monotonic_increasing == True
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "UNSORTED"
 
@@ -644,11 +642,11 @@ class TestAppend:
         dtidx = pd.date_range(initial_timestamp, periods=num_rows)
         df2 = pd.DataFrame({"c": np.arange(0, num_rows, dtype=np.int64)}, index=reversed(dtidx))
         assert df2.index.is_monotonic_decreasing == True
-        lmdb_version_store.append(symbol, df2, compact_data_inline=compact_data_inline)
+        lmdb_version_store.append(symbol, df2, compact_data=compact_data)
         info = lmdb_version_store.get_info(symbol)
         assert info["sorted"] == "UNSORTED"
 
-    def test_append_docs_example(self, lmdb_version_store, compact_data_inline):
+    def test_append_docs_example(self, lmdb_version_store, compact_data):
         # This test is really just the append example from the docs.
         # Other examples are included so that outputs can be easily re-generated.
         lib = lmdb_version_store
@@ -690,7 +688,7 @@ class TestAppend:
         print(df_append)
         df_append.index = pd.date_range(datetime(2000, 1, 2, 7), periods=5, freq="H")
 
-        lib.append("test_frame", df_append, compact_data_inline=compact_data_inline)
+        lib.append("test_frame", df_append, compact_data=compact_data)
         print(lib.tail("test_frame", 7).data)
         expected = pd.concat([df2, df.drop(df.index[:3]), df_append])
         assert_frame_equal(lib.read("test_frame").data, expected)
@@ -713,12 +711,12 @@ class TestAppend:
         ],
     )
     def test_append_mismatched_object_kind(
-        self, to_write, to_append, lmdb_version_store_dynamic_schema_v1, compact_data_inline
+        self, to_write, to_append, lmdb_version_store_dynamic_schema_v1, compact_data
     ):
         lib = lmdb_version_store_dynamic_schema_v1
         lib.write("sym", to_write)
         with pytest.raises(NormalizationException) as e:
-            lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+            lib.append("sym", to_append, compact_data=compact_data)
         assert "Append" in str(e.value)
 
     @pytest.mark.parametrize(
@@ -740,18 +738,18 @@ class TestAppend:
         ],
     )
     def test_append_series_with_different_column_name_throws(
-        self, lmdb_version_store_dynamic_schema_v1, to_write, to_append, compact_data_inline
+        self, lmdb_version_store_dynamic_schema_v1, to_write, to_append, compact_data
     ):
         # It makes sense to create a new column and turn the whole thing into a dataframe. This would require changes in the
         # logic for storing normalization metadata which is tricky. Noone has requested this, so we just throw.
         lib = lmdb_version_store_dynamic_schema_v1
         lib.write("sym", to_write)
         with pytest.raises(SchemaException) as e:
-            lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+            lib.append("sym", to_append, compact_data=compact_data)
         assert "name_1" in str(e.value) and "name_2" in str(e.value)
 
     def test_append_series_with_different_row_range_index_name(
-        self, lmdb_version_store_dynamic_schema_v1, compact_data_inline
+        self, lmdb_version_store_dynamic_schema_v1, compact_data
     ):
         lib = lmdb_version_store_dynamic_schema_v1
         to_write = pd.Series([1, 2, 3])
@@ -759,13 +757,13 @@ class TestAppend:
         to_append = pd.Series([4, 5, 6])
         to_append.index.name = "index_name_2"
         lib.write("sym", to_write)
-        lib.append("sym", to_append, compact_data_inline=compact_data_inline)
+        lib.append("sym", to_append, compact_data=compact_data)
         # The current behavior is the last modification operation is setting the index name.
         # See Monday 9797097831, it would be best to require that index names are always matching. This is the case for
         # datetime index because it's a physical column. It's a potentially breaking change.
         assert lib.read("sym").data.index.name == "index_name_2"
 
-    def test_append_after_delete_range(self, sym, lmdb_version_store, compact_data_inline):
+    def test_append_after_delete_range(self, sym, lmdb_version_store, compact_data):
         lib = lmdb_version_store
 
         start_date = datetime(2025, 9, 1)
@@ -775,7 +773,7 @@ class TestAppend:
         # create data
         while cur_date <= end_date:
             df = create_random_data(at_date=cur_date)
-            lib.append("sym", df, compact_data_inline=compact_data_inline)
+            lib.append("sym", df, compact_data=compact_data)
             cur_date = get_next_business_date(cur_date)
 
         # remove date
@@ -791,7 +789,7 @@ class TestAppend:
         while cur_date <= end_date:
             df = create_random_data(at_date=cur_date)
             expected_data = pd.concat([expected_data, df])
-            lib.append("sym", df, compact_data_inline=compact_data_inline)
+            lib.append("sym", df, compact_data=compact_data)
             cur_date = get_next_business_date(cur_date)
 
         assert_frame_equal(lib.read("sym").data, expected_data)
@@ -802,9 +800,7 @@ class TestAppend:
     @pytest.mark.parametrize("data_class", ["dataframe", "series"])
     @pytest.mark.parametrize("batch", [True, False])
     @pytest.mark.parametrize("metadata_v1", ["v1", None])
-    def test_append_empty_frame_metadata(
-        self, lmdb_version_store_v1, data_class, batch, metadata_v1, compact_data_inline
-    ):
+    def test_append_empty_frame_metadata(self, lmdb_version_store_v1, data_class, batch, metadata_v1, compact_data):
         lib = lmdb_version_store_v1
         sym = "test_append_empty_frame_metadata"
         write_data = pd.DataFrame({"col": np.arange(1)}) if data_class == "dataframe" else pd.Series(np.arange(1))
@@ -813,10 +809,10 @@ class TestAppend:
         # Using arange guarantees the dtype matches the written df
         append_data = pd.DataFrame({"col": np.arange(0)}) if data_class == "dataframe" else pd.Series(np.arange(0))
         append_vit = (
-            # TODO: 12033601732 test with batch and compact_data_inline=True as well
+            # TODO: 12033601732 test with batch and compact_data=True as well
             lib.batch_append([sym], [append_data], metadata_vector=[metadata_v1])[0]
             if batch
-            else lib.append(sym, append_data, metadata=metadata_v1, compact_data_inline=compact_data_inline)
+            else lib.append(sym, append_data, metadata=metadata_v1, compact_data=compact_data)
         )
         assert append_vit.version == 1
         assert append_vit.metadata == metadata_v1
@@ -827,7 +823,7 @@ class TestAppend:
         assert_func(read_vit.data, write_data)
 
     @pytest.mark.parametrize("batch", [True, False])
-    def test_symbol_list_key_added_on_upsert(self, lmdb_version_store_v1, batch, compact_data_inline):
+    def test_symbol_list_key_added_on_upsert(self, lmdb_version_store_v1, batch, compact_data):
         lib = lmdb_version_store_v1
         sym = "test_symbol_list_key_added_on_upsert"
         lib.write(sym, 0)
@@ -836,11 +832,7 @@ class TestAppend:
         assert not len(lib.list_symbols())
         num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
         append_df = pd.DataFrame({"col": np.arange(0)})
-        # TODO: 12033601732 test with batch and compact_data_inline=True as well
-        (
-            lib.batch_append([sym], [append_df])
-            if batch
-            else lib.append(sym, append_df, compact_data_inline=compact_data_inline)
-        )
+        # TODO: 12033601732 test with batch and compact_data=True as well
+        (lib.batch_append([sym], [append_df]) if batch else lib.append(sym, append_df, compact_data=compact_data))
         assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
         assert lib.list_symbols() == [sym]

--- a/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
@@ -31,19 +31,19 @@ from tests.util.naughty_strings import read_big_list_of_naughty_strings
 pytestmark = pytest.mark.pipeline
 
 
-def generic_compact_data_inline_test(lib, sym, df, **append_kwargs):
+def generic_append_compact_data_test(lib, sym, df, **append_kwargs):
     qs.reset_stats()  # Clear any leftover stats from a previous failed run
     vit_before_compaction = lib.read(sym, output_format="PANDAS" if isinstance(df, pd.DataFrame) else "POLARS")
     oracle_sym = sym + "_oracle"
     lib.write(oracle_sym, vit_before_compaction.data)
-    lib.append(oracle_sym, df, compact_data_inline=False, **append_kwargs)
+    lib.append(oracle_sym, df, compact_data=False, **append_kwargs)
     # Use Polars so that sparse data checking is proper
     expected = lib.read(oracle_sym, output_format="POLARS").data
     pre_compaction_index = lib.read_index(sym)
     pre_compaction_data_keys = len(pre_compaction_index)
 
     with qs.query_stats():
-        lib.append(sym, df, compact_data_inline=True, **append_kwargs)
+        lib.append(sym, df, compact_data=True, **append_kwargs)
         stats = qs.get_query_stats()
     qs.reset_stats()
     rows_per_segment = lib.lib_cfg().lib_desc.version.write_options.segment_row_size
@@ -83,7 +83,7 @@ def test_basic(in_memory_store_factory, clear_query_stats, index):
     df_1 = pd.DataFrame(
         {"col": np.arange(20, 30)}, index=None if index is None else pd.date_range("2026-01-21", periods=10)
     )
-    generic_compact_data_inline_test(lib, sym, df_1)
+    generic_append_compact_data_test(lib, sym, df_1)
 
 
 def test_frequent_append_io_counts_compact_once(in_memory_store_factory, clear_query_stats):
@@ -93,7 +93,7 @@ def test_frequent_append_io_counts_compact_once(in_memory_store_factory, clear_q
     for idx in range(99):
         lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000])
     with qs.query_stats():
-        lib.append(sym, df[99 * 2_000 :], compact_data_inline=True)
+        lib.append(sym, df[99 * 2_000 :], compact_data=True)
         stats = qs.get_query_stats()
     qs.reset_stats()
     received = lib.read(sym).data
@@ -111,7 +111,7 @@ def test_frequent_append_io_counts_compact_every_time(in_memory_store_factory, c
     df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
     for idx in range(100):
         with qs.query_stats():
-            lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000], compact_data_inline=True)
+            lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000], compact_data=True)
             stats = qs.get_query_stats()
         qs.reset_stats()
         received = lib.read(sym).data
@@ -130,7 +130,7 @@ def test_pyarrow_tables(in_memory_version_store_arrow, clear_query_stats):
     lib.write(sym, table_0)
     table_1 = pa.table({"col": pa.array(np.arange(20, 30))})
     with qs.query_stats():
-        lib.append(sym, table_1, compact_data_inline=True)
+        lib.append(sym, table_1, compact_data=True)
         stats = qs.get_query_stats()
     qs.reset_stats()
     vit = lib.read(sym)
@@ -150,7 +150,7 @@ def test_series(in_memory_store_factory, clear_query_stats, index):
     lib.write(sym, series_0)
     series_1 = pd.Series(np.arange(20, 30), index=None if index is None else pd.date_range("2026-01-21", periods=10))
     with qs.query_stats():
-        lib.append(sym, series_1, compact_data_inline=True)
+        lib.append(sym, series_1, compact_data=True)
         stats = qs.get_query_stats()
     qs.reset_stats()
     vit = lib.read(sym)
@@ -171,7 +171,7 @@ def test_numpy_arrays(in_memory_store_factory, clear_query_stats):
     lib.write(sym, array_0)
     array_1 = np.arange(20, 30)
     with qs.query_stats():
-        lib.append(sym, array_1, compact_data_inline=True)
+        lib.append(sym, array_1, compact_data=True)
         stats = qs.get_query_stats()
     qs.reset_stats()
     vit = lib.read(sym)
@@ -190,33 +190,33 @@ def test_existing_zero_rows(in_memory_store_factory, clear_query_stats):
     df_0 = pd.DataFrame({"col": np.arange(0)})
     lib.write(sym, df_0)
     df_1 = pd.DataFrame({"col": np.arange(15)}, index=pd.date_range("2026-01-21", periods=15))
-    generic_compact_data_inline_test(lib, sym, df_1)
+    generic_append_compact_data_test(lib, sym, df_1)
 
 
 @pytest.mark.parametrize("write_if_missing", [True, False])
-@pytest.mark.parametrize("compact_data_inline", [True, False])
-def test_write_if_missing(in_memory_store_factory, write_if_missing, compact_data_inline):
+@pytest.mark.parametrize("compact_data", [True, False])
+def test_write_if_missing(in_memory_store_factory, write_if_missing, compact_data):
     lib = in_memory_store_factory(segment_row_size=10)
     sym = "test_write_if_missing"
     df = pd.DataFrame({"col": np.arange(15)})
     if write_if_missing:
-        lib.append(sym, df, compact_data_inline=compact_data_inline, write_if_missing=write_if_missing)
+        lib.append(sym, df, compact_data=compact_data, write_if_missing=write_if_missing)
         assert_frame_equal(df, lib.read(sym).data)
         index = lib.read_index(sym)
         row_counts = (index["end_row"] - index["start_row"]).to_list()
-        # See comment in LocalVersionedEngine::append_internal as to why this isn't [8, 7] when compact_data_inline is
+        # See comment in LocalVersionedEngine::append_internal as to why this isn't [8, 7] when compact_data is
         # True
         assert row_counts == [10, 5]
     else:
         with pytest.raises(InternalException):
-            lib.append(sym, df, compact_data_inline=compact_data_inline, write_if_missing=write_if_missing)
+            lib.append(sym, df, compact_data=compact_data, write_if_missing=write_if_missing)
 
 
 def test_metadata(in_memory_store_factory):
     lib = in_memory_store_factory()
     sym = "test_metadata"
     lib.write(sym, pd.DataFrame({"col": [0]}), metadata="0")
-    lib.append(sym, pd.DataFrame({"col": [1]}), metadata="1", compact_data_inline=True)
+    lib.append(sym, pd.DataFrame({"col": [1]}), metadata="1", compact_data=True)
     vit = lib.read(sym)
     assert vit.metadata == "1"
     assert_frame_equal(vit.data, pd.DataFrame({"col": [0, 1]}))
@@ -231,7 +231,7 @@ def test_compact_whole_symbol(in_memory_store_factory, clear_query_stats, index)
     lib.write(sym, df[:5])
     lib.append(sym, df[5:10])
     lib.append(sym, df[10:15])
-    generic_compact_data_inline_test(lib, sym, df[15:])
+    generic_append_compact_data_test(lib, sym, df[15:])
 
 
 @pytest.mark.parametrize("index", [None, "ts"])
@@ -240,7 +240,7 @@ def test_compact_leftover_slices(in_memory_store_factory, clear_query_stats, ind
     sym = "test_compact_leftover_slices"
     df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
     lib.write(sym, df[:5])
-    generic_compact_data_inline_test(lib, sym, df[5:])
+    generic_append_compact_data_test(lib, sym, df[5:])
 
 
 def test_existing_data_compacted(in_memory_store_factory, clear_query_stats):
@@ -248,7 +248,7 @@ def test_existing_data_compacted(in_memory_store_factory, clear_query_stats):
     sym = "test_existing_data_compacted"
     df = pd.DataFrame({"col": np.arange(20)})
     lib.write(sym, df[:10])
-    generic_compact_data_inline_test(lib, sym, df[10:])
+    generic_append_compact_data_test(lib, sym, df[10:])
 
 
 @pytest.mark.parametrize("total_rows", [25, 30, 35])
@@ -260,7 +260,7 @@ def test_tail_of_existing_data_already_compacted(in_memory_store_factory, clear_
     lib.append(sym, df[5:10])
     lib.append(sym, df[10:20])
     assert len(lib.read_index(sym)) == 3
-    generic_compact_data_inline_test(lib, sym, df[20:])
+    generic_append_compact_data_test(lib, sym, df[20:])
 
 
 @pytest.mark.parametrize("index", [None, "ts"])
@@ -285,7 +285,7 @@ def test_dynamic_schema_col_ordering(in_memory_store_factory, clear_query_stats,
         },
         index=None if index is None else pd.date_range("2026-01-21", periods=10),
     )
-    generic_compact_data_inline_test(lib, sym, df_1)
+    generic_append_compact_data_test(lib, sym, df_1)
 
 
 @pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
@@ -307,7 +307,7 @@ def test_dynamic_schema_type_promotion(in_memory_store_factory, clear_query_stat
             "col_2": np.arange(40, 50, dtype=np.uint16),
         },
     )
-    generic_compact_data_inline_test(lib, sym, df_1)
+    generic_append_compact_data_test(lib, sym, df_1)
 
 
 @pytest.mark.parametrize("index", [None, "ts"])
@@ -324,7 +324,7 @@ def test_column_slicing(in_memory_store_factory, clear_query_stats, index, segme
         {f"col_{idx}": np.arange(20, 30) for idx in range(5)},
         index=None if index is None else pd.date_range("2026-01-21", periods=10),
     )
-    generic_compact_data_inline_test(lib, sym, df_1)
+    generic_append_compact_data_test(lib, sym, df_1)
 
 
 @pytest.mark.parametrize("names", [None, ["ts", None], [None, "level 2"], ["ts", "level 2"]])
@@ -340,7 +340,7 @@ def test_multiindex(in_memory_store_factory, clear_query_stats, names):
     )
     lib.write(sym, df[:5])
     with qs.query_stats():
-        lib.append(sym, df[5:], compact_data_inline=True)
+        lib.append(sym, df[5:], compact_data=True)
         stats = qs.get_query_stats()
     qs.reset_stats()
     vit = lib.read(sym)
@@ -356,7 +356,7 @@ def test_string_none_nan_handling(in_memory_store_factory, clear_query_stats):
     sym = "test_string_none_nan_handling"
     df = pd.DataFrame({"col": ["hello", np.nan, np.nan, None, None, None, np.nan, np.nan, None, None]})
     lib.write(sym, df[:5], coerce_columns={"col": object})
-    generic_compact_data_inline_test(lib, sym, df[5:], coerce_columns={"col": object})
+    generic_append_compact_data_test(lib, sym, df[5:], coerce_columns={"col": object})
 
 
 @pytest.mark.parametrize("dynamic_strings_first", [True, False])
@@ -368,7 +368,7 @@ def test_fixed_width_and_dynamic_strings(in_memory_store_factory, clear_query_st
     lib.write(sym, df[:3], dynamic_strings=dynamic_strings_first)
     lib.append(sym, df[3:5], dynamic_strings=dynamic_strings_first)
     lib.append(sym, df[5:7], dynamic_strings=not dynamic_strings_first)
-    generic_compact_data_inline_test(lib, sym, df[7:], dynamic_strings=not dynamic_strings_first)
+    generic_append_compact_data_test(lib, sym, df[7:], dynamic_strings=not dynamic_strings_first)
 
 
 @pytest.mark.parametrize("dynamic_strings_first", [True, False])
@@ -377,7 +377,7 @@ def test_blns(in_memory_store_factory, clear_query_stats, dynamic_strings_first)
     sym = "test_blns"
     df = pd.DataFrame({"col": read_big_list_of_naughty_strings()})
     lib.write(sym, df[: len(df) // 2], dynamic_strings=dynamic_strings_first)
-    generic_compact_data_inline_test(lib, sym, df[len(df) // 2 :], dynamic_strings=not dynamic_strings_first)
+    generic_append_compact_data_test(lib, sym, df[len(df) // 2 :], dynamic_strings=not dynamic_strings_first)
 
 
 def test_append_empty_frame_compacts_existing_data(in_memory_store_factory, clear_query_stats):
@@ -395,7 +395,7 @@ def test_append_empty_frame_compacts_existing_data(in_memory_store_factory, clea
     assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 0
     assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
     with qs.query_stats():
-        lib.append(sym, pd.DataFrame(), compact_data_inline=True)
+        lib.append(sym, pd.DataFrame(), compact_data=True)
         stats = qs.get_query_stats()
     qs.reset_stats()
     assert lib.read(sym).version == 3
@@ -413,7 +413,7 @@ def test_fortran_ordered_data(in_memory_store_factory, clear_query_stats, rows_t
     df_0 = pd.DataFrame(np.random.randint(0, 100, size=(5, 2)), columns=cols)
     lib.write(sym, df_0)
     df_1 = pd.DataFrame(np.random.randint(0, 100, size=(rows_to_append, 2)), columns=cols)
-    generic_compact_data_inline_test(lib, sym, df_1)
+    generic_append_compact_data_test(lib, sym, df_1)
 
 
 @pytest.mark.parametrize("index", [None, "ts"])
@@ -431,7 +431,7 @@ def test_column_filtered_read(in_memory_store_factory, clear_query_stats, index)
     )
     lib.write(sym, df[:5])
     for i in range(1, 4):
-        generic_compact_data_inline_test(lib, sym, df[i * 5 : (i + 1) * 5])
+        generic_append_compact_data_test(lib, sym, df[i * 5 : (i + 1) * 5])
     expected_col_a = df[["col_a"]]
     expected_col_bc = df[["col_b", "col_c"]]
     assert_frame_equal(expected_col_a, lib.read(sym, columns=["col_a"]).data)
@@ -449,7 +449,7 @@ def test_date_range_read(in_memory_store_factory, clear_query_stats, rows_per_se
     )
     lib.write(sym, df[:5])
     for i in range(1, 20):
-        generic_compact_data_inline_test(lib, sym, df[i * 5 : (i + 1) * 5])
+        generic_append_compact_data_test(lib, sym, df[i * 5 : (i + 1) * 5])
     mid = index[num_rows // 2]
     expected_first_half = df[:mid]
     expected_second_half = df[mid:]
@@ -462,7 +462,7 @@ def test_read_previous_version(in_memory_store_factory, clear_query_stats):
     sym = "test_read_previous_version"
     df = pd.DataFrame({"col": np.arange(10)})
     lib.write(sym, df[:5])
-    generic_compact_data_inline_test(lib, sym, df[5:])
+    generic_append_compact_data_test(lib, sym, df[5:])
     assert_frame_equal(df[:5], lib.read(sym, as_of=0).data)
     assert_frame_equal(df, lib.read(sym, as_of=1).data)
     assert_frame_equal(df, lib.read(sym).data)
@@ -478,7 +478,7 @@ def test_schema_mismatch_static(in_memory_store_factory):
     with pytest.raises(Exception) as e_without_arg:
         lib.append(sym, df_1)
     with pytest.raises(Exception) as e_with_arg:
-        lib.append(sym, df_1, compact_data_inline=True)
+        lib.append(sym, df_1, compact_data=True)
     assert e_with_arg.type == e_without_arg.type
     assert e_with_arg.typename == e_without_arg.typename
     assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
@@ -487,7 +487,7 @@ def test_schema_mismatch_static(in_memory_store_factory):
     with pytest.raises(Exception) as e_without_arg:
         lib.append(sym, df_1)
     with pytest.raises(Exception) as e_with_arg:
-        lib.append(sym, df_1, compact_data_inline=True)
+        lib.append(sym, df_1, compact_data=True)
     assert e_with_arg.type == e_without_arg.type
     assert e_with_arg.typename == e_without_arg.typename
     assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
@@ -502,7 +502,7 @@ def test_schema_mismatch_dynamic(in_memory_store_factory):
     with pytest.raises(Exception) as e_without_arg:
         lib.append(sym, df_1)
     with pytest.raises(Exception) as e_with_arg:
-        lib.append(sym, df_1, compact_data_inline=True)
+        lib.append(sym, df_1, compact_data=True)
     assert e_with_arg.type == e_without_arg.type
     assert e_with_arg.typename == e_without_arg.typename
     assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
@@ -589,9 +589,9 @@ def test_hypothesis_static_schema(
             lib.write(sym, table.slice(length=rows_to_take))
             first_iteration = False
         else:
-            # This basically does lib.append(sym, table.slice(length=rows_to_take), compact_data_inline=True), plus some
+            # This basically does lib.append(sym, table.slice(length=rows_to_take), compact_data=True), plus some
             # read-only checks
-            generic_compact_data_inline_test(lib, sym, table.slice(length=rows_to_take))
+            generic_append_compact_data_test(lib, sym, table.slice(length=rows_to_take))
         table = table.slice(offset=rows_to_take)
         remaining_rows -= rows_to_take
 
@@ -673,6 +673,6 @@ def test_hypothesis_dynamic_schema(in_memory_store_factory, clear_query_stats, n
             lib.write(sym, table)
             first_iteration = False
         else:
-            # This basically does lib.append(sym, table, compact_data_inline=True), plus some read-only checks
-            generic_compact_data_inline_test(lib, sym, table)
+            # This basically does lib.append(sym, table, compact_data=True), plus some read-only checks
+            generic_append_compact_data_test(lib, sym, table)
         remaining_rows -= rows_to_take


### PR DESCRIPTION
#### What does this implement or fix?
Pure find-replace rename of `compact_data_inline` to `compact_data`