### PR TITLE
Fix flaky query_stats test by always resetting

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1911,6 +1911,9 @@ def old_venv_and_arctic_uri(old_venv, arctic_uri):
 
 @pytest.fixture
 def clear_query_stats():
+    # Reset before the test as well as after to make sure we start and end in a clean state
+    query_stats.disable()
+    query_stats.reset_stats()
     yield
     query_stats.disable()
     query_stats.reset_stats()

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -543,7 +543,7 @@ def test_use_norm_failure_handler_known_types(lmdb_version_store_allows_pickling
     Library("dummy", nvs)
 
 
-def test_all_snapshots_not_loaded_for_tombstoned_as_of(in_memory_store_factory, tiny_thread_pool):
+def test_all_snapshots_not_loaded_for_tombstoned_as_of(in_memory_store_factory, tiny_thread_pool, clear_query_stats):
     # Prior to https://github.com/man-group/ArcticDB/pull/2699 if a version was requested as_of a version number that
     # had been tombstoned, we would load all of the snapshots into memory, and then search for the specified index key.
     # The new implementation:

--- a/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
@@ -104,7 +104,7 @@ class TestStressTimeseriesMergeUpdate:
         assert_frame_equal(result, expected)
 
     @pytest.mark.parametrize("on_segments", [[], [1, 4, 5, 6, 9], [5, 6], [1, 9], [4, 5, 9]])
-    def test_merge_update_on(self, s3_version_store_v1, on_segments):
+    def test_merge_update_on(self, s3_version_store_v1, on_segments, clear_query_stats):
         segments_to_update = [1, 4, 5, 6, 9]
         on = ["col_1", "col_130"]
         qs.reset_stats()

--- a/python/tests/unit/arcticdb/test_append_and_defrag.py
+++ b/python/tests/unit/arcticdb/test_append_and_defrag.py
@@ -276,7 +276,7 @@ def assert_data_key_ios(stats, expected_reads, expected_writes):
     assert query_stats_operation_count(stats, "S3_PutObject", "TABLE_DATA") == expected_writes
 
 
-def test_io_count_basic(s3_library_factory):
+def test_io_count_basic(s3_library_factory, clear_query_stats):
     lib = s3_library_factory(LibraryOptions(rows_per_segment=64))
     sym_0 = "test_io_count_basic_0"
     sym_1 = "test_io_count_basic_1"
@@ -339,7 +339,7 @@ def test_io_count_basic(s3_library_factory):
     assert_data_key_ios(stats, 4, 2)
 
 
-def test_io_count_many_iterations(s3_library_factory):
+def test_io_count_many_iterations(s3_library_factory, clear_query_stats):
     lib = s3_library_factory(LibraryOptions(rows_per_segment=64))
     sym = "test_io_count_many_iterations"
     rows_per_df = 4

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -165,7 +165,7 @@ def test_column_stats_query_optimisation_column_not_in_stats(
 
 
 def test_column_stats_query_optimisation_empty_segment(
-    in_memory_version_store_tiny_segment, column_stats_filtering_enabled
+    in_memory_version_store_tiny_segment, column_stats_filtering_enabled, clear_query_stats
 ):
     lib = in_memory_version_store_tiny_segment
 

--- a/python/tests/unit/arcticdb/version_store/test_collect_schema.py
+++ b/python/tests/unit/arcticdb/version_store/test_collect_schema.py
@@ -261,7 +261,7 @@ def test_collect_schema_with_query(lmdb_library):
 
 
 @pytest.mark.parametrize("create_column_stats", [True, False])
-def test_collect_schema_and_collect_multiple_times(mem_library, create_column_stats):
+def test_collect_schema_and_collect_multiple_times(mem_library, create_column_stats, clear_query_stats):
     with (
         config_context("VersionMap.ReloadInterval", 0),
         config_context("ColumnStats.UseForQueries", int(create_column_stats)),
@@ -365,7 +365,7 @@ def test_collect_schema_and_collect_multiple_times(mem_library, create_column_st
         assert_frame_equal_with_arrow(expected, received_df)
 
 
-def test_collect_schema_and_collect_version_deleted(mem_library):
+def test_collect_schema_and_collect_version_deleted(mem_library, clear_query_stats):
     with config_context("VersionMap.ReloadInterval", 0):
         lib = mem_library
         lib._nvs.set_output_format(OutputFormat.POLARS)

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -94,7 +94,9 @@ class TestLazyDataFrame:
         assert_frame_equal(expected, received)
 
     @pytest.mark.parametrize("create_column_stats", [True, False])
-    def test_lazy_filter_column_stats(self, mem_library, any_output_format, collect_schema_first, create_column_stats):
+    def test_lazy_filter_column_stats(
+        self, mem_library, any_output_format, collect_schema_first, create_column_stats, clear_query_stats
+    ):
         lib = mem_library
         lib._nvs._set_output_format_for_pipeline_tests(any_output_format)
         sym = "test_lazy_filter_column_stats"

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -1336,7 +1336,7 @@ def test_query_builder_vwap(lmdb_version_store_v1, any_output_format):
 
 
 @pytest.mark.parametrize("dynamic_schema", [True, False])
-def test_column_select_projected_column(in_memory_store_factory, dynamic_schema, any_output_format):
+def test_column_select_projected_column(in_memory_store_factory, dynamic_schema, any_output_format, clear_query_stats):
     lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "sym_0"
@@ -1353,7 +1353,9 @@ def test_column_select_projected_column(in_memory_store_factory, dynamic_schema,
 
 
 @pytest.mark.parametrize("dynamic_schema", [True, False])
-def test_column_select_projected_column_and_filter_it(in_memory_store_factory, dynamic_schema, any_output_format):
+def test_column_select_projected_column_and_filter_it(
+    in_memory_store_factory, dynamic_schema, any_output_format, clear_query_stats
+):
     lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "sym_0"
@@ -1373,7 +1375,7 @@ def test_column_select_projected_column_and_filter_it(in_memory_store_factory, d
 @pytest.mark.parametrize("dynamic_schema", [True, False])
 @pytest.mark.parametrize("column_to_read", ["b", "c"])
 def test_filter_synthetic_column_and_select_on_disk_column(
-    in_memory_store_factory, dynamic_schema, column_to_read, any_output_format
+    in_memory_store_factory, dynamic_schema, column_to_read, any_output_format, clear_query_stats
 ):
     lib = in_memory_store_factory(dynamic_schema=dynamic_schema, column_group_size=2)
     lib._set_output_format_for_pipeline_tests(any_output_format)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes issue #3267

#### What does this implement or fix?
1. Uses the clear_query_stats fixture on every query stats test
2. Makes the clear_query_stats fixture clean the query_stats before the test as well

This helps avoid flaky tests like:
```
def test_1():
    # Uses query stats but does not call reset()

def test_2(..., clear_query_stats):
    # Uses query stats, but some are still lingering from test_1
```

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
