### PR TITLE
ASV benchmarks for merge update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,11 @@ When upgrading a dependency like `sparrow` that has a custom port in vcpkg:
 
 C++ benchmark sources are in `cpp/arcticdb/*/test/benchmark_*.cpp`. ASV Python benchmarks live in `python/benchmarks/`. See [ASV Benchmarks Wiki](https://github.com/man-group/ArcticDB/wiki/Dev:-ASV-Benchmarks).
 
+ASV benchmarks that store data on SeaweedFS (e.g. `merge_functions.py`) need the single local
+server started first: `build_tooling/start_seaweed.sh start` (the CI benchmark workflow does
+this automatically). Client helpers, including `reset_arcticdb_cache_bucket()` which every
+`setup_cache` using SeaweedFS must call first, are in `python/benchmarks/seaweed_utils.py`.
+
 ## Code Review Guidelines
 
 When writing or modifying code, follow the standards in [`docs/claude/PR_REVIEW_GUIDELINES.md`](docs/claude/PR_REVIEW_GUIDELINES.md). These cover API stability, memory safety, on-disk format compatibility, concurrency, testing, and other quality gates enforced during PR review.

--- a/build_tooling/start_seaweed.sh
+++ b/build_tooling/start_seaweed.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Start (or stop) the single local SeaweedFS server used by the ASV benchmarks.
+#
+# One server hosts every benchmark in the ASV run; benchmark processes reach it on
+# localhost (see python/benchmarks/seaweed_utils.py for the client-side helpers).
+#
+# Automatic vacuuming is disabled (-master.garbageThreshold=1.1 can never be reached),
+# so space is reclaimed only by the benchmarks themselves, by dropping a bucket's
+# backing collection.
+#
+# Volumes are capped at 2GB and never preallocated, so a high -volume.max only reserves
+# slots, not disk. The slots matter because every bucket is grown to at least as many
+# volumes as ArcticDB has IO threads.
+
+set -euo pipefail
+
+SEAWEED_VERSION="${SEAWEED_VERSION:-4.40}"
+SEAWEED_DATA_DIR="${SEAWEED_DATA_DIR:-${RUNNER_TEMP:-/tmp}/seaweedfs-asv}"
+SEAWEED_BIN_DIR="${SEAWEED_BIN_DIR:-$HOME/.cache/seaweedfs/$SEAWEED_VERSION}"
+SEAWEED_IP="${SEAWEED_IP:-127.0.0.1}"
+SEAWEED_MASTER_PORT="${SEAWEED_MASTER_PORT:-9333}"
+SEAWEED_VOLUME_PORT="${SEAWEED_VOLUME_PORT:-8080}"
+SEAWEED_FILER_PORT="${SEAWEED_FILER_PORT:-8888}"
+SEAWEED_S3_PORT="${SEAWEED_S3_PORT:-8333}"
+SEAWEED_VOLUME_SIZE_LIMIT_MB="${SEAWEED_VOLUME_SIZE_LIMIT_MB:-2048}"
+SEAWEED_MAX_VOLUMES="${SEAWEED_MAX_VOLUMES:-1000}"
+
+PID_FILE="$SEAWEED_DATA_DIR/weed.pid"
+LOG_FILE="$SEAWEED_DATA_DIR/weed.log"
+
+download() {
+    if [[ -x "$SEAWEED_BIN_DIR/weed" ]]; then
+        return
+    fi
+    echo "Installing SeaweedFS $SEAWEED_VERSION"
+    mkdir -p "$SEAWEED_BIN_DIR"
+    local installer="$SEAWEED_BIN_DIR/install.sh"
+    curl -fsSL --retry 3 -o "$installer" https://raw.githubusercontent.com/seaweedfs/seaweedfs/master/install.sh
+    bash "$installer" --version "$SEAWEED_VERSION" --dir "$SEAWEED_BIN_DIR"
+    rm -f "$installer"
+}
+
+start() {
+    # A foreign server answering here would also answer the readiness probe below, making this
+    # script report success while its own process dies on the port bind
+    if curl -fsS "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" >/dev/null 2>&1; then
+        echo "Something is already answering on http://$SEAWEED_IP:$SEAWEED_MASTER_PORT;" \
+            "refusing to start a second SeaweedFS. Stop it first (or override SEAWEED_*_PORT)." >&2
+        exit 1
+    fi
+    download
+    mkdir -p "$SEAWEED_DATA_DIR"
+    nohup "$SEAWEED_BIN_DIR/weed" server \
+        -dir="$SEAWEED_DATA_DIR" \
+        -ip="$SEAWEED_IP" \
+        -ip.bind="$SEAWEED_IP" \
+        -master.port="$SEAWEED_MASTER_PORT" \
+        -master.volumeSizeLimitMB="$SEAWEED_VOLUME_SIZE_LIMIT_MB" \
+        -master.volumePreallocate=false \
+        -master.garbageThreshold=1.1 \
+        -volume.port="$SEAWEED_VOLUME_PORT" \
+        -volume.max="$SEAWEED_MAX_VOLUMES" \
+        -filer \
+        -filer.port="$SEAWEED_FILER_PORT" \
+        -s3 \
+        -s3.port="$SEAWEED_S3_PORT" \
+        >"$LOG_FILE" 2>&1 &
+    echo $! >"$PID_FILE"
+
+    # Ready when the master is up, a volume server has registered and the S3 gateway answers
+    for _ in $(seq 1 120); do
+        if ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+            rm -f "$PID_FILE"
+            echo "SeaweedFS process died on startup, last log lines:" >&2
+            tail -50 "$LOG_FILE" >&2
+            exit 1
+        fi
+        if curl -fsS "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" 2>/dev/null | grep -q '"DataNodes"' &&
+            curl -fsS "http://$SEAWEED_IP:$SEAWEED_S3_PORT" >/dev/null 2>&1; then
+            echo "SeaweedFS $SEAWEED_VERSION is up: master :$SEAWEED_MASTER_PORT, filer :$SEAWEED_FILER_PORT," \
+                "s3 :$SEAWEED_S3_PORT, data in $SEAWEED_DATA_DIR"
+            return
+        fi
+        sleep 1
+    done
+    echo "SeaweedFS failed to start, last log lines:" >&2
+    tail -50 "$LOG_FILE" >&2
+    exit 1
+}
+
+stop() {
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        kill "$(cat "$PID_FILE")"
+        for _ in $(seq 1 30); do
+            kill -0 "$(cat "$PID_FILE")" 2>/dev/null || break
+            sleep 1
+        done
+        kill -9 "$(cat "$PID_FILE")" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+    echo "SeaweedFS stopped (data left in $SEAWEED_DATA_DIR)"
+}
+
+case "${1:-start}" in
+    start) start ;;
+    stop) stop ;;
+    *)
+        echo "Usage: $0 [start|stop]" >&2
+        exit 1
+        ;;
+esac

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2630,6 +2630,386 @@
         "version": "2238d0faf29b5206ab9dd61d1acea68ae7883b8ac95bc8c0fafaefb85ff1527b",
         "warmup_time": 0.1
     },
