### PR TITLE
Make uploading to pypi verbose and skip uploaded artifacts on rerun in the CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
             ls
             python3 -m pip install twine
-            python3 -m twine upload --non-interactive --verbose *.whl
+            python3 -m twine upload --skip-existing --non-interactive --verbose *.whl
         env:
           TWINE_USERNAME: ${{vars.TWINE_USERNAME || secrets.TWINE_USERNAME}}
           TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
             ls
             python3 -m pip install twine
-            python3 -m twine upload --non-interactive *.whl
+            python3 -m twine upload --non-interactive --verbose *.whl
         env:
           TWINE_USERNAME: ${{vars.TWINE_USERNAME || secrets.TWINE_USERNAME}}
           TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}


### PR DESCRIPTION
#### Reference Issues/PRs
Monday 12639534000

#### What does this implement or fix?
Add a flag to the command releasing to pypi so that the output is verbose. Used to track errors.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
