### PR TITLE
Add ASV benchmarks for merge updates

### DIFF
--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -38,6 +38,9 @@ jobs:
       ARCTICDB_REAL_S3_REGION: eu-west-1
       ARCTICDB_REAL_S3_ENDPOINT: s3.eu-west-1.amazonaws.com
       ASV_RESULTS_BUCKET: arcticdb-ci-benchmark-results
+      # Some benchmarks use SeaweedFS because it supports parallel writes.
+      SEAWEED_DATA_DIR: ${{ runner.temp }}/seaweedfs-asv # Set the directory where local seaweed data resides
+      SEAWEED_BIN_DIR: ${{ github.workspace }}/.seaweed-bin # Set the directory where the seaweed binary is installed
       VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
       VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
       VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
@@ -107,6 +110,11 @@ jobs:
           # pytz and pandas<3 can go once latest ArcticDB release has these dependencies
           ./tooling_venv/bin/pip install "ArcticDB[Testing]" "pytz" "pandas<3"
 
+      # Use a global seaweed to avoid to cost of starting and stopping the server for each benchmark.
+      - name: Start SeaweedFS
+        shell: bash -el {0}
+        run: build_tooling/start_seaweed.sh start
+
       - name: Configure what suite or tests to execute
         shell: bash -el {0}
         run: | 
@@ -164,6 +172,13 @@ jobs:
 
           ./tooling_venv/bin/python build_tooling/summarize_asv_run.py --commit-hash $(git rev-parse HEAD)
           exit $any_worse
+
+      - name: Stop SeaweedFS
+        if: always()
+        shell: bash -el {0}
+        run: |
+          tail -20 "$SEAWEED_DATA_DIR/weed.log" || true
+          build_tooling/start_seaweed.sh stop
 
       - name: Clean up the test bucket
         if: always()

--- a/build_tooling/start_seaweed.sh
+++ b/build_tooling/start_seaweed.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Start (or stop) the single local SeaweedFS server used by the ASV benchmarks.
+#
+# One server hosts every benchmark in the ASV run; benchmark processes reach it on
+# localhost (see python/benchmarks/seaweed_utils.py for the client-side helpers).
+#
+# Automatic vacuuming is disabled (-master.garbageThreshold=1.1 can never be reached),
+# so space is reclaimed only by the benchmarks themselves, by dropping a bucket's
+# backing collection.
+#
+# Volumes are capped at 2GB and never preallocated, so a high -volume.max only reserves
+# slots, not disk. The slots matter because every bucket is grown to at least as many
+# volumes as ArcticDB has IO threads.
+
+set -euo pipefail
+
+SEAWEED_VERSION="${SEAWEED_VERSION:-4.40}"
+SEAWEED_DATA_DIR="${SEAWEED_DATA_DIR:-${RUNNER_TEMP:-/tmp}/seaweedfs-asv}"
+SEAWEED_BIN_DIR="${SEAWEED_BIN_DIR:-/usr/local/bin}"
+SEAWEED_IP="${SEAWEED_IP:-127.0.0.1}"
+SEAWEED_MASTER_PORT="${SEAWEED_MASTER_PORT:-9333}"
+SEAWEED_VOLUME_PORT="${SEAWEED_VOLUME_PORT:-8080}"
+SEAWEED_FILER_PORT="${SEAWEED_FILER_PORT:-8888}"
+SEAWEED_S3_PORT="${SEAWEED_S3_PORT:-8333}"
+SEAWEED_VOLUME_SIZE_LIMIT_MB="${SEAWEED_VOLUME_SIZE_LIMIT_MB:-2048}"
+SEAWEED_MAX_VOLUMES="${SEAWEED_MAX_VOLUMES:-1000}"
+
+PID_FILE="$SEAWEED_DATA_DIR/weed.pid"
+LOG_FILE="$SEAWEED_DATA_DIR/weed.log"
+
+download() {
+    if [[ -x "$SEAWEED_BIN_DIR/weed" ]]; then
+        return
+    fi
+    echo "Installing SeaweedFS $SEAWEED_VERSION"
+    mkdir -p "$SEAWEED_BIN_DIR"
+    local installer="$SEAWEED_BIN_DIR/install.sh"
+    curl -fsSL --retry 3 -o "$installer" https://raw.githubusercontent.com/seaweedfs/seaweedfs/master/install.sh
+    bash "$installer" --version "$SEAWEED_VERSION" --dir "$SEAWEED_BIN_DIR"
+    rm -f "$installer"
+}
+
+start() {
+    # A foreign server answering here would also answer the readiness probe below, making this
+    # script report success while its own process dies on the port bind
+    if curl -fsS "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" >/dev/null 2>&1; then
+        echo "Something is already answering on http://$SEAWEED_IP:$SEAWEED_MASTER_PORT;" \
+            "refusing to start a second SeaweedFS. Stop it first (or override SEAWEED_*_PORT)." >&2
+        exit 1
+    fi
+    download
+    mkdir -p "$SEAWEED_DATA_DIR"
+    nohup "$SEAWEED_BIN_DIR/weed" server \
+        -dir="$SEAWEED_DATA_DIR" \
+        -ip="$SEAWEED_IP" \
+        -ip.bind="$SEAWEED_IP" \
+        -master.port="$SEAWEED_MASTER_PORT" \
+        -master.volumeSizeLimitMB="$SEAWEED_VOLUME_SIZE_LIMIT_MB" \
+        -master.volumePreallocate=false \
+        -master.garbageThreshold=1.1 \
+        -volume.port="$SEAWEED_VOLUME_PORT" \
+        -volume.max="$SEAWEED_MAX_VOLUMES" \
+        -filer \
+        -filer.port="$SEAWEED_FILER_PORT" \
+        -s3 \
+        -s3.port="$SEAWEED_S3_PORT" \
+        -s3.port.iceberg=0 \
+        >"$LOG_FILE" 2>&1 &
+    echo $! >"$PID_FILE"
+
+    # Ready when the master is up, a volume server has registered and the S3 gateway answers
+    for _ in $(seq 1 120); do
+        if ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+            rm -f "$PID_FILE"
+            echo "SeaweedFS process died on startup, last log lines:" >&2
+            tail -50 "$LOG_FILE" >&2
+            exit 1
+        fi
+        if curl -fsS "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" 2>/dev/null | grep -q '"DataNodes"' &&
+            curl -fsS "http://$SEAWEED_IP:$SEAWEED_S3_PORT" >/dev/null 2>&1; then
+                    echo "SeaweedFS $SEAWEED_VERSION is up. IP: $SEAWEED_IP, PID: $(cat $PID_FILE) master port :$SEAWEED_MASTER_PORT, filer port :$SEAWEED_FILER_PORT," \
+                "s3 port :$SEAWEED_S3_PORT, data in $SEAWEED_DATA_DIR"
+            return
+        fi
+        sleep 1
+    done
+    echo "SeaweedFS failed to start, last log lines:" >&2
+    tail -50 "$LOG_FILE" >&2
+    exit 1
+}
+
+stop() {
+    if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+        kill "$(cat "$PID_FILE")"
+        for _ in $(seq 1 30); do
+            kill -0 "$(cat "$PID_FILE")" 2>/dev/null || break
+            sleep 1
+        done
+        kill -9 "$(cat "$PID_FILE")" 2>/dev/null || true
+    fi
+    rm -f "$PID_FILE"
+    echo "SeaweedFS stopped (data left in $SEAWEED_DATA_DIR)"
+}
+
+case "${1:-start}" in
+    start) start ;;
+    stop) stop ;;
+    *)
+        echo "Usage: $0 [start|stop]" >&2
+        exit 1
+        ;;
+esac

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -67,6 +67,7 @@ dependencies:
   - pytz
   - attrs
   - boto3
