### PR TITLE
Enhancement 12036601732: support compact_data arg in append_batch

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -122,7 +122,12 @@ std::vector<std::variant<ResultValueType, DataError>> transform_batch_items_or_t
             const bool is_missing_version_exception = exception.template is_compatible_with<NoSuchVersionException>();
             const bool throw_on_missing_symbol = (is_missing_version_exception && flags.throw_on_missing_symbol_);
             if (flags.throw_on_error_ && (!is_missing_version_exception || throw_on_missing_symbol)) {
-                version_or_exception.throwUnlessValue();
+                if (flags.convert_no_data_found_to_key_not_found_ &&
+                    exception.template is_compatible_with<storage::NoDataFoundException>()) {
+                    throw storage::KeyNotFoundException(exception.what().toStdString());
+                } else {
+                    version_or_exception.throwUnlessValue();
+                }
             } else {
                 DataError data_error =
                         version_queries.empty()

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -97,8 +97,7 @@ struct TransformBatchResultsFlags {
     /// For historical reasons batch reading of metadata in V1 Library API does not throw when the symbol version is
     /// missing even if throw on error is true. Every other operation must throw in this case.
     bool throw_on_missing_symbol_{true};
-    /// Applies only if TransformBatchResultsFlags::throw_on_error_ is true
-    /// Used only by batch read in order to preserve the API. For historical reasons batch_read converts
+    /// Used by batch read and batch append in order to preserve the API. For historical reasons batch_read converts
     /// ErrorCategory::MISSING_DATA to ErrorCode::E_KEY_NOT_FOUND
     bool convert_no_data_found_to_key_not_found_{false};
 };
@@ -1282,33 +1281,18 @@ CompactDataInfo LocalVersionedEngine::compact_data_explain_plan_internal(
             .get();
 }
 
-VersionedItem LocalVersionedEngine::maybe_compact_data_and_write_version(
-        const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
-        std::optional<CompactDataFrame> compact_data_frame
-) {
-    auto versioned_item =
-            compact_data_impl(store(), update_info, write_options_, rows_per_segment, compact_data_frame).get();
-    if (versioned_item.has_value()) {
-        write_version_and_prune_previous(
-                prune_previous_versions, versioned_item->key_, update_info.previous_index_key_
-        );
-        return *versioned_item;
-    } else {
-        // compact_data_impl returns nullopt if the data was already compacted, in which case the versioned item we
-        // return is for the existing version
-        return {std::move(*update_info.previous_index_key_)};
-    }
-}
-
 VersionedItem LocalVersionedEngine::compact_data_internal(
         const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: compact_data");
     py::gil_scoped_release release_gil;
     UpdateInfo update_info = compact_data_preamble(stream_id);
-    return maybe_compact_data_and_write_version(
-            update_info, rows_per_segment.value_or(write_options_.segment_row_size), prune_previous_versions
-    );
+    return async_compact_data_internal(
+                   std::move(update_info),
+                   rows_per_segment.value_or(write_options_.segment_row_size),
+                   prune_previous_versions
+    )
+            .get();
 }
 
 bool LocalVersionedEngine::is_symbol_fragmented(const StreamId& stream_id, std::optional<size_t> segment_size) {
@@ -1694,16 +1678,38 @@ folly::Future<VersionedItem> LocalVersionedEngine::async_append_internal(
 ) {
     const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
     auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
+    // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data is true,
+    // but also when it isn't. However, the read-modify-write pipeline is all built around the PipelineContext class
+    // which assumes an existing version. Better if we just make the FixedSlicer smarter so that its logic is more like
+    // ReslicingInfo
     if (update_info.previous_index_key_.has_value()) {
-        index_key_fut = frame->empty() ? async_write_metadata_impl(store(), update_info, std::move(frame->user_meta))
-                                       : async_append_impl(
-                                                 store(),
-                                                 update_info,
-                                                 frame,
-                                                 write_options_,
-                                                 append_options.validate_index,
-                                                 write_options_.empty_types
-                                         );
+        if (append_options.compact_data) {
+            auto compact_data_frame = std::make_optional<CompactDataFrame>(
+                    frame, append_options.validate_index, write_options_.empty_types
+            );
+            index_key_fut =
+                    async_compact_data_impl(
+                            store(), update_info, write_options_, write_options_.segment_row_size, compact_data_frame
+                    )
+                            .thenValueInline([](std::optional<AtomKey>&& opt_index_key) {
+                                internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                                        opt_index_key.has_value(),
+                                        "append with compact_data=true should always write a new version"
+                                );
+                                return *opt_index_key;
+                            });
+        } else {
+            index_key_fut = frame->empty()
+                                    ? async_write_metadata_impl(store(), update_info, std::move(frame->user_meta))
+                                    : async_append_impl(
+                                              store(),
+                                              update_info,
+                                              frame,
+                                              write_options_,
+                                              append_options.validate_index,
+                                              write_options_.empty_types
+                                      );
+        }
     } else {
         if (!append_options.upsert) {
             auto error_msg = fmt::format(
@@ -1835,6 +1841,30 @@ folly::Future<VersionedItem> LocalVersionedEngine::async_write_versioned_metadat
             });
 }
 
+folly::Future<VersionedItem> LocalVersionedEngine::async_compact_data_internal(
+        UpdateInfo&& update_info, uint64_t rows_per_segment, bool prune_previous_versions
+) {
+    return async_compact_data_impl(store(), update_info, write_options_, rows_per_segment)
+            .thenValueInline(
+                    [this, update_info = std::move(update_info), prune_previous_versions](auto&& opt_index_key
+                    ) mutable -> folly::Future<VersionedItem> {
+                        if (opt_index_key.has_value()) {
+                            return write_index_key_to_version_map_async(
+                                    version_map(),
+                                    std::move(*opt_index_key),
+                                    std::move(update_info),
+                                    prune_previous_versions,
+                                    false
+                            );
+                        } else {
+                            // compact_data_impl returns nullopt if the data was already compacted, in which case the
+                            // versioned item we return is for the existing version
+                            return {std::move(*update_info.previous_index_key_)};
+                        }
+                    }
+            );
+}
+
 std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_write_versioned_dataframe_internal(
         const std::vector<StreamId>& stream_ids, std::vector<std::shared_ptr<pipelines::InputFrame>>&& frames,
         bool prune_previous_versions, bool validate_index, bool throw_on_error
@@ -1928,19 +1958,6 @@ VersionedItem LocalVersionedEngine::append_internal(
 ) {
     py::gil_scoped_release release_gil;
     auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
-
-    // It would be nice if upsert also sliced into more evenly sized segments at least when compact_data is true,
-    // but also when it isn't. However, the read-modify-write pipeline is all built around the PipelineContext class
-    // which assumes an existing version. Better if we just make the FixedSlicer smarter so that its logic is more like
-    // ReslicingInfo
-    if (update_info.previous_index_key_.has_value() && append_options.compact_data) {
-        auto compact_data_frame =
-                std::make_optional<CompactDataFrame>(frame, append_options.validate_index, write_options_.empty_types);
-        return maybe_compact_data_and_write_version(
-                update_info, write_options_.segment_row_size, append_options.prune_previous_versions, compact_data_frame
-        );
-    }
-
     return async_append_internal(stream_id, std::move(update_info), frame, append_options, false).get();
 }
 
@@ -1974,6 +1991,9 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
     auto append_versions = folly::collectAll(append_versions_futs).get();
     TransformBatchResultsFlags flags;
     flags.throw_on_error_ = throw_on_error;
+    // Missing index keys raise NoDataFoundException on compact_data path, but KeyNotFoundException on non-compact path
+    // Setting this flag makes the exception bubbed up to the user the same in both cases
+    flags.convert_no_data_found_to_key_not_found_ = append_options.compact_data;
     return transform_batch_items_or_throw(std::move(append_versions), stream_ids, flags);
 }
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -328,11 +328,6 @@ class LocalVersionedEngine : public VersionedEngine {
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment
     ) override;
 
-    VersionedItem maybe_compact_data_and_write_version(
-            const UpdateInfo& update_info, uint64_t rows_per_segment, bool prune_previous_versions,
-            std::optional<CompactDataFrame> compact_data_frame = std::nullopt
-    );
-
     VersionedItem compact_data_internal(
             const StreamId& stream_id, std::optional<uint64_t> rows_per_segment, bool prune_previous_versions
     ) override;
@@ -482,6 +477,10 @@ class LocalVersionedEngine : public VersionedEngine {
     folly::Future<VersionedItem> async_write_versioned_metadata_internal(
             const StreamId& stream_id, UpdateInfo&& update_info,
             arcticdb::proto::descriptors::UserDefinedMetadata&& user_meta, bool prune_previous_versions
+    );
+
+    folly::Future<VersionedItem> async_compact_data_internal(
+            UpdateInfo&& update_info, uint64_t rows_per_segment, bool prune_previous_versions
     );
 
     std::shared_ptr<Store> store_;

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -200,6 +200,12 @@ static void check_can_append(
     );
 }
 
+// A frame being appended starts at the end of the existing data, and inherits its column bucketing
+static void set_frame_offset_and_bucketize_dynamic(InputFrame& frame, const TimeseriesDescriptor& existing_tsd) {
+    frame.set_offset(static_cast<ssize_t>(existing_tsd.total_rows()));
+    frame.set_bucketize_dynamic(existing_tsd.column_groups());
+}
+
 static void check_can_update(
         const InputFrame& frame, const index::IndexSegmentReader& index_segment_reader, bool dynamic_schema,
         bool empty_types
@@ -239,10 +245,7 @@ folly::Future<AtomKey> async_append_impl(
                         validate_index,
                         empty_types
                 );
-                bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
-                auto row_offset = index_segment_reader.tsd().total_rows();
-                frame->set_offset(static_cast<ssize_t>(row_offset));
-                frame->set_bucketize_dynamic(bucketize_dynamic);
+                set_frame_offset_and_bucketize_dynamic(*frame, index_segment_reader.tsd());
                 auto slicing_arg = get_slicing_policy(options, *frame);
                 return append_frame(
                         IndexPartialKey{frame->desc().id(), update_info.next_version_id_},
@@ -3305,30 +3308,7 @@ static std::shared_ptr<TimeseriesDescriptor> compact_data_tsd(
         const WriteOptions& write_options
 ) {
     const auto& existing_tsd = pipeline_context.tsd();
-    if (compact_data_frame.has_value()) {
-        auto& frame = compact_data_frame->frame_;
-        if (frame->num_rows > 0) {
-            check_can_append(
-                    *frame,
-                    existing_tsd,
-                    pipeline_context.last_existing_index_value_,
-                    write_options,
-                    compact_data_frame->validate_index_,
-                    compact_data_frame->empty_types_
-            );
-            frame->set_offset(existing_tsd.total_rows());
-            frame->set_bucketize_dynamic(existing_tsd.column_groups());
-            return std::make_shared<TimeseriesDescriptor>(index::get_merged_tsd(
-                    frame->offset + frame->num_rows, write_options.dynamic_schema, existing_tsd, frame
-            ));
-        } else {
-            frame->set_offset(existing_tsd.total_rows());
-            frame->set_bucketize_dynamic(existing_tsd.column_groups());
-            auto merged_tsd = std::make_shared<TimeseriesDescriptor>(existing_tsd);
-            *merged_tsd->mutable_proto().mutable_user_meta() = std::move(frame->user_meta);
-            return merged_tsd;
-        }
-    } else {
+    if (!compact_data_frame.has_value()) {
         return std::make_shared<TimeseriesDescriptor>(make_timeseries_descriptor(
                 existing_tsd.total_rows(),
                 *pipeline_context.desc_,
@@ -3338,9 +3318,27 @@ static std::shared_ptr<TimeseriesDescriptor> compact_data_tsd(
                 write_options.bucketize_dynamic
         ));
     }
+    auto& frame = compact_data_frame->frame_;
+    set_frame_offset_and_bucketize_dynamic(*frame, existing_tsd);
+    if (frame->num_rows == 0) {
+        auto merged_tsd = std::make_shared<TimeseriesDescriptor>(existing_tsd);
+        *merged_tsd->mutable_proto().mutable_user_meta() = std::move(frame->user_meta);
+        return merged_tsd;
+    }
+    check_can_append(
+            *frame,
+            existing_tsd,
+            pipeline_context.last_existing_index_value_,
+            write_options,
+            compact_data_frame->validate_index_,
+            compact_data_frame->empty_types_
+    );
+    return std::make_shared<TimeseriesDescriptor>(
+            index::get_merged_tsd(frame->offset + frame->num_rows, write_options.dynamic_schema, existing_tsd, frame)
+    );
 }
 
-folly::Future<std::optional<VersionedItem>> compact_data_impl(
+folly::Future<std::optional<AtomKey>> async_compact_data_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const WriteOptions& write_options,
         uint64_t rows_per_segment, std::optional<CompactDataFrame> compact_data_frame
 ) {
@@ -3380,9 +3378,9 @@ folly::Future<std::optional<VersionedItem>> compact_data_impl(
                                  read_query,
                                  tsd,
                                  frame](std::vector<SliceAndKey>&& slices_and_keys
-                                ) -> folly::Future<std::optional<VersionedItem>> {
+                                ) -> folly::Future<std::optional<AtomKey>> {
                                     if (slices_and_keys.empty() && !frame) {
-                                        return folly::makeFuture(std::optional<VersionedItem>());
+                                        return folly::makeFuture(std::optional<AtomKey>());
                                     }
                                     const std::vector<RowRange> new_row_ranges =
                                             find_sorted_unique_row_ranges(slices_and_keys);

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -203,7 +203,7 @@ struct CompactDataFrame {
     bool empty_types_;
 };
 
-folly::Future<std::optional<VersionedItem>> compact_data_impl(
+folly::Future<std::optional<AtomKey>> async_compact_data_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const WriteOptions& write_options,
         uint64_t rows_per_segment, std::optional<CompactDataFrame> compact_data_frame = std::nullopt
 );

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -107,10 +107,13 @@ std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_wr
 std::vector<std::variant<VersionedItem, DataError>> PythonVersionStore::batch_append(
         const std::vector<StreamId>& stream_ids, const std::vector<convert::InputItem>& items,
         const std::vector<py::object>& norms, const std::vector<py::object>& user_metas, bool prune_previous_versions,
-        bool validate_index, bool upsert, bool throw_on_error
+        bool validate_index, bool upsert, bool throw_on_error, bool compact_data
 ) {
     AppendOptions append_options{
-            .upsert = upsert, .prune_previous_versions = prune_previous_versions, .validate_index = validate_index
+            .upsert = upsert,
+            .prune_previous_versions = prune_previous_versions,
+            .validate_index = validate_index,
+            .compact_data = compact_data
     };
     auto frames = create_input_tensor_frames(
             stream_ids,

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -217,7 +217,7 @@ class PythonVersionStore : public LocalVersionedEngine {
     std::vector<VersionedItemOrError> batch_append(
             const std::vector<StreamId>& stream_ids, const std::vector<convert::InputItem>& items,
             const std::vector<py::object>& norms, const std::vector<py::object>& user_metas,
-            bool prune_previous_versions, bool validate_index, bool upsert, bool throw_on_error
+            bool prune_previous_versions, bool validate_index, bool upsert, bool throw_on_error, bool compact_data
     );
 
     std::vector<std::pair<VersionedItem, TimeseriesDescriptor>> batch_restore_version(

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2019,6 +2019,7 @@ class NativeVersionStore:
         prune_previous_version=None,
         validate_index: bool = False,
         index_column_vector: Optional[List[bool]] = None,
+        compact_data: bool = False,
         **kwargs,
     ) -> List[VersionedItem]:
         """
@@ -2049,6 +2050,13 @@ class NativeVersionStore:
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True for a given entry,
             the first column is treated as the timeseries index.
             i-th entry corresponds to i-th element of `symbols`.
+        compact_data: bool, default=False
+            If False, the data being appended will be sliced and written to disk without consideration for how
+            fragmented this may make the data.
+            If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
+            Note that this will usually involve reading some data segments from disk and doing some in-memory
+            processing, and so will generally be slower than when this argument is False. However, subsequent reads of
+            the data will generally be faster.
         kwargs :
             passed through to the write handler
 
@@ -2079,6 +2087,7 @@ class NativeVersionStore:
             validate_index,
             throw_on_error,
             index_column_vector,
+            compact_data,
             **kwargs,
         )
 
@@ -2091,6 +2100,7 @@ class NativeVersionStore:
         validate_index,
         throw_on_error,
         index_column_vector,
+        compact_data,
         **kwargs,
     ):
         proto_cfg = self._lib_cfg.lib_desc.version.write_options
@@ -2118,6 +2128,7 @@ class NativeVersionStore:
             validate_index,
             write_if_missing,
             throw_on_error,
+            compact_data,
         )
         converted = self._convert_cxx_batch_results_to_python(cxx_versioned_items, metadata_vector)
         for idx, result in enumerate(converted):

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1467,7 +1467,11 @@ class Library:
         )
 
     def append_batch(
-        self, append_payloads: List[WritePayload], prune_previous_versions: bool = False, validate_index=True
+        self,
+        append_payloads: List[WritePayload],
+        prune_previous_versions: bool = False,
+        validate_index: bool = True,
+        compact_data: bool = False,
     ) -> List[Union[VersionedItem, DataError]]:
         """
         Append data to multiple symbols in a batch fashion. This is more efficient than making multiple `append` calls in
@@ -1486,6 +1490,13 @@ class Library:
             Verify that each entry in the batch has an index that supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
             For Arrow input data, ArcticDB checks the index column directly.
+        compact_data: bool, default=False
+            If False, the data being appended will be sliced and written to disk without consideration for how
+            fragmented this may make the data.
+            If True, the data will also be compacted at the same time (see the `compact_data` method for more details).
+            Note that this will usually involve reading some data segments from disk and doing some in-memory
+            processing, and so will generally be slower than when this argument is False. However, subsequent reads of
+            the data will generally be faster.
 
         Returns
         -------
@@ -1515,6 +1526,7 @@ class Library:
             validate_index=validate_index,
             throw_on_error=throw_on_error,
             index_column_vector=[p.index_column for p in append_payloads],
+            compact_data=compact_data,
         )
 
     def update(

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -690,6 +690,7 @@ def test_append_batch(library_factory, compact_data):
         assert_frame_equal(read_dataframe.data, original_dataframe)
 
 
+# See test_basic_version_store.py::test_batch_append_missing_keys for equivalent V1 API test
 @pytest.mark.storage
 @pytest.mark.parametrize("compact_data", [False, True])
 def test_append_batch_missing_keys(arctic_library, compact_data):

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -642,7 +642,8 @@ def test_snapshots_with_delete_batch(arctic_library):
 
 
 @pytest.mark.storage
-def test_append_batch(library_factory):
+@pytest.mark.parametrize("compact_data", [False, True])
+def test_append_batch(library_factory, compact_data):
     lib = library_factory(LibraryOptions(rows_per_segment=10))
     assert lib._nvs._lib_cfg.lib_desc.version.write_options.segment_row_size == 10
     num_days = 50
@@ -659,7 +660,7 @@ def test_append_batch(library_factory):
         list_dataframes[sym] = df
 
     # When a symbol doesn't exist, we expect it to be created. In effect, append_batch functions as write_batch
-    batch = lib.append_batch(list_append_requests)
+    batch = lib.append_batch(list_append_requests, compact_data=compact_data)
     assert all(type(w) == PythonVersionedItem for w in batch)
 
     # Then
@@ -678,7 +679,7 @@ def test_append_batch(library_factory):
         list_dataframes[sym] = pd.concat([list_dataframes[sym], df])
 
     # When the symbol already exists, we expect the current dataframe to be appended to the previous dataframe
-    batch = lib.append_batch(list_append_requests)
+    batch = lib.append_batch(list_append_requests, compact_data=compact_data)
     assert all(type(w) == PythonVersionedItem for w in batch)
 
     # Then
@@ -690,7 +691,8 @@ def test_append_batch(library_factory):
 
 
 @pytest.mark.storage
-def test_append_batch_missing_keys(arctic_library):
+@pytest.mark.parametrize("compact_data", [False, True])
+def test_append_batch_missing_keys(arctic_library, compact_data):
     lib = arctic_library
 
     num_days = 2
@@ -715,7 +717,8 @@ def test_append_batch_missing_keys(arctic_library):
         [
             WritePayload("s1", df1_append, metadata="great_metadata_s1"),
             WritePayload("s2", df2_append, metadata="great_metadata_s2"),
-        ]
+        ],
+        compact_data=compact_data,
     )
 
     # Then
@@ -732,10 +735,13 @@ def test_append_batch_missing_keys(arctic_library):
     assert_frame_equal(read_dataframe.data, pd.concat([df2_write, df2_append]))
 
 
-def test_append_batch_empty_dataframe_increases_version(lmdb_version_store_v1):
-    lib = lmdb_version_store_v1
-    lib.batch_write(["sym1", "sym2"], [pd.DataFrame({"a": [1, 2, 3]}), pd.DataFrame({"b": [1, 2, 3, 4]})])
-    lib_tool = lib.library_tool()
+@pytest.mark.parametrize("compact_data", [False, True])
+def test_append_batch_empty_dataframe_increases_version(lmdb_library, compact_data):
+    lib = lmdb_library
+    lib.write_batch(
+        [WritePayload("sym1", pd.DataFrame({"a": [1, 2, 3]})), WritePayload("sym2", pd.DataFrame({"b": [1, 2, 3, 4]}))]
+    )
+    lib_tool = lib._nvs.library_tool()
 
     for symbol in ["sym1", "sym2"]:
         assert len(lib_tool.find_keys_for_symbol(KeyType.VERSION, symbol)) == 1
@@ -744,7 +750,10 @@ def test_append_batch_empty_dataframe_increases_version(lmdb_version_store_v1):
     # One symbol list entry for sym1 and one for sym2
     assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == 2
 
-    append_result = lib.batch_append(["sym1", "sym2"], [pd.DataFrame({"a": [5, 6, 7]}), pd.DataFrame({"b": []})])
+    append_result = lib.append_batch(
+        [WritePayload("sym1", pd.DataFrame({"a": [5, 6, 7]})), WritePayload("sym2", pd.DataFrame({"b": []}))],
+        compact_data=compact_data,
+    )
     assert append_result[0].version == 1
     assert append_result[1].version == 1
 

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -34,7 +34,7 @@ from arcticdb.flattener import Flattener
 from arcticdb.util.test_utils import generate_random_numpy_array, generate_random_series
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._store import VersionedItem
-from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException, StorageException
+from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException, KeyNotFoundException, StorageException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb_ext.version_store import (
     NoSuchVersionException,
@@ -2871,14 +2871,37 @@ def test_batch_append(basic_store_tombstone, three_col_df):
 
 
 @pytest.mark.storage
-def test_batch_append_with_throw_exception(basic_store, three_col_df):
+@pytest.mark.parametrize("compact_data", [False, True])
+def test_batch_append_no_versions_no_upsert_exception(basic_store, three_col_df, compact_data):
     multi_data = {"sym1": three_col_df(), "sym2": three_col_df(1)}
     with pytest.raises(NoSuchVersionException):
         basic_store.batch_append(
             list(multi_data.keys()),
             list(multi_data.values()),
+            compact_data=compact_data,
             write_if_missing=False,
         )
+
+
+# See test_arctic_batch.py::test_append_batch_missing_keys for equivalent V2 API test
+@pytest.mark.storage
+@pytest.mark.parametrize("compact_data", [False, True])
+def test_batch_append_missing_keys(in_memory_version_store, compact_data):
+    lib = in_memory_version_store
+
+    df1_write = pd.DataFrame({"col1": [1]})
+    df2_write = pd.DataFrame({"col2": [2]})
+    lib.write("s1", df1_write)
+    lib.write("s2", df2_write)
+
+    lib_tool = lib.library_tool()
+    s1_index_key = lib_tool.find_keys_for_id(KeyType.TABLE_INDEX, "s1")[0]
+    lib_tool.remove(s1_index_key)
+
+    df1_append = pd.DataFrame({"col1": [11]})
+    df2_append = pd.DataFrame({"col1": [12]})
+    with pytest.raises(KeyNotFoundException) as e:
+        lib.batch_append(["s1", "s2"], [df1_append, df2_append], compact_data=compact_data)
 
 
 @pytest.mark.parametrize("use_date_range_clause", [True, False])

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -809,8 +809,7 @@ class TestAppend:
         # Using arange guarantees the dtype matches the written df
         append_data = pd.DataFrame({"col": np.arange(0)}) if data_class == "dataframe" else pd.Series(np.arange(0))
         append_vit = (
-            # TODO: 12033601732 test with batch and compact_data=True as well
-            lib.batch_append([sym], [append_data], metadata_vector=[metadata_v1])[0]
+            lib.batch_append([sym], [append_data], metadata_vector=[metadata_v1], compact_data=compact_data)[0]
             if batch
             else lib.append(sym, append_data, metadata=metadata_v1, compact_data=compact_data)
         )
@@ -832,7 +831,10 @@ class TestAppend:
         assert not len(lib.list_symbols())
         num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
         append_df = pd.DataFrame({"col": np.arange(0)})
-        # TODO: 12033601732 test with batch and compact_data=True as well
-        (lib.batch_append([sym], [append_df]) if batch else lib.append(sym, append_df, compact_data=compact_data))
+        (
+            lib.batch_append([sym], [append_df], compact_data=compact_data)
+            if batch
+            else lib.append(sym, append_df, compact_data=compact_data)
+        )
         assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
         assert lib.list_symbols() == [sym]

--- a/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
@@ -15,6 +15,7 @@ import pyarrow as pa
 import pytest
 
 from arcticdb_ext.exceptions import InternalException
+from arcticdb_ext.version_store import NoSuchVersionException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,
@@ -31,7 +32,7 @@ from tests.util.naughty_strings import read_big_list_of_naughty_strings
 pytestmark = pytest.mark.pipeline
 
 
-def generic_append_compact_data_test(lib, sym, df, **append_kwargs):
+def generic_append_compact_data_test(lib, sym, df, batch=False, **append_kwargs):
     qs.reset_stats()  # Clear any leftover stats from a previous failed run
     vit_before_compaction = lib.read(sym, output_format="PANDAS" if isinstance(df, pd.DataFrame) else "POLARS")
     oracle_sym = sym + "_oracle"
@@ -43,7 +44,11 @@ def generic_append_compact_data_test(lib, sym, df, **append_kwargs):
     pre_compaction_data_keys = len(pre_compaction_index)
 
     with qs.query_stats():
-        lib.append(sym, df, compact_data=True, **append_kwargs)
+        (
+            lib.batch_append([sym], [df], compact_data=True, **append_kwargs)
+            if batch
+            else lib.append(sym, df, compact_data=True, **append_kwargs)
+        )
         stats = qs.get_query_stats()
     qs.reset_stats()
     rows_per_segment = lib.lib_cfg().lib_desc.version.write_options.segment_row_size
@@ -72,285 +77,7 @@ def generic_append_compact_data_test(lib, sym, df, **append_kwargs):
     assert not compact_data_info.will_do_work
 
 
-@pytest.mark.parametrize("index", [None, "ts"])
-def test_basic(in_memory_store_factory, clear_query_stats, index):
-    lib = in_memory_store_factory()
-    sym = "test_basic"
-    df_0 = pd.DataFrame(
-        {"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20)
-    )
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame(
-        {"col": np.arange(20, 30)}, index=None if index is None else pd.date_range("2026-01-21", periods=10)
-    )
-    generic_append_compact_data_test(lib, sym, df_1)
-
-
-def test_frequent_append_io_counts_compact_once(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_frequent_append_io_counts_compact_once"
-    df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
-    for idx in range(99):
-        lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000])
-    with qs.query_stats():
-        lib.append(sym, df[99 * 2_000 :], compact_data=True)
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    received = lib.read(sym).data
-    assert_frame_equal(df, received)
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 99
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
-    assert len(lib.read_index(sym)) == 2
-
-
-def test_frequent_append_io_counts_compact_every_time(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_frequent_append_io_counts_compact_every_time"
-    df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
-    for idx in range(100):
-        with qs.query_stats():
-            lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000], compact_data=True)
-            stats = qs.get_query_stats()
-        qs.reset_stats()
-        received = lib.read(sym).data
-        assert_frame_equal(df[: (idx + 1) * 2_000], received)
-        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == (0 if idx == 0 else 1)
-        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") <= 1
-        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") <= 2
-        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
-        assert len(lib.read_index(sym)) <= 2
-
-
-def test_pyarrow_tables(in_memory_version_store_arrow, clear_query_stats):
-    lib = in_memory_version_store_arrow
-    sym = "test_pyarrow_tables"
-    table_0 = pa.table({"col": pa.array(np.arange(20))})
-    lib.write(sym, table_0)
-    table_1 = pa.table({"col": pa.array(np.arange(20, 30))})
-    with qs.query_stats():
-        lib.append(sym, table_1, compact_data=True)
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    vit = lib.read(sym)
-    assert vit.version == 1
-    expected = pa.concat_tables([table_0, table_1])
-    assert expected.equals(vit.data)
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
-    assert len(lib.read_index(sym)) == 1
-
-
-@pytest.mark.parametrize("index", [None, "ts"])
-def test_series(in_memory_store_factory, clear_query_stats, index):
-    lib = in_memory_store_factory()
-    sym = "test_series"
-    series_0 = pd.Series(np.arange(20), index=None if index is None else pd.date_range("2026-01-01", periods=20))
-    lib.write(sym, series_0)
-    series_1 = pd.Series(np.arange(20, 30), index=None if index is None else pd.date_range("2026-01-21", periods=10))
-    with qs.query_stats():
-        lib.append(sym, series_1, compact_data=True)
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    vit = lib.read(sym)
-    assert vit.version == 1
-    expected = pd.concat([series_0, series_1])
-    if index is None:
-        expected.reset_index(drop=True, inplace=True)
-    assert_series_equal(expected, vit.data)
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
-    assert len(lib.read_index(sym)) == 1
-
-
-def test_numpy_arrays(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_numpy_arrays"
-    array_0 = np.arange(20)
-    lib.write(sym, array_0)
-    array_1 = np.arange(20, 30)
-    with qs.query_stats():
-        lib.append(sym, array_1, compact_data=True)
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    vit = lib.read(sym)
-    assert vit.version == 1
-    expected = np.concatenate([array_0, array_1])
-    assert (vit.data == expected).all()
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
-    assert len(lib.read_index(sym)) == 1
-
-
-def test_existing_zero_rows(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_existing_zero_rows"
-    # Zero-rowed data gets stored with a datetime index
-    df_0 = pd.DataFrame({"col": np.arange(0)})
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame({"col": np.arange(15)}, index=pd.date_range("2026-01-21", periods=15))
-    generic_append_compact_data_test(lib, sym, df_1)
-
-
-@pytest.mark.parametrize("write_if_missing", [True, False])
-@pytest.mark.parametrize("compact_data", [True, False])
-def test_write_if_missing(in_memory_store_factory, write_if_missing, compact_data):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_write_if_missing"
-    df = pd.DataFrame({"col": np.arange(15)})
-    if write_if_missing:
-        lib.append(sym, df, compact_data=compact_data, write_if_missing=write_if_missing)
-        assert_frame_equal(df, lib.read(sym).data)
-        index = lib.read_index(sym)
-        row_counts = (index["end_row"] - index["start_row"]).to_list()
-        # See comment in LocalVersionedEngine::append_internal as to why this isn't [8, 7] when compact_data is
-        # True
-        assert row_counts == [10, 5]
-    else:
-        with pytest.raises(InternalException):
-            lib.append(sym, df, compact_data=compact_data, write_if_missing=write_if_missing)
-
-
-def test_metadata(in_memory_store_factory):
-    lib = in_memory_store_factory()
-    sym = "test_metadata"
-    lib.write(sym, pd.DataFrame({"col": [0]}), metadata="0")
-    lib.append(sym, pd.DataFrame({"col": [1]}), metadata="1", compact_data=True)
-    vit = lib.read(sym)
-    assert vit.metadata == "1"
-    assert_frame_equal(vit.data, pd.DataFrame({"col": [0, 1]}))
-    assert len(lib.read_index(sym)) == 1
-
-
-@pytest.mark.parametrize("index", [None, "ts"])
-def test_compact_whole_symbol(in_memory_store_factory, clear_query_stats, index):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_compact_whole_symbol"
-    df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
-    lib.write(sym, df[:5])
-    lib.append(sym, df[5:10])
-    lib.append(sym, df[10:15])
-    generic_append_compact_data_test(lib, sym, df[15:])
-
-
-@pytest.mark.parametrize("index", [None, "ts"])
-def test_compact_leftover_slices(in_memory_store_factory, clear_query_stats, index):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_compact_leftover_slices"
-    df = pd.DataFrame({"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20))
-    lib.write(sym, df[:5])
-    generic_append_compact_data_test(lib, sym, df[5:])
-
-
-def test_existing_data_compacted(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_existing_data_compacted"
-    df = pd.DataFrame({"col": np.arange(20)})
-    lib.write(sym, df[:10])
-    generic_append_compact_data_test(lib, sym, df[10:])
-
-
-@pytest.mark.parametrize("total_rows", [25, 30, 35])
-def test_tail_of_existing_data_already_compacted(in_memory_store_factory, clear_query_stats, total_rows):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_tail_of_existing_data_already_compacted"
-    df = pd.DataFrame({"col": np.arange(total_rows)})
-    lib.write(sym, df[:5])
-    lib.append(sym, df[5:10])
-    lib.append(sym, df[10:20])
-    assert len(lib.read_index(sym)) == 3
-    generic_append_compact_data_test(lib, sym, df[20:])
-
-
-@pytest.mark.parametrize("index", [None, "ts"])
-@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
-def test_dynamic_schema_col_ordering(in_memory_store_factory, clear_query_stats, index, segment_row_size):
-    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
-    sym = "test_dynamic_schema_col_ordering"
-    df_0 = pd.DataFrame(
-        {
-            "col_0": np.arange(20, dtype=np.float64),
-            "col_1": np.arange(20, 40, dtype=np.float64),
-            "col_2": np.arange(40, 60, dtype=np.float64),
-        },
-        index=None if index is None else pd.date_range("2026-01-01", periods=20),
-    )
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame(
-        {
-            "col_3": np.arange(100, 110, dtype=np.float64),
-            "col_2": np.arange(60, 70, dtype=np.float64),
-            "col_1": np.arange(40, 50, dtype=np.float64),
-        },
-        index=None if index is None else pd.date_range("2026-01-21", periods=10),
-    )
-    generic_append_compact_data_test(lib, sym, df_1)
-
-
-@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
-def test_dynamic_schema_type_promotion(in_memory_store_factory, clear_query_stats, segment_row_size):
-    lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
-    sym = "test_dynamic_schema_type_promotion"
-    df_0 = pd.DataFrame(
-        {
-            "col_0": np.arange(20, dtype=np.float64),
-            "col_1": np.arange(20, 40, dtype=np.uint8),
-            "col_2": np.arange(40, 60, dtype=np.int16),
-        },
-    )
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame(
-        {
-            "col_0": np.arange(100, 110, dtype=np.int32),
-            "col_1": np.arange(60, 70, dtype=np.uint16),
-            "col_2": np.arange(40, 50, dtype=np.uint16),
-        },
-    )
-    generic_append_compact_data_test(lib, sym, df_1)
-
-
-@pytest.mark.parametrize("index", [None, "ts"])
-@pytest.mark.parametrize("segment_row_size", [100_000, 10, 5])
-def test_column_slicing(in_memory_store_factory, clear_query_stats, index, segment_row_size):
-    lib = in_memory_store_factory(segment_row_size=segment_row_size, column_group_size=2)
-    sym = "test_column_slicing"
-    df_0 = pd.DataFrame(
-        {f"col_{idx}": np.arange(20) for idx in range(5)},
-        index=None if index is None else pd.date_range("2026-01-01", periods=20),
-    )
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame(
-        {f"col_{idx}": np.arange(20, 30) for idx in range(5)},
-        index=None if index is None else pd.date_range("2026-01-21", periods=10),
-    )
-    generic_append_compact_data_test(lib, sym, df_1)
-
-
-@pytest.mark.parametrize("names", [None, ["ts", None], [None, "level 2"], ["ts", "level 2"]])
-def test_multiindex(in_memory_store_factory, clear_query_stats, names):
-    lib = in_memory_store_factory(segment_row_size=10, dynamic_strings=True)
-    sym = "test_multiindex"
-    num_rows = 20
-    df = pd.DataFrame(
-        {"col": np.arange(num_rows)},
-        index=pd.MultiIndex.from_product(
-            [pd.date_range("2026-01-01", periods=num_rows // 2), ["GOOG", "AAPL"]], names=names
-        ),
-    )
-    lib.write(sym, df[:5])
-    with qs.query_stats():
-        lib.append(sym, df[5:], compact_data=True)
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    vit = lib.read(sym)
-    assert vit.version == 1
-    assert_frame_equal(df, vit.data)
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
-    assert len(lib.read_index(sym)) == 2
-
-
+# batch_append does not support the coerce_columns argument
 def test_string_none_nan_handling(in_memory_store_factory, clear_query_stats):
     lib = in_memory_store_factory(dynamic_strings=True)
     sym = "test_string_none_nan_handling"
@@ -359,153 +86,526 @@ def test_string_none_nan_handling(in_memory_store_factory, clear_query_stats):
     generic_append_compact_data_test(lib, sym, df[5:], coerce_columns={"col": object})
 
 
-@pytest.mark.parametrize("dynamic_strings_first", [True, False])
-def test_fixed_width_and_dynamic_strings(in_memory_store_factory, clear_query_stats, dynamic_strings_first):
-    lib = in_memory_store_factory()
-    sym = "test_fixed_width_and_dynamic_strings"
-    # Include two segments with different widths of strings
-    df = pd.DataFrame({"col": ["a", "bb", "ccc", "dddd", "eeeee", "f", "gg", "hhhhhhhhhhhhhh", "i"]})
-    lib.write(sym, df[:3], dynamic_strings=dynamic_strings_first)
-    lib.append(sym, df[3:5], dynamic_strings=dynamic_strings_first)
-    lib.append(sym, df[5:7], dynamic_strings=not dynamic_strings_first)
-    generic_append_compact_data_test(lib, sym, df[7:], dynamic_strings=not dynamic_strings_first)
+@pytest.mark.parametrize("batch", [False, True])
+class TestAppendCompactData:
+    @pytest.mark.parametrize("index", [None, "ts"])
+    def test_basic(self, in_memory_store_factory, clear_query_stats, batch, index):
+        lib = in_memory_store_factory()
+        sym = "test_basic"
+        df_0 = pd.DataFrame(
+            {"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20)
+        )
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame(
+            {"col": np.arange(20, 30)}, index=None if index is None else pd.date_range("2026-01-21", periods=10)
+        )
+        generic_append_compact_data_test(lib, sym, df_1, batch)
+
+    def test_frequent_append_io_counts_compact_once(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory()
+        sym = "test_frequent_append_io_counts_compact_once"
+        df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
+        for idx in range(99):
+            lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000])
+        with qs.query_stats():
+            (
+                lib.batch_append([sym], [df[99 * 2_000 :]], compact_data=True)
+                if batch
+                else lib.append(sym, df[99 * 2_000 :], compact_data=True)
+            )
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        received = lib.read(sym).data
+        assert_frame_equal(df, received)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 99
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        assert len(lib.read_index(sym)) == 2
+
+    def test_frequent_append_io_counts_compact_every_time(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory()
+        sym = "test_frequent_append_io_counts_compact_every_time"
+        df = pd.DataFrame({"col": np.arange(200_000)}, index=pd.date_range("2026-01-01", freq="s", periods=200_000))
+        for idx in range(100):
+            with qs.query_stats():
+                (
+                    lib.batch_append([sym], [df[idx * 2_000 : (idx + 1) * 2_000]], compact_data=True)
+                    if batch
+                    else lib.append(sym, df[idx * 2_000 : (idx + 1) * 2_000], compact_data=True)
+                )
+                stats = qs.get_query_stats()
+            qs.reset_stats()
+            received = lib.read(sym).data
+            assert_frame_equal(df[: (idx + 1) * 2_000], received)
+            assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_INDEX") == (0 if idx == 0 else 1)
+            assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") <= 1
+            assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") <= 2
+            assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+            assert len(lib.read_index(sym)) <= 2
+
+    def test_pyarrow_tables(self, in_memory_version_store_arrow, clear_query_stats, batch):
+        lib = in_memory_version_store_arrow
+        sym = "test_pyarrow_tables"
+        table_0 = pa.table({"col": pa.array(np.arange(20))})
+        lib.write(sym, table_0)
+        table_1 = pa.table({"col": pa.array(np.arange(20, 30))})
+        with qs.query_stats():
+            (
+                lib.batch_append([sym], [table_1], compact_data=True)
+                if batch
+                else lib.append(sym, table_1, compact_data=True)
+            )
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        vit = lib.read(sym)
+        assert vit.version == 1
+        expected = pa.concat_tables([table_0, table_1])
+        assert expected.equals(vit.data)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert len(lib.read_index(sym)) == 1
+
+    @pytest.mark.parametrize("index", [None, "ts"])
+    def test_series(self, in_memory_store_factory, clear_query_stats, index, batch):
+        lib = in_memory_store_factory()
+        sym = "test_series"
+        series_0 = pd.Series(np.arange(20), index=None if index is None else pd.date_range("2026-01-01", periods=20))
+        lib.write(sym, series_0)
+        series_1 = pd.Series(
+            np.arange(20, 30), index=None if index is None else pd.date_range("2026-01-21", periods=10)
+        )
+        with qs.query_stats():
+            (
+                lib.batch_append([sym], [series_1], compact_data=True)
+                if batch
+                else lib.append(sym, series_1, compact_data=True)
+            )
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        vit = lib.read(sym)
+        assert vit.version == 1
+        expected = pd.concat([series_0, series_1])
+        if index is None:
+            expected.reset_index(drop=True, inplace=True)
+        assert_series_equal(expected, vit.data)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert len(lib.read_index(sym)) == 1
+
+    def test_numpy_arrays(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory()
+        sym = "test_numpy_arrays"
+        array_0 = np.arange(20)
+        lib.write(sym, array_0)
+        array_1 = np.arange(20, 30)
+        with qs.query_stats():
+            (
+                lib.batch_append([sym], [array_1], compact_data=True)
+                if batch
+                else lib.append(sym, array_1, compact_data=True)
+            )
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        vit = lib.read(sym)
+        assert vit.version == 1
+        expected = np.concatenate([array_0, array_1])
+        assert (vit.data == expected).all()
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert len(lib.read_index(sym)) == 1
+
+    def test_existing_zero_rows(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_existing_zero_rows"
+        # Zero-rowed data gets stored with a datetime index
+        df_0 = pd.DataFrame({"col": np.arange(0)})
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame({"col": np.arange(15)}, index=pd.date_range("2026-01-21", periods=15))
+        generic_append_compact_data_test(lib, sym, df_1, batch=batch)
+
+    @pytest.mark.parametrize("write_if_missing", [True, False])
+    @pytest.mark.parametrize("compact_data", [True, False])
+    def test_write_if_missing(self, in_memory_store_factory, write_if_missing, compact_data, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_write_if_missing"
+        df = pd.DataFrame({"col": np.arange(15)})
+        if write_if_missing:
+            (
+                lib.batch_append([sym], [df], compact_data=compact_data, write_if_missing=write_if_missing)
+                if batch
+                else lib.append(sym, df, compact_data=compact_data, write_if_missing=write_if_missing)
+            )
+            assert_frame_equal(df, lib.read(sym).data)
+            index = lib.read_index(sym)
+            row_counts = (index["end_row"] - index["start_row"]).to_list()
+            # See comment in LocalVersionedEngine::append_internal as to why this isn't [8, 7] when compact_data is
+            # True
+            assert row_counts == [10, 5]
+        else:
+            with pytest.raises(NoSuchVersionException if batch else InternalException):
+                (
+                    lib.batch_append([sym], [df], compact_data=compact_data, write_if_missing=write_if_missing)
+                    if batch
+                    else lib.append(sym, df, compact_data=compact_data, write_if_missing=write_if_missing)
+                )
+
+    def test_metadata(self, in_memory_store_factory, batch):
+        lib = in_memory_store_factory()
+        sym = "test_metadata"
+        lib.write(sym, pd.DataFrame({"col": [0]}), metadata="0")
+        (
+            lib.batch_append([sym], [pd.DataFrame({"col": [1]})], metadata_vector=["1"], compact_data=True)
+            if batch
+            else lib.append(sym, pd.DataFrame({"col": [1]}), metadata="1", compact_data=True)
+        )
+        vit = lib.read(sym)
+        assert vit.metadata == "1"
+        assert_frame_equal(vit.data, pd.DataFrame({"col": [0, 1]}))
+        assert len(lib.read_index(sym)) == 1
+
+    @pytest.mark.parametrize("index", [None, "ts"])
+    def test_compact_whole_symbol(self, in_memory_store_factory, clear_query_stats, index, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_compact_whole_symbol"
+        df = pd.DataFrame(
+            {"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20)
+        )
+        lib.write(sym, df[:5])
+        lib.append(sym, df[5:10])
+        lib.append(sym, df[10:15])
+        generic_append_compact_data_test(lib, sym, df[15:], batch)
+
+    @pytest.mark.parametrize("index", [None, "ts"])
+    def test_compact_leftover_slices(self, in_memory_store_factory, clear_query_stats, index, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_compact_leftover_slices"
+        df = pd.DataFrame(
+            {"col": np.arange(20)}, index=None if index is None else pd.date_range("2026-01-01", periods=20)
+        )
+        lib.write(sym, df[:5])
+        generic_append_compact_data_test(lib, sym, df[5:], batch)
+
+    def test_existing_data_compacted(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_existing_data_compacted"
+        df = pd.DataFrame({"col": np.arange(20)})
+        lib.write(sym, df[:10])
+        generic_append_compact_data_test(lib, sym, df[10:], batch)
+
+    @pytest.mark.parametrize("total_rows", [25, 30, 35])
+    def test_tail_of_existing_data_already_compacted(
+        self, in_memory_store_factory, clear_query_stats, total_rows, batch
+    ):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_tail_of_existing_data_already_compacted"
+        df = pd.DataFrame({"col": np.arange(total_rows)})
+        lib.write(sym, df[:5])
+        lib.append(sym, df[5:10])
+        lib.append(sym, df[10:20])
+        assert len(lib.read_index(sym)) == 3
+        generic_append_compact_data_test(lib, sym, df[20:], batch)
+
+    @pytest.mark.parametrize("index", [None, "ts"])
+    @pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
+    def test_dynamic_schema_col_ordering(
+        self, in_memory_store_factory, clear_query_stats, index, segment_row_size, batch
+    ):
+        lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
+        sym = "test_dynamic_schema_col_ordering"
+        df_0 = pd.DataFrame(
+            {
+                "col_0": np.arange(20, dtype=np.float64),
+                "col_1": np.arange(20, 40, dtype=np.float64),
+                "col_2": np.arange(40, 60, dtype=np.float64),
+            },
+            index=None if index is None else pd.date_range("2026-01-01", periods=20),
+        )
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame(
+            {
+                "col_3": np.arange(100, 110, dtype=np.float64),
+                "col_2": np.arange(60, 70, dtype=np.float64),
+                "col_1": np.arange(40, 50, dtype=np.float64),
+            },
+            index=None if index is None else pd.date_range("2026-01-21", periods=10),
+        )
+        generic_append_compact_data_test(lib, sym, df_1, batch)
+
+    @pytest.mark.parametrize("segment_row_size", [100_000, 10, 5, 2])
+    def test_dynamic_schema_type_promotion(self, in_memory_store_factory, clear_query_stats, segment_row_size, batch):
+        lib = in_memory_store_factory(segment_row_size=segment_row_size, dynamic_schema=True)
+        sym = "test_dynamic_schema_type_promotion"
+        df_0 = pd.DataFrame(
+            {
+                "col_0": np.arange(20, dtype=np.float64),
+                "col_1": np.arange(20, 40, dtype=np.uint8),
+                "col_2": np.arange(40, 60, dtype=np.int16),
+            },
+        )
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame(
+            {
+                "col_0": np.arange(100, 110, dtype=np.int32),
+                "col_1": np.arange(60, 70, dtype=np.uint16),
+                "col_2": np.arange(40, 50, dtype=np.uint16),
+            },
+        )
+        generic_append_compact_data_test(lib, sym, df_1, batch)
+
+    @pytest.mark.parametrize("index", [None, "ts"])
+    @pytest.mark.parametrize("segment_row_size", [100_000, 10, 5])
+    def test_column_slicing(self, in_memory_store_factory, clear_query_stats, index, segment_row_size, batch):
+        lib = in_memory_store_factory(segment_row_size=segment_row_size, column_group_size=2)
+        sym = "test_column_slicing"
+        df_0 = pd.DataFrame(
+            {f"col_{idx}": np.arange(20) for idx in range(5)},
+            index=None if index is None else pd.date_range("2026-01-01", periods=20),
+        )
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame(
+            {f"col_{idx}": np.arange(20, 30) for idx in range(5)},
+            index=None if index is None else pd.date_range("2026-01-21", periods=10),
+        )
+        generic_append_compact_data_test(lib, sym, df_1, batch)
+
+    @pytest.mark.parametrize("names", [None, ["ts", None], [None, "level 2"], ["ts", "level 2"]])
+    def test_multiindex(self, in_memory_store_factory, clear_query_stats, names, batch):
+        lib = in_memory_store_factory(segment_row_size=10, dynamic_strings=True)
+        sym = "test_multiindex"
+        num_rows = 20
+        df = pd.DataFrame(
+            {"col": np.arange(num_rows)},
+            index=pd.MultiIndex.from_product(
+                [pd.date_range("2026-01-01", periods=num_rows // 2), ["GOOG", "AAPL"]], names=names
+            ),
+        )
+        lib.write(sym, df[:5])
+        with qs.query_stats():
+            (
+                lib.batch_append([sym], [df[5:]], compact_data=True)
+                if batch
+                else lib.append(sym, df[5:], compact_data=True)
+            )
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        vit = lib.read(sym)
+        assert vit.version == 1
+        assert_frame_equal(df, vit.data)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        assert len(lib.read_index(sym)) == 2
+
+    @pytest.mark.parametrize("dynamic_strings_first", [True, False])
+    def test_fixed_width_and_dynamic_strings(
+        self, in_memory_store_factory, clear_query_stats, dynamic_strings_first, batch
+    ):
+        lib = in_memory_store_factory()
+        sym = "test_fixed_width_and_dynamic_strings"
+        # Include two segments with different widths of strings
+        df = pd.DataFrame({"col": ["a", "bb", "ccc", "dddd", "eeeee", "f", "gg", "hhhhhhhhhhhhhh", "i"]})
+        lib.write(sym, df[:3], dynamic_strings=dynamic_strings_first)
+        lib.append(sym, df[3:5], dynamic_strings=dynamic_strings_first)
+        lib.append(sym, df[5:7], dynamic_strings=not dynamic_strings_first)
+        generic_append_compact_data_test(lib, sym, df[7:], batch, dynamic_strings=not dynamic_strings_first)
+
+    @pytest.mark.parametrize("dynamic_strings_first", [True, False])
+    def test_blns(self, in_memory_store_factory, clear_query_stats, dynamic_strings_first, batch):
+        lib = in_memory_store_factory()
+        sym = "test_blns"
+        df = pd.DataFrame({"col": read_big_list_of_naughty_strings()})
+        lib.write(sym, df[: len(df) // 2], dynamic_strings=dynamic_strings_first)
+        generic_append_compact_data_test(lib, sym, df[len(df) // 2 :], batch, dynamic_strings=not dynamic_strings_first)
+
+    def test_append_empty_frame_compacts_existing_data(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_append_empty_frame_compacts_existing_data"
+        lib.write(sym, pd.DataFrame({"col": np.arange(5)}))
+        lib.append(sym, pd.DataFrame({"col": np.arange(5, 10)}))
+        # Schema checks happen after empty input frame checks, so we don't need the same column set
+        with qs.query_stats():
+            lib.append(sym, pd.DataFrame())
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        assert lib.read(sym).version == 2
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 0
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+        with qs.query_stats():
+            (
+                lib.batch_append([sym], [pd.DataFrame()], compact_data=True)
+                if batch
+                else lib.append(sym, pd.DataFrame(), compact_data=True)
+            )
+            stats = qs.get_query_stats()
+        qs.reset_stats()
+        assert lib.read(sym).version == 3
+        assert len(lib.read_index(sym)) == 1
+        assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 2
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
+
+    @pytest.mark.parametrize("rows_to_append", [5, 10, 15, 20])
+    def test_fortran_ordered_data(self, in_memory_store_factory, clear_query_stats, rows_to_append, batch):
+        lib = in_memory_store_factory(segment_row_size=10)
+        sym = "test_fortran_ordered_data"
+        cols = ["col_0", "col_1"]
+        df_0 = pd.DataFrame(np.random.randint(0, 100, size=(5, 2)), columns=cols)
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame(np.random.randint(0, 100, size=(rows_to_append, 2)), columns=cols)
+        generic_append_compact_data_test(lib, sym, df_1, batch)
+
+    @pytest.mark.parametrize("index", [None, "ts"])
+    def test_column_filtered_read(self, in_memory_store_factory, clear_query_stats, index, batch):
+        lib = in_memory_store_factory(column_group_size=2, segment_row_size=10)
+        sym = "test_column_filtered_read"
+        num_rows = 20
+        df = pd.DataFrame(
+            {
+                "col_a": np.arange(num_rows),
+                "col_b": np.arange(num_rows, 2 * num_rows),
+                "col_c": np.arange(2 * num_rows, 3 * num_rows),
+            },
+            index=None if index is None else pd.date_range("2026-01-01", periods=num_rows),
+        )
+        lib.write(sym, df[:5])
+        for i in range(1, 4):
+            generic_append_compact_data_test(lib, sym, df[i * 5 : (i + 1) * 5], batch)
+        expected_col_a = df[["col_a"]]
+        expected_col_bc = df[["col_b", "col_c"]]
+        assert_frame_equal(expected_col_a, lib.read(sym, columns=["col_a"]).data)
+        assert_frame_equal(expected_col_bc, lib.read(sym, columns=["col_b", "col_c"]).data)
+
+    @pytest.mark.parametrize("rows_per_segment", [3, 7, 10])
+    def test_date_range_read(self, in_memory_store_factory, clear_query_stats, rows_per_segment, batch):
+        lib = in_memory_store_factory(segment_row_size=rows_per_segment, dynamic_strings=True)
+        sym = "test_date_range_read"
+        num_rows = 100
+        index = pd.date_range("2026-01-01", periods=num_rows)
+        df = pd.DataFrame(
+            {"ints": np.arange(num_rows), "strings": 20 * ["hello", None, "gutentag", np.nan, "konichiwa"]}, index=index
+        )
+        lib.write(sym, df[:5])
+        for i in range(1, 20):
+            generic_append_compact_data_test(lib, sym, df[i * 5 : (i + 1) * 5], batch)
+        mid = index[num_rows // 2]
+        expected_first_half = df[:mid]
+        expected_second_half = df[mid:]
+        assert_frame_equal(expected_first_half, lib.read(sym, date_range=(index[0], mid)).data)
+        assert_frame_equal(expected_second_half, lib.read(sym, date_range=(mid, index[-1])).data)
+
+    def test_read_previous_version(self, in_memory_store_factory, clear_query_stats, batch):
+        lib = in_memory_store_factory()
+        sym = "test_read_previous_version"
+        df = pd.DataFrame({"col": np.arange(10)})
+        lib.write(sym, df[:5])
+        generic_append_compact_data_test(lib, sym, df[5:], batch)
+        assert_frame_equal(df[:5], lib.read(sym, as_of=0).data)
+        assert_frame_equal(df, lib.read(sym, as_of=1).data)
+        assert_frame_equal(df, lib.read(sym).data)
+
+    def test_schema_mismatch_static(self, in_memory_store_factory, batch):
+        lib = in_memory_store_factory()
+        sym = "test_schema_mismatch_static"
+        df_0 = pd.DataFrame({"col_0": [0]})
+        lib.write(sym, df_0)
+        # Different column sets
+        df_1 = pd.DataFrame({"col_1": [0]})
+        with pytest.raises(Exception) as e_without_arg:
+            lib.batch_append([sym], [df_1]) if batch else lib.append(sym, df_1)
+        with pytest.raises(Exception) as e_with_arg:
+            lib.batch_append([sym], [df_1], compact_data=True) if batch else lib.append(sym, df_1, compact_data=True)
+        assert e_with_arg.type == e_without_arg.type
+        assert e_with_arg.typename == e_without_arg.typename
+        assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+        # Different column type
+        df_1 = pd.DataFrame({"col_0": ["hello"]})
+        with pytest.raises(Exception) as e_without_arg:
+            lib.batch_append([sym], [df_1]) if batch else lib.append(sym, df_1)
+        with pytest.raises(Exception) as e_with_arg:
+            lib.batch_append([sym], [df_1], compact_data=True) if batch else lib.append(sym, df_1, compact_data=True)
+        assert e_with_arg.type == e_without_arg.type
+        assert e_with_arg.typename == e_without_arg.typename
+        assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+
+    def test_schema_mismatch_dynamic(self, in_memory_store_factory, batch):
+        lib = in_memory_store_factory(dynamic_schema=True)
+        sym = "test_schema_mismatch_dynamic"
+        df_0 = pd.DataFrame({"col_0": [0]})
+        lib.write(sym, df_0)
+        df_1 = pd.DataFrame({"col_0": ["hello"]})
+        with pytest.raises(Exception) as e_without_arg:
+            lib.batch_append([sym], [df_1]) if batch else lib.append(sym, df_1)
+        with pytest.raises(Exception) as e_with_arg:
+            lib.batch_append([sym], [df_1], compact_data=True) if batch else lib.append(sym, df_1, compact_data=True)
+        assert e_with_arg.type == e_without_arg.type
+        assert e_with_arg.typename == e_without_arg.typename
+        assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
 
 
-@pytest.mark.parametrize("dynamic_strings_first", [True, False])
-def test_blns(in_memory_store_factory, clear_query_stats, dynamic_strings_first):
+def test_batch_basic(in_memory_store_factory):
     lib = in_memory_store_factory()
-    sym = "test_blns"
+    num_symbols = 3
+    syms = [f"test_batch_duplicated_symbol_{i}" for i in range(num_symbols)]
+    write_dfs = [pd.DataFrame({"col": [i]}, index=[pd.Timestamp(0)]) for i in range(num_symbols)]
+    lib.batch_write(syms, write_dfs)
+    append_dfs = [pd.DataFrame({"col": [i + 10]}, index=[pd.Timestamp(1)]) for i in range(num_symbols)]
+    lib.batch_append(syms, append_dfs, compact_data=True)
+    expected_dfs = [pd.concat([write_dfs[i], append_dfs[i]]) for i in range(num_symbols)]
+    for sym, expected_df in zip(syms, expected_dfs):
+        received_df = lib.read(sym).data
+        assert_frame_equal(expected_df, received_df)
+        assert len(lib.read_index(sym)) == 1
+
+
+def test_batch_upsert_all(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    num_symbols = 3
+    syms = [f"test_batch_upsert_all_{i}" for i in range(num_symbols)]
+    append_dfs = [pd.DataFrame({"col": [i + 10]}, index=[pd.Timestamp(1)]) for i in range(num_symbols)]
+    lib.batch_append(syms, append_dfs, compact_data=True)
+    for sym, append_df in zip(syms, append_dfs):
+        received_df = lib.read(sym).data
+        assert_frame_equal(append_df, received_df)
+        assert len(lib.read_index(sym)) == 1
+
+
+def test_batch_upsert_some(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    num_symbols = 4
+    syms = [f"test_batch_duplicated_symbol_{i}" for i in range(num_symbols)]
+    write_dfs = [pd.DataFrame({"col": [i]}, index=[pd.Timestamp(0)]) for i in range(num_symbols // 2)]
+    lib.batch_write(syms[: num_symbols // 2], write_dfs)
+    append_dfs = [pd.DataFrame({"col": [i + 10]}, index=[pd.Timestamp(1)]) for i in range(num_symbols)]
+    lib.batch_append(syms, append_dfs, compact_data=True)
+    expected_dfs = [pd.concat([write_dfs[i], append_dfs[i]]) for i in range(num_symbols // 2)] + append_dfs[
+        num_symbols // 2 :
+    ]
+    for sym, expected_df in zip(syms, expected_dfs):
+        received_df = lib.read(sym).data
+        assert_frame_equal(expected_df, received_df)
+        assert len(lib.read_index(sym)) == 1
+
+
+# GIL must be taken for all symbols while compacting with these strings
+def test_batch_blns(in_memory_store_factory):
+    lib = in_memory_store_factory()
+    num_symbols = 10
+    num_chunks = 5
+    syms = [f"test_batch_blns_{i}" for i in range(num_symbols)]
     df = pd.DataFrame({"col": read_big_list_of_naughty_strings()})
-    lib.write(sym, df[: len(df) // 2], dynamic_strings=dynamic_strings_first)
-    generic_append_compact_data_test(lib, sym, df[len(df) // 2 :], dynamic_strings=not dynamic_strings_first)
-
-
-def test_append_empty_frame_compacts_existing_data(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_append_empty_frame_compacts_existing_data"
-    lib.write(sym, pd.DataFrame({"col": np.arange(5)}))
-    lib.append(sym, pd.DataFrame({"col": np.arange(5, 10)}))
-    # Schema checks happen after empty input frame checks, so we don't need the same column set
-    with qs.query_stats():
-        lib.append(sym, pd.DataFrame())
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    assert lib.read(sym).version == 2
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 0
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 0
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
-    with qs.query_stats():
-        lib.append(sym, pd.DataFrame(), compact_data=True)
-        stats = qs.get_query_stats()
-    qs.reset_stats()
-    assert lib.read(sym).version == 3
-    assert len(lib.read_index(sym)) == 1
-    assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 2
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
-    assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
-
-
-@pytest.mark.parametrize("rows_to_append", [5, 10, 15, 20])
-def test_fortran_ordered_data(in_memory_store_factory, clear_query_stats, rows_to_append):
-    lib = in_memory_store_factory(segment_row_size=10)
-    sym = "test_fortran_ordered_data"
-    cols = ["col_0", "col_1"]
-    df_0 = pd.DataFrame(np.random.randint(0, 100, size=(5, 2)), columns=cols)
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame(np.random.randint(0, 100, size=(rows_to_append, 2)), columns=cols)
-    generic_append_compact_data_test(lib, sym, df_1)
-
-
-@pytest.mark.parametrize("index", [None, "ts"])
-def test_column_filtered_read(in_memory_store_factory, clear_query_stats, index):
-    lib = in_memory_store_factory(column_group_size=2, segment_row_size=10)
-    sym = "test_column_filtered_read"
-    num_rows = 20
-    df = pd.DataFrame(
-        {
-            "col_a": np.arange(num_rows),
-            "col_b": np.arange(num_rows, 2 * num_rows),
-            "col_c": np.arange(2 * num_rows, 3 * num_rows),
-        },
-        index=None if index is None else pd.date_range("2026-01-01", periods=num_rows),
-    )
-    lib.write(sym, df[:5])
-    for i in range(1, 4):
-        generic_append_compact_data_test(lib, sym, df[i * 5 : (i + 1) * 5])
-    expected_col_a = df[["col_a"]]
-    expected_col_bc = df[["col_b", "col_c"]]
-    assert_frame_equal(expected_col_a, lib.read(sym, columns=["col_a"]).data)
-    assert_frame_equal(expected_col_bc, lib.read(sym, columns=["col_b", "col_c"]).data)
-
-
-@pytest.mark.parametrize("rows_per_segment", [3, 7, 10])
-def test_date_range_read(in_memory_store_factory, clear_query_stats, rows_per_segment):
-    lib = in_memory_store_factory(segment_row_size=rows_per_segment, dynamic_strings=True)
-    sym = "test_date_range_read"
-    num_rows = 100
-    index = pd.date_range("2026-01-01", periods=num_rows)
-    df = pd.DataFrame(
-        {"ints": np.arange(num_rows), "strings": 20 * ["hello", None, "gutentag", np.nan, "konichiwa"]}, index=index
-    )
-    lib.write(sym, df[:5])
-    for i in range(1, 20):
-        generic_append_compact_data_test(lib, sym, df[i * 5 : (i + 1) * 5])
-    mid = index[num_rows // 2]
-    expected_first_half = df[:mid]
-    expected_second_half = df[mid:]
-    assert_frame_equal(expected_first_half, lib.read(sym, date_range=(index[0], mid)).data)
-    assert_frame_equal(expected_second_half, lib.read(sym, date_range=(mid, index[-1])).data)
-
-
-def test_read_previous_version(in_memory_store_factory, clear_query_stats):
-    lib = in_memory_store_factory()
-    sym = "test_read_previous_version"
-    df = pd.DataFrame({"col": np.arange(10)})
-    lib.write(sym, df[:5])
-    generic_append_compact_data_test(lib, sym, df[5:])
-    assert_frame_equal(df[:5], lib.read(sym, as_of=0).data)
-    assert_frame_equal(df, lib.read(sym, as_of=1).data)
-    assert_frame_equal(df, lib.read(sym).data)
-
-
-def test_schema_mismatch_static(in_memory_store_factory):
-    lib = in_memory_store_factory()
-    sym = "test_schema_mismatch_static"
-    df_0 = pd.DataFrame({"col_0": [0]})
-    lib.write(sym, df_0)
-    # Different column sets
-    df_1 = pd.DataFrame({"col_1": [0]})
-    with pytest.raises(Exception) as e_without_arg:
-        lib.append(sym, df_1)
-    with pytest.raises(Exception) as e_with_arg:
-        lib.append(sym, df_1, compact_data=True)
-    assert e_with_arg.type == e_without_arg.type
-    assert e_with_arg.typename == e_without_arg.typename
-    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
-    # Different column type
-    df_1 = pd.DataFrame({"col_0": ["hello"]})
-    with pytest.raises(Exception) as e_without_arg:
-        lib.append(sym, df_1)
-    with pytest.raises(Exception) as e_with_arg:
-        lib.append(sym, df_1, compact_data=True)
-    assert e_with_arg.type == e_without_arg.type
-    assert e_with_arg.typename == e_without_arg.typename
-    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
-
-
-def test_schema_mismatch_dynamic(in_memory_store_factory):
-    lib = in_memory_store_factory(dynamic_schema=True)
-    sym = "test_schema_mismatch_dynamic"
-    df_0 = pd.DataFrame({"col_0": [0]})
-    lib.write(sym, df_0)
-    df_1 = pd.DataFrame({"col_0": ["hello"]})
-    with pytest.raises(Exception) as e_without_arg:
-        lib.append(sym, df_1)
-    with pytest.raises(Exception) as e_with_arg:
-        lib.append(sym, df_1, compact_data=True)
-    assert e_with_arg.type == e_without_arg.type
-    assert e_with_arg.typename == e_without_arg.typename
-    assert e_with_arg.value.args[0] == e_without_arg.value.args[0]
+    rows_per_chunk = len(df) // num_chunks
+    lib.batch_write(syms, [df[:rows_per_chunk] for _ in range(num_symbols)])
+    for chunk in range(1, num_chunks):
+        lib.batch_append(
+            syms,
+            [df[chunk * rows_per_chunk : (chunk + 1) * rows_per_chunk] for _ in range(num_symbols)],
+            compact_data=True,
+        )
+    for sym in syms:
+        received_df = lib.read(sym).data
+        assert_frame_equal(df, received_df)
+        assert len(lib.read_index(sym)) == 1
 
 
 # We are more interested in the slicing than the data, so the parameters are for:


### PR DESCRIPTION
#### Reference Issues/PRs
[12036601732](https://man312219.monday.com/boards/7852509418/pulses/12036601732)

#### What does this implement or fix?
Adds the `compact_data` argument to `append_batch/batch_append` methods.