+    "merge_functions.MergeLongWide.peakmem_merge": {
+        "code": "class MergeLongWide:\n    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        if index_kind == \"datetime\" and on_count == 1:\n            raise SkipNotImplemented  # grid-size cost decision: datetime measures on_count 0 and 50 only\n        self._setup(self.lib_name(scenario, index_kind))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "name": "merge_functions.MergeLongWide.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct"
+        ],
+        "params": [
+            [
+                "(2000000, 130)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1",
+                "50"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "20",
+                "80"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:350",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "715afbaf66e9850edffb0e11f0593da841dd4ddea8ab11833e46159eae35014d"
+    },
+    "merge_functions.MergeLongWide.time_merge": {
+        "code": "class MergeLongWide:\n    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        if index_kind == \"datetime\" and on_count == 1:\n            raise SkipNotImplemented  # grid-size cost decision: datetime measures on_count 0 and 50 only\n        self._setup(self.lib_name(scenario, index_kind))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeLongWide.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct"
+        ],
+        "params": [
+            [
+                "(2000000, 130)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1",
+                "50"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "20",
+                "80"
+            ]
+        ],
+        "repeat": 5,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:350",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "53e6cfb44fcf93b60dbed317f206bccbc3615b0878d96ca2ce5633607c5df51a",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeThin.peakmem_merge": {
+        "code": "class MergeThin:\n    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        self._setup(self.lib_name(scenario, index_kind))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "name": "merge_functions.MergeThin.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct"
+        ],
+        "params": [
+            [
+                "(10000000, 2)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "20",
+                "80"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:165",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "ddb075bfc3caee58d4689977821a7152c10f6476e9df384d955a692275115375"
+    },
+    "merge_functions.MergeThin.time_merge": {
+        "code": "class MergeThin:\n    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        self._setup(self.lib_name(scenario, index_kind))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeThin.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct"
+        ],
+        "params": [
+            [
+                "(10000000, 2)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "20",
+                "80"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:165",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "9ae34757c3f6ce6a5d7f22a8f4714f650976b2e0079ad2f7d31579df92d326d3",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeThinString.peakmem_merge": {
+        "code": "class MergeThinString:\n    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        self._setup(self.lib_name(scenario, index_kind, num_unique_strings))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target,\n            source_size,\n            matched_count,\n            on=self.on,\n            value_dtype=self.value_dtype,\n            num_unique_strings=num_unique_strings,\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "name": "merge_functions.MergeThinString.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(1000000, 2)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "20",
+                "80"
+            ],
+            [
+                "100",
+                "100000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:227",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "06036af93ea6a3fcd12bf055a74a96a6429a572cd56de081c07f038dfc6f8d58"
+    },
+    "merge_functions.MergeThinString.time_merge": {
+        "code": "class MergeThinString:\n    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        self._setup(self.lib_name(scenario, index_kind, num_unique_strings))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target,\n            source_size,\n            matched_count,\n            on=self.on,\n            value_dtype=self.value_dtype,\n            num_unique_strings=num_unique_strings,\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeThinString.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(1000000, 2)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "20",
+                "80"
+            ],
+            [
+                "100",
+                "100000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:227",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "9f1d106a1639d04a9923b4bca867ab6c0810fc0d4436f375b21a1bdf9a983a30",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeWide.peakmem_merge": {
+        "code": "class MergeWide:\n    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        if strategy != \"update\" and on_count == 1:\n            raise SkipNotImplemented  # see class docstring: grid-size cost decision, not unsupported\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        self._setup(self.lib_name(scenario, index_kind))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "name": "merge_functions.MergeWide.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct"
+        ],
+        "params": [
+            [
+                "(5000, 10000)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1",
+                "1000"
+            ],
+            [
+                "100"
+            ],
+            [
+                "20",
+                "80"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:291",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "643cd0a754e8c9317cec05e85ba7ca022b39b251a93206f91f1db271f50e6e02"
+    },
+    "merge_functions.MergeWide.time_merge": {
+        "code": "class MergeWide:\n    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):\n        if strategy != \"update\" and on_count == 1:\n            raise SkipNotImplemented  # see class docstring: grid-size cost decision, not unsupported\n        num_rows, num_value_cols = scenario\n        if index_kind == \"rowrange\" and strategy != \"update\":\n            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation\n        if index_kind == \"rowrange\" and on_count == 0:\n            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own\n        self._setup(self.lib_name(scenario, index_kind))\n        matched_count = round(source_size * matched_pct / 100)\n        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)\n        self.source = generate_merge_source(\n            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype\n        )\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeWide.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct"
+        ],
+        "params": [
+            [
+                "(5000, 10000)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "'datetime'",
+                "'rowrange'"
+            ],
+            [
+                "0",
+                "1",
+                "1000"
+            ],
+            [
+                "100"
+            ],
+            [
+                "20",
+                "80"
+            ]
+        ],
+        "repeat": 5,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:291",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "6a446c76d65096adc4c8dd19e25d046b28304e7e73d0487dc99b02a03a503cfb",
+        "warmup_time": 0
+    },
     "modification_functions.DeleteBatchSymbols.time_delete_batch_symbols": {
         "code": "class DeleteBatchSymbols:\n    def time_delete_batch_symbols(self, *args):\n        self.lib.delete_batch(self.syms)\n\n    def setup(self, num_symbols, storage):\n        if not is_storage_enabled(storage):\n            raise SkipNotImplemented\n    \n        if storage == Storage.LMDB:\n            self.ac = Arctic(f\"lmdb://{self.ARCTIC_DIR}\")\n        elif storage == Storage.AMAZON:\n            from arcticdb.storage_fixtures.s3 import real_s3_from_environment_variables\n    \n            factory = real_s3_from_environment_variables(shared_path=True, validate=True, log=True)\n            self.ac = factory.create_fixture().create_arctic()\n    \n        self.ac.delete_library(\"test_lib\")\n        self.lib = self.ac.create_library(\"test_lib\")\n    \n        df = pd.DataFrame({\"col\": range(1000)})\n        self.syms = [f\"sym_{i}\" for i in range(num_symbols)]\n        for sym in self.syms:\n            self.lib.write(sym, df)",
         "min_run_count": 2,

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -8,20 +8,61 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import os
 import random
-import shutil
-import time
+import uuid
 
 import numpy as np
 import pandas as pd
 
-from arcticdb import Arctic, LibraryOptions
+from arcticc.pb2.s3_storage_pb2 import Config as S3Config
+from arcticdb import Arctic
 from arcticdb.version_store.library import MergeStrategy
-from arcticdb.util.logger import get_logger
 from arcticdb.util.test import random_strings_of_length
+from arcticdb_ext.storage import CONFIG_LIBRARY_NAME
 from asv_runner.benchmarks.mark import SkipNotImplemented
+
+from benchmarks.seaweed_utils import (
+    ARCTICDB_CACHE_BUCKET,
+    arctic_uri,
+    copy_bucket,
+    create_bucket,
+    delete_bucket,
+    list_buckets,
+    reset_arcticdb_cache_bucket,
+)
 
 MIN_DATE = pd.Timestamp("1960-01-01")
 MAX_DATE = pd.Timestamp("2025-01-01")
+
+# merge_experimental is destructive, so every measurement runs against a pristine copy of the
+# data: setup copies the config library and the relevant data library from the cache bucket into
+# a brand new bucket and the merge runs there; teardown hard-deletes that bucket by dropping its
+# backing SeaweedFS collection.
+
+# Short-lived per-measurement bucket; each class creates its own in setup() and deletes it in
+# teardown(). The WORK_BUCKET_PREFIX sweep in _run_setup_cache() cleans up any that a killed
+# benchmark process (e.g. an ASV timeout) failed to tear down
+WORK_BUCKET_PREFIX = "arcticdb-merge-bench-"
+
+
+def _env_repeat(default):
+    # One knob to shrink local experiment runs; leaves CI defaults untouched
+    return int(os.getenv("ARCTICDB_MERGE_BENCH_REPEAT", default))
+
+
+_LIBRARY_PREFIX_CACHE = {}
+
+
+def _cache_library_prefix(lib_name):
+    """S3 key prefix of a library in the cache bucket. Libraries created through Arctic get a
+    unique "<name><nanos>" prefix, so it must be read back from the library config."""
+    if lib_name not in _LIBRARY_PREFIX_CACHE:
+        lib = Arctic(arctic_uri(ARCTICDB_CACHE_BUCKET)).get_library(lib_name)
+        config = lib._nvs.lib_cfg()
+        storage = config.storage_by_id[config.lib_desc.storage_ids[0]]
+        s3_config = S3Config()
+        storage.config.Unpack(s3_config)
+        _LIBRARY_PREFIX_CACHE[lib_name] = s3_config.prefix
+    return _LIBRARY_PREFIX_CACHE[lib_name]
 
 
 def _random_values(rng, num_rows, value_dtype, num_unique_strings):
@@ -85,14 +126,12 @@ class MergeBase:
     }
 
     def __init__(self):
-        self.logger = get_logger()
         self.SYM = "sym"
-        # Do not interleave benchmarks as they use the same LMDB directory for the measurements
         self.rounds = 1
-        # merge_experimental is destructive, so we must copy a fresh base and run once per measurement
+        # merge_experimental is destructive, so we must restore a fresh base and run once per measurement
         self.number = 1
         self.warmup_time = 0
-        self.repeat = 10
+        self.repeat = _env_repeat(10)
         self.timeout = 600
         self.ac = None
         self.lib = None
@@ -100,42 +139,29 @@ class MergeBase:
         self.value_dtype = None
         self.source = None
         self.on = None
-
-    def finish_init(self):
-        # Base LMDB instance that will be populated by setup_cache. Relevant libraries are then
-        # copied from here to a working directory for each (destructive) merge measurement.
-        self.LMDB_BASE_DIR = f"{self.LMDB_DIR}_base"
-        self.CONNECTION_STRING_BASE = f"lmdb://{self.LMDB_BASE_DIR}"
-        self.CONNECTION_STRING = f"lmdb://{self.LMDB_DIR}"
+        self.work_bucket = None
 
     def lib_name(self, scenario, index_kind, *extra):
         num_rows, num_value_cols = scenario
         return "_".join([str(num_rows), str(num_value_cols), index_kind, *[str(e) for e in extra]])
 
+    def _cache_arctic(self):
+        return Arctic(arctic_uri(ARCTICDB_CACHE_BUCKET))
+
     def _setup_cache_base(self, ac, lib_name, target):
-        ac.delete_library(lib_name)
+        # reset_arcticdb_cache_bucket() has just emptied the bucket, so the library cannot exist
         lib = ac.create_library(lib_name)
         lib.write(self.SYM, target)
 
-    def _setup(self, lib_name):
-        if os.path.isdir(self.LMDB_DIR):
-            shutil.rmtree(self.LMDB_DIR)
-        os.mkdir(self.LMDB_DIR)
-        # Copy the config database and the relevant library database for these benchmark parameters to the actual
-        # LMDB directory where the merge will happen
-        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
-        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
-        # Create a new Arctic instance, otherwise we will be holding a reference to the previous iteration's .mdb files
-        # and the deletion and recreation won't be noticed by Arctic
-        del self.ac
-        self.ac = Arctic(self.CONNECTION_STRING)
-        self.lib = self.ac.get_library(lib_name)
-        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
-        self.target = self.lib.read(self.SYM).data
-
-    def _teardown(self):
-        if os.path.isdir(self.LMDB_DIR):
-            shutil.rmtree(self.LMDB_DIR)
+    # ASV caches setup_cache results keyed by the function's source location, so every class must
+    # define its own setup_cache (delegating here); inheriting one shared method would make ASV
+    # reuse the first class's cache bucket for all of them.
+    def _run_setup_cache(self):
+        reset_arcticdb_cache_bucket()
+        for bucket in list_buckets():
+            if bucket.startswith(WORK_BUCKET_PREFIX):
+                delete_bucket(bucket)
+        self._setup_cache()
 
     def merge(self, strategy):
         self.lib.merge_experimental(self.SYM, self.source, strategy=self.STRATEGIES[strategy], on=self.on)
@@ -149,8 +175,6 @@ class MergeThin(MergeBase):
 
     def __init__(self):
         super().__init__()
-        self.LMDB_DIR = "merge_thin"
-        self.finish_init()
         self.value_dtype = "float"
         self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
         self.params = [
@@ -163,12 +187,10 @@ class MergeThin(MergeBase):
         ]
 
     def setup_cache(self):
-        start = time.time()
-        self._setup_cache()
-        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+        self._run_setup_cache()
 
     def _setup_cache(self):
-        ac = Arctic(self.CONNECTION_STRING_BASE)
+        ac = self._cache_arctic()
         for scenario in self.params[0]:
             for index_kind in self.params[2]:
                 num_rows, num_value_cols = scenario
@@ -181,7 +203,22 @@ class MergeThin(MergeBase):
             raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
         if index_kind == "rowrange" and on_count == 0:
             raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        self._setup(self.lib_name(scenario, index_kind))
+        lib_name = self.lib_name(scenario, index_kind)
+        # Create a new Arctic instance every sample so nothing cached from the previous sample's
+        # (since deleted) bucket survives
+        del self.ac
+        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
+        create_bucket(self.work_bucket)
+        # The URI-based storage override redirects the copied library config to the new bucket
+        copy_bucket(
+            ARCTICDB_CACHE_BUCKET,
+            self.work_bucket,
+            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
+        )
+        self.ac = Arctic(arctic_uri(self.work_bucket))
+        self.lib = self.ac.get_library(lib_name)
+        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
+        self.target = self.lib.read(self.SYM).data
         matched_count = round(source_size * matched_pct / 100)
         self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
         self.source = generate_merge_source(
@@ -189,7 +226,9 @@ class MergeThin(MergeBase):
         )
 
     def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
-        self._teardown()
+        if self.work_bucket is not None:
+            delete_bucket(self.work_bucket)
+            self.work_bucket = None
 
     def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
         self.merge(strategy)
@@ -202,8 +241,6 @@ class MergeThinString(MergeBase):
 
     def __init__(self):
         super().__init__()
-        self.LMDB_DIR = "merge_thin_string"
-        self.finish_init()
         self.value_dtype = "string"
         self.param_names = [
             "scenario",
@@ -225,14 +262,12 @@ class MergeThinString(MergeBase):
         ]
 
     def setup_cache(self):
-        start = time.time()
-        self._setup_cache()
-        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+        self._run_setup_cache()
 
     def _setup_cache(self):
         # Populate the base libraries only once. index_kind and num_unique_strings are shared across
         # every strategy, so each (scenario, index_kind, num_unique_strings) library is built once.
-        ac = Arctic(self.CONNECTION_STRING_BASE)
+        ac = self._cache_arctic()
         for scenario in self.params[0]:
             for index_kind in self.params[2]:
                 for num_unique_strings in self.params[6]:
@@ -248,7 +283,22 @@ class MergeThinString(MergeBase):
             raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
         if index_kind == "rowrange" and on_count == 0:
             raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        self._setup(self.lib_name(scenario, index_kind, num_unique_strings))
+        lib_name = self.lib_name(scenario, index_kind, num_unique_strings)
+        # Create a new Arctic instance every sample so nothing cached from the previous sample's
+        # (since deleted) bucket survives
+        del self.ac
+        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
+        create_bucket(self.work_bucket)
+        # The URI-based storage override redirects the copied library config to the new bucket
+        copy_bucket(
+            ARCTICDB_CACHE_BUCKET,
+            self.work_bucket,
+            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
+        )
+        self.ac = Arctic(arctic_uri(self.work_bucket))
+        self.lib = self.ac.get_library(lib_name)
+        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
+        self.target = self.lib.read(self.SYM).data
         matched_count = round(source_size * matched_pct / 100)
         self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
         self.source = generate_merge_source(
@@ -261,7 +311,9 @@ class MergeThinString(MergeBase):
         )
 
     def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
-        self._teardown()
+        if self.work_bucket is not None:
+            delete_bucket(self.work_bucket)
+            self.work_bucket = None
 
     def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
         self.merge(strategy)
@@ -274,11 +326,9 @@ class MergeWide(MergeBase):
 
     def __init__(self):
         super().__init__()
-        self.LMDB_DIR = "merge_wide"
-        self.finish_init()
         self.value_dtype = "float"
         self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
-        self.repeat = 5
+        self.repeat = _env_repeat(5)
         self.params = [
             [(5_000, 10_000)],  # scenario: (num_rows, num_value_cols)
             ["update", "insert", "update_and_insert"],  # strategy
@@ -289,14 +339,12 @@ class MergeWide(MergeBase):
         ]
 
     def setup_cache(self):
-        start = time.time()
-        self._setup_cache()
-        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+        self._run_setup_cache()
 
     def _setup_cache(self):
         # Populate the base libraries only once. index_kind is shared across every strategy, so each
         # (scenario, index_kind) base library is built exactly once and reused by all strategies.
-        ac = Arctic(self.CONNECTION_STRING_BASE)
+        ac = self._cache_arctic()
         for scenario in self.params[0]:
             for index_kind in self.params[2]:
                 num_rows, num_value_cols = scenario
@@ -311,7 +359,22 @@ class MergeWide(MergeBase):
             raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
         if index_kind == "rowrange" and on_count == 0:
             raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        self._setup(self.lib_name(scenario, index_kind))
+        lib_name = self.lib_name(scenario, index_kind)
+        # Create a new Arctic instance every sample so nothing cached from the previous sample's
+        # (since deleted) bucket survives
+        del self.ac
+        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
+        create_bucket(self.work_bucket)
+        # The URI-based storage override redirects the copied library config to the new bucket
+        copy_bucket(
+            ARCTICDB_CACHE_BUCKET,
+            self.work_bucket,
+            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
+        )
+        self.ac = Arctic(arctic_uri(self.work_bucket))
+        self.lib = self.ac.get_library(lib_name)
+        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
+        self.target = self.lib.read(self.SYM).data
         matched_count = round(source_size * matched_pct / 100)
         self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
         self.source = generate_merge_source(
@@ -319,7 +382,9 @@ class MergeWide(MergeBase):
         )
 
     def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
-        self._teardown()
+        if self.work_bucket is not None:
+            delete_bucket(self.work_bucket)
+            self.work_bucket = None
 
     def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
         self.merge(strategy)
@@ -333,9 +398,7 @@ class MergeLongWide(MergeBase):
 
     def __init__(self):
         super().__init__()
-        self.LMDB_DIR = "merge_long_wide"
-        self.finish_init()
-        self.repeat = 5
+        self.repeat = _env_repeat(5)
         self.value_dtype = "float"
         self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
         self.params = [
@@ -348,12 +411,10 @@ class MergeLongWide(MergeBase):
         ]
 
     def setup_cache(self):
-        start = time.time()
-        self._setup_cache()
-        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+        self._run_setup_cache()
 
     def _setup_cache(self):
-        ac = Arctic(self.CONNECTION_STRING_BASE)
+        ac = self._cache_arctic()
         for scenario in self.params[0]:
             for index_kind in self.params[2]:
                 num_rows, num_value_cols = scenario
@@ -368,7 +429,22 @@ class MergeLongWide(MergeBase):
             raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
         if index_kind == "datetime" and on_count == 1:
             raise SkipNotImplemented  # grid-size cost decision: datetime measures on_count 0 and 50 only
-        self._setup(self.lib_name(scenario, index_kind))
+        lib_name = self.lib_name(scenario, index_kind)
+        # Create a new Arctic instance every sample so nothing cached from the previous sample's
+        # (since deleted) bucket survives
+        del self.ac
+        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
+        create_bucket(self.work_bucket)
+        # The URI-based storage override redirects the copied library config to the new bucket
+        copy_bucket(
+            ARCTICDB_CACHE_BUCKET,
+            self.work_bucket,
+            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
+        )
+        self.ac = Arctic(arctic_uri(self.work_bucket))
+        self.lib = self.ac.get_library(lib_name)
+        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
+        self.target = self.lib.read(self.SYM).data
         matched_count = round(source_size * matched_pct / 100)
         self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
         self.source = generate_merge_source(
@@ -376,7 +452,9 @@ class MergeLongWide(MergeBase):
         )
 
     def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
-        self._teardown()
+        if self.work_bucket is not None:
+            delete_bucket(self.work_bucket)
+            self.work_bucket = None
 
     def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
         self.merge(strategy)

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -13,11 +13,9 @@ import uuid
 import numpy as np
 import pandas as pd
 
-from arcticc.pb2.s3_storage_pb2 import Config as S3Config
 from arcticdb import Arctic
 from arcticdb.version_store.library import MergeStrategy
 from arcticdb.util.test import random_strings_of_length
-from arcticdb_ext.storage import CONFIG_LIBRARY_NAME
 from asv_runner.benchmarks.mark import SkipNotImplemented
 
 from benchmarks.seaweed_utils import (
@@ -33,10 +31,17 @@ from benchmarks.seaweed_utils import (
 MIN_DATE = pd.Timestamp("1960-01-01")
 MAX_DATE = pd.Timestamp("2025-01-01")
 
-# merge_experimental is destructive, so every measurement runs against a pristine copy of the
-# data: setup copies the config library and the relevant data library from the cache bucket into
-# a brand new bucket and the merge runs there; teardown hard-deletes that bucket by dropping its
-# backing SeaweedFS collection.
+# Matches the LibraryOptions default the base libraries are written with, so slice i of a
+# datetime target covers target.iloc[i*ROWS_PER_SEGMENT:(i+1)*ROWS_PER_SEGMENT] in sorted order.
+# Used to build sources that touch a controlled fraction of the target's row slices.
+ROWS_PER_SEGMENT = 100_000
+
+# merge_experimental only mutates the target (it writes a new version), so every measurement runs
+# the merge against an isolated copy of the target: setup copies the target's known path_prefix
+# subtree (config + data) from the cache bucket into a brand new bucket and the merge runs there;
+# teardown hard-deletes that bucket by dropping its backing SeaweedFS collection. The read-only
+# source is never copied — it lives under its own path_prefix in the cache bucket and is read
+# directly from there.
 
 # Short-lived per-measurement bucket; each class creates its own in setup() and deletes it in
 # teardown(). The WORK_BUCKET_PREFIX sweep in _run_setup_cache() cleans up any that a killed
@@ -47,22 +52,6 @@ WORK_BUCKET_PREFIX = "arcticdb-merge-bench-"
 def _env_repeat(default):
     # One knob to shrink local experiment runs; leaves CI defaults untouched
     return int(os.getenv("ARCTICDB_MERGE_BENCH_REPEAT", default))
-
-
-_LIBRARY_PREFIX_CACHE = {}
-
-
-def _cache_library_prefix(lib_name):
-    """S3 key prefix of a library in the cache bucket. Libraries created through Arctic get a
-    unique "<name><nanos>" prefix, so it must be read back from the library config."""
-    if lib_name not in _LIBRARY_PREFIX_CACHE:
-        lib = Arctic(arctic_uri(ARCTICDB_CACHE_BUCKET)).get_library(lib_name)
-        config = lib._nvs.lib_cfg()
-        storage = config.storage_by_id[config.lib_desc.storage_ids[0]]
-        s3_config = S3Config()
-        storage.config.Unpack(s3_config)
-        _LIBRARY_PREFIX_CACHE[lib_name] = s3_config.prefix
-    return _LIBRARY_PREFIX_CACHE[lib_name]
 
 
 def _random_values(rng, num_rows, value_dtype, num_unique_strings):
@@ -90,13 +79,13 @@ def generate_merge_target(num_rows, num_value_cols, value_dtype, index_kind, num
 
 
 def generate_merge_source(target, source_size, matched_count, on=None, value_dtype="float", num_unique_strings=None):
+    # Only ever called for row-range targets (datetime classes use
+    # generate_merge_source_by_segments), so the index is always a RangeIndex.
     on_cols = on or []
-    index_kind = "datetime" if isinstance(target.index, pd.DatetimeIndex) else "rowrange"
-    match_cols = on_cols + (["index"] if index_kind == "datetime" else [])
     rng = np.random.default_rng(1)
     picks = rng.choice(len(target), size=matched_count, replace=False)
     matched = target.iloc[picks]
-    matched = matched[~matched.reset_index().duplicated(subset=match_cols, keep="first").values].copy()
+    matched = matched[~matched.reset_index().duplicated(subset=on_cols, keep="first").values].copy()
     for col in target.columns:
         if col not in on_cols:
             matched[col] = _random_values(rng, len(matched), value_dtype, num_unique_strings)
@@ -107,14 +96,51 @@ def generate_merge_source(target, source_size, matched_count, on=None, value_dty
             for col in target.columns
         }
     )
-    if index_kind == "datetime":
-        rest.index = _random_dates(rng, len(rest))
     source = pd.concat([matched, rest])
-    source = source[~source.reset_index().duplicated(subset=match_cols, keep="first").values]
-    if index_kind == "datetime":
-        return source.sort_index()
+    source = source[~source.reset_index().duplicated(subset=on_cols, keep="first").values]
     source.index = pd.RangeIndex(len(source))
     return source
+
+
+def generate_merge_source_by_segments(
+    target,
+    source_size,
+    segment_pct,
+    rows_per_segment=ROWS_PER_SEGMENT,
+    on=None,
+    value_dtype="float",
+    num_unique_strings=None,
+):
+    """Datetime source whose rows all fall within the first k row-slices of ``target``, where
+    ``k = round(num_segments * segment_pct / 100)``. Since the datetime merge only reads/rewrites
+    the slices whose time range overlaps the source, this makes the merge touch exactly k of the
+    target's segments. Half the rows match existing target rows (drive the update path) and half
+    are new datetimes inside the same span (drive the insert path), so one source serves every
+    strategy while touching the same k segments."""
+    on_cols = on or []
+    match_cols = on_cols + ["index"]
+    num_segments = -(-len(target) // rows_per_segment)
+    k = max(1, round(num_segments * segment_pct / 100))
+    span = min(k * rows_per_segment, len(target))
+    rng = np.random.default_rng(1)
+
+    # Matched rows can only come from the span's existing rows, so cap by span (a small span with a
+    # large source_size just means more of the source is new/inserted rows within that time range).
+    matched_count = min(source_size // 2, span)
+    picks = rng.choice(span, size=matched_count, replace=False)
+    matched = target.iloc[picks]
+    matched = matched[~matched.reset_index().duplicated(subset=match_cols, keep="first").values].copy()
+    for col in target.columns:
+        if col not in on_cols:
+            matched[col] = _random_values(rng, len(matched), value_dtype, num_unique_strings)
+
+    rest_n = source_size - len(matched)
+    rest = pd.DataFrame({col: _random_values(rng, rest_n, value_dtype, num_unique_strings) for col in target.columns})
+    lo, hi = target.index[0].value, target.index[span - 1].value
+    rest.index = pd.to_datetime(rng.integers(lo, hi + 1, size=rest_n), unit="ns")
+    source = pd.concat([matched, rest])
+    source = source[~source.reset_index().duplicated(subset=match_cols, keep="first").values]
+    return source.sort_index()
 
 
 class MergeBase:
@@ -135,23 +161,125 @@ class MergeBase:
         self.timeout = 600
         self.ac = None
         self.lib = None
-        self.target = None
         self.value_dtype = None
         self.source = None
         self.on = None
         self.work_bucket = None
+        # Per-lib_name handles to the source libraries in the (persistent) cache bucket
+        self._src_libs = {}
 
     def lib_name(self, scenario, index_kind, *extra):
         num_rows, num_value_cols = scenario
         return "_".join([str(num_rows), str(num_value_cols), index_kind, *[str(e) for e in extra]])
 
-    def _cache_arctic(self):
-        return Arctic(arctic_uri(ARCTICDB_CACHE_BUCKET))
+    # Target and source each get their own known path_prefix so the target subtree can be copied
+    # by a literal prefix (no need to infer the "<name><nanos>" leaf) and the source subtree is
+    # simply never copied. The inner library name is constant — the scenario lives in the prefix.
+    TARGET_PREFIX = "tgt"
+    SOURCE_PREFIX = "src"
+    INNER_LIB = "data"
+    SRC_SYM_PREFIX = "src_"
 
-    def _setup_cache_base(self, ac, lib_name, target):
-        # reset_arcticdb_cache_bucket() has just emptied the bucket, so the library cannot exist
-        lib = ac.create_library(lib_name)
-        lib.write(self.SYM, target)
+    def _cache_uri(self, path_prefix):
+        return arctic_uri(ARCTICDB_CACHE_BUCKET) + f"&path_prefix={path_prefix}"
+
+    def _target_path_prefix(self, lib_name):
+        return f"{self.TARGET_PREFIX}/{lib_name}"
+
+    def _source_path_prefix(self, lib_name):
+        return f"{self.SOURCE_PREFIX}/{lib_name}"
+
+    def _setup_cache_base(self, lib_name, target):
+        # reset_arcticdb_cache_bucket() has just emptied the bucket, so the libraries cannot exist.
+        # Target and source go under separate path_prefixes; the source library is returned so the
+        # caller can populate it via _precompute_sources.
+        tgt_lib = Arctic(self._cache_uri(self._target_path_prefix(lib_name))).create_library(self.INNER_LIB)
+        tgt_lib.write(self.SYM, target)
+        return Arctic(self._cache_uri(self._source_path_prefix(lib_name))).create_library(self.INNER_LIB)
+
+    def _source_lib(self, lib_name):
+        # The cache bucket is persistent and never mutated by the merge, so one read handle per
+        # lib_name is reused across samples.
+        if lib_name not in self._src_libs:
+            self._src_libs[lib_name] = Arctic(self._cache_uri(self._source_path_prefix(lib_name))).get_library(
+                self.INNER_LIB
+            )
+        return self._src_libs[lib_name]
+
+    def _source_sym(self, index_kind, on_count, source_size, matched_pct=None, num_unique_strings=None):
+        # matched_pct is part of the key only for the datetime classes that vary it (a segment %);
+        # rowrange and MergeWideDatetime omit it, matching what their setup() passes.
+        parts = [index_kind, on_count, source_size]
+        if matched_pct is not None:
+            parts.append(matched_pct)
+        if num_unique_strings is not None:
+            parts.append(num_unique_strings)
+        return self.SRC_SYM_PREFIX + "_".join(str(p) for p in parts)
+
+    def _precompute_sources(self, src_lib, target, num_value_cols, num_unique_strings=None):
+        # The source depends only on (index_kind, on_count, source_size, matched_pct[, num_unique_strings]),
+        # never on strategy, so each is generated exactly once here instead of once per (strategy x repeat)
+        # sample. setup() then only has to read back the (small) source symbol. Read from param_names by
+        # name (positions differ between the datetime and rowrange classes).
+        pmap = dict(zip(self.param_names, self.params))
+        for on_count in pmap["on_count"]:
+            on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
+            for source_size in pmap["source_size"]:
+                if self.INDEX_KIND == "datetime":
+                    # Wide has a single 100k slice, so it drops the segment axis and uses one
+                    # full-range (segment_pct=100) source per (on_count, source_size).
+                    segment_pcts = pmap["matched_pct"] if "matched_pct" in pmap else [100]
+                    for segment_pct in segment_pcts:
+                        source = generate_merge_source_by_segments(
+                            target,
+                            source_size,
+                            segment_pct,
+                            ROWS_PER_SEGMENT,
+                            on=on,
+                            value_dtype=self.value_dtype,
+                            num_unique_strings=num_unique_strings,
+                        )
+                        key_pct = segment_pct if "matched_pct" in pmap else None
+                        src_lib.write(
+                            self._source_sym(self.INDEX_KIND, on_count, source_size, key_pct, num_unique_strings),
+                            source,
+                        )
+                else:
+                    # rowrange: matched_pct dropped; hardcode 50% of source rows matching an existing row.
+                    source = generate_merge_source(
+                        target,
+                        source_size,
+                        source_size // 2,
+                        on=on,
+                        value_dtype=self.value_dtype,
+                        num_unique_strings=num_unique_strings,
+                    )
+                    src_lib.write(
+                        self._source_sym(self.INDEX_KIND, on_count, source_size, None, num_unique_strings),
+                        source,
+                    )
+
+    def _prepare_merge(self, lib_name, on_count, num_value_cols, source_sym):
+        # Shared body of every class's setup(): isolate the target in a fresh work bucket (copying
+        # only its path_prefix subtree) and load the precomputed source directly from the cache
+        # bucket. Concrete helper (not overridden) so the 8 classes don't each duplicate it.
+        target_prefix = self._target_path_prefix(lib_name)
+        # Create a new Arctic instance every sample so nothing cached from the previous sample's
+        # (since deleted) bucket survives
+        del self.ac
+        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
+        create_bucket(self.work_bucket)
+        # The URI-based storage override redirects the copied library config to the new bucket.
+        copy_bucket(ARCTICDB_CACHE_BUCKET, self.work_bucket, prefixes=[f"{target_prefix}/"])
+        self.ac = Arctic(arctic_uri(self.work_bucket) + f"&path_prefix={target_prefix}")
+        self.lib = self.ac.get_library(self.INNER_LIB)
+        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
+        self.source = self._source_lib(lib_name).read(source_sym).data
+
+    def _teardown(self):
+        if self.work_bucket is not None:
+            delete_bucket(self.work_bucket)
+            self.work_bucket = None
 
     # ASV caches setup_cache results keyed by the function's source location, so every class must
     # define its own setup_cache (delegating here); inheriting one shared method would make ASV
@@ -171,93 +299,108 @@ class MergeBase:
         return [f"val_{i}" for i in cols]
 
 
-class MergeThin(MergeBase):
+class MergeThinDatetime(MergeBase):
+    """All merge strategies, long-thin numeric dataframe (10M rows x 2 cols), datetime index.
+    matched_pct is the percent of the target's row slices the source touches (100 slices here)."""
+
+    INDEX_KIND = "datetime"
 
     def __init__(self):
         super().__init__()
         self.value_dtype = "float"
-        self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_pct"]
         self.params = [
             [(10_000_000, 2)],  # scenario: (num_rows, num_value_cols) — long-thin
             ["update", "insert", "update_and_insert"],  # strategy
-            ["datetime", "rowrange"],  # index_kind
             [0, 1],  # on_count
             [1_000, 500_000],  # source_size (source row count)
-            [20, 80],  # matched_pct (percent of source rows matching an existing target row)
+            [20, 80],  # matched_pct (percent of the target's row slices the source touches)
         ]
 
     def setup_cache(self):
         self._run_setup_cache()
 
     def _setup_cache(self):
-        ac = self._cache_arctic()
         for scenario in self.params[0]:
-            for index_kind in self.params[2]:
-                num_rows, num_value_cols = scenario
-                target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, index_kind)
-                self._setup_cache_base(ac, self.lib_name(scenario, index_kind), target)
+            num_rows, num_value_cols = scenario
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND)
+            src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND), target)
+            self._precompute_sources(src_lib, target, num_value_cols)
 
-    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def setup(self, scenario, strategy, on_count, source_size, matched_pct):
         num_rows, num_value_cols = scenario
-        if index_kind == "rowrange" and strategy != "update":
-            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
-        if index_kind == "rowrange" and on_count == 0:
-            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        lib_name = self.lib_name(scenario, index_kind)
-        # Create a new Arctic instance every sample so nothing cached from the previous sample's
-        # (since deleted) bucket survives
-        del self.ac
-        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
-        create_bucket(self.work_bucket)
-        # The URI-based storage override redirects the copied library config to the new bucket
-        copy_bucket(
-            ARCTICDB_CACHE_BUCKET,
-            self.work_bucket,
-            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
-        )
-        self.ac = Arctic(arctic_uri(self.work_bucket))
-        self.lib = self.ac.get_library(lib_name)
-        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
-        self.target = self.lib.read(self.SYM).data
-        matched_count = round(source_size * matched_pct / 100)
-        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
-        self.source = generate_merge_source(
-            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype
-        )
+        lib_name = self.lib_name(scenario, self.INDEX_KIND)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size, matched_pct)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
 
-    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
-        if self.work_bucket is not None:
-            delete_bucket(self.work_bucket)
-            self.work_bucket = None
+    def teardown(self, scenario, strategy, on_count, source_size, matched_pct):
+        self._teardown()
 
-    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_pct):
         self.merge(strategy)
 
-    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_pct):
         self.merge(strategy)
 
 
-class MergeThinString(MergeBase):
+class MergeThinRowRange(MergeBase):
+    """update only, long-thin numeric dataframe (10M rows x 2 cols), row-range index.
+    matched_pct is dropped: row-range merge reads every slice and has no insert path."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.params = [
+            [(10_000_000, 2)],  # scenario: (num_rows, num_value_cols) — long-thin
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            [1],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [1_000, 500_000],  # source_size (source row count)
+        ]
+
+    def setup_cache(self):
+        self._run_setup_cache()
+
+    def _setup_cache(self):
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND)
+            src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND), target)
+            self._precompute_sources(src_lib, target, num_value_cols)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        num_rows, num_value_cols = scenario
+        lib_name = self.lib_name(scenario, self.INDEX_KIND)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+
+class MergeThinStringDatetime(MergeBase):
+    """All merge strategies, long-thin string dataframe (1M rows x 2 cols), datetime index (10 slices)."""
+
+    INDEX_KIND = "datetime"
 
     def __init__(self):
         super().__init__()
         self.value_dtype = "string"
-        self.param_names = [
-            "scenario",
-            "strategy",
-            "index_kind",
-            "on_count",
-            "source_size",
-            "matched_pct",
-            "num_unique_strings",
-        ]
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_pct", "num_unique_strings"]
         self.params = [
             [(1_000_000, 2)],  # scenario: (num_rows, num_value_cols)
             ["update", "insert", "update_and_insert"],  # strategy
-            ["datetime", "rowrange"],  # index_kind
             [0, 1],  # on_count
             [1_000, 500_000],  # source_size (source row count)
-            [20, 80],  # matched_pct
+            [20, 80],  # matched_pct (percent of the target's row slices the source touches)
             [100, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
         ]
 
@@ -265,199 +408,252 @@ class MergeThinString(MergeBase):
         self._run_setup_cache()
 
     def _setup_cache(self):
-        # Populate the base libraries only once. index_kind and num_unique_strings are shared across
-        # every strategy, so each (scenario, index_kind, num_unique_strings) library is built once.
-        ac = self._cache_arctic()
+        # index_kind and num_unique_strings are shared across every strategy, so each
+        # (scenario, num_unique_strings) library is built once.
         for scenario in self.params[0]:
-            for index_kind in self.params[2]:
-                for num_unique_strings in self.params[6]:
-                    num_rows, num_value_cols = scenario
-                    target = generate_merge_target(
-                        num_rows, num_value_cols, self.value_dtype, index_kind, num_unique_strings=num_unique_strings
-                    )
-                    self._setup_cache_base(ac, self.lib_name(scenario, index_kind, num_unique_strings), target)
+            for num_unique_strings in self.params[5]:
+                num_rows, num_value_cols = scenario
+                target = generate_merge_target(
+                    num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, num_unique_strings=num_unique_strings
+                )
+                src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND, num_unique_strings), target)
+                self._precompute_sources(src_lib, target, num_value_cols, num_unique_strings=num_unique_strings)
 
-    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+    def setup(self, scenario, strategy, on_count, source_size, matched_pct, num_unique_strings):
         num_rows, num_value_cols = scenario
-        if index_kind == "rowrange" and strategy != "update":
-            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
-        if index_kind == "rowrange" and on_count == 0:
-            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        lib_name = self.lib_name(scenario, index_kind, num_unique_strings)
-        # Create a new Arctic instance every sample so nothing cached from the previous sample's
-        # (since deleted) bucket survives
-        del self.ac
-        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
-        create_bucket(self.work_bucket)
-        # The URI-based storage override redirects the copied library config to the new bucket
-        copy_bucket(
-            ARCTICDB_CACHE_BUCKET,
-            self.work_bucket,
-            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
-        )
-        self.ac = Arctic(arctic_uri(self.work_bucket))
-        self.lib = self.ac.get_library(lib_name)
-        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
-        self.target = self.lib.read(self.SYM).data
-        matched_count = round(source_size * matched_pct / 100)
-        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
-        self.source = generate_merge_source(
-            self.target,
-            source_size,
-            matched_count,
-            on=self.on,
-            value_dtype=self.value_dtype,
-            num_unique_strings=num_unique_strings,
-        )
+        lib_name = self.lib_name(scenario, self.INDEX_KIND, num_unique_strings)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size, matched_pct, num_unique_strings)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
 
-    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
-        if self.work_bucket is not None:
-            delete_bucket(self.work_bucket)
-            self.work_bucket = None
+    def teardown(self, scenario, strategy, on_count, source_size, matched_pct, num_unique_strings):
+        self._teardown()
 
-    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_pct, num_unique_strings):
         self.merge(strategy)
 
-    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_pct, num_unique_strings):
         self.merge(strategy)
 
 
-class MergeWide(MergeBase):
+class MergeThinStringRowRange(MergeBase):
+    """update only, long-thin string dataframe (1M rows x 2 cols), row-range index (matched_pct dropped)."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "string"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "num_unique_strings"]
+        self.params = [
+            [(1_000_000, 2)],  # scenario: (num_rows, num_value_cols)
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            [1],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [1_000, 500_000],  # source_size (source row count)
+            [100, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
+        ]
+
+    def setup_cache(self):
+        self._run_setup_cache()
+
+    def _setup_cache(self):
+        for scenario in self.params[0]:
+            for num_unique_strings in self.params[4]:
+                num_rows, num_value_cols = scenario
+                target = generate_merge_target(
+                    num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, num_unique_strings=num_unique_strings
+                )
+                src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND, num_unique_strings), target)
+                self._precompute_sources(src_lib, target, num_value_cols, num_unique_strings=num_unique_strings)
+
+    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        num_rows, num_value_cols = scenario
+        lib_name = self.lib_name(scenario, self.INDEX_KIND, num_unique_strings)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size, num_unique_strings=num_unique_strings)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
+
+    def teardown(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.merge(strategy)
+
+
+class MergeWideDatetime(MergeBase):
+    """All merge strategies, wide numeric dataframe (5k rows x 10k cols), datetime index.
+    5k rows = a single 100k row slice, so the segment (matched_pct) axis does not apply here."""
+
+    INDEX_KIND = "datetime"
 
     def __init__(self):
         super().__init__()
         self.value_dtype = "float"
-        self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
         self.repeat = _env_repeat(5)
         self.params = [
             [(5_000, 10_000)],  # scenario: (num_rows, num_value_cols)
             ["update", "insert", "update_and_insert"],  # strategy
-            ["datetime", "rowrange"],  # index_kind
             [0, 1, 1000],  # on_count
             [100],  # source_size
-            [20, 80],  # matched_pct
         ]
 
     def setup_cache(self):
         self._run_setup_cache()
 
     def _setup_cache(self):
-        # Populate the base libraries only once. index_kind is shared across every strategy, so each
-        # (scenario, index_kind) base library is built exactly once and reused by all strategies.
-        ac = self._cache_arctic()
         for scenario in self.params[0]:
-            for index_kind in self.params[2]:
-                num_rows, num_value_cols = scenario
-                target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, index_kind)
-                self._setup_cache_base(ac, self.lib_name(scenario, index_kind), target)
+            num_rows, num_value_cols = scenario
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND)
+            src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND), target)
+            self._precompute_sources(src_lib, target, num_value_cols)
 