+  - aioboto3 >=13
   - werkzeug
   - moto
   - mock

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2141,7 +2141,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "compact_data:431",
+        "setup_cache_key": "compact_data:430",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "ef9a24a988741ffb5729c46d7e75bc83ebb7cd3757890eea3160303f1f1053a8"
@@ -2173,7 +2173,7 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:431",
+        "setup_cache_key": "compact_data:430",
         "type": "time",
         "unit": "seconds",
         "version": "e8851c6ceb9da5f5c4ae5526de0225ead5f6f2d221165ea2772afeb4112a7220",
@@ -2202,7 +2202,7 @@
                 "1000000"
             ]
         ],
-        "setup_cache_key": "compact_data:333",
+        "setup_cache_key": "compact_data:332",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "85ec2af75fa362379363f90d807083ca4f66a1043a89122b6152e5c109e8535c"
@@ -2235,7 +2235,7 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:333",
+        "setup_cache_key": "compact_data:332",
         "type": "time",
         "unit": "seconds",
         "version": "98b2898dbb3b3750ffc35b30d035311796631e6d863708fb5c505b4dc59a6a1b",
@@ -2264,7 +2264,7 @@
                 "1000000"
             ]
         ],
-        "setup_cache_key": "compact_data:382",
+        "setup_cache_key": "compact_data:381",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "01966458fac955b928515db294e7f868a08bff9312199ee1b5b3a32cf5128259"
@@ -2297,14 +2297,14 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:382",
+        "setup_cache_key": "compact_data:381",
         "type": "time",
         "unit": "seconds",
         "version": "a049f0099f95d04ec69d08ebabcd44d596eff4fe34034ad6d9da0b3fbd1e2f94",
         "warmup_time": 0
     },
     "compact_data.CompactDataNumericDynamicSchema.peakmem_compact_data": {
-        "code": "class CompactDataNumericDynamicSchema:\n    def peakmem_compact_data(self, row_params, num_columns):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns):\n        self._setup(self.lib_name(row_params, num_columns), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class CompactDataNumericDynamicSchema:\n    def peakmem_compact_data(self, row_params, num_columns):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns):\n        self._setup(lib_name(row_params, num_columns), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "compact_data.CompactDataNumericDynamicSchema.peakmem_compact_data",
         "param_names": [
             "(num_rows, initial_rows_per_segment, target_rows_per_segment)",
@@ -2320,13 +2320,13 @@
                 "10000"
             ]
         ],
-        "setup_cache_key": "compact_data:220",
+        "setup_cache_key": "compact_data:219",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "310049835bc1f2bbaa094caa69c3d1a21e1858b58ef43a2e878480bf72785195"
+        "version": "c15da0bab109a8a3ef408294394b0b4492de87510ce03ef817a72ddba0572700"
     },
     "compact_data.CompactDataNumericDynamicSchema.time_compact_data": {
-        "code": "class CompactDataNumericDynamicSchema:\n    def time_compact_data(self, row_params, num_columns):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns):\n        self._setup(self.lib_name(row_params, num_columns), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class CompactDataNumericDynamicSchema:\n    def time_compact_data(self, row_params, num_columns):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns):\n        self._setup(lib_name(row_params, num_columns), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "compact_data.CompactDataNumericDynamicSchema.time_compact_data",
         "number": 1,
@@ -2347,14 +2347,14 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:220",
+        "setup_cache_key": "compact_data:219",
         "type": "time",
         "unit": "seconds",
-        "version": "2d0282bafa3f8ae8121eb1529f89761519c7b9509a7a8a5b341a807aedc2197d",
+        "version": "1a7929bda8b3b10dd3e652f070e4ccc125a28aae4caf0e7ebe539f86bc24f897",
         "warmup_time": 0
     },
     "compact_data.CompactDataNumericStaticSchema.peakmem_compact_data": {
-        "code": "class CompactDataNumericStaticSchema:\n    def peakmem_compact_data(self, row_params, num_columns, column_slicing):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing):\n        self._setup(self.lib_name(row_params, num_columns, column_slicing), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class CompactDataNumericStaticSchema:\n    def peakmem_compact_data(self, row_params, num_columns, column_slicing):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing):\n        self._setup(lib_name(row_params, num_columns, column_slicing), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "compact_data.CompactDataNumericStaticSchema.peakmem_compact_data",
         "param_names": [
             "(num_rows, initial_rows_per_segment, target_rows_per_segment)",
@@ -2376,13 +2376,13 @@
                 "True"
             ]
         ],
