### PR TITLE
Fix normalization of np.str_ and np.bytes_ types

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -164,7 +164,8 @@ _SUPPORTED_NATIVE_RETURN_TYPES = Union[FrameData]
 def _accept_array_string(v):
     # TODO remove this once arctic keeps the string type under the hood
     # and does not transform string into bytes
-    return type(v) in (str, bytes)
+    # Exact types only (see #704); also accept NumPy string scalars (#2800).
+    return type(v) in (str, bytes, np.str_, np.bytes_)
 
 
 def _is_nan(element):
@@ -194,7 +195,7 @@ def get_sample_from_non_empty_arr(arr, arr_name):
 
 def coerce_string_column_to_fixed_length_array(arr, to_type, string_max_len):
     # in python3 all text will be treated as unicode
-    if to_type == str:
+    if to_type in (str, np.str_):
         if sys.platform == "win32":
             # See https://sourceforge.net/p/numpy/mailman/numpy-discussion/thread/1139250278.7538.52.camel%40localhost.localdomain/#msg11998404
             # Different wchar size on Windows is not compatible with our current internal representation of Numpy strings
@@ -205,6 +206,21 @@ def coerce_string_column_to_fixed_length_array(arr, to_type, string_max_len):
         log.debug("converted {} to {}".format(arr.dtype, casted_arr.dtype))
 
     return casted_arr
+
+
+def _normalize_numpy_string_scalars(arr):
+    """Convert np.str_/np.bytes_ scalars to plain str/bytes for the C++ writer."""
+    return np.array(
+        [
+            str(x)
+            if type(x) is np.str_
+            else bytes(x)
+            if type(x) is np.bytes_
+            else x
+            for x in arr
+        ],
+        dtype=object,
+    )
 
 
 def get_timezone_from_metadata(norm_meta):
@@ -307,6 +323,9 @@ def _to_primitive(arr, arr_name, dynamic_strings, string_max_len=None, coerce_co
         return arr.astype(DTN64_DTYPE)
     elif _accept_array_string(sample):
         if dynamic_strings:
+            # C++ uses PyUnicode_CheckExact / PyBytes_CheckExact; coerce NumPy scalars.
+            if type(sample) in (np.str_, np.bytes_):
+                return _normalize_numpy_string_scalars(arr)
             return arr
         else:
             log.debug("Converting  array with dtype=object to native string. This might be a costly operation")

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -51,6 +51,7 @@ from arcticdb.version_store._normalization import (
     DataFrameNormalizer,
     NdArrayNormalizer,
     PandasData,
+    _accept_array_string,
 )
 from arcticdb.version_store._common import TimeFrame
 from arcticdb.util.test import (
@@ -972,6 +973,47 @@ def test_arrays_throw_without_pickling(lmdb_version_store_v1):
 
     with pytest.raises(Exception):
         lib.write(sym, df)
+
+
+def test_accept_array_string_with_numpy_types():
+    """Regression test for https://github.com/man-group/ArcticDB/issues/2800"""
+    assert _accept_array_string("hello") is True
+    assert _accept_array_string(b"hello") is True
+    assert _accept_array_string(np.str_("hello")) is True
+    assert _accept_array_string(np.bytes_(b"hello")) is True
+    assert _accept_array_string(123) is False
+    assert _accept_array_string(12.34) is False
+    assert _accept_array_string([1, 2, 3]) is False
+    assert _accept_array_string({"key": "value"}) is False
+    assert _accept_array_string(None) is False
+
+
+def test_numpy_str_type_normalization(lmdb_version_store, sym):
+    """Regression test for https://github.com/man-group/ArcticDB/issues/2800"""
+    lib = lmdb_version_store
+
+    df = pd.DataFrame({"col": [np.str_("hello"), np.str_("world")]})
+    lib.write(sym, df)
+    result = lib.read(sym).data
+    assert result["col"][0] == "hello"
+    assert result["col"][1] == "world"
+
+    df_mixed = pd.DataFrame({"col": [np.str_("numpy_str"), "regular_str"]})
+    lib.write(sym + "_mixed", df_mixed)
+    result_mixed = lib.read(sym + "_mixed").data
+    assert result_mixed["col"][0] == "numpy_str"
+    assert result_mixed["col"][1] == "regular_str"
+
+
+def test_numpy_bytes_type_normalization(lmdb_version_store, sym):
+    """Test that np.bytes_ types are correctly normalized."""
+    lib = lmdb_version_store
+
+    df = pd.DataFrame({"col": [np.bytes_(b"hello"), np.bytes_(b"world")]})
+    lib.write(sym, df)
+    result = lib.read(sym).data
+    assert result["col"][0] == b"hello"
+    assert result["col"][1] == b"world"
 
 
 def test_series_zero_name(lmdb_version_store, sym):


### PR DESCRIPTION
## Summary
- Accept `np.str_` / `np.bytes_` in `_accept_array_string` (exact-type check, consistent with #704) so object columns with NumPy string scalars normalize instead of raising `ArcticDbNotYetImplemented` (#2800).
- Coerce NumPy string scalars to plain `str` / `bytes` on the dynamic-strings path so the C++ writer (`PyUnicode_CheckExact` / `PyBytes_CheckExact`) accepts them.
- Treat `np.str_` like `str` in fixed-length string coercion.

## Test plan
- [ ] `test_accept_array_string_with_numpy_types`
- [ ] `test_numpy_str_type_normalization` / `test_numpy_bytes_type_normalization`
- [ ] CI green

Fixes #2800

Note: Prior attempt #2827 was closed unmerged; this includes the CLA sign-off and converts NumPy scalars before the C++ boundary.


Made with [Cursor](https://cursor.com)