### PR TITLE
Sketch to show improvements for forking behaviour

### DIFF
--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -29,6 +29,7 @@
 #include <arcticdb/python/python_handlers_common.hpp>
 #include <arcticdb/python/python_bindings_common.hpp>
 #include <arcticdb/util/pybind_mutex.hpp>
+#include <arcticdb/util/fork_generation.hpp>
 
 #include <pybind11/pybind11.h>
 #include <mongocxx/exception/logic_error.hpp>
@@ -226,6 +227,7 @@ PYBIND11_MODULE(arcticdb_ext, m) {
     pthread_atfork(nullptr, nullptr, &reinit_scheduler);
     pthread_atfork(nullptr, nullptr, &reinit_lmdb_warning);
     pthread_atfork(nullptr, nullptr, &register_python_handler_data_factory);
+    pthread_atfork(nullptr, nullptr, &util::increment_fork_generation);
 #endif
     // Set up the global exception handlers first, so module-specific exception handler can override it:
     auto exceptions = m.def_submodule("exceptions");

--- a/cpp/arcticdb/storage/azure/azure_client_impl.cpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.cpp
@@ -52,6 +52,7 @@
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/util/error_code.hpp>
+#include <arcticdb/util/fork_generation.hpp>
 
 namespace arcticdb::storage {
 using namespace object_store_utils;
@@ -117,6 +118,12 @@ Azure::Storage::Blobs::BlobClientOptions RealAzureClient::get_client_options(con
     if (!conf.ca_cert_dir().empty()) {
         curl_transport_options.CAPath = conf.ca_cert_dir();
     }
+    // azure-core's connection pool is a process-global static, and a forked child inherits its sockets along with
+    // the rest of the address space. Both processes then transact on the same sockets, which crosses requests and
+    // responses and surfaces as short reads and spurious 404s. The pool is keyed partly on ConnectionTimeout, so
+    // offsetting it by the fork generation puts each process in its own bucket, leaving the inherited connections
+    // in a bucket nothing will look in again. There is no supported way to flush the pool itself.
+    curl_transport_options.ConnectionTimeout += std::chrono::milliseconds(util::fork_generation());
     client_options.Transport.Transport = std::make_shared<Azure::Core::Http::CurlTransport>(curl_transport_options);
 #endif
 

--- a/cpp/arcticdb/storage/azure/azure_storage.cpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.cpp
@@ -301,11 +301,11 @@ bool do_key_exists_impl(const VariantKey& key, const std::string& root_folder, A
 std::string AzureStorage::name() const { return fmt::format("azure_storage-{}/{}", container_name_, root_folder_); }
 
 void AzureStorage::do_write(KeySegmentPair& key_seg) {
-    detail::do_write_impl(key_seg, root_folder_, *azure_client_, FlatBucketizer{}, upload_option_, request_timeout_);
+    detail::do_write_impl(key_seg, root_folder_, client(), FlatBucketizer{}, upload_option_, request_timeout_);
 }
 
 void AzureStorage::do_update(KeySegmentPair& key_seg, UpdateOpts) {
-    detail::do_update_impl(key_seg, root_folder_, *azure_client_, FlatBucketizer{}, upload_option_, request_timeout_);
+    detail::do_update_impl(key_seg, root_folder_, client(), FlatBucketizer{}, upload_option_, request_timeout_);
 }
 
 void AzureStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
@@ -313,7 +313,7 @@ void AzureStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor,
             std::move(variant_key),
             visitor,
             root_folder_,
-            *azure_client_,
+            client(),
             FlatBucketizer{},
             opts,
             download_option_,
@@ -323,23 +323,17 @@ void AzureStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor,
 
 KeySegmentPair AzureStorage::do_read(VariantKey&& variant_key, ReadKeyOpts opts) {
     return detail::do_read_impl(
-            std::move(variant_key),
-            root_folder_,
-            *azure_client_,
-            FlatBucketizer{},
-            opts,
-            download_option_,
-            request_timeout_
+            std::move(variant_key), root_folder_, client(), FlatBucketizer{}, opts, download_option_, request_timeout_
     );
 }
 
 void AzureStorage::do_remove(VariantKey&& variant_key, RemoveOpts) {
     std::array<VariantKey, 1> arr{std::move(variant_key)};
-    detail::do_remove_impl(std::span(arr), root_folder_, *azure_client_, FlatBucketizer{}, request_timeout_);
+    detail::do_remove_impl(std::span(arr), root_folder_, client(), FlatBucketizer{}, request_timeout_);
 }
 
 void AzureStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts) {
-    detail::do_remove_impl(std::move(variant_keys), root_folder_, *azure_client_, FlatBucketizer{}, request_timeout_);
+    detail::do_remove_impl(std::move(variant_keys), root_folder_, client(), FlatBucketizer{}, request_timeout_);
 }
 
 std::optional<size_t> AzureStorage::max_delete_batch_size() const {
@@ -352,11 +346,11 @@ std::optional<size_t> AzureStorage::max_delete_batch_size() const {
 bool AzureStorage::do_iterate_type_until_match(
         KeyType key_type, const IterateTypePredicate& visitor, const std::string& prefix
 ) {
-    return detail::do_iterate_type_impl(key_type, visitor, root_folder_, *azure_client_, prefix);
+    return detail::do_iterate_type_impl(key_type, visitor, root_folder_, client(), prefix);
 }
 
 bool AzureStorage::do_key_exists(const VariantKey& key) {
-    return detail::do_key_exists_impl(key, root_folder_, *azure_client_);
+    return detail::do_key_exists_impl(key, root_folder_, client());
 }
 
 std::string AzureStorage::do_key_path(const VariantKey& key) const {
@@ -391,18 +385,53 @@ namespace arcticdb::storage::azure {
 using namespace Azure::Storage;
 using namespace Azure::Storage::Blobs;
 
-AzureStorage::AzureStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf) :
-    Storage(library_path, mode),
-    root_folder_(object_store_utils::get_root_folder(library_path)),
-    container_name_(conf.container_name()),
-    request_timeout_(conf.request_timeout() == 0 ? 200000 : conf.request_timeout()) {
-    if (conf.use_mock_storage_for_testing()) {
+void AzureStorage::create_azure_client() {
+    if (conf_.use_mock_storage_for_testing()) {
         ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using Mock Azure storage");
         azure_client_ = std::make_unique<MockAzureClient>();
     } else {
         ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using Real Azure storage");
-        azure_client_ = std::make_unique<RealAzureClient>(conf);
+        azure_client_ = std::make_unique<RealAzureClient>(conf_);
     }
+}
+
+/* See the comment in RealAzureClient::get_client_options: a client built before a fork must be rebuilt here so that
+ * it draws on a connection pool bucket of its own rather than on the sockets it inherited. Leak the old one rather
+ * than destroying it, since destroying it would run libcurl teardown against those inherited sockets. */
+void AzureStorage::rebuild_client_if_forked() {
+    const auto generation = util::fork_generation();
+    if (client_fork_generation_.load(std::memory_order_acquire) == generation) {
+        return;
+    }
+    std::lock_guard lock{client_mutex_};
+    if (client_fork_generation_.load(std::memory_order_relaxed) == generation) {
+        return;
+    }
+    static_cast<void>(azure_client_.release());
+    create_azure_client();
+    client_fork_generation_.store(generation, std::memory_order_release);
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Rebuilt Azure client for generation {} after fork", generation);
+}
+
+AzureClientWrapper& AzureStorage::client() {
+    rebuild_client_if_forked();
+    return *azure_client_;
+}
+
+AzureStorage::~AzureStorage() {
+    if (client_fork_generation_.load(std::memory_order_relaxed) != util::fork_generation()) {
+        static_cast<void>(azure_client_.release());
+    }
+}
+
+AzureStorage::AzureStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf) :
+    Storage(library_path, mode),
+    conf_(conf),
+    client_fork_generation_(util::fork_generation()),
+    root_folder_(object_store_utils::get_root_folder(library_path)),
+    container_name_(conf.container_name()),
+    request_timeout_(conf.request_timeout() == 0 ? 200000 : conf.request_timeout()) {
+    create_azure_client();
     if (conf.ca_cert_path().empty()) {
         ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using default CA cert path");
     } else {

--- a/cpp/arcticdb/storage/azure/azure_storage.hpp
+++ b/cpp/arcticdb/storage/azure/azure_storage.hpp
@@ -12,6 +12,9 @@
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/pb_util.hpp>
+#include <arcticdb/util/fork_generation.hpp>
+#include <atomic>
+#include <mutex>
 #include <string>
 
 namespace arcticdb::storage::azure {
@@ -22,6 +25,8 @@ class AzureStorage final : public Storage {
     using Config = arcticdb::proto::azure_storage::Config;
 
     AzureStorage(const LibraryPath& lib, OpenMode mode, const Config& conf);
+
+    ~AzureStorage();
 
     std::string name() const final;
 
@@ -63,7 +68,17 @@ class AzureStorage final : public Storage {
     const std::set<char>& do_unsupported_library_chars() const final;
 
   private:
+    void create_azure_client();
+
+    void rebuild_client_if_forked();
+
+    AzureClientWrapper& client();
+
     std::unique_ptr<AzureClientWrapper> azure_client_;
+    // Retained so that the client can be rebuilt after a fork
+    Config conf_;
+    std::atomic<uint64_t> client_fork_generation_;
+    std::mutex client_mutex_;
 
     std::string root_folder_;
     std::string container_name_;

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.cpp
@@ -122,24 +122,57 @@ VariantKey unencode_object_id(const VariantKey& key) {
     );
 }
 
-NfsBackedStorage::NfsBackedStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf) :
-    Storage(library_path, mode),
-    s3_api_(s3::S3ApiInstance::instance()), // make sure we have an initialized AWS SDK
-    root_folder_(object_store_utils::get_root_folder(library_path)),
-    bucket_name_(conf.bucket_name()),
-    region_(conf.region()) {
-
-    if (conf.use_mock_storage_for_testing()) {
+void NfsBackedStorage::create_s3_client() {
+    if (conf_.use_mock_storage_for_testing()) {
         log::storage().warn("Using Mock S3 storage for NfsBackedStorage");
         s3_client_ = std::make_unique<s3::S3ClientTestWrapper>(std::make_unique<s3::MockS3Client>());
     } else {
         s3_client_ = std::make_unique<s3::S3ClientImpl>(
-                s3::get_aws_credentials(conf),
-                s3::get_s3_config_and_set_env_var(conf),
+                s3::get_aws_credentials(conf_),
+                s3::get_s3_config_and_set_env_var(conf_),
                 Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never,
                 false
         );
     }
+}
+
+/* As S3Storage::rebuild_client_if_forked. */
+void NfsBackedStorage::rebuild_client_if_forked() {
+    const auto generation = util::fork_generation();
+    if (client_fork_generation_.load(std::memory_order_acquire) == generation) {
+        return;
+    }
+    std::lock_guard lock{client_mutex_};
+    if (client_fork_generation_.load(std::memory_order_relaxed) == generation) {
+        return;
+    }
+    static_cast<void>(s3_client_.release());
+    create_s3_client();
+    client_fork_generation_.store(generation, std::memory_order_release);
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Rebuilt NFS backed S3 client for generation {} after fork", generation);
+}
+
+std::unique_ptr<s3::S3ClientInterface>& NfsBackedStorage::client() {
+    rebuild_client_if_forked();
+    return s3_client_;
+}
+
+NfsBackedStorage::~NfsBackedStorage() {
+    if (client_fork_generation_.load(std::memory_order_relaxed) != util::fork_generation()) {
+        static_cast<void>(s3_client_.release());
+    }
+}
+
+NfsBackedStorage::NfsBackedStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf) :
+    Storage(library_path, mode),
+    s3_api_(s3::S3ApiInstance::instance()), // make sure we have an initialized AWS SDK
+    conf_(conf),
+    client_fork_generation_(util::fork_generation()),
+    root_folder_(object_store_utils::get_root_folder(library_path)),
+    bucket_name_(conf.bucket_name()),
+    region_(conf.region()) {
+
+    create_s3_client();
 
     if (conf.prefix().empty()) {
         ARCTICDB_DEBUG(log::version(), "prefix not found, will use {}", root_folder_);
@@ -172,12 +205,12 @@ std::string NfsBackedStorage::do_key_path(const VariantKey& key) const {
 
 void NfsBackedStorage::do_write(KeySegmentPair& key_seg) {
     auto enc = KeySegmentPair{encode_object_id(key_seg.variant_key()), key_seg.segment_ptr()};
-    s3::detail::do_write_impl(enc, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    s3::detail::do_write_impl(enc, root_folder_, bucket_name_, *client(), NfsBucketizer{});
 }
 
 void NfsBackedStorage::do_update(KeySegmentPair& key_seg, UpdateOpts) {
     auto enc = KeySegmentPair{encode_object_id(key_seg.variant_key()), key_seg.segment_ptr()};
-    s3::detail::do_update_impl(enc, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    s3::detail::do_update_impl(enc, root_folder_, bucket_name_, *client(), NfsBucketizer{});
 }
 
 void NfsBackedStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visitor, ReadKeyOpts opts) {
@@ -188,7 +221,7 @@ void NfsBackedStorage::do_read(VariantKey&& variant_key, const ReadVisitor& visi
             visitor,
             root_folder_,
             bucket_name_,
-            *s3_client_,
+            *client(),
             NfsBucketizer{},
             std::move(decoder),
             opts
@@ -199,14 +232,14 @@ KeySegmentPair NfsBackedStorage::do_read(VariantKey&& variant_key, ReadKeyOpts o
     auto encoded_key = encode_object_id(variant_key);
     auto decoder = [](auto&& k) { return unencode_object_id(std::move(k)); };
     return s3::detail::do_read_impl(
-            std::move(encoded_key), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{}, std::move(decoder), opts
+            std::move(encoded_key), root_folder_, bucket_name_, *client(), NfsBucketizer{}, std::move(decoder), opts
     );
 }
 
 void NfsBackedStorage::do_remove(VariantKey&& variant_key, RemoveOpts) {
     auto enc = encode_object_id(variant_key);
     std::array<VariantKey, 1> arr{std::move(enc)};
-    s3::detail::do_remove_impl(std::span(arr), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    s3::detail::do_remove_impl(std::span(arr), root_folder_, bucket_name_, *client(), NfsBucketizer{});
 }
 
 void NfsBackedStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts) {
@@ -215,7 +248,7 @@ void NfsBackedStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts)
     std::transform(std::begin(variant_keys), std::end(variant_keys), std::back_inserter(enc), [](auto&& key) {
         return encode_object_id(key);
     });
-    s3::detail::do_remove_impl(std::span(enc), root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    s3::detail::do_remove_impl(std::span(enc), root_folder_, bucket_name_, *client(), NfsBucketizer{});
 }
 
 std::optional<size_t> NfsBackedStorage::max_delete_batch_size() const {
@@ -241,12 +274,12 @@ bool NfsBackedStorage::do_iterate_type_until_match(
         return s3::detail::visit_if_prefix_matches(visitor, prefix, unencode_object_id(key));
     };
     s3::detail::Visitor<IterateTypePredicate> final_visitor{visitor_with_prefix_filtering};
-    return s3::detail::do_iterate_type_impl(key_type, bucket_name_, *s3_client_, path_info, final_visitor);
+    return s3::detail::do_iterate_type_impl(key_type, bucket_name_, *client(), path_info, final_visitor);
 }
 
 bool NfsBackedStorage::do_key_exists(const VariantKey& key) {
     auto encoded_key = encode_object_id(key);
-    return s3::detail::do_key_exists_impl(encoded_key, root_folder_, bucket_name_, *s3_client_, NfsBucketizer{});
+    return s3::detail::do_key_exists_impl(encoded_key, root_folder_, bucket_name_, *client(), NfsBucketizer{});
 }
 
 bool NfsBackedStorage::supports_object_size_calculation() const { return true; }
@@ -267,7 +300,7 @@ void NfsBackedStorage::do_visit_object_sizes(
     };
     s3::detail::Visitor<ObjectSizesVisitor> final_visitor{visitor_with_prefix_filtering};
 
-    s3::detail::do_visit_object_sizes_for_type_impl(key_type, bucket_name_, *s3_client_, path_info, final_visitor);
+    s3::detail::do_visit_object_sizes_for_type_impl(key_type, bucket_name_, *client(), path_info, final_visitor);
 }
 
 } // namespace arcticdb::storage::nfs_backed

--- a/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
+++ b/cpp/arcticdb/storage/s3/nfs_backed_storage.hpp
@@ -12,6 +12,9 @@
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/storage/s3/s3_api.hpp>
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
+#include <arcticdb/util/fork_generation.hpp>
+#include <atomic>
+#include <mutex>
 
 namespace arcticdb::storage::nfs_backed {
 
@@ -20,6 +23,8 @@ class NfsBackedStorage final : public Storage {
     using Config = arcticdb::proto::nfs_backed_storage::Config;
 
     NfsBackedStorage(const LibraryPath& lib, OpenMode mode, const Config& conf);
+
+    ~NfsBackedStorage();
 
     std::string name() const final;
 
@@ -61,13 +66,21 @@ class NfsBackedStorage final : public Storage {
 
     std::string do_key_path(const VariantKey&) const final;
 
-    auto& client() { return s3_client_; }
+    std::unique_ptr<storage::s3::S3ClientInterface>& client();
     const std::string& bucket_name() const { return bucket_name_; }
     const std::string& root_folder() const { return root_folder_; }
     const std::string& region() const { return region_; }
 
+    void create_s3_client();
+
+    void rebuild_client_if_forked();
+
     std::shared_ptr<s3::S3ApiInstance> s3_api_;
     std::unique_ptr<storage::s3::S3ClientInterface> s3_client_;
+    // Retained so that the client can be rebuilt after a fork
+    Config conf_;
+    std::atomic<uint64_t> client_fork_generation_;
+    std::mutex client_mutex_;
     std::string root_folder_;
     std::string bucket_name_;
     std::string region_;

--- a/cpp/arcticdb/storage/s3/s3_storage.cpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.cpp
@@ -250,6 +250,8 @@ void S3Storage::create_s3_client(const S3Settings& conf, const Aws::Auth::AWSCre
 S3Storage::S3Storage(const LibraryPath& library_path, OpenMode mode, const S3Settings& conf) :
     Storage(library_path, mode),
     s3_api_(S3ApiInstance::instance()), // make sure we have an initialized AWS SDK
+    conf_(conf),
+    client_fork_generation_(util::fork_generation()),
     root_folder_(object_store_utils::get_root_folder(library_path)),
     bucket_name_(conf.bucket_name()),
     region_(conf.region()) {
@@ -274,6 +276,37 @@ S3Storage::S3Storage(const LibraryPath& library_path, OpenMode mode, const S3Set
     std::locale locale{std::locale::classic(), new std::num_put<char>()};
     (void)std::locale::global(locale);
     ARCTICDB_DEBUG(log::storage(), "Opened S3 backed storage at {}", root_folder_);
+}
+
+/* A client built before a fork owns threads that the forked process does not have and sockets that its parent is
+ * still transacting on, so it can be neither used nor destroyed here. Abandon it and build a replacement. Leaking
+ * rather than destroying also keeps any reference handed out by an earlier client() call valid. */
+void S3Storage::rebuild_client_if_forked() {
+    const auto generation = util::fork_generation();
+    if (client_fork_generation_.load(std::memory_order_acquire) == generation) {
+        return;
+    }
+    std::lock_guard lock{client_mutex_};
+    if (client_fork_generation_.load(std::memory_order_relaxed) == generation) {
+        return;
+    }
+    static_cast<void>(s3_client_.release());
+    static_cast<void>(sts_client_.release());
+    create_s3_client(conf_, get_aws_credentials(conf_));
+    client_fork_generation_.store(generation, std::memory_order_release);
+    ARCTICDB_RUNTIME_DEBUG(log::storage(), "Rebuilt S3 client for generation {} after fork", generation);
+}
+
+S3ClientInterface& S3Storage::client() {
+    rebuild_client_if_forked();
+    return *s3_client_;
+}
+
+S3Storage::~S3Storage() {
+    if (client_fork_generation_.load(std::memory_order_relaxed) != util::fork_generation()) {
+        static_cast<void>(s3_client_.release());
+        static_cast<void>(sts_client_.release());
+    }
 }
 
 bool S3Storage::supports_object_size_calculation() const { return true; }

--- a/cpp/arcticdb/storage/s3/s3_storage.hpp
+++ b/cpp/arcticdb/storage/s3/s3_storage.hpp
@@ -16,7 +16,10 @@
 #include <arcticdb/storage/s3/s3_client_interface.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 #include <arcticdb/util/configs_map.hpp>
+#include <arcticdb/util/fork_generation.hpp>
+#include <atomic>
 #include <cstdlib>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -29,6 +32,8 @@ const std::string USE_AWS_CRED_PROVIDERS_TOKEN = "_RBAC_";
 class S3Storage : public Storage, AsyncStorage {
   public:
     S3Storage(const LibraryPath& lib, OpenMode mode, const S3Settings& conf);
+
+    ~S3Storage();
 
     std::string get_key_path(const VariantKey& key) const;
 
@@ -43,7 +48,7 @@ class S3Storage : public Storage, AsyncStorage {
     std::optional<size_t> max_delete_batch_size() const override;
 
     // These are only public for testing purposes
-    S3ClientInterface& client() { return *s3_client_; }
+    S3ClientInterface& client();
     bool directory_bucket() const { return directory_bucket_; }
 
   protected:
@@ -87,11 +92,17 @@ class S3Storage : public Storage, AsyncStorage {
     const std::string& bucket_name() const { return bucket_name_; }
     const std::string& root_folder() const { return root_folder_; }
 
+    void rebuild_client_if_forked();
+
     std::shared_ptr<S3ApiInstance> s3_api_;
     std::unique_ptr<S3ClientInterface> s3_client_;
     // aws sdk annoyingly requires raw pointer being passed in the sts client factory to the s3 client
     // thus sts_client_ should have same life span as s3_client_
     std::unique_ptr<Aws::STS::STSClient> sts_client_;
+    // Retained so that the client can be rebuilt after a fork
+    S3Settings conf_;
+    std::atomic<uint64_t> client_fork_generation_;
+    std::mutex client_mutex_;
     std::string root_folder_;
     std::string bucket_name_;
     std::string region_;

--- a/cpp/arcticdb/util/fork_generation.hpp
+++ b/cpp/arcticdb/util/fork_generation.hpp
@@ -1,0 +1,29 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+
+namespace arcticdb::util {
+
+namespace detail {
+inline std::atomic<uint64_t> fork_generation_{0};
+}
+
+/* Counts how many times this process has been forked from. Storage clients record the generation they were built
+ * in, so they can detect that their threads, sockets and connection pool entries belong to a process that is no
+ * longer this one. Reading this is on the per-IO-operation path, hence an atomic rather than getpid(), which glibc
+ * has not cached since 2.25. */
+inline uint64_t fork_generation() { return detail::fork_generation_.load(std::memory_order_relaxed); }
+
+/* Registered as a pthread_atfork child handler. An atomic increment is safe to run in that context. */
+inline void increment_fork_generation() { detail::fork_generation_.fetch_add(1, std::memory_order_relaxed); }
+
+} // namespace arcticdb::util

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -6,6 +6,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
+import gc
 import multiprocessing
 import sys
 import time
@@ -18,7 +19,7 @@ from arcticdb_ext import set_config_int, unset_config_int
 
 from arcticdb.util.test import assert_frame_equal
 
-from tests.util.mark import SKIP_CONDA_MARK
+from tests.util.mark import AZURE_TESTS_MARK, SKIP_CONDA_MARK
 
 FORK_SUPPORTED = pytest.mark.skipif(sys.platform == "win32", reason="fork/forkserver not available on Windows")
 
@@ -71,12 +72,9 @@ def _read_and_assert_symbol(args):
     "store_factory",
     [
         "s3_store_factory",
-        pytest.param(
-            "azure_store_factory",
-            marks=pytest.mark.skip(
-                reason="Azure SDK's CurlConnectionPool is global and is not fork-safe. Monday ref 12128961896"
-            ),
-        ),
+        # Fails: Azure SDK's CurlConnectionPool is global, so forked children transact on sockets the parent
+        # opened. Monday ref 12128961896
+        pytest.param("azure_store_factory", marks=AZURE_TESTS_MARK),
     ],
 )
 def test_parallel_reads(store_factory, request):
@@ -135,6 +133,65 @@ def test_configs_propagated_to_child_process(request, store_fixture, start_metho
             p.map(_check_config_in_child, [(store, "TestPropagation", 12345)])
     finally:
         unset_config_int("TestPropagation")
+
+
+_INHERITED_AT_FORK = {}
+
+
+def _child_read_inherited():
+    lib = _INHERITED_AT_FORK["lib"]
+    assert_frame_equal(lib.read("sym").data, df("sym"))
+
+
+def _run_in_fork(target, timeout=120):
+    ctx = multiprocessing.get_context("fork")
+    proc = ctx.Process(target=target)
+    proc.start()
+    proc.join(timeout)
+    if proc.is_alive():
+        proc.kill()
+        proc.join()
+        pytest.fail(f"Forked child running {target.__name__} did not exit within {timeout}s")
+    return proc.exitcode
+
+
+FORK_STORAGES = [
+    pytest.param("lmdb_storage", id="lmdb"),
+    pytest.param("s3_storage", marks=SKIP_CONDA_MARK, id="s3"),
+    pytest.param("gcp_storage", marks=SKIP_CONDA_MARK, id="gcp"),
+    pytest.param("azurite_storage", marks=AZURE_TESTS_MARK, id="azure"),
+]
+
+
+@pytest.fixture
+def used_library(request, lib_name):
+    """An Arctic and a Library that have served at least one read and one write, held in a module global so
+    that a forked child can reach them through the memory it inherits."""
+    storage = request.getfixturevalue(request.param)
+    ac = Arctic(storage.arctic_uri)
+    lib = ac.create_library(lib_name)
+    lib.write("sym", df("sym"))
+    assert_frame_equal(lib.read("sym").data, df("sym"))
+    _INHERITED_AT_FORK["ac"] = ac
+    _INHERITED_AT_FORK["lib"] = lib
+    del ac, lib
+    gc.collect()
+    try:
+        yield
+    finally:
+        _INHERITED_AT_FORK.clear()
+        gc.collect()
+        Arctic(storage.arctic_uri).delete_library(lib_name)
+
+
+@FORK_SUPPORTED
+@pytest.mark.parametrize("used_library", FORK_STORAGES, indirect=True)
+def test_fork_child_reads_inherited_library(used_library):
+    """A forked child reading through a Library inherited from the parent, rather than one reconstructed
+    from a pickle, drives the storage's post-fork client rebuild and must still see correct data."""
+    assert _run_in_fork(_child_read_inherited) == 0
+
+    assert_frame_equal(_INHERITED_AT_FORK["lib"].read("sym").data, df("sym"))
 
 
 def test_set_config_int_overrides_env_var_after_spawn(lmdb_version_store_v1, monkeypatch):

--- a/python/tests/unit/arcticdb/version_store/test_fork_stress.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork_stress.py
@@ -1,0 +1,100 @@
+import gc
+import multiprocessing
+import threading
+import numpy as np
+import pandas as pd
+import pytest
+from arcticdb import Arctic
+from arcticdb_ext import set_config_int, unset_config_int
+
+HOLD = {}
+ROWS = 200_000
+
+
+def _child_drop():
+    HOLD.clear()
+    gc.collect()
+
+
+def _child_drop_then_read():
+    lib = HOLD["lib"]
+    HOLD.clear()
+    del lib
+    gc.collect()
+
+
+def _child_read():
+    HOLD["lib"].read("sym")
+
+
+def _dump_hung_child(pid):
+    import subprocess
+
+    try:
+        out = subprocess.run(
+            ["gdb", "-p", str(pid), "-batch", "-ex", "thread apply all bt 14"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        print(f"=== HUNG CHILD {pid} ===\n{out.stdout}\n{out.stderr}", flush=True)
+    except Exception as e:
+        print(f"=== could not dump {pid}: {e} ===", flush=True)
+
+
+def _reader(stop):
+    while not stop.is_set():
+        try:
+            HOLD["lib"].read("sym")
+        except Exception:
+            pass
+
+
+@pytest.mark.parametrize("s3_async", [0, 1])
+@pytest.mark.parametrize("child_fn", [_child_drop, _child_read], ids=["drop", "read"])
+@pytest.mark.parametrize("nchild", [1, 4])
+def test_fork_while_io_in_flight(s3_storage, lib_name, s3_async, child_fn, nchild):
+    set_config_int("S3.Async", s3_async)
+    try:
+        ac = Arctic(s3_storage.arctic_uri)
+        lib = ac.create_library(lib_name)
+        lib.write("sym", pd.DataFrame({"a": np.arange(ROWS), "b": np.arange(ROWS) * 1.5}))
+        lib.read("sym")
+        HOLD["ac"] = ac
+        HOLD["lib"] = lib
+        del ac, lib
+        gc.collect()
+
+        stop = threading.Event()
+        readers = [threading.Thread(target=_reader, args=(stop,), daemon=True) for _ in range(4)]
+        for t in readers:
+            t.start()
+
+        ctx = multiprocessing.get_context("fork")
+        hung, crashed, launched = 0, 0, 0
+        for i in range(40):
+            procs = [ctx.Process(target=child_fn) for _ in range(nchild)]
+            for p in procs:
+                p.start()
+                launched += 1
+            for p in procs:
+                p.join(30)
+                if p.is_alive():
+                    _dump_hung_child(p.pid)
+                    p.kill()
+                    p.join()
+                    hung += 1
+                    print(f"iteration {i}: child hung", flush=True)
+                elif p.exitcode != 0:
+                    crashed += 1
+                    print(f"iteration {i}: child exitcode {p.exitcode}", flush=True)
+        stop.set()
+        for t in readers:
+            t.join(30)
+        # Counts first: pytest truncates long assertion messages, and a per-child list gets cut off exactly
+        # when there is most to report.
+        assert hung == 0 and crashed == 0, f"of {launched} forked children, {crashed} crashed and {hung} hung"
+    finally:
+        HOLD.clear()
+        gc.collect()
+        unset_config_int("S3.Async")


### PR DESCRIPTION
## Problem

A core dump from a `multiprocessing.Pool` (fork start method) worker showed a segfault in
`pthread_join`.

```
PythonVersionStore::~PythonVersionStore
  -> LocalVersionedEngine::~LocalVersionedEngine
    -> AsyncStore::~AsyncStore
      -> Library::~Library
        -> Storages::~Storages (vector<shared_ptr<Storage>>)
          -> S3Storage::~S3Storage
            -> S3ClientImpl::~S3ClientImpl   (s3_client_impl.hpp:16)
              -> Aws::S3::S3Client::~S3Client
                -> ... -> pthread_join   <- segfault
```

Since we have special pickling logic on `NativeVersionStore` at fork to recreate the `lib`,

```
    def __setstate__(self, state):
        # Restore ConfigsMap before any library creation so that
        # settings like AWS.LogLevel are available when S3ApiInstance initializes.
        # Note: this merges into the process-wide ConfigsMap singleton rather than
        # replacing it. In spawn/forkserver children the singleton already has
        # values from env vars (set_config_from_env_vars runs on import), so the
        # merge adds back any values that were set via set_config_* in the parent.
        # Values from the pickle payload take precedence over existing entries.
        configs = state.get("configs_map")
        if configs:
            set_all_config_int(configs.get("int", {}))
            set_all_config_string(configs.get("string", {}))
            set_all_config_double(configs.get("double", {}))

        lib_cfg = LibraryConfig()
        lib_cfg.ParseFromString(state["lib_cfg"])
        custom_norm = CompositeCustomNormalizer([], False)
        custom_norm.__setstate__(state["custom_norm"])
        env = state["env"]
        open_mode = state["open_mode"]
        native_cfg = state["native_cfg"]
        self._initialize(
            library=NativeVersionStore.create_lib_from_lib_config(lib_cfg, env, open_mode, native_cfg),
            env=env,
            lib_cfg=lib_cfg,
            custom_normalizer=custom_norm,
            open_mode=open_mode,
            native_cfg=native_cfg,
        )
        if state.get("skip_df_consolidation"):
            self._normalizer.df.set_skip_df_consolidation()
```

we think the segfault is coming from GC of the original lib's copy in the fork.

## Repros

We don't have an exact repro but wrote similar ones:

- There was already a skipped test showing errors in Azure after fork `test_parallel_reads`
- `test_fork_stress.py` exposed reliably hangs or segfaults after a fork on S3. Repros were only possibly if the parent process had IO in flight.

## Solution

- Azure keeps a global connection pool, which is then shared after the fork. We can hack around this by setting a different connection timeout in the forked process, which gives it a new connection pool.
- For both Azure and S3, we detect whether this process is forked using a global counter that's incremented at fork time and which is copied in to each client. If a client observes that its counter does not match the global value, it can conclude that a fork has happened, and recreate its client.
- The destructor can then skip teardown of a client that was forked from a different process, leaking the old client (similar to what we do for the `TaskScheduler`).

If we only care about supporting cases like,

```
pool.map(partial(f, lib=lib)
```

where the lib is pickled and recreated through our `__setstate__` logic, I think we could get away with the "skip destruction" point and the Azure point, and get rid of the "recreate the client" logic.

## Impact

Azure looks to be fixed.

On S3, the stress test segfaults went away, but there were still hangs. This could be a locked lock somewhere in the SDK copied in the fork, this isn't a complete fix. The stress test went from 11 segfaults and 6 hangs to 0 segfaults and 2 hangs.

## Appendix: __setstate__

`Pool` sends tasks over a pipe, so arguments are pickled whatever the start method, and `NativeVersionStore.__setstate__` rebuilds the C++ Library, Storage and client from the config. This is why fork mostly appears to work today.

| how the child reaches storage | pickled? | covered by |
|---|---|---|
| passed as a `Pool` task argument | yes, fresh client | `__setstate__`, pre-existing |
| inherited via a module global, or `Process(target=…)` under fork | no | `client()` rebuild |
| inherited object *destroyed* in the child | n/a, it is a corpse | destructor leak guard |
| process-global SDK state | no, by construction | Azure connection-pool offset |

The reported crash is the third row.

## Conclusion

It doesn't seem possible to make a complete fix - this still leaves hangs possible, which can be worse than a crash, and it's sensitive to the details of the storage SDKs.

`fork` in multi-threaded programs is becoming deprecated from Python 3.12+. See the note on fork [here](https://docs.python.org/3/library/multiprocessing.html#contexts-and-start-methods).

These changes are quite complex, hard to test properly, hard to understand. Given that Python is moving away from `fork` - I think we should just log deprecation warnings at fork time rather than trying to cope with the `fork`.