-        "setup_cache_key": "compact_data:110",
+        "setup_cache_key": "compact_data:109",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "7ddde650100a4d862d7f8695176b37976f15d863d33961be34678a636d14286f"
+        "version": "37d8aadd1f1639c8702ca70ab8299d2d64e6b9e634862531b424ebde718e1275"
     },
     "compact_data.CompactDataNumericStaticSchema.time_compact_data": {
-        "code": "class CompactDataNumericStaticSchema:\n    def time_compact_data(self, row_params, num_columns, column_slicing):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing):\n        self._setup(self.lib_name(row_params, num_columns, column_slicing), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class CompactDataNumericStaticSchema:\n    def time_compact_data(self, row_params, num_columns, column_slicing):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing):\n        self._setup(lib_name(row_params, num_columns, column_slicing), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "compact_data.CompactDataNumericStaticSchema.time_compact_data",
         "number": 1,
@@ -2409,14 +2409,14 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:110",
+        "setup_cache_key": "compact_data:109",
         "type": "time",
         "unit": "seconds",
-        "version": "22560f846d485befae82958fd482315fb72e650d867e9ffc509eace6a2b93f03",
+        "version": "1adb81796aa15ebb66f2b9cfa6d803ffb9687ea074115073d9e0ff49fd342d73",
         "warmup_time": 0
     },
     "compact_data.CompactDataStringsStaticSchema.peakmem_compact_data": {
-        "code": "class CompactDataStringsStaticSchema:\n    def peakmem_compact_data(self, row_params, num_columns, column_slicing, num_unique_strings):\n        target_rows_per_segment = row_params[2]\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing, num_unique_strings):\n        self._setup(self.lib_name(row_params, num_columns, column_slicing, num_unique_strings), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class CompactDataStringsStaticSchema:\n    def peakmem_compact_data(self, row_params, num_columns, column_slicing, num_unique_strings):\n        target_rows_per_segment = row_params[2]\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing, num_unique_strings):\n        self._setup(lib_name(row_params, num_columns, column_slicing, num_unique_strings), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "compact_data.CompactDataStringsStaticSchema.peakmem_compact_data",
         "param_names": [
             "(num_rows, initial_rows_per_segment, target_rows_per_segment)",
@@ -2443,13 +2443,13 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "compact_data:166",
+        "setup_cache_key": "compact_data:165",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "a99039af2df70f85781dd519ac84c641eef72187661d78c10a7db379f500b5c7"
+        "version": "c0318b30706b143ac685ec9a5c549702a5d82b8f0bbe7e4587e0ceb96620e91d"
     },
     "compact_data.CompactDataStringsStaticSchema.time_compact_data": {
-        "code": "class CompactDataStringsStaticSchema:\n    def time_compact_data(self, row_params, num_columns, column_slicing, num_unique_strings):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing, num_unique_strings):\n        self._setup(self.lib_name(row_params, num_columns, column_slicing, num_unique_strings), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class CompactDataStringsStaticSchema:\n    def time_compact_data(self, row_params, num_columns, column_slicing, num_unique_strings):\n        self.compact_data(row_params[2])\n\n    def setup(self, row_params, num_columns, column_slicing, num_unique_strings):\n        self._setup(lib_name(row_params, num_columns, column_slicing, num_unique_strings), row_params[2])\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "compact_data.CompactDataStringsStaticSchema.time_compact_data",
         "number": 1,
@@ -2481,10 +2481,10 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:166",
+        "setup_cache_key": "compact_data:165",
         "type": "time",
         "unit": "seconds",
-        "version": "dd92a93207202dec280ad9849eeb15da6c3ebc0bea0dc490759473feb42ee3a5",
+        "version": "dd1b297e52b126a9abb2023c06bfd999045e847f37e7ab00a34e7e842b39a305",
         "warmup_time": 0
     },
     "finalize_staged_data.FinalizeStagedData.peakmem_finalize_staged_data": {
@@ -2813,6 +2813,454 @@
         "unit": "seconds",
         "version": "2238d0faf29b5206ab9dd61d1acea68ae7883b8ac95bc8c0fafaefb85ff1527b",
         "warmup_time": 0.1
+    },
+    "merge_functions.MergeThinDatetime.peakmem_merge": {
+        "code": "class MergeThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "name": "merge_functions.MergeThinDatetime.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices"
+        ],
+        "params": [
+            [
+                "(5000000, 3)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "0"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "10",
+                "40"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:264",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "cbfab97f86b2e4dcf663168cbc55298e56ae941d902c8cb6a3fd79ba3814f707"
+    },
+    "merge_functions.MergeThinDatetime.time_merge": {
+        "code": "class MergeThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeThinDatetime.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices"
+        ],
+        "params": [
+            [
+                "(5000000, 3)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "0"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "10",
+                "40"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:264",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "a34ddbececbef9f6234500dd1f6efb2ed19e12e0620f1b29f93a7f0066501523",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeThinRowRange.peakmem_merge": {
+        "code": "class MergeThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "name": "merge_functions.MergeThinRowRange.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(5000000, 3)"
+            ],
+            [
+                "'update'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:304",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "83ce0f1d857f8367a41b0eda0ae44c9b09680e06d7402639b4e2715e9f3fcaec"
+    },
+    "merge_functions.MergeThinRowRange.time_merge": {
+        "code": "class MergeThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeThinRowRange.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(5000000, 3)"
+            ],
+            [
+                "'update'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:304",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "32cb2f20ab4c79563a5aea377ad6caabb8fd7230fd759389d42d242bd13a5bad",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeThinStringDatetime.peakmem_merge": {
+        "code": "class MergeThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "name": "merge_functions.MergeThinStringDatetime.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(1000000, 3)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "2",
+                "8"
+            ],
+            [
+                "100",
+                "100000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:345",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "9a4715db7915ea7b2b73942e7a0a2cd83c063e074c67547ec1ed44288513c101"
+    },
+    "merge_functions.MergeThinStringDatetime.time_merge": {
+        "code": "class MergeThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeThinStringDatetime.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(1000000, 3)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "2",
+                "8"
+            ],
+            [
+                "100",
+                "100000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:345",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "7aa19f2e81803ed621ab348a8958540af05e64898025e41dc25844a5919a2ecf",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeThinStringRowRange.peakmem_merge": {
+        "code": "class MergeThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "name": "merge_functions.MergeThinStringRowRange.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(1000000, 3)"
+            ],
+            [
+                "'update'"
+            ],
+            [
+                "2"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "5000",
+                "100000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:401",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "ad7361d4bf2af736b0a1463d93711c64694b195cf605818d11da012a3ac03699"
+    },
+    "merge_functions.MergeThinStringRowRange.time_merge": {
+        "code": "class MergeThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeThinStringRowRange.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(1000000, 3)"
+            ],
+            [
+                "'update'"
+            ],
+            [
+                "2"
+            ],
+            [
+                "1000",
+                "500000"
+            ],
+            [
+                "5000",
+                "100000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:401",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "22ccdef99021933f2dc537f4d6ba6d6b71b4541cc80997b54aaf359d16a045ef",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeWideDatetime.peakmem_merge": {
+        "code": "class MergeWideDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "name": "merge_functions.MergeWideDatetime.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(5000, 10000)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "0",
+                "1000"
+            ],
+            [
+                "100"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:456",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "28ef558b79b92e01a385d0ecec377258a6201802c6eedcb369c0075a56f116d9"
+    },
+    "merge_functions.MergeWideDatetime.time_merge": {
+        "code": "class MergeWideDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeWideDatetime.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(5000, 10000)"
+            ],
+            [
+                "'update'",
+                "'insert'",
+                "'update_and_insert'"
+            ],
+            [
+                "0",
+                "1000"
+            ],
+            [
+                "100"
+            ]
+        ],
+        "repeat": 5,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:456",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "8d0da60fabfacd13ca11c1699891ed2cd5d1c600e01f01603881e627290d590b",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeWideRowRange.peakmem_merge": {
+        "code": "class MergeWideRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "name": "merge_functions.MergeWideRowRange.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(5000, 10000)"
+            ],
+            [
+                "'update'"
+            ],
+            [
+                "1",
+                "1000"
+            ],
+            [
+                "100"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:496",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "c4c62f623fa4e712d1f56e9441cca2abdd0b4ccc2ca88d3d80e6f46ef0c28b2f"
+    },
+    "merge_functions.MergeWideRowRange.time_merge": {
+        "code": "class MergeWideRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeWideRowRange.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(5000, 10000)"
+            ],
+            [
+                "'update'"
+            ],
+            [
+                "1",
+                "1000"
+            ],
+            [
+                "100"
+            ]
+        ],
+        "repeat": 5,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:496",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "717843d0191fbcd48ec7704510ce9f6683963afc0159987528abafd57c63479d",
+        "warmup_time": 0
     },
     "modification_functions.DeleteBatchSymbols.time_delete_batch_symbols": {
         "code": "class DeleteBatchSymbols:\n    def time_delete_batch_symbols(self, *args):\n        self.lib.delete_batch(self.syms)\n\n    def setup(self, num_symbols, storage):\n        if not is_storage_enabled(storage):\n            raise SkipNotImplemented\n    \n        if storage == Storage.LMDB:\n            self.ac = Arctic(f\"lmdb://{self.ARCTIC_DIR}\")\n        elif storage == Storage.AMAZON:\n            from arcticdb.storage_fixtures.s3 import real_s3_from_environment_variables\n    \n            factory = real_s3_from_environment_variables(shared_path=True, validate=True, log=True)\n            self.ac = factory.create_fixture().create_arctic()\n    \n        self.ac.delete_library(\"test_lib\")\n        self.lib = self.ac.create_library(\"test_lib\")\n    \n        df = pd.DataFrame({\"col\": range(1000)})\n        self.syms = [f\"sym_{i}\" for i in range(num_symbols)]\n        for sym in self.syms:\n            self.lib.write(sym, df)",

--- a/python/benchmarks/common.py
+++ b/python/benchmarks/common.py
@@ -81,3 +81,7 @@ def generate_benchmark_df(n, freq="min", end_timestamp="1/1/2023"):
 
 def get_prewritten_lib_name(rows):
     return f"prewritten_{rows}"
+
+
+def lib_name(*args):
+    return "_".join(f"{arg}" for arg in args)

--- a/python/benchmarks/compact_data.py
+++ b/python/benchmarks/compact_data.py
@@ -19,6 +19,8 @@ from arcticdb.options import ModifiableLibraryOption
 from arcticdb.util.logger import get_logger
 from arcticdb.util.test import random_strings_of_length
 
+from benchmarks.common import lib_name
+
 random.seed(42)
 rng = np.random.default_rng(42)
 
@@ -49,9 +51,6 @@ class CompactDataBase:
         self.LMDB_BASE_DIR = f"{self.LMDB_DIR}_base"
         self.CONNECTION_STRING_BASE = f"lmdb://{self.LMDB_BASE_DIR}"
         self.CONNECTION_STRING = f"lmdb://{self.LMDB_DIR}"
-
-    def lib_name(self, *args):
-        return "_".join(f"{arg}" for arg in args)
 
     def _setup_cache_base(self, ac, lib_name, rows_per_segment, columns_per_segment, dfs):
         ac.delete_library(lib_name)
@@ -125,14 +124,14 @@ class CompactDataNumericStaticSchema(CompactDataBase):
                     )
                     self._setup_cache_base(
                         ac,
-                        self.lib_name(row_params, num_columns, column_slicing),
+                        lib_name(row_params, num_columns, column_slicing),
                         initial_rows_per_segment,
                         num_columns // 2 if column_slicing else num_columns * 2,
                         [df],
                     )
 
     def setup(self, row_params, num_columns, column_slicing):
-        self._setup(self.lib_name(row_params, num_columns, column_slicing), row_params[2])
+        self._setup(lib_name(row_params, num_columns, column_slicing), row_params[2])
 
     def teardown(self, row_params, num_columns, column_slicing):
         self._teardown()
@@ -182,14 +181,14 @@ class CompactDataStringsStaticSchema(CompactDataBase):
                         df = pd.DataFrame({f"col_{i}": rng.choice(strings, num_rows) for i in range(num_columns)})
                         self._setup_cache_base(
                             ac,
-                            self.lib_name(row_params, num_columns, column_slicing, num_unique_strings),
+                            lib_name(row_params, num_columns, column_slicing, num_unique_strings),
                             initial_rows_per_segment,
                             num_columns // 2 if column_slicing else num_columns * 2,
                             [df],
                         )
 
     def setup(self, row_params, num_columns, column_slicing, num_unique_strings):
-        self._setup(self.lib_name(row_params, num_columns, column_slicing, num_unique_strings), row_params[2])
+        self._setup(lib_name(row_params, num_columns, column_slicing, num_unique_strings), row_params[2])
 
     def teardown(self, row_params, num_columns, column_slicing, num_unique_strings):
         self._teardown()
@@ -237,14 +236,14 @@ class CompactDataNumericDynamicSchema(CompactDataBase):
                     dfs.append(pd.DataFrame({column: np.arange(initial_rows_per_segment) for column in columns}))
                 self._setup_cache_base(
                     ac,
-                    self.lib_name(row_params, num_columns),
+                    lib_name(row_params, num_columns),
                     initial_rows_per_segment,
                     0,  # Column slicing doesn't apply to dynamic schema
                     dfs,
                 )
 
     def setup(self, row_params, num_columns):
-        self._setup(self.lib_name(row_params, num_columns), row_params[2])
+        self._setup(lib_name(row_params, num_columns), row_params[2])
 
     def teardown(self, row_params, num_columns):
         self._teardown()

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -1,0 +1,516 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import random
+
+import numpy as np
+import pandas as pd
+
+from arcticdb import Arctic
+from arcticdb.version_store.library import MergeStrategy
+from arcticdb.util.test import random_strings_of_length
+
+from benchmarks.common import lib_name
+from benchmarks.seaweed_utils import SeaweedClient
+
+CACHE_BUCKET = "arcticdb-merge-update-cache"
+WORK_BUCKET = "arcticdb-merge-work"
+ROWS_PER_SEGMENT = 100_000
+START_DATE = pd.Timestamp("1960-01-01")
+random.seed(0)  # random_strings_of_length draws string pools from stdlib random
+
+
+def generate_merge_target(num_rows, num_value_cols, value_dtype, index_kind, rng, num_unique_strings=None):
+    if pd.api.types.is_string_dtype(value_dtype):
+        assert num_unique_strings is not None
+        strings = random_strings_of_length(num_unique_strings, length=10, unique=True, kind="ascii")
+        df = pd.DataFrame({f"val_{j}": rng.choice(strings, num_rows) for j in range(num_value_cols)})
+    elif pd.api.types.is_float_dtype(value_dtype):
+        assert num_unique_strings is None
+        df = pd.DataFrame(
+            {f"val_{j}": np.linspace(0, 100_000, num_rows, dtype=value_dtype) for j in range(num_value_cols)}
+        )
+    else:
+        raise ValueError(f"Unsupported value_dtype: {value_dtype}")
+    if index_kind == "datetime":
+        df.index = pd.date_range(start=START_DATE, periods=num_rows, freq="s")
+    elif index_kind == "rowrange":
+        df.index = pd.RangeIndex(len(df))
+    return df
+
+
+def get_random_unique_rows(target, count, rng, unique_on=None):
+    """
+    Picks `count` amount of rows from `target`, drops any that repeat a join key and returns them as a dataframe.
+    The join key is `unique_on` plus, for a datetime-indexed target, the index.
+    """
+    on_cols = unique_on or []
+    picks = rng.choice(len(target), size=count, replace=False)
+    matched = target.iloc[picks]
+    key = matched[on_cols]
+    key = key.reset_index() if isinstance(matched.index, pd.DatetimeIndex) else key
+    if key.columns.empty:
+        return matched.copy()
+    return matched[~key.duplicated(keep="first").values].copy()
+
+
+def generate_source_for_row_range(target, source_size, matched_count, rng, on=None, value_dtype=None):
+    """
+    Create a dataframe with RowRange index where ~`matched_count` amount of rows match at least one row in `target` on
+    all columns in `on`. The columns that are not in `on` get fresh values.
+    """
+    on = on if on else []
+    assert len(on) > 0
+    matched = get_random_unique_rows(target, matched_count, rng, on)
+    is_string = pd.api.types.is_string_dtype(value_dtype)
+    string_pool = pd.unique(target.select_dtypes(include="object").values.ravel()) if is_string else None
+    for col in target.columns:
+        if col not in on:
+            matched[col] = (
+                rng.choice(string_pool, len(matched))
+                if is_string
+                else np.linspace(0, 100_000, len(matched), dtype=value_dtype)
+            )
+    rest_count = source_size - len(matched)
+    rest = pd.DataFrame(
+        {
+            col: (
+                rng.choice(string_pool, rest_count)
+                if is_string
+                # Must not exist in the target, whose values span [0, 100_000].
+                else np.linspace(100_000, 200_000, rest_count + 1)[1:].astype(value_dtype)
+            )
+            for col in target.columns
+        }
+    )
+    source = pd.concat([matched, rest])
+    source = source[~source.duplicated(subset=on, keep="first").values]
+    source.index = pd.RangeIndex(len(source))
+    return source.sample(frac=1, random_state=42).reset_index(drop=True)
+
+
+def generate_source_for_datetime(
+    target, source_size, rng, affected_row_slice_idx=None, rows_per_segment=100_000, on=None, value_dtype="float32"
+):
+    """
+    Spread `source_size` rows over the affected target row slices: half of each slice's share matches target rows
+    on the index + `on` columns (capped at half the slice), the rest is inserted at fresh in-slice timestamps.
+    """
+    affected_row_slice_idx = affected_row_slice_idx if affected_row_slice_idx else []
+    assert len(affected_row_slice_idx) > 0
+
+    affected_row_slices = []
+    for slice_idx in sorted(affected_row_slice_idx):
+        start = slice_idx * rows_per_segment
+        end = min(start + rows_per_segment, len(target))
+        affected_row_slices.append(target[start:end])
+
+    source_rows_per_affected_segment = source_size // len(affected_row_slices)
+
+    on = on if on else []
+    is_string = pd.api.types.is_string_dtype(value_dtype)
+    string_pool = pd.unique(target.select_dtypes(include="object").values.ravel()) if is_string else None
+
+    source_segments = []
+    for row_slice in affected_row_slices:
+        matched_count = min(source_rows_per_affected_segment // 2, len(row_slice) // 2)
+        inserted_count = source_rows_per_affected_segment - matched_count
+        matched = get_random_unique_rows(row_slice, matched_count, rng, on)
+        for col in target.columns:
+            if col not in on:
+                matched[col] = (
+                    rng.choice(string_pool, len(matched))
+                    if is_string
+                    else np.linspace(0, 100_000, len(matched), dtype=value_dtype)
+                )
+        inserted = pd.DataFrame(
+            {
+                col: (
+                    rng.choice(string_pool, inserted_count)
+                    if is_string
+                    else np.linspace(0, 100_000, inserted_count, dtype=value_dtype)
+                )
+                for col in target.columns
+            }
+        )
+        first_index, last_index = row_slice.index[0], row_slice.index[-1]
+        inserted.index = pd.to_datetime(
+            rng.integers(first_index.value, last_index.value, size=inserted_count), unit="ns"
+        )
+        source_segments.append(matched)
+        source_segments.append(inserted)
+
+    source = pd.concat(source_segments)
+    source_reset = source.reset_index()
+    index_col = source_reset.columns[0]
+    assert not source_reset.duplicated(subset=[index_col] + on).any()
+    return source.sort_index()
+
+
+def affected_slices(num_rows_in_target, matched_slices_count):
+    num_slices = max(1, (num_rows_in_target // ROWS_PER_SEGMENT))
+    count = max(1, min(matched_slices_count, num_slices))
+    return np.linspace(0, num_slices - 1, count, dtype=int).tolist()
+
+
+def reset_bucket(seaweed, bucket):
+    seaweed.delete_bucket(bucket)
+    seaweed.create_bucket(bucket)
+
+
+class MergeBase:
+
+    STRATEGIES = {
+        "update": MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
+        "insert": MergeStrategy(matched="do_nothing", not_matched_by_target="insert"),
+        "update_and_insert": MergeStrategy(matched="update", not_matched_by_target="insert"),
+    }
+
+    def __init__(self):
+        self.rounds = 1
+        # merge_experimental is destructive, so we must restore a fresh base and run once per measurement
+        self.number = 1
+        self.warmup_time = 0
+        self.repeat = 10
+        self.timeout = 600
+        self.ac = None
+        self.lib = None
+        self.value_dtype = None
+        self.source = None
+        self._source_key = None
+        self.on = None
+        self.target_prefix = "target"
+        self.source_prefix = "source"
+        self.seaweed = SeaweedClient()
+
+    SYM = "sym"
+
+    def _write_cache_target(self, lib_name, target):
+        uri = self.seaweed.arctic_uri(CACHE_BUCKET, self.target_prefix)
+        Arctic(uri).create_library(lib_name).write(self.SYM, target)
+
+    def _generate_source(self, target, source_size, matched_slices=None):
+        # Params-seeded rng: the same (class, params) always generate the identical source.
+        rng = np.random.default_rng([source_size, matched_slices or 0])
+        on = [f"val_{j}" for j in range(max(dict(zip(self.param_names, self.params))["on_count"]))]
+        if self.INDEX_KIND == "datetime":
+            slices = matched_slices or max(1, len(target) // ROWS_PER_SEGMENT)
+            return generate_source_for_datetime(
+                target,
+                source_size,
+                rng,
+                affected_row_slice_idx=affected_slices(len(target), slices),
+                rows_per_segment=ROWS_PER_SEGMENT,
+                on=on,
+                value_dtype=self.value_dtype,
+            )
+        return generate_source_for_row_range(
+            target, source_size, source_size // 2, rng, on=on, value_dtype=self.value_dtype
+        )
+
+    def _source_sym(self, source_size, matched_slices=None):
+        return f"src_{source_size}" if matched_slices is None else f"src_{source_size}_{matched_slices}"
+
+    def _precompute_sources(self, lib_name, target):
+        src_lib = Arctic(self.seaweed.arctic_uri(CACHE_BUCKET, self.source_prefix)).create_library(lib_name)
+        parameter_map = dict(zip(self.param_names, self.params))
+        for source_size in parameter_map["source_size"]:
+            for matched_slices in parameter_map.get("matched_slices", [None]):
+                source = self._generate_source(target, source_size, matched_slices)
+                src_lib.write(self._source_sym(source_size, matched_slices), source)
+
+    def _prepare_merge(self, lib_name, on_count, source_size, matched_slices=None):
+        # Fresh Arctic per sample so nothing cached from the previous sample's bucket survives.
+        del self.ac
+        reset_bucket(self.seaweed, WORK_BUCKET)
+        self.seaweed.copy_bucket(CACHE_BUCKET, WORK_BUCKET, prefixes=[f"{self.target_prefix}/"])
+        self.ac = Arctic(self.seaweed.arctic_uri(WORK_BUCKET, self.target_prefix))
+        self.lib = self.ac.get_library(lib_name)
+        self.on = [f"val_{j}" for j in range(on_count)]
+        # The source is immutable; reuse it across the repeat samples of one benchmark process.
+        key = (self.source_prefix, lib_name, self._source_sym(source_size, matched_slices))
+        if self._source_key != key:
+            src_ac = Arctic(self.seaweed.arctic_uri(CACHE_BUCKET, self.source_prefix))
+            self.source = src_ac.get_library(lib_name).read(key[2]).data
+            self._source_key = key
+
+    def merge(self, strategy):
+        self.lib.merge_experimental(self.SYM, self.source, strategy=self.STRATEGIES[strategy], on=self.on)
+
+
+class MergeThinDatetime(MergeBase):
+    """All merge strategies, long-thin numeric dataframe (5M rows x 3 cols), datetime index.
+    matched_slices is the number of the target's row slices the source touches (50 slices here)."""
+
+    INDEX_KIND = "datetime"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float32"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_slices"]
+        self.params = [
+            [(5_000_000, 3)],  # scenario: (num_rows, num_value_cols) — long-thin
+            ["update", "insert", "update_and_insert"],  # strategy
+            [0],  # on_count
+            [1_000, 500_000],  # source_size (source row count)
+            [10, 40],  # matched_slices (number of the target's 50 row slices the source touches)
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            rng = np.random.default_rng([num_rows, num_value_cols])
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
+            lib_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(lib_name, target)
+            self._precompute_sources(lib_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size, matched_slices):
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
+
+    def teardown(self, scenario, strategy, on_count, source_size, matched_slices):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):
+        self.merge(strategy)
+
+
+class MergeThinRowRange(MergeBase):
+    """update only, long-thin numeric dataframe (5M rows x 3 cols), row-range index.
+    matched_slices is dropped: row-range merge reads every slice and has no insert path."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float32"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.params = [
+            [(5_000_000, 3)],  # scenario: (num_rows, num_value_cols) — long-thin
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            [1],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [1_000, 500_000],  # source_size (source row count)
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            rng = np.random.default_rng([num_rows, num_value_cols])
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
+            lib_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(lib_name, target)
+            self._precompute_sources(lib_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+
+class MergeThinStringDatetime(MergeBase):
+    """All merge strategies, long-thin string dataframe (1M rows x 3 cols), datetime index (10 slices)."""
+
+    INDEX_KIND = "datetime"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "string"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_slices", "num_unique_strings"]
+        self.params = [
+            [(1_000_000, 3)],  # scenario: (num_rows, num_value_cols)
+            ["update", "insert", "update_and_insert"],  # strategy
+            [1],  # on_count
+            [1_000, 500_000],  # source_size (source row count)
+            [2, 8],  # matched_slices (number of the target's 10 row slices the source touches)
+            [100, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        parameter_map = dict(zip(self.param_names, self.params))
+        for scenario in parameter_map["scenario"]:
+            for num_unique_strings in parameter_map["num_unique_strings"]:
+                num_rows, num_value_cols = scenario
+                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])
+                target = generate_merge_target(
+                    num_rows,
+                    num_value_cols,
+                    self.value_dtype,
+                    self.INDEX_KIND,
+                    rng,
+                    num_unique_strings=num_unique_strings,
+                )
+                # One target per pool size; per-size prefixes let setup copy only the variant being merged.
+                self.target_prefix = f"target_{num_unique_strings}"
+                self.source_prefix = f"source_{num_unique_strings}"
+                lib_name = lib_name(*scenario, self.INDEX_KIND)
+                self._write_cache_target(lib_name, target)
+                self._precompute_sources(lib_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.target_prefix = f"target_{num_unique_strings}"
+        self.source_prefix = f"source_{num_unique_strings}"
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
+
+    def teardown(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.merge(strategy)
+
+
+class MergeThinStringRowRange(MergeBase):
+    """update only, long-thin string dataframe (1M rows x 3 cols), row-range index (matched_slices dropped)."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "string"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "num_unique_strings"]
+        self.params = [
+            [(1_000_000, 3)],  # scenario: (num_rows, num_value_cols)
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            # on_count: the source needs source_size unique join keys and the key space is
+            # num_unique_strings ** on_count, so one column would cap the source at the pool size.
+            [2],
+            [1_000, 500_000],  # source_size (source row count)
+            [5000, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        param_map = dict(zip(self.param_names, self.params))
+        for scenario in param_map["scenario"]:
+            for num_unique_strings in param_map["num_unique_strings"]:
+                num_rows, num_value_cols = scenario
+                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])
+                target = generate_merge_target(
+                    num_rows,
+                    num_value_cols,
+                    self.value_dtype,
+                    self.INDEX_KIND,
+                    rng,
+                    num_unique_strings=num_unique_strings,
+                )
+                # One target per pool size; per-size prefixes let setup copy only the variant being merged.
+                self.target_prefix = f"target_{num_unique_strings}"
+                self.source_prefix = f"source_{num_unique_strings}"
+                lib_name = lib_name(*scenario, self.INDEX_KIND)
+                self._write_cache_target(lib_name, target)
+                self._precompute_sources(lib_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.target_prefix = f"target_{num_unique_strings}"
+        self.source_prefix = f"source_{num_unique_strings}"
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
+
+    def teardown(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.merge(strategy)
+
+
+class MergeWideDatetime(MergeBase):
+    """All merge strategies, wide numeric dataframe (5k rows x 10k cols), datetime index.
+    5k rows = a single 100k row slice, so the segment (matched_slices) axis does not apply here."""
+
+    INDEX_KIND = "datetime"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float32"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.repeat = 5
+        self.params = [
+            [(5_000, 10_000)],  # scenario: (num_rows, num_value_cols)
+            ["update", "insert", "update_and_insert"],  # strategy
+            [0, 1000],  # on_count
+            [100],  # source_size
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            rng = np.random.default_rng([num_rows, num_value_cols])
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
+            lib_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(lib_name, target)
+            self._precompute_sources(lib_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+
+class MergeWideRowRange(MergeBase):
+    """update only, wide numeric dataframe (5k rows x 10k cols), row-range index (matched_slices dropped)."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float32"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.repeat = 5
+        self.params = [
+            [(5_000, 10_000)],  # scenario: (num_rows, num_value_cols)
+            ["update"],  # strategy: only update is implemented for row-range indexes
+            [1, 1000],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [100],  # source_size
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            rng = np.random.default_rng([num_rows, num_value_cols])
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
+            lib_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(lib_name, target)
+            self._precompute_sources(lib_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)

--- a/python/benchmarks/seaweed_utils.py
+++ b/python/benchmarks/seaweed_utils.py
@@ -1,0 +1,174 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+
+Utilities for ASV benchmarks that store data on SeaweedFS.
+
+A single SeaweedFS server (started by build_tooling/start_seaweed.sh) is shared by every
+benchmark in the ASV run. The server disables automatic vacuuming, so reclaiming space is
+the benchmarks' responsibility: hard-delete a whole bucket (SeaweedFS backs each bucket
+with a collection of the same name, and dropping the collection removes its volume files
+wholesale, no vacuum needed).
+
+Benchmark classes create their own SeaweedClient and use it to reset whatever cache bucket they
+own at the start of setup_cache() (delete + recreate the bucket) so each run starts empty and the
+previous run's data is reclaimed.
+
+This module has no notion of any other bucket a benchmark class might use (e.g. a per-measurement
+work bucket): creating, naming, and deleting those is entirely the calling class's responsibility.
+"""
+
+import asyncio
+from typing import Iterable, List, Optional
+from urllib.parse import urlsplit
+
+import aioboto3
+import boto3
+import botocore
+import requests
+from arcticdb_ext.cpp_async import io_thread_count
+from botocore.config import Config as BotoConfig
+
+
+class SeaweedClient:
+    """Client for the shared benchmark SeaweedFS server.
+
+    The connection options default to the local benchmark server. The sync S3 client is created
+    lazily on first use and then reused so repeated calls share its connection pool; copy_bucket
+    spins up its own short-lived async client and event loop for the duration of the copy.
+    """
+
+    def __init__(
+        self,
+        master_url: str = "http://127.0.0.1:9333",
+        s3_endpoint: str = "http://127.0.0.1:8333",
+        # The benchmark server runs without an S3 identity file, so any credentials are accepted
+        s3_access_key: str = "seaweed",
+        s3_secret_key: str = "seaweed",
+        # (connect, read): connection failures surface quickly, but dropping collections with many
+        # volumes can take a while
+        http_timeout=(5, 600),
+    ):
+        self.master_url = master_url
+        self.s3_endpoint = s3_endpoint
+        self.s3_access_key = s3_access_key
+        self.s3_secret_key = s3_secret_key
+        self.http_timeout = http_timeout
+
+        # The sync client starts uninitialised and is created on the first call that needs it
+        self.sync_client = None
+
+    def _get_sync_client(self):
+        """Sync S3 client for the benchmark server; created once and reused so repeated calls
+        share the same client and connection pool instead of reconnecting every time."""
+        if self.sync_client is None:
+            self.sync_client = boto3.client(
+                "s3",
+                endpoint_url=self.s3_endpoint,
+                aws_access_key_id=self.s3_access_key,
+                aws_secret_access_key=self.s3_secret_key,
+                region_name="us-east-1",
+                config=BotoConfig(s3={"addressing_style": "path"}, max_pool_connections=64),
+            )
+        return self.sync_client
+
+    def arctic_uri(self, bucket: str, path_prefix: Optional[str] = None) -> str:
+        """Arctic connection string for a bucket on the benchmark SeaweedFS server, optionally scoped
+        to a path_prefix within the bucket."""
+        parsed = urlsplit(self.s3_endpoint)
+        scheme = "s3s" if parsed.scheme == "https" else "s3"
+        uri = f"{scheme}://{parsed.hostname}:{bucket}?access={self.s3_access_key}&secret={self.s3_secret_key}"
+        if parsed.port:
+            uri += f"&port={parsed.port}"
+        if path_prefix is not None:
+            uri += f"&path_prefix={path_prefix}"
+        return uri
+
+    def grow_bucket_volumes(self, bucket: str, count: Optional[int] = None) -> None:
+        """
+        Pre-create `count` volumes (default: ArcticDB's actual IO thread count) in the bucket's collection.
+
+        Volumes serialise appends, so a bucket needs at least as many volumes as ArcticDB has IO
+        threads for concurrent writes not to contend on volume-level locks. /vol/grow is additive,
+        so only call this on a freshly created bucket.
+        """
+        count = count if count is not None else io_thread_count()
+        response = requests.get(
+            f"{self.master_url}/vol/grow", params={"collection": bucket, "count": count}, timeout=self.http_timeout
+        )
+        try:
+            body = response.json() if response.content else {}
+        except ValueError:
+            body = {}
+        error = body.get("error") if isinstance(body, dict) else None
+        if error:
+            raise RuntimeError(f"SeaweedFS master /vol/grow failed: {error}")
+        response.raise_for_status()
+
+    def create_bucket(self, bucket: str, volume_count: Optional[int] = None) -> None:
+        """Create the bucket and pre-grow its volumes (see grow_bucket_volumes)."""
+        self._get_sync_client().create_bucket(Bucket=bucket)
+        self.grow_bucket_volumes(bucket, volume_count)
+
+    def delete_bucket(self, bucket: str) -> None:
+        try:
+            self._get_sync_client().delete_bucket(Bucket=bucket)
+        except botocore.exceptions.ClientError as e:
+            if e.response["Error"]["Code"] == "NoSuchBucket":
+                return
+            raise
+
+    def _async_client(self, max_concurrency: int = 64):
+        return aioboto3.Session().client(
+            "s3",
+            endpoint_url=self.s3_endpoint,
+            aws_access_key_id=self.s3_access_key,
+            aws_secret_access_key=self.s3_secret_key,
+            region_name="us-east-1",
+            config=BotoConfig(s3={"addressing_style": "path"}, max_pool_connections=max_concurrency),
+        )
+
+    @staticmethod
+    async def _list_prefix(client, bucket: str, prefix: str) -> List[str]:
+        keys = []
+        async for page in client.get_paginator("list_objects_v2").paginate(Bucket=bucket, Prefix=prefix):
+            keys.extend(obj["Key"] for obj in page.get("Contents", []))
+        return keys
+
+    async def _copy_bucket_async(
+        self, source: str, destination: str, prefixes: Optional[Iterable[str]], max_concurrency: int
+    ) -> int:
+        async with self._async_client(max_concurrency) as client:
+            # A TaskGroup runs the children concurrently and, if any raises, cancels the rest and
+            # awaits them before propagating (no stranded tasks left pending on loop teardown).
+            async with asyncio.TaskGroup() as tg:
+                listings = [
+                    tg.create_task(self._list_prefix(client, source, p))
+                    for p in (prefixes if prefixes is not None else [""])
+                ]
+            # Deduplicated so overlapping prefixes cannot copy the same key twice
+            keys = list(dict.fromkeys(key for listing in listings for key in listing.result()))
+            # Every copy is issued at once; the client's connection pool caps how many actually run
+            async with asyncio.TaskGroup() as tg:
+                for key in keys:
+                    tg.create_task(
+                        client.copy_object(Bucket=destination, Key=key, CopySource={"Bucket": source, "Key": key})
+                    )
+            return len(keys)
+
+    def copy_bucket(
+        self, source: str, destination: str, prefixes: Optional[Iterable[str]] = None, max_concurrency: int = 64
+    ) -> int:
+        """
+        Server-side copy of `source` into the existing bucket `destination`, optionally restricted
+        to the given key prefixes. Returns the number of objects copied.
+
+        Spins up a fresh event loop and async S3 client for the duration of the copy (async is only
+        worth its overhead here, where the per-key copies run concurrently). Every copy is handed to
+        the client at once; max_concurrency sizes its connection pool, which bounds how many are
+        actually in flight.
+        """
+        return asyncio.run(self._copy_bucket_async(source, destination, prefixes, max_concurrency))

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,6 +124,7 @@ Testing =
     future
     mock
     boto3
+    aioboto3>=13
     moto
     flask  # Used by moto
     flask-cors


### PR DESCRIPTION
# ASV Benchmarks for merge

Monday: 12526108851

Implement ASV benchmarks for merge updates. This PR adds benchmarks for all strategies (update, insert, update and insert). Note update and insert is not yet implemented for row ranges.

There are two main scenarios long and thin dataframe and short and wide. The two different index kinds are separated in a separate classes.

The number of columns to match on does not affect the runtime significantly unless the number very high which is why only the short wide scenario matches on more than one column.

Datetime indexes perform filtering of the loaded segments. That is why they are tested with two scenarios work on approximately 20 and 80% of the segments. (The parameter uses the absolute value of segments to work on). Row ranges must process all segments, that is why this parameter does not make sense for them.

This uses seaweedfs to enable parallel writes. It caches **both** the sources and the targets. The workflow is.

On setup_cache cache generate all possible source in a cache bucket and store them in a specific prefix. Generate also the target in the same cache bucket but at a different prefix. This is done so that there's an easy way to copy only the target from the cache. Each invocation of setup_cache will recreate the bucket effectively cleaning the data from before. The sources are generate using the target similar to how hypotheses tests for insertion works.
1. Select random rows from the target and add them to the source.
2. Change all columns that are not in the `on` columns
3. Add random rows to the source until its filled.

Each setup will copy the target cache from the cache read the source and cache it. (Pickling and asv's approach to passing data from the setup_cache was empirically proven to be slower than storing in arctic and reading from arctic). The teardown drops the working bucket.

Sample runs on a build server suing 16 CPU and 24 IO threads.

## MergeThinDatetime

`repeat = 10`

| scenario | strategy | on_count | source_size | matched_slices | single rep | all reps |
|---|---|---|---|---|---|---|
| (5000000, 3) | update | 0 | 1000 | 10 | 42ms | 416ms |
| (5000000, 3) | update | 0 | 1000 | 40 | 99ms | 993ms |
| (5000000, 3) | update | 0 | 500000 | 10 | 44ms | 440ms |
| (5000000, 3) | update | 0 | 500000 | 40 | 102ms | 1s 20ms |
| (5000000, 3) | insert | 0 | 1000 | 10 | 42ms | 420ms |
| (5000000, 3) | insert | 0 | 1000 | 40 | 103ms | 1s 30ms |
| (5000000, 3) | insert | 0 | 500000 | 10 | 56ms | 558ms |
| (5000000, 3) | insert | 0 | 500000 | 40 | 112ms | 1s 120ms |
| (5000000, 3) | update_and_insert | 0 | 1000 | 10 | 43ms | 428ms |
| (5000000, 3) | update_and_insert | 0 | 1000 | 40 | 101ms | 1s 10ms |
| (5000000, 3) | update_and_insert | 0 | 500000 | 10 | 55ms | 553ms |
| (5000000, 3) | update_and_insert | 0 | 500000 | 40 | 109ms | 1s 90ms |

## MergeThinRowRange

`repeat = 10`

| scenario | strategy | on_count | source_size | single rep | all reps |
|---|---|---|---|---|---|
| (5000000, 3) | update | 1 | 1000 | 113ms | 1s 130ms |
| (5000000, 3) | update | 1 | 500000 | 546ms | 5s 460ms |

## MergeThinStringDatetime

`repeat = 10`

| scenario | strategy | on_count | source_size | matched_slices | num_unique_strings | single rep | all reps |
|---|---|---|---|---|---|---|---|
| (1000000, 3) | update | 1 | 1000 | 2 | 100 | 45ms | 446ms |
| (1000000, 3) | update | 1 | 1000 | 2 | 100000 | 84ms | 844ms |
| (1000000, 3) | update | 1 | 1000 | 8 | 100 | 47ms | 473ms |
| (1000000, 3) | update | 1 | 1000 | 8 | 100000 | 92ms | 915ms |
| (1000000, 3) | update | 1 | 500000 | 2 | 100 | 50ms | 496ms |
| (1000000, 3) | update | 1 | 500000 | 2 | 100000 | 107ms | 1s 70ms |
| (1000000, 3) | update | 1 | 500000 | 8 | 100 | 48ms | 479ms |
| (1000000, 3) | update | 1 | 500000 | 8 | 100000 | 101ms | 1s 10ms |
| (1000000, 3) | insert | 1 | 1000 | 2 | 100 | 53ms | 528ms |
| (1000000, 3) | insert | 1 | 1000 | 2 | 100000 | 114ms | 1s 140ms |
| (1000000, 3) | insert | 1 | 1000 | 8 | 100 | 59ms | 587ms |
| (1000000, 3) | insert | 1 | 1000 | 8 | 100000 | 129ms | 1s 290ms |
| (1000000, 3) | insert | 1 | 500000 | 2 | 100 | 155ms | 1s 550ms |
| (1000000, 3) | insert | 1 | 500000 | 2 | 100000 | 305ms | 3s 50ms |
| (1000000, 3) | insert | 1 | 500000 | 8 | 100 | 76ms | 755ms |
| (1000000, 3) | insert | 1 | 500000 | 8 | 100000 | 164ms | 1s 640ms |
| (1000000, 3) | update_and_insert | 1 | 1000 | 2 | 100 | 53ms | 533ms |
| (1000000, 3) | update_and_insert | 1 | 1000 | 2 | 100000 | 116ms | 1s 160ms |
| (1000000, 3) | update_and_insert | 1 | 1000 | 8 | 100 | 56ms | 557ms |
| (1000000, 3) | update_and_insert | 1 | 1000 | 8 | 100000 | 123ms | 1s 230ms |
| (1000000, 3) | update_and_insert | 1 | 500000 | 2 | 100 | 155ms | 1s 550ms |
| (1000000, 3) | update_and_insert | 1 | 500000 | 2 | 100000 | 313ms | 3s 130ms |
| (1000000, 3) | update_and_insert | 1 | 500000 | 8 | 100 | 76ms | 760ms |
| (1000000, 3) | update_and_insert | 1 | 500000 | 8 | 100000 | 184ms | 1s 840ms |

## MergeThinStringRowRange

`repeat = 10`

| scenario | strategy | on_count | source_size | num_unique_strings | single rep | all reps |
|---|---|---|---|---|---|---|
| (1000000, 3) | update | 1 | 1000 | 100 | 45ms | 450ms |
| (1000000, 3) | update | 1 | 1000 | 100000 | 92ms | 925ms |
| (1000000, 3) | update | 1 | 500000 | 100 | 44ms | 441ms |
| (1000000, 3) | update | 1 | 500000 | 100000 | 117ms | 1s 170ms |

## MergeWideDatetime

`repeat = 5`

| scenario | strategy | on_count | source_size | single rep | all reps |
|---|---|---|---|---|---|
| (5000, 10000) | update | 0 | 100 | 378ms | 1s 890ms |
| (5000, 10000) | update | 1000 | 100 | 1s 320ms | 6s 600ms |
| (5000, 10000) | insert | 0 | 100 | 669ms | 3s 345ms |
| (5000, 10000) | insert | 1000 | 100 | 1s 560ms | 7s 800ms |
| (5000, 10000) | update_and_insert | 0 | 100 | 702ms | 3s 510ms |
| (5000, 10000) | update_and_insert | 1000 | 100 | 1s 570ms | 7s 850ms |

## MergeWideRowRange

`repeat = 5`

| scenario | strategy | on_count | source_size | single rep | all reps |
|---|---|---|---|---|---|
| (5000, 10000) | update | 1 | 100 | 379ms | 1s 895ms |
| (5000, 10000) | update | 1000 | 100 | 1s 310ms | 6s 550ms |

## Per-class totals

Real wall-clock to run all repetitions of all parameter combinations of a class: `time_merge` + `peakmem_merge` + one-time `setup_cache` (from `asv --durations all`).

| class | time_merge | peakmem_merge | setup_cache | total |
|---|---|---|---|---|
| MergeThinDatetime | 42s 500ms | 8s 930ms | 1s 990ms | 53s 420ms |
| MergeThinRowRange | 11s 600ms | 2s 80ms | 1s 880ms | 15s 560ms |
| MergeThinStringDatetime | 1m 13s | 17s 600ms | 5s 890ms | 1m 37s |
| MergeThinStringRowRange | 10s 300ms | 2s 650ms | 3s 900ms | 16s 850ms |
| MergeWideDatetime | 45s 300ms | 13s 600ms | 4s 740ms | 1m 4s |
| MergeWideRowRange | 13s 0ms | 4s 290ms | 4s 710ms | 22s 0ms |
| **all classes** | | | | **4m 28s** |

# SeaweedFS

This introduces seedweedfs. It can be started via `start_seaweed.sh` it downloads a pinned version 4.4 and starts it. For the ASV benchmarks we spawn a single server at the beginning of the suite. This server is going to be used by all tests. Thus each benchmark must work in a separate bucket.

There's a seaweed_utils.py providing basic utilities need by ASV benchmarks on arcticdb.