-    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def setup(self, scenario, strategy, on_count, source_size):
         if strategy != "update" and on_count == 1:
-            raise SkipNotImplemented  # see class docstring: grid-size cost decision, not unsupported
+            raise SkipNotImplemented  # grid-size cost decision, not unsupported
         num_rows, num_value_cols = scenario
-        if index_kind == "rowrange" and strategy != "update":
-            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
-        if index_kind == "rowrange" and on_count == 0:
-            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        lib_name = self.lib_name(scenario, index_kind)
-        # Create a new Arctic instance every sample so nothing cached from the previous sample's
-        # (since deleted) bucket survives
-        del self.ac
-        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
-        create_bucket(self.work_bucket)
-        # The URI-based storage override redirects the copied library config to the new bucket
-        copy_bucket(
-            ARCTICDB_CACHE_BUCKET,
-            self.work_bucket,
-            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
-        )
-        self.ac = Arctic(arctic_uri(self.work_bucket))
-        self.lib = self.ac.get_library(lib_name)
-        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
-        self.target = self.lib.read(self.SYM).data
-        matched_count = round(source_size * matched_pct / 100)
-        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
-        self.source = generate_merge_source(
-            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype
-        )
+        lib_name = self.lib_name(scenario, self.INDEX_KIND)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
 
