### PR TITLE
Fix date_range/row_range reads retaining full segment buffers (OOM)

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1640,11 +1640,9 @@ class NativeVersionStore:
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         # Take a copy as _get_read_queries can modify the input argument, which makes reusing the input counter-intuitive
         per_symbol_query_builders = copy.deepcopy(per_symbol_query_builders)
-        # Needed to force date_range and row_range arguments to go through the read_and_process path rather than the
-        # direct read path if no explicit query is provided for a symbol
-        force_ranges_to_queries = True
+        # Ranges default to the processing-pipeline path (see _get_read_query / #2348).
         read_queries = self._get_read_queries(
-            len(symbols), date_ranges, row_ranges, columns, per_symbol_query_builders, force_ranges_to_queries
+            len(symbols), date_ranges, row_ranges, columns, per_symbol_query_builders, force_ranges_to_queries=True
         )
         read_options, output_format = self._get_read_options_and_output_format(**kwargs)
         return self._adapt_read_res(
@@ -2228,9 +2226,27 @@ class NativeVersionStore:
         row_range: Tuple[int, int],
         columns: Optional[List[str]],
         query_builder: Optional[QueryBuilder],
+        force_ranges_to_queries: bool = True,
     ):
+        """
+        Build a ReadQuery for a single symbol.
+
+        When ``force_ranges_to_queries`` is True (the default) and a ``date_range`` /
+        ``row_range`` is supplied without an existing QueryBuilder, the range is
+        converted into a processing clause. That path truncates segment buffers in
+        C++ so returned frames do not retain unused rows from intersecting segments
+        (see issue #2348). Set ``force_ranges_to_queries=False`` only for callers that
+        intentionally want the legacy zero-copy Python post-filter view.
+        """
         check(date_range is None or row_range is None, "Date range and row range both specified")
         read_query = _PythonVersionStoreReadQuery()
+
+        if (
+            force_ranges_to_queries
+            and query_builder is None
+            and (date_range is not None or row_range is not None)
+        ):
+            query_builder = QueryBuilder()
 
         if date_range is not None and query_builder is not None:
             query_builder.prepend(QueryBuilder().date_range(date_range))
@@ -2258,7 +2274,7 @@ class NativeVersionStore:
         row_ranges: Optional[List[Optional[Tuple[int, int]]]],
         columns: Optional[List[List[str]]],
         query_builder: Optional[Union[QueryBuilder, List[QueryBuilder]]],
-        force_ranges_to_queries: bool = False,
+        force_ranges_to_queries: bool = True,
     ):
         read_queries = []
 
@@ -2305,7 +2321,7 @@ class NativeVersionStore:
             if query_builder is not None:
                 query = copy.deepcopy(query_builder) if isinstance(query_builder, QueryBuilder) else query_builder[idx]
 
-            if query is None and force_ranges_to_queries:
+            if query is None and force_ranges_to_queries and (date_range is not None or row_range is not None):
                 query = QueryBuilder()
 
             read_query = self._get_read_query(
@@ -2313,6 +2329,7 @@ class NativeVersionStore:
                 row_range=row_range,
                 columns=these_columns,
                 query_builder=query,
+                force_ranges_to_queries=force_ranges_to_queries,
             )
 
             read_queries.append(read_query)
@@ -2478,9 +2495,8 @@ class NativeVersionStore:
         date_range: `Optional[DateRangeInput]`, default=None
             DateRange to read data for. Inclusive both for lower and upper bounds. Applicable only for dataframes with
             a DateTime index. Returns only the part of the data that falls within the given range.
-            The same effect can  be achieved by using the date_range clause of the QueryBuilder class, which will be
-            slower, but return data with a smaller memory footprint. See the QueryBuilder.date_range docstring for more
-            details.
+            Ranges are applied via the processing pipeline (same path as ``QueryBuilder.date_range``) so returned
+            frames do not retain unused rows from intersecting data segments.
             Only one of date_range or row_range can be provided.
         row_range : `Optional[Tuple[Optional[int], Optional[int]]]`, default=None
             Row range to read data for. Inclusive of the lower bound, exclusive of the upper bound.
@@ -2488,6 +2504,7 @@ class NativeVersionStore:
             the handling of negative start/end values.
             Leaving either element as None leaves that side of the range open-ended. For example (5, None) would
             include everything from the 5th row onwards.
+            Like ``date_range``, this is applied via the processing pipeline so unused segment rows are truncated.
             Only one of date_range or row_range can be provided.
         columns: `Optional[List[str]]`, default=None
             Applicable only for dataframes. Determines which columns to return data for.
@@ -2658,11 +2675,14 @@ class NativeVersionStore:
                 return self._postprocess_df_with_only_rowcount_idx(read_result, row_range)
 
             if read_query.row_filter is not None and read_query.needs_post_processing:
