### PR TITLE
Make uploading to pypi verbose and skip uploaded artifacts on rerun in the CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
             ls
             python3 -m pip install twine
-            python3 -m twine upload --non-interactive *.whl
+            python3 -m twine upload --skip-existing --non-interactive --verbose *.whl
         env:
           TWINE_USERNAME: ${{vars.TWINE_USERNAME || secrets.TWINE_USERNAME}}
           TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}


### PR DESCRIPTION
#### Reference Issues/PRs
Monday 12639534000

#### What does this implement or fix?
Add a flag to the command releasing to pypi so that the output is verbose. Used to track errors.