-    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
-        if self.work_bucket is not None:
-            delete_bucket(self.work_bucket)
-            self.work_bucket = None
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self._teardown()
 
-    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def time_merge(self, scenario, strategy, on_count, source_size):
         self.merge(strategy)
 
-    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
         self.merge(strategy)
 
 
-class MergeLongWide(MergeBase):
-    """All merge strategies, long-wide numeric dataframe (2M rows x 130 value cols)."""
+class MergeWideRowRange(MergeBase):
+    """update only, wide numeric dataframe (5k rows x 10k cols), row-range index (matched_pct dropped)."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.repeat = _env_repeat(5)
+        self.params = [
+            [(5_000, 10_000)],  # scenario: (num_rows, num_value_cols)
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            [1, 1000],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [100],  # source_size
+        ]
+
+    def setup_cache(self):
+        self._run_setup_cache()
+
+    def _setup_cache(self):
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND)
+            src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND), target)
+            self._precompute_sources(src_lib, target, num_value_cols)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        num_rows, num_value_cols = scenario
+        lib_name = self.lib_name(scenario, self.INDEX_KIND)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+
+class MergeLongWideDatetime(MergeBase):
+    """All merge strategies, long-wide numeric dataframe (2M rows x 130 value cols), datetime
+    index (20 slices). datetime measures on_count 0 and 50 only (grid-size cost decision)."""
+
+    INDEX_KIND = "datetime"
 
     def __init__(self):
         super().__init__()
         self.repeat = _env_repeat(5)
         self.value_dtype = "float"
-        self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_pct"]
         self.params = [
             [(2_000_000, 130)],  # scenario: (num_rows, num_value_cols)
             ["update", "insert", "update_and_insert"],  # strategy
-            ["datetime", "rowrange"],  # index_kind
-            [0, 1, 50],  # on_count: datetime runs {0, 50} (0 = match on index only), rowrange runs {1, 50}
+            [0, 50],  # on_count: 0 = match on index only
             [1_000, 500_000],  # source_size (source row count)
-            [20, 80],  # matched_pct
+            [20, 80],  # matched_pct (percent of the target's row slices the source touches)
         ]
 
     def setup_cache(self):
         self._run_setup_cache()
 
     def _setup_cache(self):
-        ac = self._cache_arctic()
         for scenario in self.params[0]:
-            for index_kind in self.params[2]:
-                num_rows, num_value_cols = scenario
-                target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, index_kind)
-                self._setup_cache_base(ac, self.lib_name(scenario, index_kind), target)
+            num_rows, num_value_cols = scenario
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND)
+            src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND), target)
+            self._precompute_sources(src_lib, target, num_value_cols)
 
-    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def setup(self, scenario, strategy, on_count, source_size, matched_pct):
         num_rows, num_value_cols = scenario
-        if index_kind == "rowrange" and strategy != "update":
-            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
-        if index_kind == "rowrange" and on_count == 0:
-            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
-        if index_kind == "datetime" and on_count == 1:
-            raise SkipNotImplemented  # grid-size cost decision: datetime measures on_count 0 and 50 only
-        lib_name = self.lib_name(scenario, index_kind)
-        # Create a new Arctic instance every sample so nothing cached from the previous sample's
-        # (since deleted) bucket survives
-        del self.ac
-        self.work_bucket = f"{WORK_BUCKET_PREFIX}{uuid.uuid4().hex[:12]}"
-        create_bucket(self.work_bucket)
-        # The URI-based storage override redirects the copied library config to the new bucket
-        copy_bucket(
-            ARCTICDB_CACHE_BUCKET,
-            self.work_bucket,
-            prefixes=[f"{CONFIG_LIBRARY_NAME}/", f"{_cache_library_prefix(lib_name)}/"],
-        )
-        self.ac = Arctic(arctic_uri(self.work_bucket))
-        self.lib = self.ac.get_library(lib_name)
-        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
-        self.target = self.lib.read(self.SYM).data
-        matched_count = round(source_size * matched_pct / 100)
-        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
-        self.source = generate_merge_source(
-            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype
-        )
+        lib_name = self.lib_name(scenario, self.INDEX_KIND)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size, matched_pct)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
 
-    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
-        if self.work_bucket is not None:
-            delete_bucket(self.work_bucket)
-            self.work_bucket = None
+    def teardown(self, scenario, strategy, on_count, source_size, matched_pct):
+        self._teardown()
 
-    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_pct):
         self.merge(strategy)
 
-    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_pct):
+        self.merge(strategy)
+
+
+class MergeLongWideRowRange(MergeBase):
+    """update only, long-wide numeric dataframe (2M rows x 130 value cols), row-range index
+    (matched_pct dropped)."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.repeat = _env_repeat(5)
+        self.value_dtype = "float"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.params = [
+            [(2_000_000, 130)],  # scenario: (num_rows, num_value_cols)
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            [1, 50],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [1_000, 500_000],  # source_size (source row count)
+        ]
+
+    def setup_cache(self):
+        self._run_setup_cache()
+
+    def _setup_cache(self):
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND)
+            src_lib = self._setup_cache_base(self.lib_name(scenario, self.INDEX_KIND), target)
+            self._precompute_sources(src_lib, target, num_value_cols)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        num_rows, num_value_cols = scenario
+        lib_name = self.lib_name(scenario, self.INDEX_KIND)
+        source_sym = self._source_sym(self.INDEX_KIND, on_count, source_size)
+        self._prepare_merge(lib_name, on_count, num_value_cols, source_sym)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
         self.merge(strategy)

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -1,0 +1,385 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import os
+import random
+import shutil
+import time
+
+import numpy as np
+import pandas as pd
+
+from arcticdb import Arctic, LibraryOptions
+from arcticdb.version_store.library import MergeStrategy
+from arcticdb.util.logger import get_logger
+from arcticdb.util.test import random_strings_of_length
+from asv_runner.benchmarks.mark import SkipNotImplemented
+
+MIN_DATE = pd.Timestamp("1960-01-01")
+MAX_DATE = pd.Timestamp("2025-01-01")
+
+
+def _random_values(rng, num_rows, value_dtype, num_unique_strings):
+    if value_dtype == "string":
+        random.seed(0)
+        strings = sorted(random_strings_of_length(num_unique_strings, length=10, unique=True, kind="ascii"))
+        return rng.choice(strings, num_rows)
+    return rng.random(num_rows, dtype=np.float64)
+
+
+def _random_dates(rng, num_rows):
+    return pd.to_datetime(rng.integers(MIN_DATE.value, MAX_DATE.value, size=num_rows), unit="ns")
+
+
+def generate_merge_target(num_rows, num_value_cols, value_dtype, index_kind, num_unique_strings=None):
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame(
+        {f"val_{j}": _random_values(rng, num_rows, value_dtype, num_unique_strings) for j in range(num_value_cols)}
+    )
+    if index_kind == "datetime":
+        df.index = _random_dates(rng, num_rows).sort_values()
+    else:
+        df.index = pd.RangeIndex(num_rows)
+    return df
+
+
+def generate_merge_source(target, source_size, matched_count, on=None, value_dtype="float", num_unique_strings=None):
+    on_cols = on or []
+    index_kind = "datetime" if isinstance(target.index, pd.DatetimeIndex) else "rowrange"
+    match_cols = on_cols + (["index"] if index_kind == "datetime" else [])
+    rng = np.random.default_rng(1)
+    picks = rng.choice(len(target), size=matched_count, replace=False)
+    matched = target.iloc[picks]
+    matched = matched[~matched.reset_index().duplicated(subset=match_cols, keep="first").values].copy()
+    for col in target.columns:
+        if col not in on_cols:
+            matched[col] = _random_values(rng, len(matched), value_dtype, num_unique_strings)
+
+    rest = pd.DataFrame(
+        {
+            col: _random_values(rng, source_size - len(matched), value_dtype, num_unique_strings)
+            for col in target.columns
+        }
+    )
+    if index_kind == "datetime":
+        rest.index = _random_dates(rng, len(rest))
+    source = pd.concat([matched, rest])
+    source = source[~source.reset_index().duplicated(subset=match_cols, keep="first").values]
+    if index_kind == "datetime":
+        return source.sort_index()
+    source.index = pd.RangeIndex(len(source))
+    return source
+
+
+class MergeBase:
+
+    STRATEGIES = {
+        "update": MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
+        "insert": MergeStrategy(matched="do_nothing", not_matched_by_target="insert"),
+        "update_and_insert": MergeStrategy(matched="update", not_matched_by_target="insert"),
+    }
+
+    def __init__(self):
+        self.logger = get_logger()
+        self.SYM = "sym"
+        # Do not interleave benchmarks as they use the same LMDB directory for the measurements
+        self.rounds = 1
+        # merge_experimental is destructive, so we must copy a fresh base and run once per measurement
+        self.number = 1
+        self.warmup_time = 0
+        self.repeat = 10
+        self.timeout = 600
+        self.ac = None
+        self.lib = None
+        self.target = None
+        self.value_dtype = None
+        self.source = None
+        self.on = None
+
+    def finish_init(self):
+        # Base LMDB instance that will be populated by setup_cache. Relevant libraries are then
+        # copied from here to a working directory for each (destructive) merge measurement.
+        self.LMDB_BASE_DIR = f"{self.LMDB_DIR}_base"
+        self.CONNECTION_STRING_BASE = f"lmdb://{self.LMDB_BASE_DIR}"
+        self.CONNECTION_STRING = f"lmdb://{self.LMDB_DIR}"
+
+    def lib_name(self, scenario, index_kind, *extra):
+        num_rows, num_value_cols = scenario
+        return "_".join([str(num_rows), str(num_value_cols), index_kind, *[str(e) for e in extra]])
+
+    def _setup_cache_base(self, ac, lib_name, target):
+        ac.delete_library(lib_name)
+        lib = ac.create_library(lib_name)
+        lib.write(self.SYM, target)
+
+    def _setup(self, lib_name):
+        if os.path.isdir(self.LMDB_DIR):
+            shutil.rmtree(self.LMDB_DIR)
+        os.mkdir(self.LMDB_DIR)
+        # Copy the config database and the relevant library database for these benchmark parameters to the actual
+        # LMDB directory where the merge will happen
+        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
+        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
+        # Create a new Arctic instance, otherwise we will be holding a reference to the previous iteration's .mdb files
+        # and the deletion and recreation won't be noticed by Arctic
+        del self.ac
+        self.ac = Arctic(self.CONNECTION_STRING)
+        self.lib = self.ac.get_library(lib_name)
+        # Read the symbol both to warm up the cache and to have real target rows to build the source from.
+        self.target = self.lib.read(self.SYM).data
+
+    def _teardown(self):
+        if os.path.isdir(self.LMDB_DIR):
+            shutil.rmtree(self.LMDB_DIR)
+
+    def merge(self, strategy):
+        self.lib.merge_experimental(self.SYM, self.source, strategy=self.STRATEGIES[strategy], on=self.on)
+
+    def _select_on(self, on_count, num_value_cols):
+        cols = np.random.default_rng(0).choice(num_value_cols, size=on_count, replace=False)
+        return [f"val_{i}" for i in cols]
+
+
+class MergeThin(MergeBase):
+
+    def __init__(self):
+        super().__init__()
+        self.LMDB_DIR = "merge_thin"
+        self.finish_init()
+        self.value_dtype = "float"
+        self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
+        self.params = [
+            [(10_000_000, 2)],  # scenario: (num_rows, num_value_cols) — long-thin
+            ["update", "insert", "update_and_insert"],  # strategy
+            ["datetime", "rowrange"],  # index_kind
+            [0, 1],  # on_count
+            [1_000, 500_000],  # source_size (source row count)
+            [20, 80],  # matched_pct (percent of source rows matching an existing target row)
+        ]
+
+    def setup_cache(self):
+        start = time.time()
+        self._setup_cache()
+        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+
+    def _setup_cache(self):
+        ac = Arctic(self.CONNECTION_STRING_BASE)
+        for scenario in self.params[0]:
+            for index_kind in self.params[2]:
+                num_rows, num_value_cols = scenario
+                target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, index_kind)
+                self._setup_cache_base(ac, self.lib_name(scenario, index_kind), target)
+
+    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        num_rows, num_value_cols = scenario
+        if index_kind == "rowrange" and strategy != "update":
+            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
+        if index_kind == "rowrange" and on_count == 0:
+            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
+        self._setup(self.lib_name(scenario, index_kind))
+        matched_count = round(source_size * matched_pct / 100)
+        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
+        self.source = generate_merge_source(
+            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype
+        )
+
+    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self.merge(strategy)
+
+
+class MergeThinString(MergeBase):
+
+    def __init__(self):
+        super().__init__()
+        self.LMDB_DIR = "merge_thin_string"
+        self.finish_init()
+        self.value_dtype = "string"
+        self.param_names = [
+            "scenario",
+            "strategy",
+            "index_kind",
+            "on_count",
+            "source_size",
+            "matched_pct",
+            "num_unique_strings",
+        ]
+        self.params = [
+            [(1_000_000, 2)],  # scenario: (num_rows, num_value_cols)
+            ["update", "insert", "update_and_insert"],  # strategy
+            ["datetime", "rowrange"],  # index_kind
+            [0, 1],  # on_count
+            [1_000, 500_000],  # source_size (source row count)
+            [20, 80],  # matched_pct
+            [100, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
+        ]
+
+    def setup_cache(self):
+        start = time.time()
+        self._setup_cache()
+        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+
+    def _setup_cache(self):
+        # Populate the base libraries only once. index_kind and num_unique_strings are shared across
+        # every strategy, so each (scenario, index_kind, num_unique_strings) library is built once.
+        ac = Arctic(self.CONNECTION_STRING_BASE)
+        for scenario in self.params[0]:
+            for index_kind in self.params[2]:
+                for num_unique_strings in self.params[6]:
+                    num_rows, num_value_cols = scenario
+                    target = generate_merge_target(
+                        num_rows, num_value_cols, self.value_dtype, index_kind, num_unique_strings=num_unique_strings
+                    )
+                    self._setup_cache_base(ac, self.lib_name(scenario, index_kind, num_unique_strings), target)
+
+    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+        num_rows, num_value_cols = scenario
+        if index_kind == "rowrange" and strategy != "update":
+            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
+        if index_kind == "rowrange" and on_count == 0:
+            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
+        self._setup(self.lib_name(scenario, index_kind, num_unique_strings))
+        matched_count = round(source_size * matched_pct / 100)
+        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
+        self.source = generate_merge_source(
+            self.target,
+            source_size,
+            matched_count,
+            on=self.on,
+            value_dtype=self.value_dtype,
+            num_unique_strings=num_unique_strings,
+        )
+
+    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct, num_unique_strings):
+        self.merge(strategy)
+
+
+class MergeWide(MergeBase):
+
+    def __init__(self):
+        super().__init__()
+        self.LMDB_DIR = "merge_wide"
+        self.finish_init()
+        self.value_dtype = "float"
+        self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
+        self.repeat = 5
+        self.params = [
+            [(5_000, 10_000)],  # scenario: (num_rows, num_value_cols)
+            ["update", "insert", "update_and_insert"],  # strategy
+            ["datetime", "rowrange"],  # index_kind
+            [0, 1, 1000],  # on_count
+            [100],  # source_size
+            [20, 80],  # matched_pct
+        ]
+
+    def setup_cache(self):
+        start = time.time()
+        self._setup_cache()
+        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+
+    def _setup_cache(self):
+        # Populate the base libraries only once. index_kind is shared across every strategy, so each
+        # (scenario, index_kind) base library is built exactly once and reused by all strategies.
+        ac = Arctic(self.CONNECTION_STRING_BASE)
+        for scenario in self.params[0]:
+            for index_kind in self.params[2]:
+                num_rows, num_value_cols = scenario
+                target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, index_kind)
+                self._setup_cache_base(ac, self.lib_name(scenario, index_kind), target)
+
+    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        if strategy != "update" and on_count == 1:
+            raise SkipNotImplemented  # see class docstring: grid-size cost decision, not unsupported
+        num_rows, num_value_cols = scenario
+        if index_kind == "rowrange" and strategy != "update":
+            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
+        if index_kind == "rowrange" and on_count == 0:
+            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
+        self._setup(self.lib_name(scenario, index_kind))
+        matched_count = round(source_size * matched_pct / 100)
+        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
+        self.source = generate_merge_source(
+            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype
+        )
+
+    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self.merge(strategy)
+
+
+class MergeLongWide(MergeBase):
+    """All merge strategies, long-wide numeric dataframe (2M rows x 130 value cols)."""
+
+    def __init__(self):
+        super().__init__()
+        self.LMDB_DIR = "merge_long_wide"
+        self.finish_init()
+        self.repeat = 5
+        self.value_dtype = "float"
+        self.param_names = ["scenario", "strategy", "index_kind", "on_count", "source_size", "matched_pct"]
+        self.params = [
+            [(2_000_000, 130)],  # scenario: (num_rows, num_value_cols)
+            ["update", "insert", "update_and_insert"],  # strategy
+            ["datetime", "rowrange"],  # index_kind
+            [0, 1, 50],  # on_count: datetime runs {0, 50} (0 = match on index only), rowrange runs {1, 50}
+            [1_000, 500_000],  # source_size (source row count)
+            [20, 80],  # matched_pct
+        ]
+
+    def setup_cache(self):
+        start = time.time()
+        self._setup_cache()
+        self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
+
+    def _setup_cache(self):
+        ac = Arctic(self.CONNECTION_STRING_BASE)
+        for scenario in self.params[0]:
+            for index_kind in self.params[2]:
+                num_rows, num_value_cols = scenario
+                target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, index_kind)
+                self._setup_cache_base(ac, self.lib_name(scenario, index_kind), target)
+
+    def setup(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        num_rows, num_value_cols = scenario
+        if index_kind == "rowrange" and strategy != "update":
+            raise SkipNotImplemented  # not_matched_by_target=insert has no row-range implementation
+        if index_kind == "rowrange" and on_count == 0:
+            raise SkipNotImplemented  # row-range indexes cannot be a join key on their own
+        if index_kind == "datetime" and on_count == 1:
+            raise SkipNotImplemented  # grid-size cost decision: datetime measures on_count 0 and 50 only
+        self._setup(self.lib_name(scenario, index_kind))
+        matched_count = round(source_size * matched_pct / 100)
+        self.on = None if on_count == 0 else self._select_on(on_count, num_value_cols)
+        self.source = generate_merge_source(
+            self.target, source_size, matched_count, on=self.on, value_dtype=self.value_dtype
+        )
+
+    def teardown(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self._teardown()
+
+    def time_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, index_kind, on_count, source_size, matched_pct):
+        self.merge(strategy)

--- a/python/benchmarks/seaweed_utils.py
+++ b/python/benchmarks/seaweed_utils.py
@@ -1,0 +1,252 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+
+Utilities for ASV benchmarks that store data on SeaweedFS.
+
+A single SeaweedFS server (started by build_tooling/start_seaweed.sh) is shared by every
+benchmark in the ASV run. The server disables automatic vacuuming, so reclaiming space is
+the benchmarks' responsibility: hard-delete a whole bucket (SeaweedFS backs each bucket
+with a collection of the same name, and dropping the collection removes its volume files
+wholesale, no vacuum needed).
+
+Benchmark classes share the ARCTICDB_CACHE_BUCKET bucket for data written by setup_cache().
+Every such class must call reset_arcticdb_cache_bucket() at the start of its setup_cache()
+so it starts from an empty bucket and the previous class's data is reclaimed.
+
+This module has no notion of any other bucket a benchmark class might use (e.g. a per-measurement
+work bucket): creating, naming, and deleting those is entirely the calling class's responsibility.
+"""
+
+import asyncio
+import atexit
+import os
+from typing import Iterable, List, Optional
+from urllib.parse import urlsplit
+
+import aioboto3
+import boto3
+import requests
+from arcticdb_ext.cpp_async import io_thread_count
+from botocore.config import Config as BotoConfig
+
+SEAWEED_MASTER_URL = os.getenv("ARCTICDB_SEAWEED_MASTER_URL", "http://127.0.0.1:9333")
+SEAWEED_FILER_URL = os.getenv("ARCTICDB_SEAWEED_FILER_URL", "http://127.0.0.1:8888")
+SEAWEED_S3_ENDPOINT = os.getenv("ARCTICDB_SEAWEED_S3_ENDPOINT", "http://127.0.0.1:8333")
+# The benchmark server runs without an S3 identity file, so any credentials are accepted
+SEAWEED_S3_ACCESS_KEY = os.getenv("ARCTICDB_SEAWEED_S3_ACCESS_KEY", "seaweed")
+SEAWEED_S3_SECRET_KEY = os.getenv("ARCTICDB_SEAWEED_S3_SECRET_KEY", "seaweed")
+
+# Underscores are not allowed in bucket names, hence the dashes
+ARCTICDB_CACHE_BUCKET = "arcticdb-cache"
+
+# (connect, read): connection failures surface quickly, but dropping collections with many
+# volumes can take a while
+_HTTP_TIMEOUT = (5, 600)
+
+# Reused across grow_bucket_volumes()/delete_bucket() calls so requests to the master/filer
+# keep-alive their TCP connections instead of reconnecting every time
+_http_session = requests.Session()
+
+
+_s3_client_singleton = None
+
+
+def s3_client():
+    """Sync S3 client for the benchmark server; a singleton so repeated calls reuse the same
+    client and connection pool instead of reconnecting every time."""
+    global _s3_client_singleton
+    if _s3_client_singleton is None:
+        _s3_client_singleton = boto3.client(
+            "s3",
+            endpoint_url=SEAWEED_S3_ENDPOINT,
+            aws_access_key_id=SEAWEED_S3_ACCESS_KEY,
+            aws_secret_access_key=SEAWEED_S3_SECRET_KEY,
+            region_name="us-east-1",
+            config=BotoConfig(s3={"addressing_style": "path"}, max_pool_connections=64),
+        )
+    return _s3_client_singleton
+
+
+_async_s3_loop = None
+_async_s3_client_cm = None
+_async_s3_client_singleton = None
+
+
+def _async_s3_loop_get():
+    global _async_s3_loop
+    if _async_s3_loop is None:
+        _async_s3_loop = asyncio.new_event_loop()
+    return _async_s3_loop
+
+
+async def async_s3_client():
+    """Async S3 client for the benchmark server; a singleton, entered once and kept open for
+    the life of the process. Only worth the asyncio overhead where calls need real concurrency
+    (e.g. copy_bucket's per-key copies); everything else should use the plain sync s3_client().
+
+    aioboto3/aiohttp connectors are bound to the event loop they were created on, so this must
+    only be awaited on the dedicated _async_s3_loop_get() loop. It is awaitable (rather than a
+    sync accessor) because the loop is already running when the cold-start __aenter__ happens,
+    and run_until_complete cannot be nested."""
+    global _async_s3_client_cm, _async_s3_client_singleton
+    if _async_s3_client_singleton is None:
+        _async_s3_client_cm = aioboto3.Session().client(
+            "s3",
+            endpoint_url=SEAWEED_S3_ENDPOINT,
+            aws_access_key_id=SEAWEED_S3_ACCESS_KEY,
+            aws_secret_access_key=SEAWEED_S3_SECRET_KEY,
+            region_name="us-east-1",
+            config=BotoConfig(s3={"addressing_style": "path"}, max_pool_connections=64),
+        )
+        _async_s3_client_singleton = await _async_s3_client_cm.__aenter__()
+    return _async_s3_client_singleton
+
+
+@atexit.register
+def _close_async_s3_client():
+    """Close the async client and its loop so aiohttp does not warn about unclosed sessions at
+    interpreter exit."""
+    if _async_s3_client_singleton is not None:
+        _async_s3_loop.run_until_complete(_async_s3_client_cm.__aexit__(None, None, None))
+    if _async_s3_loop is not None:
+        _async_s3_loop.close()
+
+
+def arctic_uri(bucket: str) -> str:
+    """Arctic connection string for a bucket on the benchmark SeaweedFS server."""
+    parsed = urlsplit(SEAWEED_S3_ENDPOINT)
+    scheme = "s3s" if parsed.scheme == "https" else "s3"
+    uri = f"{scheme}://{parsed.hostname}:{bucket}?access={SEAWEED_S3_ACCESS_KEY}&secret={SEAWEED_S3_SECRET_KEY}"
+    if parsed.port:
+        uri += f"&port={parsed.port}"
+    return uri
+
+
+def grow_bucket_volumes(bucket: str, count: Optional[int] = None) -> None:
+    """
+    Pre-create `count` volumes (default: ArcticDB's actual IO thread count) in the bucket's collection.
+
+    Volumes serialise appends, so a bucket needs at least as many volumes as ArcticDB has IO
+    threads for concurrent writes not to contend on volume-level locks. /vol/grow is additive,
+    so only call this on a freshly created bucket.
+    """
+    count = count if count is not None else io_thread_count()
+    response = _http_session.get(
+        f"{SEAWEED_MASTER_URL}/vol/grow", params={"collection": bucket, "count": count}, timeout=_HTTP_TIMEOUT
+    )
+    try:
+        body = response.json() if response.content else {}
+    except ValueError:
+        body = {}
+    error = body.get("error") if isinstance(body, dict) else None
+    if error:
+        raise RuntimeError(f"SeaweedFS master /vol/grow failed: {error}")
+    response.raise_for_status()
+
+
+def create_bucket(bucket: str, volume_count: Optional[int] = None) -> None:
+    """Create the bucket and pre-grow its volumes (see grow_bucket_volumes)."""
+    s3_client().create_bucket(Bucket=bucket)
+    grow_bucket_volumes(bucket, volume_count)
+
+
+def list_buckets() -> List[str]:
+    return [b["Name"] for b in s3_client().list_buckets()["Buckets"]]
+
+
+def delete_bucket(bucket: str) -> None:
+    """
+    Hard-delete a bucket without per-object deletes.
+
+    Dropping the bucket's backing collection removes its volume files wholesale and reclaims
+    the space immediately, no vacuum needed. The filer metadata is removed afterwards (chunk
+    deletion skipped: the data is already gone with the collection).
+    """
+    response = _http_session.get(
+        f"{SEAWEED_MASTER_URL}/col/delete", params={"collection": bucket}, timeout=_HTTP_TIMEOUT
+    )
+    try:
+        body = response.json() if response.content else {}
+    except ValueError:
+        body = {}
+    error = body.get("error") if isinstance(body, dict) else None
+    # A bucket that never had data has no backing collection yet, which is fine to "delete"
+    if error and not ("not exist" in error or "not found" in error):
+        raise RuntimeError(f"SeaweedFS master /col/delete failed: {error}")
+    if not error:
+        response.raise_for_status()
+    response = _http_session.delete(
+        f"{SEAWEED_FILER_URL}/buckets/{bucket}",
+        params={"recursive": "true", "ignoreRecursiveError": "true", "skipChunkDeletion": "true"},
+        timeout=_HTTP_TIMEOUT,
+    )
+    if response.status_code not in (200, 204, 404):
+        response.raise_for_status()
+
+
+def reset_arcticdb_cache_bucket() -> str:
+    """
+    Hard-delete and recreate the shared setup_cache bucket.
+
+    Must be called at the start of every setup_cache() that stores data on SeaweedFS.
+    """
+    try:
+        delete_bucket(ARCTICDB_CACHE_BUCKET)
+    except requests.ConnectionError as e:
+        raise RuntimeError(
+            f"Cannot reach the SeaweedFS benchmark server at {SEAWEED_MASTER_URL}; "
+            "start it with: build_tooling/start_seaweed.sh start"
+        ) from e
+    create_bucket(ARCTICDB_CACHE_BUCKET)
+    return ARCTICDB_CACHE_BUCKET
+
+
+async def _gather_all(coros):
+    """gather() that waits for every task even when one fails (a fail-fast gather would strand
+    the rest as pending tasks on the shared loop, where they would resume mid-flight during an
+    unrelated later run_until_complete), then raises the first error."""
+    results = await asyncio.gather(*coros, return_exceptions=True)
+    errors = [result for result in results if isinstance(result, BaseException)]
+    if errors:
+        raise errors[0]
+    return results
+
+
+def copy_bucket(
+    source: str, destination: str, prefixes: Optional[Iterable[str]] = None, max_concurrency: int = 64
+) -> int:
+    """
+    Server-side copy of `source` into the existing bucket `destination`, optionally restricted
+    to the given key prefixes. Returns the number of objects copied.
+
+    max_concurrency bounds how many copies are in flight at once; the connection pool is fixed
+    at 64 by the async_s3_client() singleton.
+    """
+
+    async def _copy():
+        client = await async_s3_client()
+
+        async def list_prefix(prefix):
+            prefix_keys = []
+            async for page in client.get_paginator("list_objects_v2").paginate(Bucket=source, Prefix=prefix):
+                prefix_keys.extend(obj["Key"] for obj in page.get("Contents", []))
+            return prefix_keys
+
+        listed = await _gather_all(list_prefix(p) for p in (prefixes if prefixes is not None else [""]))
+        # Deduplicated so overlapping prefixes cannot copy the same key twice
+        keys = list(dict.fromkeys(key for prefix_keys in listed for key in prefix_keys))
+
+        in_flight = asyncio.Semaphore(max_concurrency)
+
+        async def copy_one(key):
+            async with in_flight:
+                await client.copy_object(Bucket=destination, Key=key, CopySource={"Bucket": source, "Key": key})
+
+        await _gather_all(copy_one(key) for key in keys)
+        return len(keys)
+
+    return _async_s3_loop_get().run_until_complete(_copy())

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,6 +124,7 @@ Testing =
     future
     mock
     boto3
+    aioboto3  # Used by the SeaweedFS ASV benchmark helpers (python/benchmarks/seaweed_utils.py)
     moto
     flask  # Used by moto
     flask-cors


### PR DESCRIPTION
# ASV benchmarks for `merge`

`python/benchmarks/merge_functions.py` adds four ASV benchmark classes covering
`Library.merge_experimental` against an LMDB-backed library. Each class defines a
`time_merge` benchmark (reported below) and a `peakmem_merge` benchmark over the same
parameter grid.

## Parameters

| Parameter | Meaning |
|---|---|
| `scenario` | row count and column count of the target symbol |
| `strategy` | `update` (matched=update), `insert` (not_matched_by_target=insert), `update_and_insert` (both) |
| `index_kind` | `datetime` (sorted datetime index) or `rowrange` |
| `on_count` | number of value columns used as extra join keys via `on` (0 = match on index only) |
| `source_size` | row count of the source dataframe passed to the merge |
| `matched_pct` | percentage of source rows that match an existing target row |
| `num_unique_strings` | size of the string pool values are drawn from (string class only) |

Rows showing `n/a` are combinations skipped via `SkipNotImplemented`:

- `index_kind=rowrange` with `insert` / `update_and_insert`: `not_matched_by_target=insert`
  has no row-range implementation.
- `index_kind=rowrange` with `on_count=0`: a row-range index cannot be a join key on its own.
- `MergeWide`: non-`update` strategies skip `on_count=1`; `MergeLongWide`: `datetime` skips
  `on_count=1` — grid-size cost decisions, not unsupported features.

Results below are `time_merge` (mean ± std over repeats). Run on a 128-logical-core Linux
host, release build, local-disk LMDB.

## Harness design (shared `MergeBase`)

- `merge_experimental` is destructive, so each measurement restores a fresh copy of the
  pre-built base library (LMDB directory copy) before running a single merge
  (`number=1`, `rounds=1`, `warmup_time=0`).
- Target symbols are built once per class in `setup_cache`; `repeat=10` for the two thin
  classes and `repeat=5` for the two wide classes.

## `MergeThin` — long, thin numeric table

Target: **10,000,000 rows × 2 float64 columns**. Measures merge cost on a large narrow
symbol where the target scan dominates. `repeat=10`.

| scenario | strategy | index_kind | on_count | source_size | matched_pct | time |
|---|---|---|---|---|---|---|
| (10000000, 2) | update | datetime | 0 | 1000 | 20 | 1.36±0.01s |
| (10000000, 2) | update | datetime | 0 | 1000 | 80 | 1.43±0.03s |
| (10000000, 2) | update | datetime | 0 | 500000 | 20 | 1.42±0.01s |
| (10000000, 2) | update | datetime | 0 | 500000 | 80 | 1.44±0.02s |
| (10000000, 2) | update | datetime | 1 | 1000 | 20 | 1.35±0.01s |
| (10000000, 2) | update | datetime | 1 | 1000 | 80 | 1.44±0.01s |
| (10000000, 2) | update | datetime | 1 | 500000 | 20 | 1.42±0s |
| (10000000, 2) | update | datetime | 1 | 500000 | 80 | 1.44±0.01s |
| (10000000, 2) | update | rowrange | 1 | 1000 | 20 | 951±9ms |
| (10000000, 2) | update | rowrange | 1 | 1000 | 80 | 1.02±0.01s |
| (10000000, 2) | update | rowrange | 1 | 500000 | 20 | 1.08±0.01s |
| (10000000, 2) | update | rowrange | 1 | 500000 | 80 | 1.07±0.01s |
| (10000000, 2) | insert | datetime | 0 | 1000 | 20 | 1.41±0.01s |
| (10000000, 2) | insert | datetime | 0 | 1000 | 80 | 1.34±0.01s |
| (10000000, 2) | insert | datetime | 0 | 500000 | 20 | 1.46±0.01s |
| (10000000, 2) | insert | datetime | 0 | 500000 | 80 | 1.42±0.01s |
| (10000000, 2) | insert | datetime | 1 | 1000 | 20 | 1.40±0s |
| (10000000, 2) | insert | datetime | 1 | 1000 | 80 | 1.31±0.01s |
| (10000000, 2) | insert | datetime | 1 | 500000 | 20 | 1.44±0.01s |
| (10000000, 2) | insert | datetime | 1 | 500000 | 80 | 1.43±0.01s |
| (10000000, 2) | update_and_insert | datetime | 0 | 1000 | 20 | 1.43±0.01s |
| (10000000, 2) | update_and_insert | datetime | 0 | 1000 | 80 | 1.39±0.01s |
| (10000000, 2) | update_and_insert | datetime | 0 | 500000 | 20 | 1.44±0.01s |
| (10000000, 2) | update_and_insert | datetime | 0 | 500000 | 80 | 1.41±0.01s |
| (10000000, 2) | update_and_insert | datetime | 1 | 1000 | 20 | 1.40±0.01s |
| (10000000, 2) | update_and_insert | datetime | 1 | 1000 | 80 | 1.42±0.01s |
| (10000000, 2) | update_and_insert | datetime | 1 | 500000 | 20 | 1.44±0.01s |
| (10000000, 2) | update_and_insert | datetime | 1 | 500000 | 80 | 1.45±0.01s |

## `MergeThinString` — long, thin string table

Target: **1,000,000 rows × 2 string columns**. Adds the `num_unique_strings` dimension
(pool of 100 vs 100,000 distinct 10-char strings) to capture string pool/hashing costs.
`repeat=10`.

| scenario | strategy | index_kind | on_count | source_size | matched_pct | num_unique_strings | time |
|---|---|---|---|---|---|---|---|
| (1000000, 2) | update | datetime | 0 | 1000 | 20 | 100 | 102±6ms |
| (1000000, 2) | update | datetime | 0 | 1000 | 20 | 100000 | 196±2ms |
| (1000000, 2) | update | datetime | 0 | 1000 | 80 | 100 | 101±0.8ms |
| (1000000, 2) | update | datetime | 0 | 1000 | 80 | 100000 | 204±4ms |
| (1000000, 2) | update | datetime | 0 | 500000 | 20 | 100 | 113±2ms |
| (1000000, 2) | update | datetime | 0 | 500000 | 20 | 100000 | 212±2ms |
| (1000000, 2) | update | datetime | 0 | 500000 | 80 | 100 | 130±0.6ms |
| (1000000, 2) | update | datetime | 0 | 500000 | 80 | 100000 | 229±3ms |
| (1000000, 2) | update | datetime | 1 | 1000 | 20 | 100 | 103±1ms |
| (1000000, 2) | update | datetime | 1 | 1000 | 20 | 100000 | 196±2ms |
| (1000000, 2) | update | datetime | 1 | 1000 | 80 | 100 | 103±0.9ms |
| (1000000, 2) | update | datetime | 1 | 1000 | 80 | 100000 | 196±3ms |
| (1000000, 2) | update | datetime | 1 | 500000 | 20 | 100 | 110±1ms |
| (1000000, 2) | update | datetime | 1 | 500000 | 20 | 100000 | 207±3ms |
| (1000000, 2) | update | datetime | 1 | 500000 | 80 | 100 | 120±2ms |
| (1000000, 2) | update | datetime | 1 | 500000 | 80 | 100000 | 217±5ms |
| (1000000, 2) | update | rowrange | 1 | 1000 | 20 | 100 | 61.6±2ms |
| (1000000, 2) | update | rowrange | 1 | 1000 | 20 | 100000 | 166±1ms |
| (1000000, 2) | update | rowrange | 1 | 1000 | 80 | 100 | 62.6±2ms |
| (1000000, 2) | update | rowrange | 1 | 1000 | 80 | 100000 | 166±2ms |
| (1000000, 2) | update | rowrange | 1 | 500000 | 20 | 100 | 63.7±3ms |
| (1000000, 2) | update | rowrange | 1 | 500000 | 20 | 100000 | 204±2ms |
| (1000000, 2) | update | rowrange | 1 | 500000 | 80 | 100 | 64.3±4ms |
| (1000000, 2) | update | rowrange | 1 | 500000 | 80 | 100000 | 208±3ms |
| (1000000, 2) | insert | datetime | 0 | 1000 | 20 | 100 | 109±2ms |
| (1000000, 2) | insert | datetime | 0 | 1000 | 20 | 100000 | 222±6ms |
| (1000000, 2) | insert | datetime | 0 | 1000 | 80 | 100 | 110±3ms |
| (1000000, 2) | insert | datetime | 0 | 1000 | 80 | 100000 | 220±3ms |
| (1000000, 2) | insert | datetime | 0 | 500000 | 20 | 100 | 164±3ms |
| (1000000, 2) | insert | datetime | 0 | 500000 | 20 | 100000 | 287±5ms |
| (1000000, 2) | insert | datetime | 0 | 500000 | 80 | 100 | 130±3ms |
| (1000000, 2) | insert | datetime | 0 | 500000 | 80 | 100000 | 245±3ms |
| (1000000, 2) | insert | datetime | 1 | 1000 | 20 | 100 | 111±4ms |
| (1000000, 2) | insert | datetime | 1 | 1000 | 20 | 100000 | 217±3ms |
| (1000000, 2) | insert | datetime | 1 | 1000 | 80 | 100 | 110±1ms |
| (1000000, 2) | insert | datetime | 1 | 1000 | 80 | 100000 | 219±2ms |
| (1000000, 2) | insert | datetime | 1 | 500000 | 20 | 100 | 164±4ms |
| (1000000, 2) | insert | datetime | 1 | 500000 | 20 | 100000 | 295±3ms |
| (1000000, 2) | insert | datetime | 1 | 500000 | 80 | 100 | 132±2ms |
| (1000000, 2) | insert | datetime | 1 | 500000 | 80 | 100000 | 245±4ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 1000 | 20 | 100 | 108±1ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 1000 | 20 | 100000 | 219±4ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 1000 | 80 | 100 | 109±3ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 1000 | 80 | 100000 | 219±3ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 500000 | 20 | 100 | 169±3ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 500000 | 20 | 100000 | 298±4ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 500000 | 80 | 100 | 158±3ms |
| (1000000, 2) | update_and_insert | datetime | 0 | 500000 | 80 | 100000 | 278±5ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 1000 | 20 | 100 | 110±3ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 1000 | 20 | 100000 | 218±3ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 1000 | 80 | 100 | 110±3ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 1000 | 80 | 100000 | 222±3ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 500000 | 20 | 100 | 167±3ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 500000 | 20 | 100000 | 297±3ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 500000 | 80 | 100 | 145±2ms |
| (1000000, 2) | update_and_insert | datetime | 1 | 500000 | 80 | 100000 | 266±4ms |

## `MergeWide` — short, very wide numeric table

Target: **5,000 rows × 10,000 float64 columns**, source of 100 rows. Exercises the
many-columns path, including joining on up to 1,000 columns. `repeat=5`.

| scenario | strategy | index_kind | on_count | source_size | matched_pct | time |
|---|---|---|---|---|---|---|
| (5000, 10000) | update | datetime | 0 | 100 | 20 | 2.41±0s |
| (5000, 10000) | update | datetime | 0 | 100 | 80 | 2.41±0.02s |
| (5000, 10000) | update | datetime | 1 | 100 | 20 | 2.41±0.01s |
| (5000, 10000) | update | datetime | 1 | 100 | 80 | 2.43±0.02s |
| (5000, 10000) | update | datetime | 1000 | 100 | 20 | 3.50±0.02s |
| (5000, 10000) | update | datetime | 1000 | 100 | 80 | 3.51±0s |
| (5000, 10000) | update | rowrange | 1 | 100 | 20 | 2.39±0.01s |
| (5000, 10000) | update | rowrange | 1 | 100 | 80 | 2.42±0s |
| (5000, 10000) | update | rowrange | 1000 | 100 | 20 | 3.47±0.01s |
| (5000, 10000) | update | rowrange | 1000 | 100 | 80 | 3.51±0.02s |
| (5000, 10000) | insert | datetime | 0 | 100 | 20 | 2.80±0.03s |
| (5000, 10000) | insert | datetime | 0 | 100 | 80 | 2.79±0.02s |
| (5000, 10000) | insert | datetime | 1000 | 100 | 20 | 3.92±0.03s |
| (5000, 10000) | insert | datetime | 1000 | 100 | 80 | 3.94±0.02s |
| (5000, 10000) | update_and_insert | datetime | 0 | 100 | 20 | 2.83±0.02s |
| (5000, 10000) | update_and_insert | datetime | 0 | 100 | 80 | 2.80±0.03s |
| (5000, 10000) | update_and_insert | datetime | 1000 | 100 | 20 | 3.89±0.02s |
| (5000, 10000) | update_and_insert | datetime | 1000 | 100 | 80 | 3.94±0.05s |

## `MergeLongWide` — long, wide numeric table

Target: **2,000,000 rows × 130 float64 columns** (~2 GB of data), the "realistic large
symbol" case. Joins on up to 50 columns. `repeat=5`.

| scenario | strategy | index_kind | on_count | source_size | matched_pct | time |
|---|---|---|---|---|---|---|
| (2000000, 130) | update | datetime | 0 | 1000 | 20 | 11.4±0.04s |
| (2000000, 130) | update | datetime | 0 | 1000 | 80 | 11.3±0.1s |
| (2000000, 130) | update | datetime | 0 | 500000 | 20 | 11.4±0.04s |
| (2000000, 130) | update | datetime | 0 | 500000 | 80 | 11.4±0.08s |
| (2000000, 130) | update | datetime | 50 | 1000 | 20 | 11.5±0.04s |
| (2000000, 130) | update | datetime | 50 | 1000 | 80 | 11.4±0.01s |
| (2000000, 130) | update | datetime | 50 | 500000 | 20 | 11.1±0.01s |
| (2000000, 130) | update | datetime | 50 | 500000 | 80 | 11.4±0.03s |
| (2000000, 130) | update | rowrange | 1 | 1000 | 20 | 11.3±0.06s |
| (2000000, 130) | update | rowrange | 1 | 1000 | 80 | 11.3±0.07s |
| (2000000, 130) | update | rowrange | 1 | 500000 | 20 | 11.5±0.03s |
| (2000000, 130) | update | rowrange | 1 | 500000 | 80 | 11.4±0.05s |
| (2000000, 130) | update | rowrange | 50 | 1000 | 20 | 11.4±0.2s |
| (2000000, 130) | update | rowrange | 50 | 1000 | 80 | 11.4±0.09s |
| (2000000, 130) | update | rowrange | 50 | 500000 | 20 | 11.4±0.03s |
| (2000000, 130) | update | rowrange | 50 | 500000 | 80 | 11.5±0.04s |
| (2000000, 130) | insert | datetime | 0 | 1000 | 20 | 11.5±0.03s |
| (2000000, 130) | insert | datetime | 0 | 1000 | 80 | 11.5±0.02s |
| (2000000, 130) | insert | datetime | 0 | 500000 | 20 | 12.9±0.2s |
| (2000000, 130) | insert | datetime | 0 | 500000 | 80 | 11.6±0.02s |
| (2000000, 130) | insert | datetime | 50 | 1000 | 20 | 11.5±0.03s |
| (2000000, 130) | insert | datetime | 50 | 1000 | 80 | 11.5±0.1s |
| (2000000, 130) | insert | datetime | 50 | 500000 | 20 | 12.6±0.08s |
| (2000000, 130) | insert | datetime | 50 | 500000 | 80 | 11.9±0.04s |
| (2000000, 130) | update_and_insert | datetime | 0 | 1000 | 20 | 11.5±0s |
| (2000000, 130) | update_and_insert | datetime | 0 | 1000 | 80 | 11.5±0.2s |
| (2000000, 130) | update_and_insert | datetime | 0 | 500000 | 20 | 12.9±0.06s |
| (2000000, 130) | update_and_insert | datetime | 0 | 500000 | 80 | 11.9±0.03s |
| (2000000, 130) | update_and_insert | datetime | 50 | 1000 | 20 | 11.5±0.04s |
| (2000000, 130) | update_and_insert | datetime | 50 | 1000 | 80 | 11.5±0.04s |
| (2000000, 130) | update_and_insert | datetime | 50 | 500000 | 20 | 12.8±0.03s |
| (2000000, 130) | update_and_insert | datetime | 50 | 500000 | 80 | 11.9±0.07s |

## Total runtime

Wall-clock time per class for the full ASV run (`setup_cache` + per-repeat library
restore and source generation + `time_merge` repeats + one `peakmem_merge` pass):

| Class | repeat | Wall time |
|---|---|---|
| `MergeThin` | 10 | 8m 47s |
| `MergeThinString` | 10 | 8m 31s |
| `MergeWide` | 5 | 9m 35s |
| `MergeLongWide` | 5 | 48m 35s |
| **Total** | | **75m 28s** |

