### PR TITLE
Correctly filter against NaT as a timestamp rather than an int64 with the query builder

### DIFF
--- a/cpp/arcticdb/pipeline/test/test_value.cpp
+++ b/cpp/arcticdb/pipeline/test/test_value.cpp
@@ -144,6 +144,16 @@ TEST_P(ValueDataType, ValueConstruct) {
 
 INSTANTIATE_TEST_SUITE_P(ValueConstruct, ValueDataType, testing::ValuesIn(data_types()));
 
+TEST(Value, ToStringTimeType) {
+    ASSERT_EQ(Value(timestamp{0}, DataType::NANOSECONDS_UTC64).to_string<timestamp>(), "1970-01-01 00:00:00.000000000");
+    ASSERT_EQ(
+            Value(timestamp{1735689600000000001}, DataType::NANOSECONDS_UTC64).to_string<timestamp>(),
+            "2025-01-01 00:00:00.000000001"
+    );
+    ASSERT_EQ(Value(NaT, DataType::NANOSECONDS_UTC64).to_string<timestamp>(), "NaT");
+    ASSERT_EQ(Value(timestamp{0}, DataType::INT64).to_string<timestamp>(), "0");
+}
+
 class ValueDataTypePair : public ::testing::TestWithParam<std::tuple<DataType, DataType>> {};
 
 template<typename TypeTag>

--- a/cpp/arcticdb/pipeline/value.hpp
+++ b/cpp/arcticdb/pipeline/value.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/util/format_date.hpp>
 
 namespace arcticdb {
 
@@ -101,6 +102,9 @@ struct Value {
     [[nodiscard]] std::string to_string() const {
         if (has_sequence_type()) {
             return "\"" + std::string(*str_data(), len()) + "\"";
+        } else if (is_time_type(data_type_)) {
+            // The offset of a tz-aware input is discarded before the Value is built, so this is the UTC instant.
+            return util::format_timestamp(get<timestamp>());
         } else {
             return fmt::format("{}", get<RawType>());
         }
@@ -173,6 +177,8 @@ VALUE_CONSTRUCT(int32_t, INT32)
 VALUE_CONSTRUCT(int64_t, INT64)
 VALUE_CONSTRUCT(float, FLOAT32)
 VALUE_CONSTRUCT(double, FLOAT64)
+
+inline Value construct_timestamp_value(const timestamp ts) { return Value{ts, DataType::NANOSECONDS_UTC64}; }
 
 inline Value construct_string_value(const std::string& str) { return Value{str, DataType::UTF_DYNAMIC64}; }
 

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -181,6 +181,7 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
     version.def("ValueInt64", &construct_value<int64_t>);
     version.def("ValueFloat32", &construct_value<float>);
     version.def("ValueFloat64", &construct_value<double>);
+    version.def("ValueTimestamp", &construct_timestamp_value);
 
     version.def("Value", &construct_value<uint8_t>);
     version.def("Value", &construct_value<uint16_t>);

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -53,6 +53,7 @@ from arcticdb_ext.version_store import (
     ValueInt64,
     ValueFloat32,
     ValueFloat64,
+    ValueTimestamp,
 )
 from arcticdb_ext.version_store import ExpressionNode as _ExpressionNode
 from arcticdb_ext.version_store import OperationType as _OperationType
@@ -1262,7 +1263,7 @@ def create_value(value):
         f = CONSTRUCTOR_MAP.get(min_scalar_type.kind).get(min_scalar_type.itemsize)
     elif isinstance(value, supported_time_types):
         value = nanoseconds_from_utc(value)
-        f = ValueInt64
+        f = ValueTimestamp
     elif isinstance(value, (datetime.timedelta, pd.Timedelta)):
         value = nanoseconds_timedelta(value)
         f = ValueInt64

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -958,7 +958,7 @@ def test_column_stats_three_chained_filter_clauses(
 
 
 def test_column_stats_repeated_expressions(in_memory_version_store, clear_query_stats, column_stats_filtering_enabled):
-    """Nonreg test: ConstMap.set_value is called repeatedly with name=Num(2) here. We shouldn't validate against the repetition."""
+    """Nonreg test: the leaf labelled Val(UINT8:2) recurs throughout this query. We shouldn't validate against the repetition."""
     lib = in_memory_version_store
 
     df0 = pd.DataFrame({"col_1": [1, 2]}, index=pd.date_range("2000-01-01", periods=2))

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -487,6 +487,21 @@ def test_df_query_wrong_type(lmdb_version_store_v1, any_output_format):
     ):
         lib.read(sym, query_builder=q)
 
+    q = QueryBuilder()
+    q = q[q["col_str"] > pd.Timestamp(2025, 1, 1)]
+    with pytest.raises(
+        UserInputException,
+        match="Invalid comparison.*col_str.*type=STRING.*>.*2025-01-01 00:00:00.000000000.*type=NANOSECONDS_UTC64",
+    ):
+        lib.read(sym, query_builder=q)
+
+    q = QueryBuilder()
+    q = q[q["col_str"] > pd.NaT]
+    with pytest.raises(
+        UserInputException, match="Invalid comparison.*col_str.*type=STRING.*>.*NaT.*type=NANOSECONDS_UTC64"
+    ):
+        lib.read(sym, query_builder=q)
+
 
 def test_filter_datetime_nanoseconds(
     lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -1335,46 +1335,6 @@ def test_query_builder_vwap(lmdb_version_store_v1, any_output_format):
     assert_frame_equal(expected, received, check_dtype=False)
 
 
-def test_to_strings():
-    q = QueryBuilder().row_range((1, 10))
-    assert str(q) == "ROWRANGE: RANGE, start=1, end=10"
-
-    q = QueryBuilder().head(10)
-    assert str(q) == "ROWRANGE: HEAD, n=10"
-
-    q = QueryBuilder().tail(9)
-    assert str(q) == "ROWRANGE: TAIL, n=9"
-
-    q = QueryBuilder().date_range((pd.Timestamp(1000), pd.Timestamp(2000)))
-    assert str(q) == "DATE RANGE 1000 - 2000"
-
-    q = QueryBuilder().date_range((None, pd.Timestamp(2000)))
-    assert str(q) == f"DATE RANGE {pd.Timestamp.min.value} - 2000"
-
-    q = QueryBuilder().date_range((pd.Timestamp(1000), None))
-    assert str(q) == f"DATE RANGE 1000 - {pd.Timestamp.max.value}"
-
-    q = QueryBuilder()
-    q["def"] = 2 * q["abc"]
-    assert str(q) == 'PROJECT Column["def"] = (Val(UINT8:2) MUL Column["abc"])'
-
-    q = QueryBuilder()
-    q = q[q["abc"] > 3]
-    assert str(q) == 'WHERE (Column["abc"] GT Val(UINT8:3))'
-
-    q = QueryBuilder()
-    q = q[q["abc"] > 3]
-    q = q[q["def"] > q["ghi"]]
-    q.row_range((1, 10))
-    assert (
-        str(q)
-        == 'WHERE (Column["abc"] GT Val(UINT8:3)) | WHERE (Column["def"] GT Column["ghi"]) | ROWRANGE: RANGE, start=1, end=10'
-    )
-
-    q = QueryBuilder().resample("1min").agg({"col": "sum"})
-    assert str(q) == "RESAMPLE(1min) | AGGREGATE {col: (col, sum), }"
-
-
 @pytest.mark.parametrize("dynamic_schema", [True, False])
 def test_column_select_projected_column(in_memory_store_factory, dynamic_schema, any_output_format):
     lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_nat.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_nat.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 import numpy as np
 import pandas as pd
+import pyarrow as pa
 import pytest
 
 from arcticdb.util.test import assert_frame_equal, query_stats_operation_count
@@ -25,13 +26,31 @@ sym = "sym"
     [
         lambda q: q["col"] == pd.NaT,
         lambda q: q["col"] != pd.NaT,
+        lambda q: q["col"] > pd.NaT,
+        lambda q: q["col"] < pd.NaT,
+        lambda q: q["col"] >= pd.NaT,
+        lambda q: q["col"] <= pd.NaT,
+        lambda q: pd.NaT < q["col"],
         lambda q: q["col"] > pd.Timestamp("2024-01-01"),
         lambda q: q["col"] < pd.Timestamp("2024-01-01"),
         lambda q: q["col"] >= pd.Timestamp("2024-01-01"),
         lambda q: q["col"] <= pd.Timestamp("2024-01-01"),
         lambda q: pd.Timestamp("2024-01-01") < q["col"],
     ],
-    ids=["eq_nat", "ne_nat", "gt_ts", "lt_ts", "ge_ts", "le_ts", "ts_lt_col"],
+    ids=[
+        "eq_nat",
+        "ne_nat",
+        "gt_nat",
+        "lt_nat",
+        "ge_nat",
+        "le_nat",
+        "nat_lt_col",
+        "gt_ts",
+        "lt_ts",
+        "ge_ts",
+        "le_ts",
+        "ts_lt_col",
+    ],
 )
 def test_filter_nat_values(in_memory_version_store, column_stats_filtering_enabled_and_disabled, query_expr):
     lib = in_memory_version_store
@@ -55,6 +74,74 @@ def test_filter_nat_values(in_memory_version_store, column_stats_filtering_enabl
 
     full_df = pd.concat([df0, df1])
     expected = full_df[query_expr(full_df)]
+    assert_frame_equal(expected, result)
+
+
+SPARSE_QUERY_EXPRS = [
+    lambda q: q["col"] == pd.NaT,
+    lambda q: q["col"] != pd.NaT,
+    lambda q: q["col"] > pd.NaT,
+    lambda q: q["col"] < pd.NaT,
+    lambda q: q["col"] >= pd.NaT,
+    lambda q: q["col"] <= pd.NaT,
+    lambda q: pd.NaT < q["col"],
+]
+SPARSE_QUERY_IDS = ["eq_nat", "ne_nat", "gt_nat", "lt_nat", "ge_nat", "le_nat", "nat_lt_col"]
+
+
+def _write_sparse_time_col(lib):
+    lib._set_allow_arrow_input()
+    table = pa.table(
+        {
+            "ts": pa.Array.from_pandas(pd.date_range("2000-01-01", periods=9), type=pa.timestamp("ns")),
+            "col": pa.array(
+                [
+                    pd.Timestamp("2024-01-01").value,
+                    None,
+                    pd.Timestamp("2024-01-03").value,
+                    None,
+                    None,
+                    None,
+                    pd.Timestamp("2024-01-07").value,
+                    None,
+                    None,
+                ],
+                pa.timestamp("ns"),
+            ),
+            "other": pa.array(range(9), pa.int64()),
+        }
+    )
+    lib.write(sym, table, index_column=True)
+    lib.create_column_stats_experimental(sym)
+
+
+@pytest.mark.parametrize("query_expr", SPARSE_QUERY_EXPRS, ids=SPARSE_QUERY_IDS)
+def test_filter_sparse_col_vs_nat(in_memory_store_factory, column_stats_filtering_enabled_and_disabled, query_expr):
+    lib = in_memory_store_factory(segment_row_size=3)
+    _write_sparse_time_col(lib)
+
+    q = QueryBuilder()
+    q = q[query_expr(q)]
+    result = lib.read(sym, query_builder=q, output_format="PANDAS").data
+
+    full_df = lib.read(sym, output_format="PANDAS").data
+    expected = full_df[query_expr(full_df)]
+    assert_frame_equal(expected, result)
+
+
+@pytest.mark.parametrize("query_expr", SPARSE_QUERY_EXPRS, ids=SPARSE_QUERY_IDS)
+def test_filter_sparse_col_vs_nat_then_filter(
+    in_memory_store_factory, column_stats_filtering_enabled_and_disabled, query_expr
+):
+    lib = in_memory_store_factory(segment_row_size=3)
+    _write_sparse_time_col(lib)
+
+    q = QueryBuilder()
+    q = q[query_expr(q) & (q["other"] > 3)]
+    result = lib.read(sym, query_builder=q, output_format="PANDAS").data
+
+    full_df = lib.read(sym, output_format="PANDAS").data
+    expected = full_df[query_expr(full_df) & (full_df["other"] > 3)]
     assert_frame_equal(expected, result)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_str.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_str.py
@@ -1,0 +1,171 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import datetime
+import numpy as np
+import pandas as pd
+import pytest
+
+from arcticdb.version_store.processing import QueryBuilder, where
+
+pytestmark = pytest.mark.pipeline
+
+
+def test_to_strings():
+    q = QueryBuilder().row_range((1, 10))
+    assert str(q) == "ROWRANGE: RANGE, start=1, end=10"
+
+    q = QueryBuilder().head(10)
+    assert str(q) == "ROWRANGE: HEAD, n=10"
+
+    q = QueryBuilder().tail(9)
+    assert str(q) == "ROWRANGE: TAIL, n=9"
+
+    q = QueryBuilder().date_range((pd.Timestamp(1000), pd.Timestamp(2000)))
+    assert str(q) == "DATE RANGE 1000 - 2000"
+
+    q = QueryBuilder().date_range((None, pd.Timestamp(2000)))
+    assert str(q) == f"DATE RANGE {pd.Timestamp.min.value} - 2000"
+
+    q = QueryBuilder().date_range((pd.Timestamp(1000), None))
+    assert str(q) == f"DATE RANGE 1000 - {pd.Timestamp.max.value}"
+
+    q = QueryBuilder()
+    q["def"] = 2 * q["abc"]
+    assert str(q) == 'PROJECT Column["def"] = (Val(UINT8:2) MUL Column["abc"])'
+
+    q = QueryBuilder()
+    q = q[q["abc"] > 3]
+    assert str(q) == 'WHERE (Column["abc"] GT Val(UINT8:3))'
+
+    q = QueryBuilder()
+    q = q[q["abc"] > 3]
+    q = q[q["def"] > q["ghi"]]
+    q.row_range((1, 10))
+    assert (
+        str(q)
+        == 'WHERE (Column["abc"] GT Val(UINT8:3)) | WHERE (Column["def"] GT Column["ghi"]) | ROWRANGE: RANGE, start=1, end=10'
+    )
+
+    q = QueryBuilder().resample("1min").agg({"col": "sum"})
+    assert str(q) == "RESAMPLE(1min) | AGGREGATE {col: (col, sum), }"
+
+
+@pytest.mark.parametrize(
+    "value, expected_leaf_str",
+    [
+        (True, "Val(BOOL8:true)"),
+        (False, "Val(BOOL8:false)"),
+        (3, "Val(UINT8:3)"),
+        (-3, "Val(INT8:-3)"),
+        (300, "Val(UINT16:300)"),
+        (100_000, "Val(UINT32:100000)"),
+        (3.5, "Val(FLOAT32:3.5)"),
+        (np.uint8(3), "Val(UINT8:3)"),
+        (np.int16(-3), "Val(INT8:-3)"),
+        (np.float32(3.5), "Val(FLOAT32:3.5)"),
+        # datetime and date have identical nanosecond payloads, so the Python type is not recoverable.
+        (datetime.datetime(2025, 1, 1), "Val(NANOSECONDS_UTC64:2025-01-01 00:00:00.000000000)"),
+        (datetime.date(2025, 1, 1), "Val(NANOSECONDS_UTC64:2025-01-01 00:00:00.000000000)"),
+        (pd.Timestamp(2025, 1, 1, 12, 30, 15, 123456), "Val(NANOSECONDS_UTC64:2025-01-01 12:30:15.123456000)"),
+        (pd.Timestamp("2025-01-01 00:00:00.000000001"), "Val(NANOSECONDS_UTC64:2025-01-01 00:00:00.000000001)"),
+        (pd.NaT, "Val(NANOSECONDS_UTC64:NaT)"),
+        # There is no duration DataType, so durations stay raw nanoseconds.
+        (datetime.timedelta(days=1), "Val(INT64:86400000000000)"),
+        (pd.Timedelta("1 days"), "Val(INT64:86400000000000)"),
+    ],
+)
+def test_to_strings_numeric_and_bool_leaf(value, expected_leaf_str):
+    q = QueryBuilder()
+    q = q[q["c"] > value]
+    assert str(q) == f'WHERE (Column["c"] GT {expected_leaf_str})'
+
+
+def test_to_strings_string_leaf():
+    q = QueryBuilder()
+    q = q[q["c"] == "hello"]
+    assert str(q) == 'WHERE (Column["c"] EQ Val(UTF_DYNAMIC64:"hello"))'
+
+
+def test_to_strings_regex_leaf():
+    q = QueryBuilder()
+    q = q[q["c"].regex_match("^abc.*")]
+    assert str(q) == 'WHERE (Column["c"] REGEX_MATCH Regex(^abc.*))'
+
+
+@pytest.mark.parametrize("method, op", [("isin", "ISIN"), ("isnotin", "ISNOTIN")])
+@pytest.mark.parametrize(
+    "values, expected_leaf_str",
+    [
+        ([1, 2, 3], "ValueSet(INT64,n=3)"),
+        (["a", "b"], "ValueSet(UTF_DYNAMIC64,n=2)"),
+        (np.arange(200), "ValueSet(INT64,n=200)"),
+    ],
+)
+def test_to_strings_value_set_leaf(method, op, values, expected_leaf_str):
+    q = QueryBuilder()
+    q = q[getattr(q["c"], method)(values)]
+    assert str(q) == f'WHERE (Column["c"] {op} {expected_leaf_str})'
+
+
+def test_to_strings_unary_operations():
+    q = QueryBuilder()
+    q = q[-q["c"] > 0]
+    assert str(q) == 'WHERE (NEG(Column["c"]) GT Val(UINT8:0))'
+
+    q = QueryBuilder()
+    q = q[abs(q["c"]) > 0]
+    assert str(q) == 'WHERE (ABS(Column["c"]) GT Val(UINT8:0))'
+
+    q = QueryBuilder()
+    q = q[~(q["c"] > 0)]
+    assert str(q) == 'WHERE NOT((Column["c"] GT Val(UINT8:0)))'
+
+    q = QueryBuilder()
+    q = q[q["col"]]
+    assert str(q) == 'WHERE IDENTITY(Column["col"])'
+
+    q = QueryBuilder()
+    q = q[~q["col"]]
+    assert str(q) == 'WHERE NOT(Column["col"])'
+
+
+def test_to_strings_ternary_where():
+    q = QueryBuilder()
+    q = q.apply("d", where(q["c"] > 0, q["a"], q["b"]))
+    assert str(q) == 'PROJECT Column["d"] = Column["a"] if (Column["c"] GT Val(UINT8:0)) else Column["b"]'
+
+
+def test_to_strings_groupby_and_concat_clauses():
+    q = QueryBuilder().groupby("c").agg({"a": "sum"})
+    assert str(q) == 'GROUPBY Column["c"] | AGGREGATE {a: (a, sum), }'
+
+    q = QueryBuilder().concat("outer")
+    assert str(q) == "CONCAT"
+
+
+def test_to_strings_datetime_range_filter():
+    start_date = datetime.datetime(2025, 1, 1)
+    end_date = datetime.datetime(2025, 1, 31)
+
+    q1 = QueryBuilder()
+    q1 = q1[q1["date_col"] >= start_date]
+
+    q2 = QueryBuilder()
+    q2 = q2[q2["date_col"] < end_date]
+
+    assert f"{q1} | {q2}" == (
+        'WHERE (Column["date_col"] GE Val(NANOSECONDS_UTC64:2025-01-01 00:00:00.000000000)) | '
+        'WHERE (Column["date_col"] LT Val(NANOSECONDS_UTC64:2025-01-31 00:00:00.000000000))'
+    )
+
+
+def test_to_strings_datetime_projection():
+    q = QueryBuilder()
+    q["shifted"] = q["date_col"] + datetime.timedelta(days=1)
+    assert str(q) == 'PROJECT Column["shifted"] = (Column["date_col"] ADD Val(INT64:86400000000000))'


### PR DESCRIPTION
Correctly filter against NaT as a timestamp rather than an int64 with the query builder.

Backport of #3265 .

Correctly filter against `NaT` as a timestamp rather than an int64 with the query builder, so `q["col"] > pd.NaT` will now return nothing (like Pandas). This is because we are now tracking that `pd.NaT` is a time type, whereas before we treated it as `int64`.

This also fixes the str() formatting of query builder expression nodes to have special formatting for strings, which regressed in PR #3201 and broke some internal tests. Before #3201 we used Python str representations of values to encode edges in the AST graph when we created it. These were reflected in the `str()` form of `ExpressionNode` objects. After that PR, no such strings are passed in to the C++ layer, what is presented to the user is all calculated in the C++ layer.

Note there are some limitations where we have still "regressed" from #3201 but I think minorly:

- We format the datetimes at nanosecond precision, whereas we used to strip trailing zeroes (in particular on dates)
- We don't have special formatting for `timedelta` objects

We also now format string values properly in error messages.