### PR TITLE
Fix flaky-test tracker opening a duplicate issue every run

### DIFF
--- a/.github/scripts/tests/test_track_ci_issues.py
+++ b/.github/scripts/tests/test_track_ci_issues.py
@@ -316,3 +316,14 @@ class TestSanitiseSearchQuery:
         result = _sanitise_search_query(title)
         for word in ["tests", "stress", "arcticdb", "test_foo", "test_bar"]:
             assert word in result
+
+    def test_keeps_filename_dot_intact(self):
+        """The '.' in a filename must not be stripped. GitHub indexes
+        ``test_foo.py`` as one term; splitting it into a bare ``test_foo``
+        term makes the ANDed search match nothing, so a duplicate issue is
+        opened every run."""
+        result = _sanitise_search_query(
+            "Flaky test: tests/integration/foo/test_num_storage_operations.py::test_read_as_of_version"
+        )
+        assert "test_num_storage_operations.py" in result
+        assert "test_read_as_of_version" in result

--- a/.github/scripts/track_ci_issues.py
+++ b/.github/scripts/track_ci_issues.py
@@ -36,12 +36,17 @@ def read_lines(path: str) -> list[str]:
 def _sanitise_search_query(title: str) -> str:
     """Strip characters that GitHub Search treats as special syntax.
 
-    GitHub's issue search interprets [ ] : / . \\ as operators or escape
+    GitHub's issue search interprets [ ] : / \\ as operators or escape
     characters, which causes queries for test paths (especially Windows
     backslash paths) to return zero results. We strip these from the search
     query and rely on the exact title match below to filter accurately.
+
+    The dot is kept: GitHub indexes a filename token like ``test_foo.py`` as
+    a single term, so splitting it at the dot leaves a bare ``test_foo`` term
+    that matches nothing. Because search ANDs the terms, that dead term drops
+    the whole query to zero results and a duplicate issue is opened each run.
     """
-    return re.sub(r'[\[\]:/.\\"]', " ", title)
+    return re.sub(r'[\[\]:/\\"]', " ", title)
 
 
 def find_existing_issue(repo: str, label: str, title: str) -> int | None:


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
`find_existing_issue` searches with `gh issue list --search`, but `_sanitise_search_query` replaced `'.'` with a space, turning the filename token `test_foo.py` into a bare `test_foo` term. GitHub indexes the filename as a single token, so that bare term matches nothing; because search ANDs terms, the whole query returned zero results, the existing issue was never found, and a new duplicate was opened on every master run.

Keep the dot so the filename token stays intact.

#### Any other comments?

Duplicates before this PR that were fixed:

 | Test | Duplicate issues | Kept |
  |------|------------------|------|
  | `test_num_storage_operations.py::test_read_as_of_version` | [#3267](https://github.com/man-group/ArcticDB/issues/3267) [#3271](https://github.com/man-group/ArcticDB/issues/3271), [#3273](https://github.com/man-group/ArcticDB/issues/3273) | #3267 |
  | `test_arctic_batch.py::test_read_batch_missing_keys` | [#3268](https://github.com/man-group/ArcticDB/issues/3268), [#3275](https://github.com/man-group/ArcticDB/issues/3275) | #3268 |
  | `test_arrow_sparse.py::TestSparseArrowResample::test_single_agg` | [#3161](https://github.com/man-group/ArcticDB/issues/3161), [#3260](https://github.com/man-group/ArcticDB/issues/3260) | #3161 |
  | `test_snapshot.py::test_add_to_snapshot_rejects_multiple_deleted_versions` | [#3166](https://github.com/man-group/ArcticDB/issues/3166),  [#3198](https://github.com/man-group/ArcticDB/issues/3198) | #3166 |
  | `test_resample.py::TestResampleDynamicSchema` |  [#3171](https://github.com/man-group/ArcticDB/issues/3171),  [#3175](https://github.com/man-group/ArcticDB/issues/3175) | #3171 |

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
