### PR TITLE
Reject mixed timestamp/numeric types in QueryBuilder expressions

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1109,6 +1109,7 @@ if(${TEST})
             processing/test/test_join_schemas.cpp
             processing/test/test_type_promotion.cpp
             processing/test/test_operation_dispatch.cpp
+            processing/test/test_operation_dispatch_ternary.cpp
             processing/test/test_output_schema_aggregator_types.cpp
             processing/test/test_output_schema_ast_validity.cpp
             processing/test/test_query_planner.cpp

--- a/cpp/arcticdb/column_store/column_algorithms.hpp
+++ b/cpp/arcticdb/column_store/column_algorithms.hpp
@@ -335,10 +335,10 @@ static void transform(
 // std::upper_bound.
 
 // Constraints shared by the four sorted-search functions: scalar type, dense iterator, and a
-// numeric raw type (integers, floats, or timestamps — matches `is_numeric_type` in entity/types.hpp).
+// numeric raw type (integers, floats, or timestamps — matches `is_numeric_or_time_type` in entity/types.hpp).
 template<typename TDT, IteratorDensity ID>
 concept SortedSearchInputs = util::instantiation_of<TDT, TypeDescriptorTag> && (TDT::dimension() == Dimension::Dim0) &&
-                             (ID == IteratorDensity::DENSE) && is_numeric_type(TDT::DataTypeTag::data_type);
+                             (ID == IteratorDensity::DENSE) && is_numeric_or_time_type(TDT::DataTypeTag::data_type);
 
 namespace search_detail {
 

--- a/cpp/arcticdb/column_store/column_utils.cpp
+++ b/cpp/arcticdb/column_store/column_utils.cpp
@@ -27,7 +27,7 @@ py::array array_at(const SegmentInMemory& frame, std::size_t col_pos) {
                 } else {
                     dtype = "O";
                 }
-            } else if constexpr ((is_numeric_type(data_type) || is_bool_type(data_type)) &&
+            } else if constexpr ((is_numeric_or_time_type(data_type) || is_bool_type(data_type)) &&
                                  tag.dimension() == Dimension::Dim0) {
                 constexpr auto dim = TypeTag::DimensionTag::value;
                 util::check(dim == Dimension::Dim0, "Only scalars supported, {}", data_type);
@@ -79,7 +79,7 @@ py::array array_at(const SegmentInMemory& frame, std::size_t col_pos) {
             } else {
                 dtype = "O";
             }
-        } else if constexpr ((is_numeric_type(data_type) || is_bool_type(data_type)) &&
+        } else if constexpr ((is_numeric_or_time_type(data_type) || is_bool_type(data_type)) &&
                              tag.dimension() == Dimension::Dim0) {
             constexpr auto dim = TypeTag::DimensionTag::value;
             util::check(dim == Dimension::Dim0, "Only scalars supported, {}", frame.field(col_pos));

--- a/cpp/arcticdb/column_store/memory_segment_impl.cpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.cpp
@@ -627,7 +627,7 @@ std::shared_ptr<SegmentInMemoryImpl> SegmentInMemoryImpl::filter(
                             } else {
                                 *output_ptr = value;
                             }
-                        } else if constexpr (is_numeric_type(DataTypeTag::data_type) ||
+                        } else if constexpr (is_numeric_or_time_type(DataTypeTag::data_type) ||
                                              is_bool_type(DataTypeTag::data_type)) {
                             *output_ptr = value;
                         } else if constexpr (is_empty_type(DataTypeTag::data_type)) {
@@ -668,7 +668,7 @@ std::shared_ptr<SegmentInMemoryImpl> SegmentInMemoryImpl::filter(
                             } else {
                                 *output_ptr = value;
                             }
-                        } else if constexpr (is_numeric_type(DataTypeTag::data_type) ||
+                        } else if constexpr (is_numeric_or_time_type(DataTypeTag::data_type) ||
                                              is_bool_type(DataTypeTag::data_type)) {
                             *output_ptr = value;
                         } else if constexpr (is_empty_type(DataTypeTag::data_type)) {
@@ -825,7 +825,7 @@ bool operator==(const SegmentInMemoryImpl& left, const SegmentInMemoryImpl& righ
             for (auto row = 0u; row < left_col.row_count(); ++row)
                 if (left.string_at(row, col) != right.string_at(row, col))
                     return false;
-        } else if (is_numeric_type(left_data_type) || is_bool_type(left_data_type)) {
+        } else if (is_numeric_or_time_type(left_data_type) || is_bool_type(left_data_type)) {
             if (left.column(col) != right.column(col))
                 return false;
         } else if (is_empty_type(left_data_type)) {
@@ -1087,7 +1087,7 @@ void SegmentInMemoryImpl::calculate_statistics() {
     for (auto& column : columns_) {
         if (column->type().dimension() == Dimension::Dim0) {
             const auto type = column->type();
-            if (is_numeric_type(type.data_type()) || is_sequence_type(type.data_type())) {
+            if (is_numeric_or_time_type(type.data_type()) || is_sequence_type(type.data_type())) {
                 details::visit_scalar(type, [&column](auto tdt) {
                     using TagType = std::decay_t<decltype(tdt)>;
                     column->set_statistics(generate_column_statistics<TagType>(column->data()));

--- a/cpp/arcticdb/column_store/memory_segment_impl.hpp
+++ b/cpp/arcticdb/column_store/memory_segment_impl.hpp
@@ -54,7 +54,8 @@ class SegmentInMemoryImpl {
                             std::string_view{field.name()},
                             type_desc_tag
                     );
-                else if constexpr (is_numeric_type(DataTypeTag::data_type) || is_bool_type(DataTypeTag::data_type))
+                else if constexpr (is_numeric_or_time_type(DataTypeTag::data_type) ||
+                                   is_bool_type(DataTypeTag::data_type))
                     return c(
                             parent_->scalar_at<RawType>(row_id_, column_id_),
                             std::string_view{field.name()},
@@ -192,7 +193,7 @@ class SegmentInMemoryImpl {
                     if constexpr (is_sequence_type(T::DataTypeTag::data_type)) {
                         // test only for now
                         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("string type not implemented");
-                    } else if constexpr (is_numeric_type(T::DataTypeTag::data_type) ||
+                    } else if constexpr (is_numeric_or_time_type(T::DataTypeTag::data_type) ||
                                          is_bool_type(T::DataTypeTag::data_type)) {
                         if constexpr (std::is_same_v<RawType, S>) {
                             val = parent_->scalar_at<RawType>(row_id_, col);

--- a/cpp/arcticdb/column_store/statistics.hpp
+++ b/cpp/arcticdb/column_store/statistics.hpp
@@ -165,7 +165,7 @@ FieldStatsImpl generate_column_statistics(ColumnData column_data) {
         auto block = column_data.next<TagType>();
         const RawType* ptr = block->data();
         const size_t count = block->row_count();
-        if constexpr (is_numeric_type(TagType::DataTypeTag::data_type)) {
+        if constexpr (is_numeric_or_time_type(TagType::DataTypeTag::data_type)) {
             return generate_numeric_statistics<RawType>(std::span{ptr, count});
         } else if constexpr (is_dynamic_string_type(TagType::DataTypeTag::data_type) &&
                              !is_arrow_output_only_type(TagType::DataTypeTag::data_type)) {
@@ -178,7 +178,7 @@ FieldStatsImpl generate_column_statistics(ColumnData column_data) {
         while (auto block = column_data.next<TagType>()) {
             const RawType* ptr = block->data();
             const size_t count = block->row_count();
-            if constexpr (is_numeric_type(TagType::DataTypeTag::data_type)) {
+            if constexpr (is_numeric_or_time_type(TagType::DataTypeTag::data_type)) {
                 auto local_stats = generate_numeric_statistics<RawType>(std::span{ptr, count});
                 stats.compose<RawType>(local_stats);
             } else if constexpr (is_dynamic_string_type(TagType::DataTypeTag::data_type) &&

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -123,8 +123,10 @@ constexpr bool is_sequence_type(ValueType v) {
 constexpr bool is_time_type(ValueType v) { return uint8_t(v) == uint8_t(ValueType::NANOSECONDS_UTC); }
 
 constexpr bool is_numeric_type(ValueType v) {
-    return is_time_type(v) || (uint8_t(v) >= uint8_t(ValueType::UINT) && uint8_t(v) <= uint8_t(ValueType::FLOAT));
+    return uint8_t(v) >= uint8_t(ValueType::UINT) && uint8_t(v) <= uint8_t(ValueType::FLOAT);
 }
+
+constexpr bool is_numeric_or_time_type(ValueType v) { return is_numeric_type(v) || is_time_type(v); }
 
 constexpr bool is_floating_point_type(ValueType v) { return uint8_t(v) == uint8_t(ValueType::FLOAT); }
 
@@ -249,6 +251,10 @@ constexpr bool is_sequence_type(DataType v) { return is_sequence_type(slice_valu
 
 constexpr bool is_numeric_type(DataType v) { return is_numeric_type(slice_value_type(v)); }
 
+constexpr bool is_time_type(DataType v) { return is_time_type(slice_value_type(v)); }
+
+constexpr bool is_numeric_or_time_type(DataType v) { return is_numeric_type(v) || is_time_type(v); }
+
 constexpr bool is_bool_type(DataType dt) { return slice_value_type(dt) == ValueType::BOOL; }
 
 constexpr bool is_bool_object_type(DataType dt) { return slice_value_type(dt) == ValueType::BOOL_OBJECT; }
@@ -258,8 +264,6 @@ constexpr bool is_unsigned_type(DataType dt) { return slice_value_type(dt) == Va
 constexpr bool is_signed_type(DataType dt) { return slice_value_type(dt) == ValueType::INT; }
 
 constexpr bool is_floating_point_type(DataType v) { return is_floating_point_type(slice_value_type(v)); }
-
-constexpr bool is_time_type(DataType v) { return is_time_type(slice_value_type(v)); }
 
 constexpr bool is_integer_type(DataType v) { return is_integer_type(slice_value_type(v)); }
 
@@ -273,9 +277,42 @@ constexpr bool is_utf_type(DataType v) { return is_utf_type(slice_value_type(v))
 
 constexpr bool is_empty_type(DataType v) { return is_empty_type(slice_value_type(v)); }
 
+// Timestamps are stored as int64 nanosecond counts, so mixing them with plain numeric types compiles and silently
+// produces meaningless results. These two predicates gate the QueryBuilder expression pipeline against that.
+constexpr bool is_time_numeric_mismatch(DataType a, DataType b) {
+    return is_numeric_or_time_type(a) && is_numeric_or_time_type(b) && is_time_type(a) != is_time_type(b);
+}
+
+constexpr bool numeric_or_time_types_compatible(DataType a, DataType b) {
+    return is_numeric_or_time_type(a) && is_numeric_or_time_type(b) && !is_time_numeric_mismatch(a, b);
+}
+
+// There is no duration type, so a timedelta reaches the processing pipeline as a plain integer and cannot be told
+// apart from one. Adding or subtracting an integer from a timestamp is therefore permitted and treated as a
+// nanosecond offset. Restricted to integers so that the result is always representable as a timestamp.
+constexpr bool is_time_offset_pair(DataType a, DataType b) {
+    return (is_time_type(a) && is_integer_type(b)) || (is_integer_type(a) && is_time_type(b));
+}
+
 static_assert(slice_value_type(DataType::UINT16) == ValueType(1));
 static_assert(get_type_size(DataType::UINT32) == 4);
 static_assert(get_type_size(DataType::UINT64) == 8);
+
+static_assert(is_numeric_or_time_type(DataType::NANOSECONDS_UTC64));
+static_assert(!is_numeric_type(DataType::NANOSECONDS_UTC64));
+static_assert(is_numeric_type(DataType::INT64));
+static_assert(is_time_numeric_mismatch(DataType::NANOSECONDS_UTC64, DataType::INT64));
+static_assert(!is_time_numeric_mismatch(DataType::NANOSECONDS_UTC64, DataType::NANOSECONDS_UTC64));
+static_assert(!is_time_numeric_mismatch(DataType::NANOSECONDS_UTC64, DataType::UTF_DYNAMIC64));
+static_assert(numeric_or_time_types_compatible(DataType::NANOSECONDS_UTC64, DataType::NANOSECONDS_UTC64));
+static_assert(numeric_or_time_types_compatible(DataType::INT64, DataType::FLOAT32));
+static_assert(!numeric_or_time_types_compatible(DataType::NANOSECONDS_UTC64, DataType::INT64));
+static_assert(!numeric_or_time_types_compatible(DataType::EMPTYVAL, DataType::INT64));
+static_assert(is_time_offset_pair(DataType::NANOSECONDS_UTC64, DataType::INT64));
+static_assert(is_time_offset_pair(DataType::UINT8, DataType::NANOSECONDS_UTC64));
+static_assert(!is_time_offset_pair(DataType::NANOSECONDS_UTC64, DataType::FLOAT64));
+static_assert(!is_time_offset_pair(DataType::NANOSECONDS_UTC64, DataType::NANOSECONDS_UTC64));
+static_assert(!is_time_offset_pair(DataType::INT64, DataType::INT64));
 
 constexpr ValueType get_value_type(char specifier) noexcept {
     switch (specifier) {
@@ -461,7 +498,7 @@ constexpr bool must_contain_data(TypeDescriptor td) {
 /// @important Be sure to match this with the type handler registry in:
 /// cpp/arcticdb/python/python_module.cpp#register_type_handlers
 constexpr bool is_array_type(TypeDescriptor td) {
-    return (is_numeric_type(td.data_type()) || is_bool_type(td.data_type()) || is_empty_type(td.data_type())) &&
+    return (is_numeric_or_time_type(td.data_type()) || is_bool_type(td.data_type()) || is_empty_type(td.data_type())) &&
            (td.dimension() == Dimension::Dim1);
 }
 

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -174,7 +174,7 @@ ColumnStats::ColumnStats(
 
 namespace {
 bool is_col_eligible_for_stats(DataType col_data_type) {
-    return is_numeric_type(col_data_type) || is_bool_type(col_data_type);
+    return is_numeric_or_time_type(col_data_type) || is_bool_type(col_data_type);
 }
 
 // Type-disambiguated key for duplicate detection, so that e.g. an integer column labelled 2

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
@@ -71,10 +71,7 @@ StatsComparison stats_membership_comparator(const ColumnStatsValues& stats, Valu
             using SetTag = std::remove_reference_t<decltype(set_tag)>;
 
             // TODO add bool support once the bool PR is merged
-            // Monday: 8065794446 we should disallow comparing time types to non-time numeric types
-            // This is also wrong downstream in the rest of the processing pipeline
-            if constexpr ((is_numeric_type(StatsTag::data_type) || is_time_type(StatsTag::data_type)) &&
-                          (is_numeric_type(SetTag::data_type) || is_time_type(SetTag::data_type))) {
+            if constexpr (numeric_or_time_types_compatible(StatsTag::data_type, SetTag::data_type)) {
                 using StatsRawType = StatsTag::raw_type;
                 using SetRawType = SetTag::raw_type;
                 using comp = Comparable<StatsRawType, SetRawType>;

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -146,17 +146,13 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value
         return details::visit_type(val_rhs.data_type(), [&](auto val_tag) -> StatsComparison {
             using ValTag = std::remove_reference_t<decltype(val_tag)>;
 
-            // Monday: 8065794446 we should disallow comparing time types to non-time numeric types
-            // This is also wrong downstream in the rest of the processing pipeline
-            constexpr bool stats_supported = is_numeric_type(StatsTag::data_type) ||
-                                             is_time_type(StatsTag::data_type) || is_bool_type(StatsTag::data_type);
-            constexpr bool val_supported = is_numeric_type(ValTag::data_type) || is_time_type(ValTag::data_type) ||
-                                           is_bool_type(ValTag::data_type);
+            constexpr bool both_bool = is_bool_type(StatsTag::data_type) && is_bool_type(ValTag::data_type);
             // Mixed bool/non-bool comparisons are rejected at runtime by check_no_mixed_bool_comparison.
             // MSVC C4804 treats `numeric > bool` as an error.
             constexpr bool bool_compatible = is_bool_type(StatsTag::data_type) == is_bool_type(ValTag::data_type);
             check_no_mixed_bool_comparison<StatsTag::data_type, ValTag::data_type>(*stats_lhs.min, val_rhs);
-            if constexpr (stats_supported && val_supported && bool_compatible) {
+            if constexpr ((numeric_or_time_types_compatible(StatsTag::data_type, ValTag::data_type) || both_bool) &&
+                          bool_compatible) {
                 using StatsRawType = StatsTag::raw_type;
                 using ValRawType = ValTag::raw_type;
                 using comp = Comparable<StatsRawType, ValRawType>;
@@ -197,8 +193,7 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Colum
         return details::visit_type(stats_rhs.min->data_type(), [&](auto rhs_tag) -> StatsComparison {
             using RhsTag = std::remove_reference_t<decltype(rhs_tag)>;
 
-            if constexpr ((is_numeric_type(LhsTag::data_type) || is_time_type(LhsTag::data_type)) &&
-                          (is_numeric_type(RhsTag::data_type) || is_time_type(RhsTag::data_type))) {
+            if constexpr (numeric_or_time_types_compatible(LhsTag::data_type, RhsTag::data_type)) {
                 using LhsRawType = LhsTag::raw_type;
                 using RhsRawType = RhsTag::raw_type;
                 using comp = Comparable<LhsRawType, RhsRawType>;

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -201,8 +201,7 @@ std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
 
         details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
             using type_info = ScalarTypeInfo<T>;
-            if constexpr (is_numeric_type(type_info::data_type) || is_time_type(type_info::data_type) ||
-                          is_bool_type(type_info::data_type)) {
+            if constexpr (is_numeric_or_time_type(type_info::data_type) || is_bool_type(type_info::data_type)) {
                 for (const auto& entry : stats_metadata_for_column.entries) {
                     if (entry.stat_type != MIN_V1 && entry.stat_type != MAX_V1) {
                         continue;

--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -291,7 +291,8 @@ std::optional<convert::StringEncodingError> set_array_type(
         //  case for it and it will throw exception which is not meaningful. Adding BYTES_DYNAMIC64 in
         //  TypeDescriptor::visit_tag leads to a bunch of compilation errors spread all over the code.
         normalization::check<ErrorCode::E_UNIMPLEMENTED_COLUMN_SECONDARY_TYPE>(
-                is_numeric_type(row_type_descriptor.data_type()) || is_empty_type(row_type_descriptor.data_type()),
+                is_numeric_or_time_type(row_type_descriptor.data_type()) ||
+                        is_empty_type(row_type_descriptor.data_type()),
                 "Numpy array type {} is not implemented. Only dense int and float arrays are supported.",
                 datatype_to_str(row_type_descriptor.data_type())
         );
@@ -300,7 +301,7 @@ std::optional<convert::StringEncodingError> set_array_type(
             using ArrayType = typename ArrayDataTypeTag::raw_type;
             if constexpr (is_empty_type(ArrayDataTypeTag::data_type)) {
                 arr_col.set_empty_array(last_logical_row, row_tensor.ndim());
-            } else if constexpr (is_numeric_type(ArrayDataTypeTag::data_type)) {
+            } else if constexpr (is_numeric_or_time_type(ArrayDataTypeTag::data_type)) {
                 if (row_tensor.nbytes()) {
                     TypedTensor<ArrayType> typed_tensor{row_tensor};
                     arr_col.set_array(last_logical_row, typed_tensor);
@@ -344,7 +345,7 @@ inline std::optional<convert::StringEncodingError> segment_set_data(
             auto maybe_error = set_sequence_type<TagType, RawType>(seg, tensor, col, rows_to_write, row);
             if (maybe_error)
                 return maybe_error;
-        } else if constexpr ((is_numeric_type(dt) || is_bool_type(dt)) && tag.dimension() == Dimension::Dim0) {
+        } else if constexpr ((is_numeric_or_time_type(dt) || is_bool_type(dt)) && tag.dimension() == Dimension::Dim0) {
             set_integral_scalar_type<TagType, RawType>(
                     seg, tensor, col, rows_to_write, row, sparsify_floats, copy_mode
             );

--- a/cpp/arcticdb/pipeline/test/test_column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_dispatch.cpp
@@ -1491,3 +1491,96 @@ INSTANTIATE_TEST_SUITE_P(
                 )
         )
 );
+
+// Mixing a timestamp with a plain numeric type is rejected upstream in the processing pipeline. Column stats must not
+// prune anything based on such a comparison, since it cannot be given a meaningful answer here either.
+// We let the error handling happen in one place downstream, since column stats may or may not be enabled.
+class StatsComparatorTimeNumericMismatchTest : public ::testing::TestWithParam<std::tuple<OperationType>> {};
+
+TEST_P(StatsComparatorTimeNumericMismatchTest, ReturnsUnknown) {
+    auto [op] = GetParam();
+    std::vector<ColumnStatsValues> time_stats{
+            {Value(timestamp{1}, DataType::NANOSECONDS_UTC64), Value(timestamp{5}, DataType::NANOSECONDS_UTC64)}
+    };
+    std::vector<ColumnStatsValues> int_stats{{construct_value(int64_t{1}), construct_value(int64_t{5})}};
+
+    // Time-typed stats against a numeric query value
+    auto numeric_query = std::get<std::vector<StatsComparison>>(
+            dispatch_binary_stats(time_stats, std::make_shared<Value>(construct_value(int64_t{3})), op)
+    );
+    ASSERT_EQ(numeric_query.size(), 1);
+    ASSERT_EQ(numeric_query.at(0), StatsComparison::UNKNOWN);
+
+    // Numeric stats against a time-typed query value
+    auto time_query = std::get<std::vector<StatsComparison>>(
+            dispatch_binary_stats(int_stats, std::make_shared<Value>(construct_timestamp_value(3)), op)
+    );
+    ASSERT_EQ(time_query.size(), 1);
+    ASSERT_EQ(time_query.at(0), StatsComparison::UNKNOWN);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        AllComparisonOps, StatsComparatorTimeNumericMismatchTest,
+        ::testing::Values(
+                OperationType::LT, OperationType::LE, OperationType::GT, OperationType::GE, OperationType::EQ,
+                OperationType::NE
+        )
+);
+
+// Timestamp against timestamp must still give a real answer rather than falling back to UNKNOWN
+TEST(StatsComparatorTimeTime, GivesRealAnswer) {
+    std::vector<ColumnStatsValues> time_stats{
+            {Value(timestamp{1}, DataType::NANOSECONDS_UTC64), Value(timestamp{5}, DataType::NANOSECONDS_UTC64)}
+    };
+    auto all_match = std::get<std::vector<StatsComparison>>(
+            dispatch_binary_stats(time_stats, std::make_shared<Value>(construct_timestamp_value(10)), OperationType::LT)
+    );
+    ASSERT_EQ(all_match.at(0), StatsComparison::ALL_MATCH);
+    auto none_match = std::get<std::vector<StatsComparison>>(
+            dispatch_binary_stats(time_stats, std::make_shared<Value>(construct_timestamp_value(0)), OperationType::LT)
+    );
+    ASSERT_EQ(none_match.at(0), StatsComparison::NONE_MATCH);
+}
+
+class StatsComparatorColumnColumnTimeNumericMismatchTest : public ::testing::TestWithParam<std::tuple<OperationType>> {
+};
+
+TEST_P(StatsComparatorColumnColumnTimeNumericMismatchTest, ReturnsUnknown) {
+    auto [op] = GetParam();
+    std::vector<ColumnStatsValues> time_stats{
+            {Value(timestamp{1}, DataType::NANOSECONDS_UTC64), Value(timestamp{5}, DataType::NANOSECONDS_UTC64)}
+    };
+    std::vector<ColumnStatsValues> int_stats{{construct_value(int64_t{1}), construct_value(int64_t{5})}};
+
+    auto time_vs_int = std::get<std::vector<StatsComparison>>(dispatch_binary_stats(time_stats, int_stats, op));
+    ASSERT_EQ(time_vs_int.size(), 1);
+    ASSERT_EQ(time_vs_int.at(0), StatsComparison::UNKNOWN);
+
+    auto int_vs_time = std::get<std::vector<StatsComparison>>(dispatch_binary_stats(int_stats, time_stats, op));
+    ASSERT_EQ(int_vs_time.size(), 1);
+    ASSERT_EQ(int_vs_time.at(0), StatsComparison::UNKNOWN);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+        AllComparisonOps, StatsComparatorColumnColumnTimeNumericMismatchTest,
+        ::testing::Values(
+                OperationType::LT, OperationType::LE, OperationType::GT, OperationType::GE, OperationType::EQ,
+                OperationType::NE
+        )
+);
+
+// Two timestamp columns' stats against each other must still give a real answer rather than falling back to UNKNOWN
+TEST(StatsComparatorColumnColumnTimeTime, GivesRealAnswer) {
+    std::vector<ColumnStatsValues> low_stats{
+            {Value(timestamp{1}, DataType::NANOSECONDS_UTC64), Value(timestamp{5}, DataType::NANOSECONDS_UTC64)}
+    };
+    std::vector<ColumnStatsValues> high_stats{
+            {Value(timestamp{10}, DataType::NANOSECONDS_UTC64), Value(timestamp{20}, DataType::NANOSECONDS_UTC64)}
+    };
+    auto all_match =
+            std::get<std::vector<StatsComparison>>(dispatch_binary_stats(low_stats, high_stats, OperationType::LT));
+    ASSERT_EQ(all_match.at(0), StatsComparison::ALL_MATCH);
+    auto none_match =
+            std::get<std::vector<StatsComparison>>(dispatch_binary_stats(high_stats, low_stats, OperationType::LT));
+    ASSERT_EQ(none_match.at(0), StatsComparison::NONE_MATCH);
+}

--- a/cpp/arcticdb/pipeline/test/test_column_stats_isin.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_isin.cpp
@@ -213,7 +213,9 @@ TEST_P(StatsMembershipNaTTest, IsinAndIsnotin) {
     ColumnStatsValues csv{
             std::optional<Value>{make_timestamp_value(block_min)}, std::optional<Value>{make_timestamp_value(block_max)}
     };
-    auto vs = std::make_shared<ValueSet>(
+    // A set of timestamps must be tagged as such. An untagged int64 set is a numeric set, and mixing that with a
+    // timestamp column is rejected.
+    auto vs = ValueSet::from_nanoseconds(
             NumericSetType{std::make_shared<std::unordered_set<int64_t>>(set_values.begin(), set_values.end())}
     );
     ASSERT_EQ(stats_membership_comparator(csv, *vs, OperationType::ISIN), expected_isin);

--- a/cpp/arcticdb/pipeline/test/test_value.cpp
+++ b/cpp/arcticdb/pipeline/test/test_value.cpp
@@ -44,7 +44,7 @@ consteval auto generate_numeric_testing_values() {
 
 TEST_P(ValueDataType, ValueConstruct) {
     details::visit_type(GetParam(), []<typename TypeTag>(TypeTag) {
-        if constexpr (is_numeric_type(TypeTag::data_type) || is_bool_type(TypeTag::data_type)) {
+        if constexpr (is_numeric_or_time_type(TypeTag::data_type) || is_bool_type(TypeTag::data_type)) {
             using raw_type = typename TypeTag::raw_type;
             constexpr static std::array values = generate_numeric_testing_values<TypeTag>();
             for (const auto& v : values) {

--- a/cpp/arcticdb/pipeline/value_set.cpp
+++ b/cpp/arcticdb/pipeline/value_set.cpp
@@ -64,6 +64,19 @@ ValueSet::ValueSet(py::array value_list) {
     util::variant_match(numeric_base_set_, [&](const auto& numeric_base_set) { empty_ = numeric_base_set->empty(); });
 }
 
+namespace {
+
+void retag_as_time_type(entity::TypeDescriptor& base_type) {
+    util::check(
+            base_type == make_scalar_type(combine_data_type(entity::ValueType::INT, entity::SizeBits::S64)),
+            "Time-typed ValueSet expects int64 nanoseconds, got {}",
+            base_type
+    );
+    base_type = make_scalar_type(entity::DataType::NANOSECONDS_UTC64);
+}
+
+} // namespace
+
 ValueSet::ValueSet(NumericSetType&& value_set) : numeric_base_set_(std::move(value_set)) {
     util::variant_match(
             numeric_base_set_,
@@ -99,6 +112,18 @@ ValueSet::ValueSet(NumericSetType&& value_set) : numeric_base_set_(std::move(val
             }
     );
     util::variant_match(numeric_base_set_, [&](const auto& numeric_base_set) { empty_ = numeric_base_set->empty(); });
+}
+
+std::shared_ptr<ValueSet> ValueSet::from_nanoseconds(py::array value_list) {
+    auto value_set = std::make_shared<ValueSet>(value_list);
+    retag_as_time_type(value_set->base_type_);
+    return value_set;
+}
+
+std::shared_ptr<ValueSet> ValueSet::from_nanoseconds(NumericSetType&& value_set) {
+    auto result = std::make_shared<ValueSet>(std::move(value_set));
+    retag_as_time_type(result->base_type_);
+    return result;
 }
 
 bool ValueSet::empty() const { return empty_; }
@@ -150,13 +175,14 @@ void ValueSet::compute_min_max() const {
                     max_val = elem;
             }
             if (min_val) {
-                cached_min_ = construct_value<ElemType>(*min_val);
-                cached_max_ = construct_value<ElemType>(*max_val);
+                // base_type_ rather than ElemType, so that a time-typed set does not present its bounds as numeric
+                cached_min_ = Value{*min_val, base_type_.data_type()};
+                cached_max_ = Value{*max_val, base_type_.data_type()};
             }
         } else {
             auto [min_it, max_it] = std::minmax_element(set_ptr->begin(), set_ptr->end());
-            cached_min_ = construct_value<ElemType>(*min_it);
-            cached_max_ = construct_value<ElemType>(*max_it);
+            cached_min_ = Value{*min_it, base_type_.data_type()};
+            cached_max_ = Value{*max_it, base_type_.data_type()};
         }
     });
 }

--- a/cpp/arcticdb/pipeline/value_set.hpp
+++ b/cpp/arcticdb/pipeline/value_set.hpp
@@ -41,6 +41,11 @@ class ValueSet {
     explicit ValueSet(py::array value_list);
     explicit ValueSet(NumericSetType&& value_set);
 
+    // Builds a set of timestamps from int64 nanoseconds since epoch. The resulting base type is NANOSECONDS_UTC64
+    // rather than INT64, so that mixing the set with a plain numeric column is rejected.
+    static std::shared_ptr<ValueSet> from_nanoseconds(py::array value_list);
+    static std::shared_ptr<ValueSet> from_nanoseconds(NumericSetType&& value_set);
+
     bool empty() const;
 
     size_t size() const;

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -189,7 +189,7 @@ std::vector<EntityId> ProjectClause::process(std::vector<EntityId>&& entity_ids)
                         const auto offset = string_pool->get(*val->str_data(), val->len()).offset();
                         auto data = output_column->ptr_cast<TargetType>(0, output_bytes);
                         std::fill_n(data, rows, offset);
-                    } else if constexpr (is_numeric_type(val_type_info::data_type) ||
+                    } else if constexpr (is_numeric_or_time_type(val_type_info::data_type) ||
                                          is_bool_type(val_type_info::data_type)) {
                         using TargetType = val_type_info::RawType;
                         auto value = static_cast<TargetType>(val->get<typename val_type_info::RawType>());

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -269,7 +269,7 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
             user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                     std::holds_alternative<DataType>(left_type), "Unexpected bitset input to {}", operation_type_
             );
-            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res](auto tag) {
+            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, this, &operation](auto tag) {
                 using type_info = ScalarTypeInfo<decltype(tag)>;
                 if constexpr (is_numeric_type(type_info::data_type)) {
                     if (operation_type_ == OperationType::ABS) {
@@ -286,7 +286,11 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     }
                 } else {
                     user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                            "Unexpected data type {} input to {}", type_info::data_type, operation_type_
+                            "Cannot perform unary operation {}({}) ({}) in query '{}'",
+                            operation_type_,
+                            operation.left_->label_,
+                            type_info::data_type,
+                            label_
                     );
                 }
             });
@@ -335,12 +339,13 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     "Unexpected value set input to {}",
                     operation_type_
             );
-            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, right_type](auto left_tag) {
+            details::visit_type(std::get<DataType>(left_type), [&](auto left_tag) {
                 using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
-                details::visit_type(std::get<DataType>(right_type), [operation_type_, &res](auto right_tag) {
+                details::visit_type(std::get<DataType>(right_type), [&](auto right_tag) {
                     using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
-                    if constexpr (is_numeric_type(left_type_info::data_type) &&
-                                  is_numeric_type(right_type_info::data_type)) {
+                    if constexpr (numeric_or_time_types_compatible(
+                                          left_type_info::data_type, right_type_info::data_type
+                                  )) {
                         switch (operation_type_) {
                         case OperationType::ADD: {
                             using TargetType = typename binary_operation_promoted_type<
@@ -393,6 +398,27 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                         default:
                             internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unexpected binary operator");
                         }
+                    } else if constexpr (is_time_numeric_mismatch(
+                                                 left_type_info::data_type, right_type_info::data_type
+                                         )) {
+                        // Addition is commutative so the integer may be on either side, but subtraction needs the
+                        // timestamp on the left, as subtracting a timestamp from an integer is not a timestamp
+                        const bool offset_arithmetic =
+                                is_time_offset_pair(left_type_info::data_type, right_type_info::data_type) &&
+                                (operation_type_ == OperationType::ADD ||
+                                 (operation_type_ == OperationType::SUB && is_time_type(left_type_info::data_type)));
+                        if (offset_arithmetic) {
+                            res = DataType::NANOSECONDS_UTC64;
+                        } else {
+                            raise_time_numeric_mismatch(
+                                    label_,
+                                    operation.left_->label_,
+                                    left_type_info::data_type,
+                                    operation.right_->label_,
+                                    right_type_info::data_type,
+                                    MixedTimeNumericOp::ARITHMETIC
+                            );
+                        }
                     } else {
                         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                                 "Unexpected data types {} {} input to {}",
@@ -425,9 +451,18 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     "Unexpected value set input to {}",
                     operation_type_
             );
+            if (is_time_numeric_mismatch(std::get<DataType>(left_type), std::get<DataType>(right_type))) {
+                raise_time_numeric_mismatch(
+                        label_,
+                        operation.left_->label_,
+                        std::get<DataType>(left_type),
+                        operation.right_->label_,
+                        std::get<DataType>(right_type),
+                        MixedTimeNumericOp::COMPARE
+                );
+            }
             user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                    (is_numeric_type(std::get<DataType>(left_type)) && is_numeric_type(std::get<DataType>(right_type))
-                    ) ||
+                    numeric_or_time_types_compatible(std::get<DataType>(left_type), std::get<DataType>(right_type)) ||
                             (is_bool_type(std::get<DataType>(left_type)) && is_bool_type(std::get<DataType>(right_type))
                             ) ||
                             (is_sequence_type(std::get<DataType>(left_type)) &&
@@ -481,11 +516,22 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     operation_type_
             );
             if (right_value_set_state == ValueSetState::NON_EMPTY_SET) {
+                if (is_time_numeric_mismatch(std::get<DataType>(left_type), std::get<DataType>(right_type))) {
+                    raise_time_numeric_mismatch(
+                            label_,
+                            operation.left_->label_,
+                            std::get<DataType>(left_type),
+                            operation.right_->label_,
+                            std::get<DataType>(right_type),
+                            MixedTimeNumericOp::COMPARE
+                    );
+                }
                 user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                         (is_sequence_type(std::get<DataType>(left_type)) &&
                          is_sequence_type(std::get<DataType>(right_type))) ||
-                                (is_numeric_type(std::get<DataType>(left_type)) &&
-                                 is_numeric_type(std::get<DataType>(right_type))),
+                                numeric_or_time_types_compatible(
+                                        std::get<DataType>(left_type), std::get<DataType>(right_type)
+                                ),
                         "Unexpected data types {} {} input to {}",
                         std::get<DataType>(left_type),
                         std::get<DataType>(right_type),
@@ -537,9 +583,9 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
             );
         }
         if (std::holds_alternative<DataType>(left_type) && std::holds_alternative<DataType>(right_type)) {
-            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, right_type](auto left_tag) {
+            details::visit_type(std::get<DataType>(left_type), [&](auto left_tag) {
                 using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
-                details::visit_type(std::get<DataType>(right_type), [operation_type_, &res](auto right_tag) {
+                details::visit_type(std::get<DataType>(right_type), [&](auto right_tag) {
                     using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
                     if constexpr (is_sequence_type(left_type_info::data_type) &&
                                   is_sequence_type(right_type_info::data_type)) {
@@ -555,8 +601,13 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                                     operation_type_
                             );
                         }
-                    } else if constexpr (is_numeric_type(left_type_info::data_type) &&
-                                         is_numeric_type(right_type_info::data_type)) {
+                    } else if constexpr (is_time_type(left_type_info::data_type) &&
+                                         is_time_type(right_type_info::data_type)) {
+                        // ternary_operation_promoted_type would give INT64, as timestamp is int64_t
+                        res = left_type_info::data_type;
+                    } else if constexpr (numeric_or_time_types_compatible(
+                                                 left_type_info::data_type, right_type_info::data_type
+                                         )) {
                         using TargetType = typename ternary_operation_promoted_type<
                                 typename left_type_info::RawType,
                                 typename right_type_info::RawType>::type;
@@ -564,6 +615,17 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     } else if constexpr (is_bool_type(left_type_info::data_type) &&
                                          is_bool_type(right_type_info::data_type)) {
                         res = DataType::BOOL8;
+                    } else if constexpr (is_time_numeric_mismatch(
+                                                 left_type_info::data_type, right_type_info::data_type
+                                         )) {
+                        raise_time_numeric_mismatch(
+                                label_,
+                                operation.left_->label_,
+                                left_type_info::data_type,
+                                operation.right_->label_,
+                                right_type_info::data_type,
+                                MixedTimeNumericOp::TERNARY
+                        );
                     } else {
                         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                                 "Unexpected data types {} {} input to {}",

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -75,6 +75,30 @@ inline std::string binary_operation_with_types_to_string(
 }
 
 template<typename Func>
+constexpr bool is_plus_operator = std::is_same_v<std::remove_reference_t<Func>, PlusOperator>;
+
+template<typename Func>
+constexpr bool is_minus_operator = std::is_same_v<std::remove_reference_t<Func>, MinusOperator>;
+
+// Adding or subtracting an integer from a timestamp is a nanosecond offset, and yields a timestamp. left and right are
+// in expression order: addition is commutative so the integer may be on either side, but subtraction needs the
+// timestamp on the left, as subtracting a timestamp from an integer is not a timestamp.
+template<typename Func, DataType left, DataType right, typename TargetType>
+constexpr bool is_offset_arithmetic =
+        (is_plus_operator<Func> || is_minus_operator<Func>) && is_time_offset_pair(left, right) &&
+        std::is_integral_v<TargetType> && (is_plus_operator<Func> || is_time_type(left));
+
+// data_type_from_raw_type would give INT64 for an offset result, as timestamp is int64_t
+template<typename Func, DataType left, DataType right, typename TargetType>
+constexpr DataType binary_arithmetic_output_type() {
+    if constexpr (is_offset_arithmetic<Func, left, right, TargetType>) {
+        return DataType::NANOSECONDS_UTC64;
+    } else {
+        return data_type_from_raw_type<TargetType>();
+    }
+}
+
+template<typename Func>
 VariantData binary_membership(const ColumnWithStrings& column_with_strings, ValueSet& value_set, Func&& func) {
     if (is_empty_type(column_with_strings.column_->type().data_type())) {
         if constexpr (std::is_same_v<std::remove_reference_t<Func>, IsInOperator>) {
@@ -128,8 +152,9 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                                 "Binary membership '{}' not implemented for bools", func
                         );
-                    } else if constexpr (is_numeric_type(col_type_info::data_type) &&
-                                         is_numeric_type(val_set_type_info::data_type)) {
+                    } else if constexpr (numeric_or_time_types_compatible(
+                                                 col_type_info::data_type, val_set_type_info::data_type
+                                         )) {
                         using WideType = typename binary_operation_promoted_type<
                                 typename col_type_info::RawType,
                                 typename val_set_type_info::RawType,
@@ -156,6 +181,17 @@ VariantData binary_membership(const ColumnWithStrings& column_with_strings, Valu
                                         return func(static_cast<WideType>(input_value), *typed_value_set);
                                     }
                                 }
+                        );
+                    } else if constexpr (is_time_numeric_mismatch(
+                                                 col_type_info::data_type, val_set_type_info::data_type
+                                         )) {
+                        raise_time_numeric_mismatch(
+                                fmt::format("{}({}, set)", func, column_with_strings.column_name_),
+                                column_with_strings.column_name_,
+                                col_type_info::data_type,
+                                "the value set",
+                                val_set_type_info::data_type,
+                                MixedTimeNumericOp::COMPARE
                         );
                     } else {
                         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -234,8 +270,9 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
                             );
                         }
                 );
-            } else if constexpr ((is_numeric_type(left_type_info::data_type) &&
-                                  is_numeric_type(right_type_info::data_type)) ||
+            } else if constexpr (numeric_or_time_types_compatible(
+                                         left_type_info::data_type, right_type_info::data_type
+                                 ) ||
                                  (is_bool_type(left_type_info::data_type) && is_bool_type(right_type_info::data_type)
                                  )) {
                 using comp = typename arcticdb::
@@ -259,6 +296,15 @@ VariantData binary_comparator(const ColumnWithStrings& left, const ColumnWithStr
                                     static_cast<typename comp::right_type>(right_value)
                             );
                         }
+                );
+            } else if constexpr (is_time_numeric_mismatch(left_type_info::data_type, right_type_info::data_type)) {
+                raise_time_numeric_mismatch(
+                        binary_operation_column_name(left.column_name_, func, right.column_name_),
+                        left.column_name_,
+                        left_type_info::data_type,
+                        right.column_name_,
+                        right_type_info::data_type,
+                        MixedTimeNumericOp::COMPARE
                 );
             } else {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -326,8 +372,9 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                                     }
                                 }
                         );
-                    } else if constexpr ((is_numeric_type(col_type_info::data_type) &&
-                                          is_numeric_type(val_type_info::data_type)) ||
+                    } else if constexpr (numeric_or_time_types_compatible(
+                                                 col_type_info::data_type, val_type_info::data_type
+                                         ) ||
                                          (is_bool_type(col_type_info::data_type) &&
                                           is_bool_type(val_type_info::data_type))) {
                         using ColType = typename col_type_info::RawType;
@@ -367,6 +414,19 @@ VariantData binary_comparator(const ColumnWithStrings& column_with_strings, cons
                                 }
                         );
 
+                    } else if constexpr (is_time_numeric_mismatch(col_type_info::data_type, val_type_info::data_type)) {
+                        raise_time_numeric_mismatch(
+                                binary_operation_column_name(
+                                        column_with_strings.column_name_,
+                                        func,
+                                        val.to_string<typename val_type_info::RawType>()
+                                ),
+                                column_with_strings.column_name_,
+                                col_type_info::data_type,
+                                val.to_string<typename val_type_info::RawType>(),
+                                val_type_info::data_type,
+                                MixedTimeNumericOp::COMPARE
+                        );
                     } else {
                         user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                                 "Invalid comparison {}",
@@ -490,7 +550,30 @@ VariantData binary_operator(const Value& left, const Value& right, Func&& func) 
         using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
         details::visit_type(right.data_type(), [&](auto right_tag) {
             using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
-            if constexpr (!is_numeric_type(left_type_info::data_type) || !is_numeric_type(right_type_info::data_type)) {
+            using TargetType = typename binary_operation_promoted_type<
+                    typename left_type_info::RawType,
+                    typename right_type_info::RawType,
+                    std::remove_reference_t<Func>>::type;
+            constexpr bool offset_arithmetic =
+                    is_offset_arithmetic<Func, left_type_info::data_type, right_type_info::data_type, TargetType>;
+            if constexpr (is_time_numeric_mismatch(left_type_info::data_type, right_type_info::data_type) &&
+                          !offset_arithmetic) {
+                raise_time_numeric_mismatch(
+                        binary_operation_column_name(
+                                left.to_string<typename left_type_info::RawType>(),
+                                func,
+                                right.to_string<typename right_type_info::RawType>()
+                        ),
+                        left.to_string<typename left_type_info::RawType>(),
+                        left_type_info::data_type,
+                        right.to_string<typename right_type_info::RawType>(),
+                        right_type_info::data_type,
+                        MixedTimeNumericOp::ARITHMETIC
+                );
+            } else if constexpr (!numeric_or_time_types_compatible(
+                                         left_type_info::data_type, right_type_info::data_type
+                                 ) &&
+                                 !offset_arithmetic) {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                         "Non-numeric type provided to binary operation: {}",
                         binary_operation_with_types_to_string(
@@ -504,12 +587,13 @@ VariantData binary_operator(const Value& left, const Value& right, Func&& func) 
             }
             auto right_value = right.get<typename right_type_info::RawType>();
             auto left_value = left.get<typename left_type_info::RawType>();
-            using TargetType = typename binary_operation_promoted_type<
-                    typename left_type_info::RawType,
-                    typename right_type_info::RawType,
-                    std::remove_reference_t<Func>>::type;
             *output_value =
-                    Value{TargetType{func.apply(left_value, right_value)}, data_type_from_raw_type<TargetType>()};
+                    Value{TargetType{func.apply(left_value, right_value)},
+                          binary_arithmetic_output_type<
+                                  Func,
+                                  left_type_info::data_type,
+                                  right_type_info::data_type,
+                                  TargetType>()};
         });
     });
     return VariantData(std::move(output_value));
@@ -527,7 +611,26 @@ VariantData binary_operator(const ColumnWithStrings& left, const ColumnWithStrin
         using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
         details::visit_type(right.column_->type().data_type(), [&](auto right_tag) {
             using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
-            if constexpr (!is_numeric_type(left_type_info::data_type) || !is_numeric_type(right_type_info::data_type)) {
+            using TargetType = typename binary_operation_promoted_type<
+                    typename left_type_info::RawType,
+                    typename right_type_info::RawType,
+                    std::remove_reference_t<decltype(func)>>::type;
+            constexpr bool offset_arithmetic =
+                    is_offset_arithmetic<Func, left_type_info::data_type, right_type_info::data_type, TargetType>;
+            if constexpr (is_time_numeric_mismatch(left_type_info::data_type, right_type_info::data_type) &&
+                          !offset_arithmetic) {
+                raise_time_numeric_mismatch(
+                        binary_operation_column_name(left.column_name_, func, right.column_name_),
+                        left.column_name_,
+                        left_type_info::data_type,
+                        right.column_name_,
+                        right_type_info::data_type,
+                        MixedTimeNumericOp::ARITHMETIC
+                );
+            } else if constexpr (!numeric_or_time_types_compatible(
+                                         left_type_info::data_type, right_type_info::data_type
+                                 ) &&
+                                 !offset_arithmetic) {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                         "Non-numeric column provided to binary operation: {}",
                         binary_operation_with_types_to_string(
@@ -535,11 +638,11 @@ VariantData binary_operator(const ColumnWithStrings& left, const ColumnWithStrin
                         )
                 );
             }
-            using TargetType = typename binary_operation_promoted_type<
-                    typename left_type_info::RawType,
-                    typename right_type_info::RawType,
-                    std::remove_reference_t<decltype(func)>>::type;
-            constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
+            constexpr auto output_data_type = binary_arithmetic_output_type<
+                    Func,
+                    left_type_info::data_type,
+                    right_type_info::data_type,
+                    TargetType>();
             output_column = std::make_unique<Column>(make_scalar_type(output_data_type), Sparsity::PERMITTED);
             arcticdb::transform<
                     typename left_type_info::TDT,
@@ -571,7 +674,30 @@ VariantData binary_operator(const ColumnWithStrings& col, const Value& val, Func
         using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
         details::visit_type(val.data_type(), [&](auto val_tag) {
             using val_type_info = ScalarTypeInfo<decltype(val_tag)>;
-            if constexpr (!is_numeric_type(col_type_info::data_type) || !is_numeric_type(val_type_info::data_type)) {
+            using TargetType = typename binary_operation_promoted_type<
+                    typename col_type_info::RawType,
+                    typename val_type_info::RawType,
+                    std::remove_reference_t<decltype(func)>>::type;
+            // arguments_reversed means the value is the left operand in the expression
+            constexpr auto expr_left = arguments_reversed ? val_type_info::data_type : col_type_info::data_type;
+            constexpr auto expr_right = arguments_reversed ? col_type_info::data_type : val_type_info::data_type;
+            constexpr bool offset_arithmetic = is_offset_arithmetic<Func, expr_left, expr_right, TargetType>;
+            if constexpr (is_time_numeric_mismatch(col_type_info::data_type, val_type_info::data_type) &&
+                          !offset_arithmetic) {
+                raise_time_numeric_mismatch(
+                        binary_operation_column_name(
+                                col.column_name_, func, val.to_string<typename val_type_info::RawType>()
+                        ),
+                        col.column_name_,
+                        col_type_info::data_type,
+                        val.to_string<typename val_type_info::RawType>(),
+                        val_type_info::data_type,
+                        MixedTimeNumericOp::ARITHMETIC
+                );
+            } else if constexpr (!numeric_or_time_types_compatible(
+                                         col_type_info::data_type, val_type_info::data_type
+                                 ) &&
+                                 !offset_arithmetic) {
                 std::string error_message;
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
                         "Non-numeric type provided to binary operation: {}",
@@ -586,13 +712,10 @@ VariantData binary_operator(const ColumnWithStrings& col, const Value& val, Func
                 );
             }
             const auto& raw_value = val.get<typename val_type_info::RawType>();
-            using TargetType = typename binary_operation_promoted_type<
-                    typename col_type_info::RawType,
-                    typename val_type_info::RawType,
-                    std::remove_reference_t<decltype(func)>>::type;
             if constexpr (arguments_reversed) {
                 column_name = binary_operation_column_name(fmt::format("{}", raw_value), func, col.column_name_);
-                constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
+                constexpr auto output_data_type =
+                        binary_arithmetic_output_type<Func, expr_left, expr_right, TargetType>();
                 output_column = std::make_unique<Column>(make_scalar_type(output_data_type), Sparsity::PERMITTED);
                 arcticdb::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
                         *(col.column_),
@@ -603,7 +726,8 @@ VariantData binary_operator(const ColumnWithStrings& col, const Value& val, Func
                 );
             } else {
                 column_name = binary_operation_column_name(col.column_name_, func, fmt::format("{}", raw_value));
-                constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
+                constexpr auto output_data_type =
+                        binary_arithmetic_output_type<Func, expr_left, expr_right, TargetType>();
                 output_column = std::make_unique<Column>(make_scalar_type(output_data_type), Sparsity::PERMITTED);
                 arcticdb::transform<typename col_type_info::TDT, ScalarTagType<DataTypeTag<output_data_type>>>(
                         *(col.column_),

--- a/cpp/arcticdb/processing/operation_dispatch_ternary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_ternary.cpp
@@ -166,14 +166,19 @@ VariantData ternary_operator(
                             right.column_name_
                     );
                 }
-            } else if constexpr ((is_numeric_type(left_type_info::data_type) &&
-                                  is_numeric_type(right_type_info::data_type)) ||
+            } else if constexpr (numeric_or_time_types_compatible(
+                                         left_type_info::data_type, right_type_info::data_type
+                                 ) ||
                                  (is_bool_type(left_type_info::data_type) && is_bool_type(right_type_info::data_type)
                                  )) {
                 using TargetType = typename ternary_operation_promoted_type<
                         typename left_type_info::RawType,
                         typename right_type_info::RawType>::type;
-                constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
+                // timestamp is int64_t, so data_type_from_raw_type would give INT64 for two time columns
+                constexpr auto output_data_type =
+                        is_time_type(left_type_info::data_type) && is_time_type(right_type_info::data_type)
+                                ? DataType::NANOSECONDS_UTC64
+                                : data_type_from_raw_type<TargetType>();
                 output_column = std::make_unique<Column>(make_scalar_type(output_data_type), Sparsity::PERMITTED);
                 ternary_transform<
                         typename left_type_info::TDT,
@@ -186,6 +191,15 @@ VariantData ternary_operator(
                         [](bool condition, TargetType left_val, TargetType right_val) {
                             return condition ? left_val : right_val;
                         }
+                );
+            } else if constexpr (is_time_numeric_mismatch(left_type_info::data_type, right_type_info::data_type)) {
+                raise_time_numeric_mismatch(
+                        ternary_operation_column_name(left.column_name_, right.column_name_),
+                        left.column_name_,
+                        left_type_info::data_type,
+                        right.column_name_,
+                        right_type_info::data_type,
+                        MixedTimeNumericOp::TERNARY
                 );
             } else {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -261,13 +275,16 @@ VariantData ternary_operator(const util::BitSet& condition, const ColumnWithStri
                             "Ternary operator does not support fixed width string columns '{}'", col.column_name_
                     );
                 }
-            } else if constexpr ((is_numeric_type(col_type_info::data_type) && is_numeric_type(val_type_info::data_type)
-                                 ) ||
+            } else if constexpr (numeric_or_time_types_compatible(col_type_info::data_type, val_type_info::data_type) ||
                                  (is_bool_type(col_type_info::data_type) && is_bool_type(val_type_info::data_type))) {
                 using TargetType = typename ternary_operation_promoted_type<
                         typename col_type_info::RawType,
                         typename val_type_info::RawType>::type;
-                constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
+                // timestamp is int64_t, so data_type_from_raw_type would give INT64 for a time column and time value
+                constexpr auto output_data_type =
+                        is_time_type(col_type_info::data_type) && is_time_type(val_type_info::data_type)
+                                ? DataType::NANOSECONDS_UTC64
+                                : data_type_from_raw_type<TargetType>();
                 output_column = std::make_unique<Column>(make_scalar_type(output_data_type), Sparsity::PERMITTED);
                 auto value = static_cast<TargetType>(val.get<typename val_type_info::RawType>());
                 value_string = fmt::format("{}", value);
@@ -282,6 +299,17 @@ VariantData ternary_operator(const util::BitSet& condition, const ColumnWithStri
                         [](bool condition, TargetType left_val, TargetType right_val) {
                             return condition ? left_val : right_val;
                         }
+                );
+            } else if constexpr (is_time_numeric_mismatch(col_type_info::data_type, val_type_info::data_type)) {
+                raise_time_numeric_mismatch(
+                        ternary_operation_column_name<arguments_reversed>(
+                                col.column_name_, val.to_string<typename val_type_info::RawType>()
+                        ),
+                        col.column_name_,
+                        col_type_info::data_type,
+                        val.to_string<typename val_type_info::RawType>(),
+                        val_type_info::data_type,
+                        MixedTimeNumericOp::TERNARY
                 );
             } else {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -319,8 +347,8 @@ VariantData ternary_operator(const util::BitSet& condition, const ColumnWithStri
 
     details::visit_type(col.column_->type().data_type(), [&](auto col_tag) {
         using col_type_info = ScalarTypeInfo<decltype(col_tag)>;
-        if constexpr (is_dynamic_string_type(col_type_info::data_type) || is_numeric_type(col_type_info::data_type) ||
-                      is_bool_type(col_type_info::data_type)) {
+        if constexpr (is_dynamic_string_type(col_type_info::data_type) ||
+                      is_numeric_or_time_type(col_type_info::data_type) || is_bool_type(col_type_info::data_type)) {
             if constexpr (is_dynamic_string_type(col_type_info::data_type)) {
                 // We do not need to construct a new string pool, as all the strings in the output column come from the
                 // input column
@@ -389,14 +417,19 @@ VariantData ternary_operator(const util::BitSet& condition, const Value& left, c
                             "Unexpected fixed-width string value in ternary operator"
                     );
                 }
-            } else if constexpr ((is_numeric_type(left_type_info::data_type) &&
-                                  is_numeric_type(right_type_info::data_type)) ||
+            } else if constexpr (numeric_or_time_types_compatible(
+                                         left_type_info::data_type, right_type_info::data_type
+                                 ) ||
                                  (is_bool_type(left_type_info::data_type) && is_bool_type(right_type_info::data_type)
                                  )) {
                 using TargetType = typename ternary_operation_promoted_type<
                         typename left_type_info::RawType,
                         typename right_type_info::RawType>::type;
-                constexpr auto output_data_type = data_type_from_raw_type<TargetType>();
+                // timestamp is int64_t, so data_type_from_raw_type would give INT64 for two time values
+                constexpr auto output_data_type =
+                        is_time_type(left_type_info::data_type) && is_time_type(right_type_info::data_type)
+                                ? DataType::NANOSECONDS_UTC64
+                                : data_type_from_raw_type<TargetType>();
                 output_column = std::make_unique<Column>(make_scalar_type(output_data_type), Sparsity::PERMITTED);
                 auto left_value = static_cast<TargetType>(left.get<typename left_type_info::RawType>());
                 auto right_value = static_cast<TargetType>(right.get<typename right_type_info::RawType>());
@@ -404,6 +437,18 @@ VariantData ternary_operator(const util::BitSet& condition, const Value& left, c
                 right_string = fmt::format("{}", right_value);
                 ternary_transform<ScalarTagType<DataTypeTag<output_data_type>>>(
                         condition, left_value, right_value, *output_column
+                );
+            } else if constexpr (is_time_numeric_mismatch(left_type_info::data_type, right_type_info::data_type)) {
+                raise_time_numeric_mismatch(
+                        ternary_operation_column_name(
+                                left.to_string<typename left_type_info::RawType>(),
+                                right.to_string<typename right_type_info::RawType>()
+                        ),
+                        left.to_string<typename left_type_info::RawType>(),
+                        left_type_info::data_type,
+                        right.to_string<typename right_type_info::RawType>(),
+                        right_type_info::data_type,
+                        MixedTimeNumericOp::TERNARY
                 );
             } else {
                 user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -443,7 +488,8 @@ VariantData ternary_operator(const util::BitSet& condition, const Value& val, Em
             ternary_transform<typename val_type_info::TDT, arguments_reversed>(
                     condition, offset_string.offset(), EmptyResult{}, *output_column
             );
-        } else if constexpr (is_numeric_type(val_type_info::data_type) || is_bool_type(val_type_info::data_type)) {
+        } else if constexpr (is_numeric_or_time_type(val_type_info::data_type) ||
+                             is_bool_type(val_type_info::data_type)) {
             using TargetType = val_type_info::RawType;
             output_column = std::make_unique<Column>(val.descriptor(), Sparsity::PERMITTED);
             auto value = static_cast<TargetType>(val.get<typename val_type_info::RawType>());

--- a/cpp/arcticdb/processing/operation_types.hpp
+++ b/cpp/arcticdb/processing/operation_types.hpp
@@ -151,6 +151,36 @@ constexpr bool is_binary_operation(OperationType o) {
 
 constexpr bool is_ternary_operation(OperationType o) { return uint8_t(o) >= uint8_t(OperationType::TERNARY); }
 
+enum class MixedTimeNumericOp { COMPARE, ARITHMETIC, TERNARY };
+
+[[noreturn]] inline void raise_time_numeric_mismatch(
+        std::string_view query, std::string_view left, entity::DataType left_type, std::string_view right,
+        entity::DataType right_type, MixedTimeNumericOp kind
+) {
+    std::string_view verb;
+    switch (kind) {
+    case MixedTimeNumericOp::COMPARE:
+        verb = "compared to";
+        break;
+    case MixedTimeNumericOp::ARITHMETIC:
+        verb = "combined with";
+        break;
+    case MixedTimeNumericOp::TERNARY:
+        verb = "returned alongside";
+        break;
+    }
+    user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            "In query '{}': {} is of type {} and cannot be {} {}, which is of type {}. Timestamp and numeric types "
+            "cannot be mixed.",
+            query,
+            left,
+            left_type,
+            verb,
+            right,
+            right_type
+    );
+}
+
 struct AbsOperator;
 struct NegOperator;
 struct PlusOperator;

--- a/cpp/arcticdb/processing/sorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.cpp
@@ -18,17 +18,17 @@ namespace arcticdb {
 template<typename InputTypeInfo, typename OutputTypeInfo>
 requires util::instantiation_of<InputTypeInfo, ScalarTypeInfo> && util::instantiation_of<OutputTypeInfo, ScalarTypeInfo>
 consteval bool is_aggregation_allowed(const AggregationOperator aggregation_operator) {
-    return (is_numeric_type(InputTypeInfo::data_type) && is_numeric_type(OutputTypeInfo::data_type)) ||
+    return (is_numeric_or_time_type(InputTypeInfo::data_type) && is_numeric_or_time_type(OutputTypeInfo::data_type)) ||
            (is_sequence_type(InputTypeInfo::data_type) &&
             (is_sequence_type(OutputTypeInfo::data_type) || aggregation_operator == AggregationOperator::COUNT)) ||
            (is_bool_type(InputTypeInfo::data_type) &&
-            (is_bool_type(OutputTypeInfo::data_type) || is_numeric_type(OutputTypeInfo::data_type)));
+            (is_bool_type(OutputTypeInfo::data_type) || is_numeric_or_time_type(OutputTypeInfo::data_type)));
 }
 
 template<typename OutputTypeInfo>
 requires util::instantiation_of<OutputTypeInfo, ScalarTypeInfo>
 consteval bool is_aggregation_allowed(const AggregationOperator aggregation_operator) {
-    return is_numeric_type(OutputTypeInfo::data_type) || is_bool_type(OutputTypeInfo::data_type) ||
+    return is_numeric_or_time_type(OutputTypeInfo::data_type) || is_bool_type(OutputTypeInfo::data_type) ||
            (is_sequence_type(OutputTypeInfo::data_type) &&
             (aggregation_operator == AggregationOperator::FIRST || aggregation_operator == AggregationOperator::LAST));
 }
@@ -397,7 +397,7 @@ void SortedAggregator<aggregation_operator, closed_boundary>::check_aggregator_s
 ) const {
     schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
             (is_time_type(data_type) && aggregation_operator != AggregationOperator::SUM) ||
-                    (is_numeric_type(data_type) && !is_time_type(data_type)) || is_bool_type(data_type) ||
+                    is_numeric_type(data_type) || is_bool_type(data_type) ||
                     (is_sequence_type(data_type) && (aggregation_operator == AggregationOperator::FIRST ||
                                                      aggregation_operator == AggregationOperator::LAST ||
                                                      aggregation_operator == AggregationOperator::COUNT)),

--- a/cpp/arcticdb/processing/sorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/sorted_aggregation.hpp
@@ -419,7 +419,7 @@ class SortedAggregator {
     ) const {
         if constexpr (is_time_type(input_data_type) && aggregation_operator == AggregationOperator::COUNT) {
             bucket_aggregator.template push<timestamp, true>(value);
-        } else if constexpr (is_numeric_type(input_data_type) || is_bool_type(input_data_type)) {
+        } else if constexpr (is_numeric_or_time_type(input_data_type) || is_bool_type(input_data_type)) {
             bucket_aggregator.push(value);
         } else if constexpr (is_sequence_type(input_data_type)) {
             bucket_aggregator.push(column_with_strings.string_at_offset(value));
@@ -431,7 +431,7 @@ class SortedAggregator {
     template<DataType output_data_type, typename Aggregator>
     [[nodiscard]] auto finalize_aggregator(Aggregator& bucket_aggregator, ARCTICDB_UNUSED StringPool& string_pool)
             const {
-        if constexpr (is_numeric_type(output_data_type) || is_bool_type(output_data_type) ||
+        if constexpr (is_numeric_or_time_type(output_data_type) || is_bool_type(output_data_type) ||
                       aggregation_operator == AggregationOperator::COUNT) {
             return bucket_aggregator.finalize();
         } else if constexpr (is_sequence_type(output_data_type)) {
@@ -474,7 +474,7 @@ class SortedAggregator {
         } else if constexpr (aggregation_operator == AggregationOperator::FIRST) {
             if constexpr (is_time_type(scalar_type_info::data_type)) {
                 return FirstAggregatorSorted<typename scalar_type_info::RawType, true>();
-            } else if constexpr (is_numeric_type(scalar_type_info::data_type) ||
+            } else if constexpr (is_numeric_or_time_type(scalar_type_info::data_type) ||
                                  is_bool_type(scalar_type_info::data_type)) {
                 return FirstAggregatorSorted<typename scalar_type_info::RawType>();
             } else if constexpr (is_sequence_type(scalar_type_info::data_type)) {
@@ -483,7 +483,7 @@ class SortedAggregator {
         } else if constexpr (aggregation_operator == AggregationOperator::LAST) {
             if constexpr (is_time_type(scalar_type_info::data_type)) {
                 return LastAggregatorSorted<typename scalar_type_info::RawType, true>();
-            } else if constexpr (is_numeric_type(scalar_type_info::data_type) ||
+            } else if constexpr (is_numeric_or_time_type(scalar_type_info::data_type) ||
                                  is_bool_type(scalar_type_info::data_type)) {
                 return LastAggregatorSorted<typename scalar_type_info::RawType>();
             } else if constexpr (is_sequence_type(scalar_type_info::data_type)) {

--- a/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
+++ b/cpp/arcticdb/processing/test/test_operation_dispatch.cpp
@@ -146,3 +146,165 @@ TEST(OperationDispatch, binary_membership) {
     ASSERT_TRUE(std::holds_alternative<FullResult>(visit_binary_membership(empty_column, value_set, IsNotInOperator{}))
     );
 }
+
+TEST(OperationDispatch, unary_operator_datetime) {
+    using namespace arcticdb;
+    auto datetime_column = ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(100)), "datetime_col");
+    auto datetime_value = std::make_shared<Value>(construct_timestamp_value(50));
+
+    EXPECT_THROW(visit_unary_operator(datetime_column, NegOperator{}), UserInputException);
+    EXPECT_THROW(visit_unary_operator(datetime_column, AbsOperator{}), UserInputException);
+    EXPECT_THROW(visit_unary_operator(datetime_value, NegOperator{}), UserInputException);
+}
+
+TEST(OperationDispatch, binary_operator_datetime) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+    auto int_value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
+    auto float_value = std::make_shared<Value>(static_cast<double>(1.5), DataType::FLOAT64);
+    auto datetime_value = std::make_shared<Value>(construct_timestamp_value(50));
+
+    // Multiplying or dividing a timestamp is meaningless whichever side the numeric operand is on
+    EXPECT_THROW(visit_binary_operator(datetime_column, int_column, TimesOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_operator(int_column, datetime_column, TimesOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_operator(datetime_column, int_value, DivideOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_operator(datetime_value, int_value, TimesOperator{}), UserInputException);
+
+    // A float cannot be a nanosecond offset
+    EXPECT_THROW(visit_binary_operator(datetime_column, float_value, PlusOperator{}), UserInputException);
+
+    // Adding or subtracting an integer is a nanosecond offset, and yields a timestamp
+    for (auto&& variant_data :
+         {visit_binary_operator(datetime_column, int_column, PlusOperator{}),
+          visit_binary_operator(datetime_column, int_value, PlusOperator{}),
+          visit_binary_operator(datetime_column, int_value, MinusOperator{})}) {
+        ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(variant_data));
+        ASSERT_EQ(DataType::NANOSECONDS_UTC64, std::get<ColumnWithStrings>(variant_data).column_->type().data_type());
+    }
+
+    // Subtracting one timestamp from another gives a duration, which has no type of its own
+    auto difference = visit_binary_operator(datetime_column, datetime_column, MinusOperator{});
+    ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(difference));
+    ASSERT_EQ(DataType::INT64, std::get<ColumnWithStrings>(difference).column_->type().data_type());
+
+    // Two literal Values also do offset arithmetic when one is a timestamp and the other an integer
+    auto value_plus_value = visit_binary_operator(datetime_value, int_value, PlusOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<Value>>(value_plus_value));
+    auto plus_value = std::get<std::shared_ptr<Value>>(value_plus_value);
+    ASSERT_EQ(DataType::NANOSECONDS_UTC64, plus_value->data_type());
+    ASSERT_EQ(100, plus_value->get<timestamp>());
+
+    auto value_minus_value = visit_binary_operator(datetime_value, int_value, MinusOperator{});
+    ASSERT_TRUE(std::holds_alternative<std::shared_ptr<Value>>(value_minus_value));
+    auto minus_value = std::get<std::shared_ptr<Value>>(value_minus_value);
+    ASSERT_EQ(DataType::NANOSECONDS_UTC64, minus_value->data_type());
+    ASSERT_EQ(0, minus_value->get<timestamp>());
+
+    // A timestamp Value minus an integer Column is still an offset even though the Value is the left operand
+    auto value_minus_column = visit_binary_operator(datetime_value, int_column, MinusOperator{});
+    ASSERT_TRUE(std::holds_alternative<ColumnWithStrings>(value_minus_column));
+    auto minus_column = std::get<ColumnWithStrings>(value_minus_column).column_;
+    ASSERT_EQ(DataType::NANOSECONDS_UTC64, minus_column->type().data_type());
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(50 - static_cast<timestamp>(idx), minus_column->scalar_at<timestamp>(idx));
+    }
+
+    // The reverse direction is not an offset: an integer minus a timestamp is not a timestamp, whether the
+    // timestamp is a Value or a Column
+    EXPECT_THROW(visit_binary_operator(int_value, datetime_column, MinusOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_operator(int_column, datetime_column, MinusOperator{}), UserInputException);
+}
+
+TEST(OperationDispatch, binary_comparator_datetime) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+    auto int_value = std::make_shared<Value>(static_cast<int64_t>(50), DataType::INT64);
+    auto datetime_value = std::make_shared<Value>(construct_timestamp_value(50));
+
+    EXPECT_THROW(visit_binary_comparator(datetime_column, int_column, LessThanOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_comparator(int_column, datetime_column, LessThanOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_comparator(datetime_column, int_value, LessThanOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_comparator(int_column, datetime_value, LessThanOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_comparator(datetime_value, int_column, LessThanOperator{}), UserInputException);
+
+    // Timestamp against timestamp must keep working
+    auto variant_data = visit_binary_comparator(datetime_column, datetime_value, LessThanOperator{});
+    ASSERT_TRUE(std::holds_alternative<util::BitSet>(variant_data));
+    auto results_bitset = std::get<util::BitSet>(variant_data);
+    for (size_t idx = 0; idx < num_rows; idx++) {
+        ASSERT_EQ(idx < 50, results_bitset.get_bit(idx));
+    }
+    // Column against itself is false for every row, which the dispatch layer collapses to EmptyResult. An all-true
+    // result is deliberately not collapsed to FullResult, see transform_to_placeholder.
+    ASSERT_TRUE(std::holds_alternative<EmptyResult>(
+            visit_binary_comparator(datetime_column, datetime_column, LessThanOperator{})
+    ));
+    auto all_true = visit_binary_comparator(datetime_column, datetime_column, LessThanEqualsOperator{});
+    ASSERT_TRUE(std::holds_alternative<util::BitSet>(all_true));
+    ASSERT_EQ(num_rows, std::get<util::BitSet>(all_true).count());
+}
+
+TEST(OperationDispatch, binary_membership_datetime) {
+    using namespace arcticdb;
+    size_t num_rows = 100;
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+    std::unordered_set<int64_t> raw_set{0, 23, 82};
+    auto int_set = std::make_shared<ValueSet>(std::make_shared<std::unordered_set<int64_t>>(raw_set));
+
+    EXPECT_THROW(visit_binary_membership(datetime_column, int_set, IsInOperator{}), UserInputException);
+    EXPECT_THROW(visit_binary_membership(datetime_column, int_set, IsNotInOperator{}), UserInputException);
+    // The int column against the same set is fine, so it is the type mixing that is rejected
+    ASSERT_TRUE(std::holds_alternative<util::BitSet>(visit_binary_membership(int_column, int_set, IsInOperator{})));
+}
+
+namespace {
+using namespace arcticdb;
+
+template<typename Func, DataType left_dt, typename LeftRaw, DataType right_dt, typename RightRaw>
+constexpr bool offset_arithmetic_for = is_offset_arithmetic<
+        Func, left_dt, right_dt, typename binary_operation_promoted_type<LeftRaw, RightRaw, Func>::type>;
+
+template<typename Func, typename LeftRaw, typename RightRaw>
+constexpr bool promotes_to_integral =
+        std::is_integral_v<typename binary_operation_promoted_type<LeftRaw, RightRaw, Func>::type>;
+
+constexpr auto TS = DataType::NANOSECONDS_UTC64;
+
+// Adding or subtracting an integer offset is permitted at every integer width and both signednesses. Each permitted
+// combination must promote to an integral type: the output is tagged NANOSECONDS_UTC64, so a floating point promotion
+// would write doubles into an int64 column.
+static_assert(offset_arithmetic_for<PlusOperator, TS, timestamp, DataType::INT8, int8_t>);
+static_assert(offset_arithmetic_for<PlusOperator, TS, timestamp, DataType::UINT8, uint8_t>);
+static_assert(offset_arithmetic_for<PlusOperator, TS, timestamp, DataType::INT64, int64_t>);
+static_assert(offset_arithmetic_for<PlusOperator, TS, timestamp, DataType::UINT64, uint64_t>);
+static_assert(promotes_to_integral<PlusOperator, timestamp, uint64_t>);
+static_assert(promotes_to_integral<MinusOperator, timestamp, uint64_t>);
+static_assert(promotes_to_integral<PlusOperator, timestamp, int8_t>);
+
+// The integer may be on either side of an addition, since addition is commutative
+static_assert(offset_arithmetic_for<PlusOperator, DataType::INT64, int64_t, TS, timestamp>);
+
+// Subtraction needs the timestamp on the left: an integer minus a timestamp is not a timestamp
+static_assert(offset_arithmetic_for<MinusOperator, TS, timestamp, DataType::INT64, int64_t>);
+static_assert(!offset_arithmetic_for<MinusOperator, DataType::INT64, int64_t, TS, timestamp>);
+
+// A float cannot be a nanosecond offset, and scaling a timestamp is meaningless whatever the other operand
+static_assert(!offset_arithmetic_for<PlusOperator, TS, timestamp, DataType::FLOAT64, double>);
+static_assert(!offset_arithmetic_for<TimesOperator, TS, timestamp, DataType::INT64, int64_t>);
+static_assert(!offset_arithmetic_for<DivideOperator, TS, timestamp, DataType::INT64, int64_t>);
+static_assert(!offset_arithmetic_for<PowOperator, TS, timestamp, DataType::INT64, int64_t>);
+
+// Two timestamps are not an offset pair, so they keep the plain integer difference
+static_assert(!offset_arithmetic_for<MinusOperator, TS, timestamp, TS, timestamp>);
+// Two plain numerics are unaffected
+static_assert(!offset_arithmetic_for<PlusOperator, DataType::INT64, int64_t, DataType::INT32, int32_t>);
+
+} // namespace

--- a/cpp/arcticdb/processing/test/test_operation_dispatch_ternary.cpp
+++ b/cpp/arcticdb/processing/test/test_operation_dispatch_ternary.cpp
@@ -1,0 +1,112 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/processing/operation_dispatch_ternary.hpp>
+#include <arcticdb/pipeline/value.hpp>
+#include <arcticdb/util/test/generators.hpp>
+
+namespace {
+
+using namespace arcticdb;
+
+constexpr size_t num_rows = 100;
+
+util::BitSet alternating_condition() {
+    util::BitSet condition(num_rows);
+    for (size_t idx = 0; idx < num_rows; ++idx) {
+        condition.set(idx, idx % 2 == 0);
+    }
+    return condition;
+}
+
+DataType output_data_type(const VariantData& variant_data) {
+    return std::get<ColumnWithStrings>(variant_data).column_->type().data_type();
+}
+
+} // namespace
+
+TEST(OperationDispatchTernary, DatetimeNumericMismatchColumnColumn) {
+    auto condition = alternating_condition();
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+
+    EXPECT_THROW(ternary_operator(condition, datetime_column, int_column), UserInputException);
+    EXPECT_THROW(ternary_operator(condition, int_column, datetime_column), UserInputException);
+}
+
+TEST(OperationDispatchTernary, DatetimeNumericMismatchColumnValue) {
+    auto condition = alternating_condition();
+    auto int_column = ColumnWithStrings(std::make_unique<Column>(generate_int_column(num_rows)), "int_col");
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+    auto int_value = Value{static_cast<int64_t>(5), DataType::INT64};
+    auto datetime_value = construct_timestamp_value(5);
+
+    EXPECT_THROW(ternary_operator(condition, datetime_column, int_value), UserInputException);
+    EXPECT_THROW((ternary_operator<true>(condition, datetime_column, int_value)), UserInputException);
+    EXPECT_THROW(ternary_operator(condition, int_column, datetime_value), UserInputException);
+    EXPECT_THROW((ternary_operator<true>(condition, int_column, datetime_value)), UserInputException);
+}
+
+TEST(OperationDispatchTernary, DatetimeNumericMismatchValueValue) {
+    auto condition = alternating_condition();
+    auto int_value = Value{static_cast<int64_t>(5), DataType::INT64};
+    auto datetime_value = construct_timestamp_value(5);
+
+    EXPECT_THROW(ternary_operator(condition, datetime_value, int_value), UserInputException);
+    EXPECT_THROW(ternary_operator(condition, int_value, datetime_value), UserInputException);
+}
+
+// timestamp is int64_t, so without an explicit branch the output would be tagged INT64
+TEST(OperationDispatchTernary, DatetimeOutputTypeIsTimestamp) {
+    auto condition = alternating_condition();
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+    auto other_datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "other_datetime_col");
+    auto datetime_value = construct_timestamp_value(5);
+
+    ASSERT_EQ(
+            DataType::NANOSECONDS_UTC64,
+            output_data_type(ternary_operator(condition, datetime_column, other_datetime_column))
+    );
+    ASSERT_EQ(
+            DataType::NANOSECONDS_UTC64, output_data_type(ternary_operator(condition, datetime_column, datetime_value))
+    );
+    ASSERT_EQ(
+            DataType::NANOSECONDS_UTC64,
+            output_data_type((ternary_operator<true>(condition, datetime_column, datetime_value)))
+    );
+    ASSERT_EQ(
+            DataType::NANOSECONDS_UTC64, output_data_type(ternary_operator(condition, datetime_value, datetime_value))
+    );
+    // Only one real operand, so there is nothing to mismatch against and the column type is reused
+    ASSERT_EQ(
+            DataType::NANOSECONDS_UTC64, output_data_type(ternary_operator(condition, datetime_column, EmptyResult{}))
+    );
+    ASSERT_EQ(
+            DataType::NANOSECONDS_UTC64, output_data_type(ternary_operator(condition, datetime_value, EmptyResult{}))
+    );
+}
+
+TEST(OperationDispatchTernary, DatetimeColumnColumnSelectsCorrectValues) {
+    auto condition = alternating_condition();
+    auto datetime_column =
+            ColumnWithStrings(std::make_unique<Column>(generate_datetime_column(num_rows)), "datetime_col");
+    auto datetime_value = construct_timestamp_value(-1);
+
+    auto variant_data = ternary_operator(condition, datetime_column, datetime_value);
+    auto output = std::get<ColumnWithStrings>(variant_data).column_;
+    for (size_t idx = 0; idx < num_rows; ++idx) {
+        const auto expected = idx % 2 == 0 ? static_cast<timestamp>(idx) : timestamp{-1};
+        ASSERT_EQ(expected, output->scalar_at<timestamp>(idx));
+    }
+}

--- a/cpp/arcticdb/processing/test/test_unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/test/test_unsorted_aggregation.cpp
@@ -35,7 +35,7 @@ TEST_P(UnsortedAggregationDataTypeParametrizationFixture, Sum) {
 TEST_P(UnsortedAggregationDataTypeParametrizationFixture, Mean) {
     MeanAggregatorData aggregator_data;
     const DataType dt = GetParam();
-    if (!(is_numeric_type(dt) || is_bool_type(dt) || is_empty_type(dt))) {
+    if (!(is_numeric_or_time_type(dt) || is_bool_type(dt) || is_empty_type(dt))) {
         ASSERT_THROW(aggregator_data.add_data_type(dt), SchemaException);
     } else {
         aggregator_data.add_data_type(dt);

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -450,7 +450,7 @@ void MaxAggregatorData::add_data_type(DataType data_type) { add_data_type_impl(d
 
 DataType MaxAggregatorData::get_output_data_type() {
     schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
-            is_numeric_type(*data_type_) || is_bool_type(*data_type_) || is_empty_type(*data_type_),
+            is_numeric_or_time_type(*data_type_) || is_bool_type(*data_type_) || is_empty_type(*data_type_),
             "Max aggregation not supported with type {}",
             *data_type_
     );
@@ -479,7 +479,7 @@ void MinAggregatorData::add_data_type(DataType data_type) { add_data_type_impl(d
 
 DataType MinAggregatorData::get_output_data_type() {
     schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
-            is_numeric_type(*data_type_) || is_bool_type(*data_type_) || is_empty_type(*data_type_),
+            is_numeric_or_time_type(*data_type_) || is_bool_type(*data_type_) || is_empty_type(*data_type_),
             "Min aggregation not supported with type {}",
             *data_type_
     );
@@ -506,7 +506,7 @@ std::optional<Value> MinAggregatorData::get_default_value() { return {}; }
 
 void MeanAggregatorData::add_data_type(DataType data_type) {
     schema::check<ErrorCode::E_UNSUPPORTED_COLUMN_TYPE>(
-            is_numeric_type(data_type) || is_bool_type(data_type) || is_empty_type(data_type),
+            is_numeric_or_time_type(data_type) || is_bool_type(data_type) || is_empty_type(data_type),
             "Mean aggregation not supported with type {}",
             data_type
     );

--- a/cpp/arcticdb/util/test/generators.hpp
+++ b/cpp/arcticdb/util/test/generators.hpp
@@ -80,6 +80,16 @@ inline Column generate_int_column(size_t num_rows) {
     return column;
 }
 
+// Generates a nanosecond timestamp Column where the value in each row is equal to the row index
+inline Column generate_datetime_column(size_t num_rows) {
+    using TDT = TypeDescriptorTag<DataTypeTag<DataType::NANOSECONDS_UTC64>, DimensionTag<Dimension ::Dim0>>;
+    Column column(static_cast<TypeDescriptor>(TDT{}), 0, AllocationType::DYNAMIC, Sparsity::NOT_PERMITTED);
+    for (size_t idx = 0; idx < num_rows; ++idx) {
+        column.set_scalar<timestamp>(static_cast<ssize_t>(idx), static_cast<timestamp>(idx));
+    }
+    return column;
+}
+
 // Generates an int64_t Column where the value in one row out of two is equal to the row index
 inline Column generate_int_sparse_column(size_t num_rows) {
     using TDT = TypeDescriptorTag<DataTypeTag<DataType::INT64>, DimensionTag<Dimension ::Dim0>>;

--- a/cpp/arcticdb/util/test/test_utils.hpp
+++ b/cpp/arcticdb/util/test/test_utils.hpp
@@ -51,7 +51,7 @@ consteval auto all_data_types() {
 }
 
 consteval bool is_allowed_mean_input(const DataType dt) {
-    return is_numeric_type(dt) || is_bool_type(dt) || is_empty_type(dt);
+    return is_numeric_or_time_type(dt) || is_bool_type(dt) || is_empty_type(dt);
 }
 
 consteval auto allowed_mean_input_types() {

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -205,7 +205,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             .def(py::init([](std::vector<std::string>&& value_list) {
                 return std::make_shared<ValueSet>(std::move(value_list));
             }))
-            .def(py::init([](py::array value_list) { return std::make_shared<ValueSet>(value_list); }));
+            .def(py::init([](py::array value_list) { return std::make_shared<ValueSet>(value_list); }))
+            .def_static("from_nanoseconds", [](py::array value_list) {
+                return ValueSet::from_nanoseconds(value_list);
+            });
 
     py::class_<storage::KeySegmentPair>(version, "KeySegmentPair").def(py::init<>());
 

--- a/docs/claude/cpp/ENTITY.md
+++ b/docs/claude/cpp/ENTITY.md
@@ -76,7 +76,7 @@ Helper functions in `cpp/arcticdb/entity/types.hpp`:
 - `get_type_size(DataType)` - Returns byte size of type
 - `is_floating_point_type(DataType)` - Check if float type
 - `is_integer_type(DataType)` - Check if integer type
-- `is_numeric_type(DataType)` - Check if numeric (int or float)
+- `is_numeric_or_time_type(DataType)` - Check if int, float or nanosecond timestamp
 - `is_sequence_type(DataType)` - Check if string/array type
 
 ## Type Descriptors

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -386,15 +386,28 @@ def value_list_from_args(*args):
     array_list = []
     value_set = set()
     contains_integer = False
+    contains_time_type = False
+    all_time_types = True
     if len(collection) > 0:
         for value in collection:
             if value not in value_set:
                 value_set.add(value)
                 if isinstance(value, supported_time_types):
+                    contains_time_type = True
                     value = nanoseconds_from_utc(value)
-                elem = np.array([value]) if isinstance(value, (int, np.integer)) else np.full(1, value, dtype=None)
+                    # dtype must be forced to int64 rather than relying on the platform-dependent default integer
+                    # type (32-bit on Windows), otherwise the view to datetime64[ns] below can fail to apply
+                    elem = np.array([value], dtype=np.int64)
+                else:
+                    all_time_types = False
+                    elem = np.array([value]) if isinstance(value, (int, np.integer)) else np.full(1, value, dtype=None)
                 array_list.append(elem)
                 contains_integer = contains_integer or isinstance(value, (int, np.integer))
+        if contains_time_type and not all_time_types:
+            # Without this, a Timestamp mixed with a plain number would silently degrade to an all-numeric value
+            # list containing the Timestamp's raw nanosecond integer, rather than being rejected like a value list
+            # of only Timestamps compared against a numeric column already is
+            raise UserInputException("Timestamp and numeric types cannot be mixed in the same value set")
         value_list = np.concatenate(array_list)
         if contains_integer and value_list.dtype == np.float64:
             raise UserInputException("Invalid datatype conversion to double")
@@ -402,6 +415,9 @@ def value_list_from_args(*args):
             value_list = value_list.astype(np.float32)
         elif value_list.dtype.kind == "U":
             value_list = value_list.tolist()
+        elif all_time_types and value_list.dtype == np.int64:
+            # Carry the time type through to the ValueSet, so that mixing it with a numeric column is rejected
+            value_list = value_list.view("datetime64[ns]")
     else:
         # Return an empty list. This will call the string ctor for ValueSet, but also set a bool flag so that numeric
         # types also behave as expected
@@ -1282,6 +1298,9 @@ def visit_expression(expr):
                 return _ExpressionNode(_ColumnName(node.left))
             return _visit(node)
         elif isinstance(node, (np.ndarray, list)):
+            # "M" is numpy's dtype kind code for datetime64
+            if isinstance(node, np.ndarray) and node.dtype.kind == "M":
+                return _ExpressionNode(_ValueSet.from_nanoseconds(node.view("int64")))
             return _ExpressionNode(_ValueSet(node))
         elif isinstance(node, _RegexGeneric):
             return _ExpressionNode(node)

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -8,6 +8,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 
 from datetime import datetime
 from itertools import cycle
+import operator
 import math
 import numpy as np
 from packaging.version import Version
@@ -252,8 +253,7 @@ def test_filter_datetime_naive(lmdb_version_store_v1, any_output_format, column_
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
 @pytest.mark.parametrize("flipped", (True, False))
-@pytest.mark.parametrize("function", ("__lt__", "__le__", "__eq__", "__ne__", "__gt__", "__ge__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("function", (operator.lt, operator.le, operator.eq, operator.ne, operator.gt, operator.ge))
 def test_filter_datetime_col_against_numeric_value(
     dtype, flipped, function, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
@@ -266,17 +266,16 @@ def test_filter_datetime_col_against_numeric_value(
     value = dtype(pd.Timestamp(1).value)
     q = QueryBuilder()
     if flipped:
-        q = q[getattr(value, function)(q["a"])]
+        q = q[function(value, q["a"])]
     else:
-        q = q[getattr(q["a"], function)(value)]
-    with pytest.raises(UserInputException):
+        q = q[function(q["a"], value)]
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
 @pytest.mark.parametrize("flipped", (True, False))
-@pytest.mark.parametrize("function", ("__lt__", "__le__", "__eq__", "__ne__", "__gt__", "__ge__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("function", (operator.lt, operator.le, operator.eq, operator.ne, operator.gt, operator.ge))
 def test_filter_numeric_col_against_datetime_value(
     dtype, flipped, function, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
@@ -289,16 +288,15 @@ def test_filter_numeric_col_against_datetime_value(
     value = pd.Timestamp(1)
     q = QueryBuilder()
     if flipped:
-        q = q[getattr(value, function)(q["a"])]
+        q = q[function(value, q["a"])]
     else:
-        q = q[getattr(q["a"], function)(value)]
-    with pytest.raises(UserInputException):
+        q = q[function(q["a"], value)]
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
 @pytest.mark.parametrize("function", ("isin", "isnotin"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
 def test_filter_datetime_against_numeric_isin(
     function, dtype, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
@@ -310,13 +308,12 @@ def test_filter_datetime_against_numeric_isin(
     lib.create_column_stats_experimental(symbol)
     q = QueryBuilder()
     q = q[getattr(q["a"], function)([dtype(pd.Timestamp(1).value)])]
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
 @pytest.mark.parametrize("function", ("isin", "isnotin"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
 def test_filter_numeric_against_datetime_isin(
     function, dtype, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
@@ -328,13 +325,31 @@ def test_filter_numeric_against_datetime_isin(
     lib.create_column_stats_experimental(symbol)
     q = QueryBuilder()
     q = q[getattr(q["a"], function)([pd.Timestamp(1)])]
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+@pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
+@pytest.mark.parametrize("function", ("isin", "isnotin"))
+def test_filter_numeric_against_mixed_time_numeric_isin(
+    function, dtype, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
+):
+    # A value set mixing a Timestamp with a plain number must be rejected rather than silently falling back to
+    # comparing the column against the Timestamp's raw nanosecond integer
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame({"a": [0, 1]}, dtype=dtype)
+    lib.write(symbol, df)
+    lib.create_column_stats_experimental(symbol)
+    q = QueryBuilder()
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        q = q[getattr(q["a"], function)([pd.Timestamp(1), dtype(0)])]
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
 @pytest.mark.parametrize("function", ("__lt__", "__le__", "__eq__", "__ne__", "__gt__", "__ge__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
 def test_filter_datetime_col_against_numeric_col(
     dtype, function, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
@@ -346,13 +361,12 @@ def test_filter_datetime_col_against_numeric_col(
     lib.create_column_stats_experimental(symbol)
     q = QueryBuilder()
     q = q[getattr(q["a"], function)(q["b"])]
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
 @pytest.mark.parametrize("function", ("__lt__", "__le__", "__eq__", "__ne__", "__gt__", "__ge__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
 def test_filter_numeric_col_against_datetime_col(
     dtype, function, lmdb_version_store_v1, any_output_format, column_stats_filtering_enabled_and_disabled
 ):
@@ -364,7 +378,7 @@ def test_filter_numeric_col_against_datetime_col(
     lib.create_column_stats_experimental(symbol)
     q = QueryBuilder()
     q = q[getattr(q["a"], function)(q["b"])]
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
+++ b/python/tests/unit/arcticdb/version_store/test_lazy_dataframe.py
@@ -13,6 +13,7 @@ import pickle
 import pytest
 
 from arcticdb import col, LazyDataFrame, LazyDataFrameCollection, QueryBuilder, ReadRequest, where
+from arcticdb.exceptions import UserInputException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import assert_frame_equal, config_context, query_stats_operation_count
 
@@ -675,3 +676,68 @@ def test_lazy_batch_pickling(lmdb_library, any_output_format):
     received_roundtripped = roundtripped.collect()
     for vit in received_roundtripped:
         assert_frame_equal(expected, vit.data)
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        lambda lazy_df: lazy_df["dt"] < lazy_df["num"],
+        lambda lazy_df: lazy_df["num"] < lazy_df["dt"],
+        lambda lazy_df: lazy_df["dt"].isin([0, 1]),
+    ],
+)
+def test_lazy_collect_schema_rejects_mixed_time_numeric_filter(lmdb_library, expression):
+    lib = lmdb_library
+    sym = "test_lazy_collect_schema_rejects_mixed_time_numeric_filter"
+    lib.write(
+        sym,
+        pd.DataFrame({"dt": [pd.Timestamp("2000-01-01")], "num": np.array([0], dtype=np.int64)}),
+    )
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df[expression(lazy_df)]
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lazy_df._collect_schema()
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        lambda lazy_df: lazy_df["dt"] * lazy_df["num"],
+        lambda lazy_df: lazy_df["num"] - lazy_df["dt"],
+        lambda lazy_df: where(lazy_df["cond"], lazy_df["dt"], lazy_df["num"]),
+    ],
+)
+def test_lazy_collect_schema_rejects_mixed_time_numeric_projection(lmdb_library, expression):
+    lib = lmdb_library
+    sym = "test_lazy_collect_schema_rejects_mixed_time_numeric_projection"
+    lib.write(
+        sym,
+        pd.DataFrame(
+            {"cond": [True], "dt": [pd.Timestamp("2000-01-01")], "num": np.array([0], dtype=np.int64)},
+        ),
+    )
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df.apply("projected", expression(lazy_df))
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lazy_df._collect_schema()
+
+
+# The static layer must agree with the runtime layer on the output type, not just on what is rejected
+def test_lazy_collect_schema_datetime_offset_and_ternary(lmdb_library):
+    lib = lmdb_library
+    sym = "test_lazy_collect_schema_datetime_offset_and_ternary"
+    lib.write(
+        sym,
+        pd.DataFrame(
+            {"cond": [True], "dt1": [pd.Timestamp("2000-01-01")], "dt2": [pd.Timestamp("2001-01-01")]},
+        ),
+    )
+    lazy_df = lib.read(sym, lazy=True)
+    lazy_df = lazy_df.apply("offset", lazy_df["dt1"] + np.int64(1))
+    lazy_df = lazy_df.apply("chosen", where(lazy_df["cond"], lazy_df["dt1"], lazy_df["dt2"]))
+    schema = lazy_df._collect_schema()
+    assert schema["offset"] == pl.Datetime("ns")
+    assert schema["chosen"] == pl.Datetime("ns")
+    received = lazy_df.collect().data
+    assert received["offset"].dtype == np.dtype("datetime64[ns]")
+    assert received["chosen"].dtype == np.dtype("datetime64[ns]")

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -270,8 +270,7 @@ def test_project_pow_dynamic(lmdb_version_store_dynamic_schema_v1, any_output_fo
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
-@pytest.mark.parametrize("op", ("__add__", "__sub__", "__mul__", "__truediv__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("op", ("__mul__", "__truediv__", "__pow__"))
 def test_project_datetime_col_with_numeric_scalar(dtype, op, lmdb_version_store_v1, any_output_format):
     lib = lmdb_version_store_v1
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -281,13 +280,12 @@ def test_project_datetime_col_with_numeric_scalar(dtype, op, lmdb_version_store_
     value = dtype(1)
     q = QueryBuilder()
     q = q.apply("result", getattr(q["a"], op)(value))
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
-@pytest.mark.parametrize("op", ("__add__", "__sub__", "__mul__", "__truediv__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("op", ("__mul__", "__truediv__", "__pow__"))
 def test_project_numeric_col_with_datetime_scalar(dtype, op, lmdb_version_store_v1, any_output_format):
     lib = lmdb_version_store_v1
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -297,13 +295,12 @@ def test_project_numeric_col_with_datetime_scalar(dtype, op, lmdb_version_store_
     value = pd.Timestamp(1)
     q = QueryBuilder()
     q = q.apply("result", getattr(q["a"], op)(value))
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
-@pytest.mark.parametrize("op", ("__add__", "__sub__", "__mul__", "__truediv__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("op", ("__mul__", "__truediv__", "__pow__"))
 def test_project_datetime_col_with_numeric_col(dtype, op, lmdb_version_store_v1, any_output_format):
     lib = lmdb_version_store_v1
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -312,13 +309,12 @@ def test_project_datetime_col_with_numeric_col(dtype, op, lmdb_version_store_v1,
     lib.write(symbol, df)
     q = QueryBuilder()
     q = q.apply("result", getattr(q["a"], op)(q["b"]))
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
 @pytest.mark.parametrize("dtype", (np.int64, np.uint64, np.float64, np.float32))
-@pytest.mark.parametrize("op", ("__add__", "__sub__", "__mul__", "__truediv__"))
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("op", ("__mul__", "__truediv__", "__pow__"))
 def test_project_numeric_col_with_datetime_col(dtype, op, lmdb_version_store_v1, any_output_format):
     lib = lmdb_version_store_v1
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -327,11 +323,114 @@ def test_project_numeric_col_with_datetime_col(dtype, op, lmdb_version_store_v1,
     lib.write(symbol, df)
     q = QueryBuilder()
     q = q.apply("result", getattr(q["a"], op)(q["b"]))
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
         lib.read(symbol, query_builder=q)
 
 
-@pytest.mark.xfail(reason="Bug - see 8065794446")
+@pytest.mark.parametrize("dtype", (np.float64, np.float32))
+@pytest.mark.parametrize("op", ("__add__", "__sub__"))
+def test_project_datetime_col_with_float_offset(dtype, op, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame({"a": [pd.Timestamp(0), pd.Timestamp(1)]})
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q.apply("result", getattr(q["a"], op)(dtype(1)))
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+# A timedelta reaches the processing pipeline as a plain integer, so integer addition and subtraction must remain
+# permitted, and must produce a timestamp rather than the int64 the promoted raw type would imply
+@pytest.mark.parametrize("dtype", (np.int8, np.uint8, np.int64, np.uint64))
+@pytest.mark.parametrize("op", ("__add__", "__sub__"))
+def test_project_datetime_col_with_integer_offset_scalar(dtype, op, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame({"a": [pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")]})
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q.apply("result", getattr(q["a"], op)(dtype(1)))
+    received = lib.read(symbol, query_builder=q).data
+    expected = df.copy()
+    expected["result"] = getattr(df["a"], op)(pd.Timedelta(1, "ns"))
+    assert received["result"].dtype == np.dtype("datetime64[ns]")
+    assert_frame_equal(expected, received)
+
+
+@pytest.mark.parametrize("op", ("__add__", "__sub__"))
+def test_project_datetime_col_with_integer_offset_col(op, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame(
+        {"a": [pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")], "b": np.array([1, 2], dtype=np.int64)}
+    )
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q.apply("result", getattr(q["a"], op)(q["b"]))
+    received = lib.read(symbol, query_builder=q).data
+    expected = df.copy()
+    expected["result"] = getattr(df["a"], op)(df["b"].astype("timedelta64[ns]"))
+    assert received["result"].dtype == np.dtype("datetime64[ns]")
+    assert_frame_equal(expected, received)
+
+
+# Addition is commutative so the integer may be on either side, but an integer minus a timestamp is not a timestamp.
+# Pandas raises TypeError for this.
+@pytest.mark.parametrize("scalar", (True, False))
+def test_project_integer_minus_datetime_col(scalar, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame(
+        {"a": [pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")], "b": np.array([1, 2], dtype=np.int64)}
+    )
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q.apply("result", np.int64(5) - q["a"] if scalar else q["b"] - q["a"])
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+@pytest.mark.parametrize("scalar", (True, False))
+def test_project_integer_plus_datetime_col(scalar, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame(
+        {"a": [pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")], "b": np.array([1, 2], dtype=np.int64)}
+    )
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q.apply("result", np.int64(1) + q["a"] if scalar else q["b"] + q["a"])
+    received = lib.read(symbol, query_builder=q).data
+    expected = df.copy()
+    offset = pd.Timedelta(1, "ns") if scalar else df["b"].astype("timedelta64[ns]")
+    expected["result"] = df["a"] + offset
+    assert received["result"].dtype == np.dtype("datetime64[ns]")
+    assert_frame_equal(expected, received)
+
+
+def test_project_datetime_col_minus_datetime_col(lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "sym"
+    df = pd.DataFrame(
+        {"a": [pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-04")], "b": [pd.Timestamp(0), pd.Timestamp(1)]}
+    )
+    lib.write(symbol, df)
+    q = QueryBuilder()
+    q = q.apply("result", q["a"] - q["b"])
+    received = lib.read(symbol, query_builder=q).data
+    # There is no duration type, so the nanosecond difference comes back as an integer
+    expected = df.copy()
+    expected["result"] = (df["a"] - df["b"]).astype("int64")
+    assert_frame_equal(expected, received)
+
+
 def test_project_abs_datetime_col(lmdb_version_store_v1, any_output_format):
     lib = lmdb_version_store_v1
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -340,11 +439,10 @@ def test_project_abs_datetime_col(lmdb_version_store_v1, any_output_format):
     lib.write(symbol, df)
     q = QueryBuilder()
     q = q.apply("result", abs(q["a"]))
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Cannot perform unary operation"):
         lib.read(symbol, query_builder=q)
 
 
-@pytest.mark.xfail(reason="Bug - see 8065794446")
 def test_project_neg_datetime_col(lmdb_version_store_v1, any_output_format):
     lib = lmdb_version_store_v1
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -353,7 +451,7 @@ def test_project_neg_datetime_col(lmdb_version_store_v1, any_output_format):
     lib.write(symbol, df)
     q = QueryBuilder()
     q = q.apply("result", -q["a"])
-    with pytest.raises(UserInputException):
+    with pytest.raises(UserInputException, match="Cannot perform unary operation"):
         lib.read(symbol, query_builder=q)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder.py
@@ -16,8 +16,8 @@ import datetime
 import dateutil
 
 from arcticdb import OutputFormat
-from arcticdb.exceptions import SchemaException
-from arcticdb.version_store.processing import QueryBuilder
+from arcticdb.exceptions import SchemaException, UserInputException
+from arcticdb.version_store.processing import QueryBuilder, value_list_from_args
 from arcticdb.util.test import assert_frame_equal, query_stats_operation_count
 import arcticdb.toolbox.query_stats as qs
 
@@ -1398,3 +1398,25 @@ def test_filter_synthetic_column_and_select_on_disk_column(
         # filter and then read the second column slice to return the requested column
         data_keys_count = 2
     assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == data_keys_count
+
+
+def test_value_list_from_args_tags_small_timestamps_as_time_type(monkeypatch):
+    # numpy's default integer dtype for a bare Python int follows the C `long` type, which is 32-bit on
+    # Windows but 64-bit on Linux/macOS. Simulate the Windows behaviour here so the test is meaningful on
+    # any platform: value_list_from_args must force int64 explicitly for timestamp values rather than
+    # relying on this platform-dependent default, otherwise the view to datetime64[ns] is silently skipped.
+    real_array = np.array
+
+    def windows_like_array(seq, *args, **kwargs):
+        if not args and "dtype" not in kwargs:
+            kwargs["dtype"] = np.int32
+        return real_array(seq, *args, **kwargs)
+
+    monkeypatch.setattr(np, "array", windows_like_array)
+    value_list = value_list_from_args([pd.Timestamp(0), pd.Timestamp(1)])
+    assert value_list.dtype == np.dtype("datetime64[ns]")
+
+
+def test_value_list_from_args_rejects_mixed_time_and_numeric():
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        value_list_from_args([pd.Timestamp(0), 5])

--- a/python/tests/unit/arcticdb/version_store/test_ternary.py
+++ b/python/tests/unit/arcticdb/version_store/test_ternary.py
@@ -1038,6 +1038,160 @@ def test_filter_ternary_invalid_arguments(lmdb_version_store_v1, any_output_form
         lib.read(symbol, query_builder=q)
 
 
+@pytest.fixture
+def ternary_datetime_sym(lmdb_version_store_v1):
+    df = pd.DataFrame(
+        {
+            "conditional": [True, False, True],
+            "dt1": [pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02"), pd.Timestamp("2000-01-03")],
+            "dt2": [pd.Timestamp("2001-01-01"), pd.Timestamp("2001-01-02"), pd.Timestamp("2001-01-03")],
+            "numeric": np.array([0, 1, 2], dtype=np.int64),
+        }
+    )
+    symbol = "ternary_datetime_sym"
+    lmdb_version_store_v1.write(symbol, df)
+    return symbol, df
+
+
+@pytest.mark.parametrize("flipped", (True, False))
+def test_project_ternary_datetime_col_numeric_col(
+    ternary_datetime_sym, flipped, lmdb_version_store_v1, any_output_format
+):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol, _ = ternary_datetime_sym
+    q = QueryBuilder()
+    args = ("numeric", "dt1") if flipped else ("dt1", "numeric")
+    q = q.apply("projected", where(q["conditional"], q[args[0]], q[args[1]]))
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+@pytest.mark.parametrize("flipped", (True, False))
+def test_project_ternary_datetime_col_numeric_value(
+    ternary_datetime_sym, flipped, lmdb_version_store_v1, any_output_format
+):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol, _ = ternary_datetime_sym
+    q = QueryBuilder()
+    q = q.apply("projected", where(q["conditional"], 0, q["dt1"]) if flipped else where(q["conditional"], q["dt1"], 0))
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+@pytest.mark.parametrize("value", (1.5, np.float32(1.5)))
+def test_project_ternary_datetime_col_float_value(
+    ternary_datetime_sym, value, lmdb_version_store_v1, any_output_format
+):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol, _ = ternary_datetime_sym
+    q = QueryBuilder()
+    q = q.apply("projected", where(q["conditional"], q["dt1"], value))
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+def test_project_ternary_datetime_value_numeric_value(lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_project_ternary_datetime_value_numeric_value"
+    lib.write(symbol, pd.DataFrame({"conditional": [True, False]}))
+    q = QueryBuilder()
+    q = q.apply("projected", where(q["conditional"], pd.Timestamp("2000-01-01"), 0))
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+@pytest.mark.parametrize("flipped", (True, False))
+def test_project_ternary_datetime_value_numeric_col(
+    ternary_datetime_sym, flipped, lmdb_version_store_v1, any_output_format
+):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol, _ = ternary_datetime_sym
+    value = pd.Timestamp("2000-01-01")
+    q = QueryBuilder()
+    q = q.apply(
+        "projected",
+        where(q["conditional"], q["numeric"], value) if flipped else where(q["conditional"], value, q["numeric"]),
+    )
+    with pytest.raises(UserInputException, match="Timestamp and numeric types cannot be mixed"):
+        lib.read(symbol, query_builder=q)
+
+
+# Both branches being timestamps must keep working, and must produce a datetime64 column rather than the int64 that
+# the promoted raw type would imply
+def test_project_ternary_datetime_col_col(ternary_datetime_sym, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol, df = ternary_datetime_sym
+    q = QueryBuilder()
+    q = q.apply("projected", where(q["conditional"], q["dt1"], q["dt2"]))
+    received = lib.read(symbol, query_builder=q).data
+    expected = df.copy(deep=True)
+    expected["projected"] = np.where(df["conditional"].to_numpy(), df["dt1"], df["dt2"])
+    assert received["projected"].dtype == np.dtype("datetime64[ns]")
+    assert_frame_equal(expected, received)
+
+
+@pytest.mark.parametrize("flipped", (True, False))
+def test_project_ternary_datetime_col_value(ternary_datetime_sym, flipped, lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol, df = ternary_datetime_sym
+    value = pd.Timestamp("2002-06-05")
+    q = QueryBuilder()
+    q = q.apply(
+        "projected",
+        where(q["conditional"], value, q["dt1"]) if flipped else where(q["conditional"], q["dt1"], value),
+    )
+    received = lib.read(symbol, query_builder=q).data
+    expected = df.copy(deep=True)
+    # np.where with a Series and a scalar Timestamp loses the datetime64 dtype
+    if flipped:
+        expected["projected"] = df["dt1"].where(~df["conditional"], value)
+    else:
+        expected["projected"] = df["dt1"].where(df["conditional"], value)
+    assert received["projected"].dtype == np.dtype("datetime64[ns]")
+    assert_frame_equal(expected, received)
+
+
+def test_project_ternary_datetime_value_value(lmdb_version_store_v1, any_output_format):
+    lib = lmdb_version_store_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_project_ternary_datetime_value_value"
+    df = pd.DataFrame({"conditional": [True, False]})
+    lib.write(symbol, df)
+    left = pd.Timestamp("2000-01-01")
+    right = pd.Timestamp("2001-01-01")
+    q = QueryBuilder()
+    q = q.apply("projected", where(q["conditional"], left, right))
+    received = lib.read(symbol, query_builder=q).data
+    expected = df.copy(deep=True)
+    expected["projected"] = np.where(df["conditional"].to_numpy(), left, right)
+    assert received["projected"].dtype == np.dtype("datetime64[ns]")
+    assert_frame_equal(expected, received)
+
+
+# Only one branch is a real operand under dynamic schema, so there is nothing to mismatch against
+def test_project_ternary_datetime_dynamic_missing_column(lmdb_version_store_dynamic_schema_v1, any_output_format):
+    lib = lmdb_version_store_dynamic_schema_v1
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    symbol = "test_project_ternary_datetime_dynamic_missing_column"
+    df_0 = pd.DataFrame(
+        {"conditional": [True, False], "dt1": [pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")]}, index=[0, 1]
+    )
+    df_1 = pd.DataFrame({"conditional": [True, False]}, index=[2, 3])
+    lib.write(symbol, df_0)
+    lib.append(symbol, df_1)
+    q = QueryBuilder()
+    q = q.apply("projected", where(q["conditional"], q["dt1"], q["dt1"]))
+    received = lib.read(symbol, query_builder=q).data
+    assert received["projected"].dtype == np.dtype("datetime64[ns]")
+
+
 def test_filter_ternary_pythonic_syntax():
     q = QueryBuilder()
     with pytest.raises(UserInputException):


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes 8065794446.

#### What does this implement or fix?

`QueryBuilder` expressions that mixed a timestamp (`pd.Timestamp`/`datetime64` column) with a plain numeric type (`int`, `uint`, `float`) previously either silently compared/computed against the timestamp's raw nanosecond-since-epoch integer, or raised a confusing, unrelated error. This PR makes all mismatches raise a `UserInputException`:

```
Timestamp and numeric types cannot be mixed
```

This affects comparisons, `isin`/`isnotin`, `where(...)` (ternary), and arithmetic, in any
combination of column/column, column/value, or value/value operands. The one exception is
adding or subtracting a plain integer to/from a timestamp, which is unchanged and still treated
as a nanosecond offset (see below), because ArcticDB has no separate timedelta type.

##### Comparisons and filtering

Before, this would silently compare the raw nanosecond count against `5`, filtering on an
almost-certainly unintended condition, rather than raising:

```python
q = QueryBuilder()
q = q[q["timestamp_col"] > 5]
lib.read("sym", query_builder=q)
```

Now this raises:

```
UserInputException: ... timestamp_col is of type NANOSECONDS_UTC64 and cannot be compared to 5,
which is of type INT64. Timestamp and numeric types cannot be mixed.
```

The same applies to `isin`/`isnotin` when the value set mixes timestamps and plain numbers:

```python
q = q[q["timestamp_col"].isin([pd.Timestamp("2024-01-01"), 5])]  # now raises
```

##### Projections (`where`, arithmetic)

```python
q = q.apply("result", where(q["cond"], q["timestamp_col"], 0))       # now raises
q = q.apply("result", q["timestamp_col"] * 2)                        # now raises
q = q.apply("result", q["timestamp_col"] / 2)                        # now raises
```

Two timestamp columns/values on both sides of a `where(...)` continue to work, and now correctly
produce a `datetime64[ns]` result column (previously this path could produce an `int64` column
instead, since a timestamp's underlying raw type is `int64`):

```python
q = q.apply("result", where(q["cond"], q["dt1"], q["dt2"]))
# result column dtype: datetime64[ns]
```

##### Timestamp +/- integer offsets keep working

Adding or subtracting an integer to/from a timestamp column or value is unaffected by this
change and continues to be treated as a nanosecond offset (there is no distinct timedelta type
in ArcticDB's processing pipeline), and the result is correctly typed as a timestamp rather than
an integer:

```python
q = q.apply("result", q["timestamp_col"] + 1)          # result: timestamp_col + 1 nanosecond
q = q.apply("result", q["timestamp_col"] - q["int_col"])  # result: timestamp column
```

Subtracting two timestamp columns/values is also unaffected, and returns an `int64` nanosecond
difference (as before), since there is no timedelta type to represent the result:

```python
q = q.apply("result", q["dt_col_a"] - q["dt_col_b"])   # result: int64 nanoseconds
```

An integer minus a timestamp still raises, matching pandas' behaviour for the equivalent
`Series` operation (a `TypeError` in pandas):

```python
q = q.apply("result", 5 - q["timestamp_col"])          # now raises
```

##### Unary operations on timestamp columns

`abs()` and unary negation on a timestamp column now raise a clearer message
(`Cannot perform unary operation ...`) rather than the previous, less specific wording. This was
already rejected before; only the message text has changed.