### PR TITLE
Implement upsert and write new version even when source is empty

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -2492,18 +2492,17 @@ VersionedItem LocalVersionedEngine::merge_internal(
     const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
     if (update_info.previous_index_key_.has_value()) {
         const ReadOptions read_options;
-        const WriteOptions write_options = get_write_options();
         index_key_fut = source->empty() ? async_write_metadata_impl(store(), update_info, std::move(source->user_meta))
                                         : merge_update_impl(
                                                   store(),
                                                   update_info,
                                                   read_options,
-                                                  write_options,
+                                                  write_options_,
                                                   IndexPartialKey{stream_id, update_info.next_version_id_},
                                                   std::move(on),
                                                   strategy,
                                                   std::move(source),
-                                                  get_de_dup_map(stream_id, update_info, write_options)
+                                                  get_de_dup_map(stream_id, update_info, write_options_)
                                           );
     } else if (upsert) {
         user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
@@ -2515,13 +2514,7 @@ VersionedItem LocalVersionedEngine::merge_internal(
                 strategy
         );
         index_key_fut = async_write_dataframe_impl(
-                store(),
-                update_info.next_version_id_,
-                source,
-                get_write_options(),
-                std::make_shared<DeDupMap>(),
-                false,
-                true
+                store(), update_info.next_version_id_, source, write_options_, std::make_shared<DeDupMap>(), false, true
         );
     } else {
         storage::raise<ErrorCode::E_SYMBOL_NOT_FOUND>("Cannot merge into non-existent symbol \"{}\".", stream_id);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -2488,39 +2488,57 @@ VersionedItem LocalVersionedEngine::merge_internal(
     );
     py::gil_scoped_release release_gil;
     auto update_info = get_next_version_id_and_optionally_latest_undeleted_version(store(), version_map(), stream_id);
+    auto index_key_fut = folly::Future<AtomKey>::makeEmpty();
+    const bool add_new_symbol_list_entry = !update_info.previous_index_key_.has_value() && cfg().symbol_list();
     if (update_info.previous_index_key_.has_value()) {
-        if (source->empty()) {
-            ARCTICDB_RUNTIME_DEBUG(
-                    log::version(),
-                    "Merging into existing data with an empty source has no effect. \n No new version is being "
-                    "created "
-                    "for symbol='{}', and the last version is returned",
-                    stream_id
-            );
-            return VersionedItem{*std::move(update_info.previous_index_key_)};
-        }
         const ReadOptions read_options;
-        VersionedItem versioned_item =
-                merge_update_impl(
-                        store(),
-                        update_info,
-                        read_options,
-                        write_options_,
-                        IndexPartialKey{.id = stream_id, .version_id = update_info.next_version_id_},
-                        std::move(on),
-                        strategy,
-                        std::move(source),
-                        get_de_dup_map(stream_id, update_info, write_options_)
-                )
-                        .get();
-        write_version_and_prune_previous(prune_previous_versions, versioned_item.key_, update_info.previous_index_key_);
-        return versioned_item;
+        const WriteOptions write_options = get_write_options();
+        index_key_fut = source->empty() ? async_write_metadata_impl(store(), update_info, std::move(source->user_meta))
+                                        : merge_update_impl(
+                                                  store(),
+                                                  update_info,
+                                                  read_options,
+                                                  write_options,
+                                                  IndexPartialKey{stream_id, update_info.next_version_id_},
+                                                  std::move(on),
+                                                  strategy,
+                                                  std::move(source),
+                                                  get_de_dup_map(stream_id, update_info, write_options)
+                                          );
     } else if (upsert) {
-        internal::raise<ErrorCode::E_NOT_SUPPORTED>(
-                "Error upserting symbol \"{}\". Upsert is not supported for merge yet.", stream_id
+        user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                strategy.insert(),
+                "Error upserting non-existent symbol \"{}\". {} never inserts rows that are not matched by the "
+                "target, so the new symbol would be empty. Either use a merge strategy with "
+                "not_matched_by_target=insert or create the symbol before merging.",
+                stream_id,
+                strategy
         );
+        index_key_fut = async_write_dataframe_impl(
+                store(),
+                update_info.next_version_id_,
+                source,
+                get_write_options(),
+                std::make_shared<DeDupMap>(),
+                false,
+                true
+        );
+    } else {
+        storage::raise<ErrorCode::E_SYMBOL_NOT_FOUND>("Cannot merge into non-existent symbol \"{}\".", stream_id);
     }
-    storage::raise<ErrorCode::E_SYMBOL_NOT_FOUND>("Cannot merge into non-existent symbol \"{}\".", stream_id);
+    return std::move(index_key_fut)
+            .thenValue([this, update_info = std::move(update_info), prune_previous_versions, add_new_symbol_list_entry](
+                               AtomKey&& index_key
+                       ) mutable {
+                return write_index_key_to_version_map_async(
+                        version_map(),
+                        std::move(index_key),
+                        std::move(update_info),
+                        prune_previous_versions,
+                        add_new_symbol_list_entry
+                );
+            })
+            .get();
 }
 
 } // namespace arcticdb::version_store

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -3101,7 +3101,7 @@ folly::Future<VersionedItem> read_modify_write_impl(
             });
 }
 