-                # post filter
+                # post filter — numpy slicing would retain a view onto the full
+                # intersecting segment buffers (#2348). Always copy so unused rows
+                # can be freed once the parent FrameData is dropped.
                 start_idx, end_idx = self._compute_filter_start_end_row(read_result, read_query)
                 data = []
                 for c in read_result.frame_data.data:
-                    data.append(c[start_idx:end_idx])
+                    sliced = c[start_idx:end_idx]
+                    data.append(sliced.copy() if hasattr(sliced, "copy") else sliced)
                 row_count = len(data[0]) if len(data) else 0
                 read_result.frame_data = FrameData(
                     data,

--- a/python/arcticdb/version_store/processing.py
+++ b/python/arcticdb/version_store/processing.py
@@ -1033,9 +1033,8 @@ class QueryBuilder:
     def date_range(self, date_range: DateRangeInput):
         """
         DateRange to read data for.  Applicable only for Pandas data with a DateTime index. Returns only the part
-        of the data that falls within the given range. If this is the only processing clause being applied, then the
-        returned data object will use less memory than passing date_range directly as an argument to the read method, at
-         the cost of possibly being slightly slower.
+        of the data that falls within the given range. Segment buffers are truncated in C++ so unused rows from
+        intersecting segments are not retained (same memory behaviour as ``lib.read(..., date_range=...)``).
 
         Parameters
         ----------

--- a/python/tests/unit/arcticdb/version_store/test_date_range_memory.py
+++ b/python/tests/unit/arcticdb/version_store/test_date_range_memory.py
@@ -1,0 +1,177 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+"""Regression coverage for unexpected memory retention on ranged reads (#2348).
+
+``lib.read(..., date_range=...)`` used to return numpy views onto full intersecting
+segment buffers. Repeated ranged reads in a loop therefore retained entire segments
+and could OOM. Ranges now go through the processing pipeline (C++ truncate) by
+default, and any remaining Python post-filter path copies sliced columns.
+"""
+
+import gc
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from arcticdb import QueryBuilder
+from arcticdb.util.test import assert_frame_equal
+
+
+def _wide_frame(n_rows: int, n_cols: int = 50) -> pd.DataFrame:
+    index = pd.date_range("2020-01-01", periods=n_rows, freq="h")
+    data = {f"c{i}": np.arange(n_rows, dtype=np.float64) + i for i in range(n_cols)}
+    return pd.DataFrame(data, index=index)
+
+
+def test_get_read_query_routes_date_range_through_processing_pipeline(lmdb_version_store):
+    lib = lmdb_version_store
+    read_query = lib._get_read_query(
+        date_range=(pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")),
+        row_range=None,
+        columns=None,
+        query_builder=None,
+    )
+    # Processing clauses disable Python post-filtering; C++ truncates segments.
+    assert read_query.needs_post_processing is False
+    assert read_query.row_filter is not None
+
+
+def test_get_read_query_routes_row_range_through_processing_pipeline(lmdb_version_store):
+    lib = lmdb_version_store
+    read_query = lib._get_read_query(
+        date_range=None,
+        row_range=(10, 20),
+        columns=None,
+        query_builder=None,
+    )
+    assert read_query.needs_post_processing is False
+
+
+def test_legacy_force_ranges_false_still_needs_post_processing(lmdb_version_store):
+    lib = lmdb_version_store
+    read_query = lib._get_read_query(
+        date_range=(pd.Timestamp("2020-01-01"), pd.Timestamp("2020-01-02")),
+        row_range=None,
+        columns=None,
+        query_builder=None,
+        force_ranges_to_queries=False,
+    )
+    assert read_query.needs_post_processing is True
+    assert read_query.row_filter is not None
+
+
+def test_date_range_read_matches_query_builder(lmdb_version_store):
+    lib = lmdb_version_store
+    sym = "date_range_memory_correctness"
+    df = _wide_frame(200)
+    lib.write(sym, df)
+
+    start, end = pd.Timestamp("2020-01-03"), pd.Timestamp("2020-01-05")
+    via_arg = lib.read(sym, date_range=(start, end)).data
+    via_qb = lib.read(sym, query_builder=QueryBuilder().date_range((start, end))).data
+    expected = df.loc[start:end]
+
+    assert_frame_equal(via_arg, expected)
+    assert_frame_equal(via_qb, expected)
+    assert_frame_equal(via_arg, via_qb)
+
+
+def test_row_range_read_matches_iloc(lmdb_version_store):
+    lib = lmdb_version_store
+    sym = "row_range_memory_correctness"
+    df = _wide_frame(150)
+    lib.write(sym, df)
+
+    via_arg = lib.read(sym, row_range=(25, 40)).data
+    assert_frame_equal(via_arg, df.iloc[25:40])
+
+
+def test_batch_read_date_ranges_match_single_read(lmdb_version_store):
+    lib = lmdb_version_store
+    symbols = ["batch_mem_a", "batch_mem_b"]
+    frames = [_wide_frame(120), _wide_frame(120)]
+    for sym, df in zip(symbols, frames):
+        lib.write(sym, df)
+
+    start, end = pd.Timestamp("2020-01-02"), pd.Timestamp("2020-01-04")
+    date_ranges = [(start, end), (start, end)]
+    batch = lib.read_batch(symbols, date_ranges=date_ranges)
+    for i, sym in enumerate(symbols):
+        assert_frame_equal(batch[i].data, lib.read(sym, date_range=(start, end)).data)
+        assert_frame_equal(batch[i].data, frames[i].loc[start:end])
+
+
+def test_repeated_date_range_reads_do_not_retain_segment_views(lmdb_version_store_tiny_segment):
+    """Repeated small date_range reads must not keep growing retained array bases.
+
+    With tiny segments, a short date_range still intersects whole segments. The
+    returned columns must be owned copies (or truncated buffers), not views onto
+    a growing set of parent segment allocations.
+    """
+    lib = lmdb_version_store_tiny_segment
+    sym = "date_range_memory_loop"
+    # 40 rows with segment_row_size=2 => many segments; request 2 hours at a time.
+    df = _wide_frame(40, n_cols=20)
+    lib.write(sym, df)
+
+    retained = []
+    for i in range(15):
+        start = pd.Timestamp("2020-01-01") + pd.Timedelta(hours=i)
+        end = start + pd.Timedelta(hours=1)
+        out = lib.read(sym, date_range=(start, end)).data
+        retained.append(out)
+        # Column values should be contiguous owned arrays, not views of a larger buffer.
+        for col in out.columns:
+            values = out[col].to_numpy()
+            # Either no base (owned) or base is not dramatically larger than the slice.
+            if values.base is not None and isinstance(values.base, np.ndarray):
+                assert values.base.size <= values.size * 4
+
+    gc.collect()
+    # Sanity: we actually retained the small frames.
+    assert sum(len(frame) for frame in retained) > 0
+
+
+def test_legacy_python_post_filter_copies_column_buffers(lmdb_version_store):
+    """Safety net: if the legacy post-filter path is used, sliced columns are copied."""
+    lib = lmdb_version_store
+    sym = "legacy_post_filter_copy"
+    df = _wide_frame(100, n_cols=5)
+    lib.write(sym, df)
+
+    version_query, read_options, read_query, output_format = lib._get_queries(
+        as_of=None,
+        date_range=(pd.Timestamp("2020-01-02"), pd.Timestamp("2020-01-03")),
+        row_range=None,
+        columns=None,
+        query_builder=None,
+    )
+    # Rebuild with legacy zero-copy routing disabled so post-processing runs.
+    read_query = lib._get_read_query(
+        date_range=(pd.Timestamp("2020-01-02"), pd.Timestamp("2020-01-03")),
+        row_range=None,
+        columns=None,
+        query_builder=None,
+        force_ranges_to_queries=False,
+    )
+    assert read_query.needs_post_processing is True
+
+    read_result = lib._read_dataframe(sym, version_query, read_query, read_options)
+    # Before post-process the frame still holds full intersecting segments.
+    loaded_rows = read_result.frame_data.row_count
+    assert loaded_rows > 0
+
+    vitem = lib._post_process_dataframe(read_result, read_query, read_options, output_format)
+    for col in vitem.data.columns:
+        values = vitem.data[col].to_numpy()
+        # Copied slices must not share storage with a larger parent segment buffer.
+        assert values.base is None or (
+            isinstance(values.base, np.ndarray) and values.base.size <= values.size * 2
+        )


### PR DESCRIPTION
## Summary

Fixes **#2348**: `lib.read(symbol, date_range=...)` (and `row_range` / `read_batch`) could OOM when callers looped over small windows of a large symbol.

### Why

Intersecting segments (default ~100k rows) were loaded, then Python post-filtering returned **numpy views** onto those full buffers. Storing each “small” slice kept the parent segment alive → cumulative memory growth.

`QueryBuilder.date_range` already avoided this via C++ `DateRangeClause` truncate. `batch_read_and_join` already forced ranges onto that path. Single `read` / `read_batch` did not.

### What changed

1. **Default:** `_get_read_query` / `_get_read_queries` now route `date_range` / `row_range` through the processing pipeline (`force_ranges_to_queries=True`), matching the QueryBuilder / join behaviour so segments are truncated in C++.
2. **Safety net:** any remaining Python post-filter path **copies** sliced column arrays instead of returning views.
3. **Docs:** `read` / `QueryBuilder.date_range` no longer advertise the old “views are leaner” tradeoff.
4. **Tests:** correctness vs QueryBuilder / iloc, batch parity, legacy post-filter ownership, and a tiny-segment loop regression.

`force_ranges_to_queries=False` remains available for callers that intentionally want the legacy post-filter path (still copy-safe).

## Test plan

- [ ] `python/tests/unit/arcticdb/version_store/test_date_range_memory.py`
- [ ] Existing date_range / row_range / QueryBuilder / batch_read suites
- [ ] CI green

Fixes #2348


Made with [Cursor](https://cursor.com)