-folly::Future<VersionedItem> merge_update_impl(
+folly::Future<AtomKey> merge_update_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
         std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -187,7 +187,7 @@ folly::Future<VersionedItem> read_modify_write_impl(
         std::optional<proto::descriptors::UserDefinedMetadata>&& user_meta_proto
 );
 
-folly::Future<VersionedItem> merge_update_impl(
+folly::Future<AtomKey> merge_update_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
         std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4341,10 +4341,9 @@ class NativeVersionStore:
         prune_previous_versions : bool, default False
             If True, removes previous versions from the version list.
         upsert : bool, default False
-            !!! warning
-                Not yet implemented
-
-            If True and `not_matched_by_target="insert"`, creates the symbol if it does not exist.
+            If True and the symbol does not exist, create it by writing `source` to the store. Requires a strategy
+            with `not_matched_by_target="insert"`; combining it with an update-only strategy raises
+            `UserInputException` as the newly created symbol would be empty.
 
         Returns
         -------
@@ -4357,7 +4356,8 @@ class NativeVersionStore:
         StorageException
             If symbol doesn't exist and `upsert=False`
         UserInputException
-            If strategy is not one of the supported strategies listed above
+            If strategy is not one of the supported strategies listed above or if `upsert=True` is used with an
+            update-only strategy and the symbol doesn't exist
         UnsortedDataException
             If date-time index is used and source or target are not sorted
         SchemaException

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3482,10 +3482,9 @@ class Library:
         prune_previous_versions : bool, default False
             If True, removes previous versions from the version list.
         upsert : bool, default False
-            !!! warning
-                Not yet implemented
-
-            If True and `not_matched_by_target="insert"`, creates the symbol if it does not exist.
+            If True and the symbol does not exist, create it by writing `source` to the store. Requires a strategy
+            with `not_matched_by_target="insert"`; combining it with an update-only strategy raises
+            `UserInputException` as the newly created symbol would be empty.
 
         Returns
         -------
@@ -3498,7 +3497,8 @@ class Library:
         StorageException
             If symbol doesn't exist and `upsert=False`
         UserInputException
-            If strategy is not one of the supported strategies listed above
+            If strategy is not one of the supported strategies listed above or if `upsert=True` is used with an
+            update-only strategy and the symbol doesn't exist
         UnsortedDataException
             If date-time index is used and source or target are not sorted
         SchemaException

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -33,13 +33,6 @@ def mock_find_keys_for_symbol(key_types):
     return lambda key_type, symbol: keys[key_type]
 
 
-def raise_wrapper(exception, message=None):
-    def _raise(*args, **kwargs):
-        raise exception(message)
-
-    return _raise
-
-
 def generic_merge_test(
     lib,
     sym: str,
@@ -132,24 +125,19 @@ class TestMergeTimeseriesCommon:
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
     @pytest.mark.parametrize("metadata", ({"meta": "data"}, None))
-    def test_merge_does_not_write_new_version_with_empty_source(self, lmdb_library, metadata, strategy):
+    def test_merge_writes_new_version_with_empty_source(self, lmdb_library, metadata, strategy):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
-        write_vit = lib.write("sym", target)
+        lib.write("sym", target, metadata="v0")
         merge_vit = lib.merge_experimental("sym", pd.DataFrame(), metadata=metadata, strategy=strategy)
-        # There's a bug in append, update, and merge when there's an empty source. All of them return the passed
-        # metadata even though it's not used.
-        merge_vit.metadata = write_vit.metadata
-        assert_vit_equals_except_data(write_vit, merge_vit)
-        assert merge_vit.data is None and write_vit.data is None
+        assert merge_vit.metadata is None if metadata is None else merge_vit.metadata == metadata
         lt = lib._dev_tools.library_tool()
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
-        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 1
-
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
         read_vit = lib.read("sym")
-        assert read_vit.version == 0
-        assert read_vit.metadata is None
+        assert read_vit.version == 1
+        assert merge_vit.metadata is None if metadata is None else merge_vit.metadata == metadata
         assert_frame_equal(read_vit.data, target)
 
     @pytest.mark.parametrize(
@@ -579,20 +567,22 @@ class TestMergeTimeseriesUpdate:
             lib.merge_experimental("sym", source, strategy=self.strategy)
 
     @pytest.mark.parametrize("merge_metadata", (None, "meta"))
-    @pytest.mark.xfail(reason="Monday: 12518592426")
     def test_target_is_empty(self, lmdb_library, merge_metadata):
         lib = lmdb_library
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
         lib.write("sym", target)
-
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
         merge_vit = lib.merge_experimental(
             "sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING), metadata=merge_metadata
         )
-        expected = target
+        assert merge_vit.metadata is None if merge_metadata is None else merge_vit.metadata == merge_metadata
+        lt = lib._dev_tools.library_tool()
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 0
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
         read_vit = lib.read("sym")
         assert read_vit.metadata is None if merge_metadata is None else read_vit.metadata == merge_metadata
-        assert_frame_equal(read_vit.data, expected)
+        assert_frame_equal(read_vit.data, target)
 
     @pytest.mark.parametrize(
         "source",
@@ -602,23 +592,31 @@ class TestMergeTimeseriesUpdate:
             pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")])),
         ),
     )
-    @pytest.mark.parametrize("upsert", (pytest.param(True, marks=pytest.mark.xfail), False))
+    @pytest.mark.parametrize("upsert", (True, False))
     def test_target_symbol_does_not_exist(self, lmdb_library, source, upsert):
+        # An update-only strategy never inserts unmatched rows, so upserting into a non-existent symbol could only
+        # ever create an empty symbol. That is most likely a user error, thus it throws instead.
         lib = lmdb_library
 
-        if not upsert:
-            with pytest.raises(StorageException):
-                lib.merge_experimental(
-                    "sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING), upsert=upsert
-                )
-        else:
-            merge_vit = lib.merge_experimental(
+        expected_exception = UserInputException if upsert else StorageException
+        with pytest.raises(expected_exception):
+            lib.merge_experimental(
                 "sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING), upsert=upsert
             )
-            expected = pd.DataFrame({"a": []}, index=pd.DatetimeIndex([]))
-            read_vit = lib.read("sym")
-            assert_vit_equals_except_data(merge_vit, read_vit)
-            assert_frame_equal(read_vit.data, expected)
+        assert not lib.has_symbol("sym")
+
+    def test_upsert_with_existing_symbol(self, lmdb_library):
+        # When the symbol exists upsert is irrelevant and a regular merge is performed.
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+        source = pd.DataFrame(
+            {"a": [20, 40]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-04")])
+        )
+        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, upsert=True)
+        assert merge_vit.version == 1
+        expected = pd.DataFrame({"a": [1, 20, 3]}, index=pd.date_range("2024-01-01", periods=3))
+        assert_frame_equal(lib.read("sym").data, expected)
 
     def test_updates_the_latest_live_version(self, lmdb_version_store_v1):
         lib = lmdb_version_store_v1
@@ -1151,44 +1149,6 @@ class TestMergeTimeseriesInsert:
         expected = pd.concat([target, source]).sort_index()
         assert_frame_equal(lib.read("sym").data, expected)
 
-    @pytest.mark.parametrize(
-        "date",
-        (
-            pd.Timestamp("2023-01-01"),  # Before first value
-            pd.Timestamp("2024-01-01 10:00:00"),  # After first value and before second value
-            pd.Timestamp("2024-01-02 10:00:00"),  # After second value
-        ),
-    )
-    def test_merge_insert_in_full_segment_creates_new_segment(self, lmdb_library_factory, date, monkeypatch):
-        lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=2, columns_per_segment=2))
-        target = pd.DataFrame(
-            {"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["a", "b", "c"]}, index=pd.date_range("2024-01-01", periods=3)
-        )
-        lib.write("sym", target)
-        lt = lib._dev_tools.library_tool()
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
-
-        source = pd.DataFrame({"a": [10], "b": [20.0], "c": ["A"]}, index=pd.DatetimeIndex([date]))
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
-        lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
-        expected = pd.concat([target, source]).sort_index()
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
-        received = lib.read("sym").data
-        assert_frame_equal(received, expected)
-
-        lt = lib._dev_tools.library_tool()
-        # The first segment is changed
-        # A new segment is created because after the insert the first segment overflows the rows_per_segment setting
-        # Each new segment is column sliced -> 2 * 2 = 4 new data keys
-        monkeypatch.setattr(
-            lt,
-            "find_keys_for_symbol",
-            mock_find_keys_for_symbol({KeyType.TABLE_DATA: 8, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}),
-        )
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 8
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
-        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
-
     # The row slice is not re-emitted when unchanged, so no second data key is written regardless of dedup.
     @pytest.mark.parametrize("dedup, expected_data_keys", [(False, 1), (True, 1)])
     def test_writes_new_version_even_if_nothing_is_changed(self, lmdb_library_factory, dedup, expected_data_keys):
@@ -1719,60 +1679,6 @@ class TestMergeTimeseriesUpdateAndInsert:
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
     @pytest.mark.parametrize(
-        "slicing_policy",
-        [{"rows_per_segment": 2}, {"columns_per_segment": 2}, {"rows_per_segment": 2, "columns_per_segment": 2}],
-    )
-    def test_slicing(self, lmdb_library_factory, monkeypatch, slicing_policy):
-        lib = lmdb_library_factory(arcticdb.LibraryOptions(**slicing_policy))
-        target = pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 5.0], "c": ["a", "b", "c", "d", "e"]},
-            index=pd.date_range("2024-01-01", periods=5),
-        )
-        lib.write("sym", target)
-
-        # Insertion pushes the row to be updated into a new segment
-        source = pd.DataFrame(
-            {"a": [-1, 40], "b": [-1.1, 40.4], "c": ["a", "f"]},
-            index=pd.DatetimeIndex([pd.Timestamp("2024-01-03 15:00:00"), pd.Timestamp("2024-01-04")]),
-        )
-        monkeypatch.setattr(lib.__class__, "merge_experimental", lambda *args, **kwargs: None, raising=False)
-        lib.merge_experimental("sym", source)
-
-        expected = pd.DataFrame(
-            {"a": [1, 2, 3, -1, 40, 5], "b": [1.0, 2.0, 3.0, -1.1, 40.4, 5.0], "c": ["a", "b", "c", "a", "f", "e"]},
-            index=pd.DatetimeIndex(
-                [
-                    pd.Timestamp("2024-01-01"),
-                    pd.Timestamp("2024-01-02"),
-                    pd.Timestamp("2024-01-03"),
-                    pd.Timestamp("2024-01-03 15:00:00"),
-                    pd.Timestamp("2024-01-04"),
-                    pd.Timestamp("2024-01-05"),
-                ]
-            ),
-        )
-        monkeypatch.setattr(lib, "read", lambda *args, **kwargs: VersionedItem("sym", "lib", expected, 2))
-        assert_frame_equal(lib.read("sym").data, expected)
-
-        lt = lib._dev_tools.library_tool()
-        if "rows_per_segment" in slicing_policy and "columns_per_segment" in slicing_policy:
-            expected_data_keys = 10
-        elif "rows_per_segment" in slicing_policy:
-            expected_data_keys = 5
-        elif "columns_per_segment" in slicing_policy:
-            expected_data_keys = 4
-        monkeypatch.setattr(
-            lt,
-            "find_keys_for_symbol",
-            mock_find_keys_for_symbol(
-                {KeyType.TABLE_DATA: expected_data_keys, KeyType.TABLE_INDEX: 2, KeyType.VERSION: 2}
-            ),
-        )
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == expected_data_keys
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
-        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
-
-    @pytest.mark.parametrize(
         "source",
         (
             pd.DataFrame([], index=pd.DatetimeIndex([])),
@@ -1782,7 +1688,8 @@ class TestMergeTimeseriesUpdateAndInsert:
     )
     @pytest.mark.parametrize("upsert", (True, False))
     @pytest.mark.parametrize("strategy", (MergeStrategy("update", "insert"), MergeStrategy("do_nothing", "insert")))
-    def test_target_symbol_does_not_exist(self, lmdb_library, monkeypatch, source, upsert, strategy):
+    @pytest.mark.parametrize("metadata", (None, {"meta": "data"}))
+    def test_target_symbol_does_not_exist(self, lmdb_library, source, upsert, strategy, metadata):
         # Model non-existing target after Library.update
         # There is an upsert parameter to control whether to create the index. If upsert=False exception is thrown.
         # Since we're doing a merge on non-existing data, I think it's logical to assume that nothing matches. No
@@ -1790,44 +1697,55 @@ class TestMergeTimeseriesUpdateAndInsert:
         lib = lmdb_library
 
         if not upsert:
-            monkeypatch.setattr(lib.__class__, "merge_experimental", raise_wrapper(StorageException), raising=False)
             with pytest.raises(StorageException):
-                lib.merge_experimental("sym", source, strategy=strategy, upsert=upsert)
+                lib.merge_experimental("sym", source, strategy=strategy, upsert=upsert, metadata=metadata)
+            assert not lib.has_symbol("sym")
         else:
-            import datetime
-
-            monkeypatch.setattr(
-                lib.__class__,
-                "merge_experimental",
-                lambda *args, **kwargs: VersionedItem(
-                    symbol="sym",
-                    library=lmdb_library.name,
-                    data=None,
-                    version=0,
-                    metadata=None,
-                    host=lmdb_library._nvs.env,
-                    timestamp=pd.Timestamp(datetime.datetime.now()),
-                ),
-                raising=False,
-            )
-            merge_vit = lib.merge_experimental("sym", source, strategy=strategy, upsert=upsert)
-            expected = source
-            monkeypatch.setattr(
-                lib,
-                "read",
-                lambda *args, **kwargs: VersionedItem(
-                    symbol=merge_vit.symbol,
-                    library=merge_vit.library,
-                    data=expected,
-                    version=merge_vit.version,
-                    metadata=merge_vit.metadata,
-                    host=merge_vit.host,
-                    timestamp=merge_vit.timestamp,
-                ),
-            )
+            merge_vit = lib.merge_experimental("sym", source, strategy=strategy, upsert=upsert, metadata=metadata)
+            assert merge_vit.version == 0
+            assert merge_vit.metadata == metadata
+            assert lib.list_symbols() == ["sym"]
             read_vit = lib.read("sym")
             assert_vit_equals_except_data(merge_vit, read_vit)
-            assert_frame_equal(read_vit.data, expected)
+            assert_frame_equal(read_vit.data, source)
+
+    def test_upsert_with_existing_symbol(self, lmdb_library):
+        # When the symbol exists upsert is irrelevant and a regular merge is performed.
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3]}, index=pd.date_range("2024-01-01", periods=3))
+        lib.write("sym", target)
+        source = pd.DataFrame(
+            {"a": [20, 40]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-04")])
+        )
+        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, upsert=True)
+        assert merge_vit.version == 1
+        expected = pd.DataFrame(
+            {"a": [1, 20, 3, 40]},
+            index=pd.DatetimeIndex(
+                [
+                    pd.Timestamp("2024-01-01"),
+                    pd.Timestamp("2024-01-02"),
+                    pd.Timestamp("2024-01-03"),
+                    pd.Timestamp("2024-01-04"),
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_upsert_recreates_symbol_after_delete(self, lmdb_library):
+        # Recreating a deleted symbol continues the version counter and adds a symbol list key.
+        lib = lmdb_library
+        lib.write("sym", pd.DataFrame({"a": [1, 2, 3]}, index=pd.date_range("2024-01-01", periods=3)))
+        lib.delete("sym")
+        lib_tool = lib._dev_tools.library_tool()
+        assert not len(lib.list_symbols())
+        num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
+        source = pd.DataFrame({"a": [10]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-05")]))
+        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, upsert=True)
+        assert merge_vit.version == 1
+        assert_frame_equal(lib.read("sym").data, source)
+        assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
+        assert lib.list_symbols() == ["sym"]
 
     def test_on_index_and_column(self, lmdb_library):
         lib = lmdb_library
@@ -2740,24 +2658,20 @@ class TestMergeRowrangeCommon:
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
     @pytest.mark.parametrize("metadata", ({"meta": "data"}, None))
-    def test_merge_does_not_write_new_version_with_empty_source(self, lmdb_library, metadata, strategy):
+    def test_merge_writes_new_version_with_empty_source(self, lmdb_library, metadata, strategy):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
-        write_vit = lib.write("sym", target)
+        lib.write("sym", target)
         merge_vit = lib.merge_experimental("sym", pd.DataFrame(), metadata=metadata, strategy=strategy, on=["a"])
-        # There's a bug in append, update, and merge when there's an empty source. All of them return the passed
-        # metadata even though it's not used.
-        merge_vit.metadata = write_vit.metadata
-        assert_vit_equals_except_data(write_vit, merge_vit)
-        assert merge_vit.data is None and write_vit.data is None
+        assert merge_vit.metadata is None if metadata is None else merge_vit.metadata == metadata
         lt = lib._dev_tools.library_tool()
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 1
-        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 1
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
+        assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 
         read_vit = lib.read("sym")
-        assert read_vit.version == 0
-        assert read_vit.metadata is None
+        assert read_vit.version == 1
+        assert read_vit.metadata is None if metadata is None else read_vit.metadata == metadata
         assert_frame_equal(read_vit.data, target)
 
     @pytest.mark.parametrize(

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -137,7 +137,7 @@ class TestMergeTimeseriesCommon:
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
         read_vit = lib.read("sym")
         assert read_vit.version == 1
-        assert merge_vit.metadata is None if metadata is None else merge_vit.metadata == metadata
+        assert read_vit.metadata is None if metadata is None else read_vit.metadata == metadata
         assert_frame_equal(read_vit.data, target)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
#### Reference Issues/PRs
Upsert: Monday 18041316370
Metadata: Monday 12518592426

#### What does this implement or fix?
**Upsert** When the strategy allows insertion and the symbol does not exist it will be created and filled with the source data. If the symbol does not exist, upsert is true and the strategy is update only an exception is thrown.

**Metadata** Increase the version and store metadata even when empty source dataframes are passed. Similar to append/update/write.
#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
