### PR TITLE
Log a warning in a process using arcticdb that forks, from Python 3.12+ on Linux

### DIFF
--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -18,6 +18,7 @@
 #include <folly/executors/ThreadPoolExecutor.h>
 #include <folly/system/ThreadName.h>
 #include <fmt/format.h>
+#include <atomic>
 #include <thread>
 #include <algorithm>
 #include <filesystem>
@@ -46,12 +47,21 @@ struct TaskSchedulerPtrWrapper {
     TaskScheduler& operator*() const { return *ptr_; }
 };
 
+// The IO pool never retires an idle thread, so once this is set the
+// process has ArcticDB threads for the rest of its life. Therefore this never moves from true to false.
+inline std::atomic<bool> io_pool_thread_started{false};
+
 class InstrumentedNamedFactory : public folly::ThreadFactory {
   public:
-    explicit InstrumentedNamedFactory(folly::StringPiece prefix) : named_factory_(prefix) {}
+    explicit InstrumentedNamedFactory(folly::StringPiece prefix, std::atomic<bool>* started_flag = nullptr) :
+        named_factory_(prefix),
+        started_flag_(started_flag) {}
 
     std::thread newThread(folly::Func&& func) override {
         std::lock_guard lock{mutex_};
+        if (started_flag_) {
+            started_flag_->store(true, std::memory_order_relaxed);
+        }
         return named_factory_.newThread([func = std::move(func)]() mutable {
             ARCTICDB_SAMPLE_THREAD();
             func();
@@ -63,6 +73,7 @@ class InstrumentedNamedFactory : public folly::ThreadFactory {
   private:
     std::mutex mutex_;
     folly::NamedThreadFactory named_factory_;
+    std::atomic<bool>* started_flag_;
 };
 
 inline std::string format_task_stats_line(
@@ -233,7 +244,7 @@ class TaskScheduler {
                         : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", (int)(cpu_thread_count_ * 1.5))
         ),
         cpu_exec_(cpu_thread_count_, std::make_shared<InstrumentedNamedFactory>("CPUPool")),
-        io_exec_(io_thread_count_, std::make_shared<InstrumentedNamedFactory>("IOPool")) {
+        io_exec_(io_thread_count_, std::make_shared<InstrumentedNamedFactory>("IOPool", &io_pool_thread_started)) {
         util::check(
                 cpu_thread_count_ > 0 && io_thread_count_ > 0,
                 "Zero IO or CPU threads: {} {}",
@@ -336,7 +347,7 @@ class TaskScheduler {
         ARCTICDB_RUNTIME_DEBUG(log::schedule(), "CPU exec num threads: {}", cpu_exec_.numActiveThreads());
         set_active_threads(0);
         set_max_threads(0);
-        io_exec_.set_thread_factory(std::make_shared<InstrumentedNamedFactory>("IOPool"));
+        io_exec_.set_thread_factory(std::make_shared<InstrumentedNamedFactory>("IOPool", &io_pool_thread_started));
         cpu_exec_.set_thread_factory(std::make_shared<InstrumentedNamedFactory>("CPUPool"));
         io_exec_.setNumThreads(io_thread_count_);
         cpu_exec_.setNumThreads(cpu_thread_count_);

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -206,7 +206,6 @@ void reinit_lmdb_warning() {
 
 // Windows has no fork(), so there is nothing to warn about there.
 #if !defined(WIN32) && PY_VERSION_HEX >= ARCTICDB_PY_FORK_DEPRECATED_HEX
-#include <unistd.h>
 
 static std::atomic_flag warned_about_fork;
 
@@ -214,6 +213,12 @@ static std::atomic_flag warned_about_fork;
 // hang: the sink's mutex may be inherited locked, and an async logger has no flusher thread there.
 void warn_about_fork() {
     using namespace arcticdb;
+    // Importing arcticdb, and even creating libraries, starts no pool threads, so there would be
+    // nothing to warn about. This also keeps a multiprocessing forkserver quiet: it forks every
+    // worker, but does no ArcticDB work itself.
+    if (!async::io_pool_thread_started.load(std::memory_order_relaxed)) {
+        return;
+    }
     if (ConfigsMap::instance()->get_int("Fork.WarnOnFork", 1) == 0) {
         return;
     }
@@ -221,12 +226,11 @@ void warn_about_fork() {
         return;
     }
     log::version().warn(
-            "fork() called in a process using ArcticDB (pid={}). ArcticDB and the storage SDKs run background "
-            "threads which are not duplicated into the child, so Arctic, Library and NativeVersionStore objects "
-            "created before the fork must not be used in the child; doing so may deadlock or crash. Create a new "
-            "Arctic instance in the child, or use the 'spawn' or 'forkserver' multiprocessing start method. Later "
-            "forks are not logged. Set Fork.WarnOnFork to 0 to silence this warning.",
-            getpid()
+            "fork() called in a process using ArcticDB. ArcticDB and the storage SDKs run background threads "
+            "which are not duplicated into the child, so Arctic, Library and NativeVersionStore objects created "
+            "before the fork must not be used in the child; doing so may deadlock or crash. Create a new Arctic "
+            "instance in the child, or use the 'spawn' multiprocessing start method. Later forks are not logged. "
+            "Set Fork.WarnOnFork to 0 to silence this warning."
     );
 }
 

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -205,7 +205,12 @@ void reinit_lmdb_warning() {
 }
 
 // Windows has no fork(), so there is nothing to warn about there.
-#if !defined(WIN32) && PY_VERSION_HEX >= ARCTICDB_PY_FORK_DEPRECATED_HEX
+//
+// macOS is excluded too: pthread_atfork handlers cannot tell a plain fork() from a fork() that is
+// immediately followed by exec() in the child, and on macOS CPython's subprocess/multiprocessing
+// routinely fork() for that fork+exec case (e.g. subprocess.run with a non-default env, or the
+// spawn/forkserver start methods)
+#if !defined(WIN32) && !defined(__APPLE__) && PY_VERSION_HEX >= ARCTICDB_PY_FORK_DEPRECATED_HEX
 
 static std::atomic_flag warned_about_fork;
 

--- a/cpp/arcticdb/python/python_module.cpp
+++ b/cpp/arcticdb/python/python_module.cpp
@@ -35,6 +35,12 @@
 
 #include <logger.pb.h>
 
+#include <atomic>
+
+// Python 3.12 raises its own DeprecationWarning when a multi-threaded process forks, but attributes it
+// to the caller of os.fork(), so for multiprocessing the default filters drop it. We warn instead.
+#define ARCTICDB_PY_FORK_DEPRECATED_HEX 0x030C0000
+
 namespace py = pybind11;
 
 void register_configs_map_api(py::module& m) {
@@ -198,6 +204,37 @@ void reinit_lmdb_warning() {
     arcticdb::storage::lmdb::LmdbStorage::reset_warning_counter();
 }
 
+// Windows has no fork(), so there is nothing to warn about there.
+#if !defined(WIN32) && PY_VERSION_HEX >= ARCTICDB_PY_FORK_DEPRECATED_HEX
+#include <unistd.h>
+
+static std::atomic_flag warned_about_fork;
+
+// Registered as a prepare handler so that it runs in the parent. Logging from a child handler can
+// hang: the sink's mutex may be inherited locked, and an async logger has no flusher thread there.
+void warn_about_fork() {
+    using namespace arcticdb;
+    if (ConfigsMap::instance()->get_int("Fork.WarnOnFork", 1) == 0) {
+        return;
+    }
+    if (warned_about_fork.test_and_set(std::memory_order_relaxed)) {
+        return;
+    }
+    log::version().warn(
+            "fork() called in a process using ArcticDB (pid={}). ArcticDB and the storage SDKs run background "
+            "threads which are not duplicated into the child, so Arctic, Library and NativeVersionStore objects "
+            "created before the fork must not be used in the child; doing so may deadlock or crash. Create a new "
+            "Arctic instance in the child, or use the 'spawn' or 'forkserver' multiprocessing start method. Later "
+            "forks are not logged. Set Fork.WarnOnFork to 0 to silence this warning.",
+            getpid()
+    );
+}
+
+void register_fork_warning() { pthread_atfork(&warn_about_fork, nullptr, nullptr); }
+#else
+void register_fork_warning() {}
+#endif
+
 void register_instrumentation(py::module&& m) {
     auto remotery = m.def_submodule("remotery");
 #if defined(USE_REMOTERY)
@@ -227,6 +264,7 @@ PYBIND11_MODULE(arcticdb_ext, m) {
     pthread_atfork(nullptr, nullptr, &reinit_lmdb_warning);
     pthread_atfork(nullptr, nullptr, &register_python_handler_data_factory);
 #endif
+    register_fork_warning();
     // Set up the global exception handlers first, so module-specific exception handler can override it:
     auto exceptions = m.def_submodule("exceptions");
     auto base_exception =

--- a/docs/claude/cpp/PYTHON_BINDINGS.md
+++ b/docs/claude/cpp/PYTHON_BINDINGS.md
@@ -137,6 +137,45 @@ For large numeric arrays, `py::array_t<>` can wrap C++ buffers without copying u
 
 Configuration functions `set_config_int()` and `set_config_string()` are exposed to Python via `arcticdb_ext`. These call into `ConfigsMap::instance()` on the C++ side.
 
+## Fork Handling
+
+`PYBIND11_MODULE` registers `pthread_atfork` handlers on non-Windows platforms. `fork()` duplicates only the calling thread, so the folly pools and the storage SDKs' background threads do not exist in the child, and any mutex they held stays locked forever.
+
+| Handler | Phase | Purpose |
+|---------|-------|---------|
+| `warn_about_fork` | prepare (parent) | Warn that inherited ArcticDB objects must not be used in the child, if pool threads exist |
+| `SingleThreadMutexHolder::reset_mutex` | child | Leak and replace the pybind entry mutex, which may have been locked by a thread that did not survive |
+| `reinit_scheduler` | child | `TaskScheduler::reattach_instance()` — leak the inherited scheduler and construct a new one with live threads |
+| `reinit_lmdb_warning` | child | Reset `LmdbStorage::times_path_opened` so the child does not inherit the parent's open counts |
+| `register_python_handler_data_factory` | child | Replace the `PythonHandlerData` factory, which holds a `py::handle` and atomic refcounts from the parent |
+
+The child handlers all leak rather than destroy inherited state, because running those destructors would join threads that do not exist.
+
+`warn_about_fork` is the only prepare handler, and the only one compiled conditionally, on `PY_VERSION_HEX >= ARCTICDB_PY_FORK_DEPRECATED_HEX` (3.12) — the CPython version that began raising its own `DeprecationWarning` for forking a multi-threaded process. That warning is invisible in practice: it is attributed to `multiprocessing/popen_fork.py` rather than `__main__`, where the default filters would show it.
+
+It runs in the parent deliberately. Logging from a child handler can hang, because the sink mutex may be inherited locked and an `async_logger` configured with `async_overflow_policy::block` has no flusher thread in the child. It is suppressible with the `Fork.WarnOnFork` config and fires at most once per process via a `std::atomic_flag`. The flag is not cleared in the child, so a child that forks again is silent.
+
+### Gating the warning on live threads
+
+Importing `arcticdb`, constructing an `Arctic`, calling `get_library()` and calling `list_symbols()` all start zero pool threads; the first real read or write starts them. So the warning is gated on `async::io_pool_thread_started`, a latch in `task_scheduler.hpp` set from `InstrumentedNamedFactory::newThread`. That factory is the only choke point that catches every IO path — a great many call sites reach the executor directly via `.via(&async::io_executor())` rather than through `submit_io_task`.
+
+A latch is exact rather than approximate here, because of how the pools retire threads:
+
+| Pool | Idle reclamation |
+|------|------------------|
+| IO | None. `IOThreadPoolExecutor` is constructed with `minThreads == maxThreads`, and each thread owns an `EventBase`. Threads observed flat at 161 across 150 s idle. |
+| CPU | Yes. `FLAGS_dynamic_cputhreadpoolexecutor` is true, so `minThreads` is 0 and idle workers exit after `FLAGS_threadtimeout_ms` (60 s). Observed dropping 20 → 1, then holding at a floor of 1 indefinitely. |
+
+Neither pool is ever shut down mid-life. The only stop is at interpreter exit, `Py_AtExit(shutdown_globals)` → `TaskScheduler::stop_active_threads()`, followed by static destruction of `instance_` running `~TaskSchedulerPtrWrapper`. So once an IO thread exists the process has ArcticDB threads until it exits, and the latch cannot be stale-true in the process that set it.
+
+It *is* stale-true in a child, where `reinit_scheduler` has installed a fresh scheduler with no threads. That is harmless only because `warned_about_fork` is also inherited set. Anything that later clears `warned_about_fork` in the child must clear the latch too.
+
+Two cases still warn where the user can do little about it. A script doing ArcticDB IO at module level, outside the `if __name__ == "__main__"` guard, starts threads in the forkserver process, which then warns as it forks each worker. And `subprocess.run(..., preexec_fn=...)` warns because disabling CPython's `vfork` optimisation makes it a real `fork()` with live threads; a prepare handler cannot tell fork-for-exec from fork-for-work. Plain `subprocess.run` and the `spawn` start method are silent because they use `vfork`, which does not run `pthread_atfork` handlers.
+
+Registering the handler through `os.register_at_fork(before=...)` instead would not change any of this: its coverage is identical across `os.fork`, all three start methods, and both `subprocess` forms.
+
+Note that `TaskScheduler::forked_`, `is_forked()` and `set_forked()` are dead: nothing calls `set_forked(true)`, so the `reattach_instance()` branch in `LocalVersionedEngine`'s constructor never runs. Setting that flag from a fork handler would reattach the scheduler a second time and leak another `TaskScheduler`. `re_init()` is dead for the same reason, and with it `set_active_threads()` and `set_max_threads()`, which nothing else calls.
+
 ## Key Files
 
 | File | Purpose |

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -134,7 +134,10 @@ Values:
 * 1: Enable (Default)
 
 The warning is only present in builds for Python 3.12 and later, the version where CPython itself began raising a
-`DeprecationWarning` for the same problem.
+`DeprecationWarning` for the same problem. It is also not present on macOS: unlike Linux, macOS's `subprocess` and
+`multiprocessing` routinely use a real `fork()` followed by `exec()` to launch child processes (e.g. `spawn` and
+`forkserver`), which is indistinguishable from an unsafe fork at the point the warning would be logged, so it would
+fire for those safe cases too.
 
 ### VersionStore.WillItemBePickledWarningMsg
 

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -118,6 +118,20 @@ The `thread` field is not supported on Windows and reads `unknown` there.
 
 The [`scripts/analyze_task_scheduler_queues.py`](https://github.com/man-group/ArcticDB/blob/master/scripts/analyze_task_scheduler_queues.py) script parses the captured log and provides a visualization.
 
+### Fork.WarnOnFork
+
+Control whether ArcticDB logs a warning when the process calls `fork()`, for example through
+`multiprocessing` with the `fork` start method.
+
+The warning is logged at most once per process, no matter how many times the process forks.
+
+Values:
+* 0: Disable
+* 1: Enable (Default)
+
+The warning is only present in builds for Python 3.12 and later, the version where CPython itself began raising a
+`DeprecationWarning` for the same problem.
+
 ### VersionStore.WillItemBePickledWarningMsg
 
 Control whether a detailed message explaining how the item is normalized is logged when calling the `will_item_be_pickled` function.

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -125,6 +125,10 @@ Control whether ArcticDB logs a warning when the process calls `fork()`, for exa
 
 The warning is logged at most once per process, no matter how many times the process forks.
 
+It is only logged once ArcticDB has started its background threads, which happens on the first read or write.
+A process that imports `arcticdb`, or that creates libraries without reading or writing, and then forks has
+nothing to warn about and stays silent.
+
 Values:
 * 0: Disable
 * 1: Enable (Default)

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -146,22 +146,46 @@ def test_configs_propagated_to_child_process(request, store_fixture, start_metho
         unset_config_int("TestPropagation")
 
 
-def _count_fork_warnings(body, env=None):
-    """Run body in a fresh interpreter and count the fork warnings it logs to stderr."""
+def _run_and_count(argv, env=None):
     child_env = dict(os.environ)
     child_env.update(env or {})
-    proc = subprocess.run([sys.executable, "-c", textwrap.dedent(body)], capture_output=True, text=True, env=child_env)
+    proc = subprocess.run(argv, capture_output=True, text=True, env=child_env)
     assert proc.returncode == 0, proc.stderr
     return proc.stderr.count(FORK_WARNING)
 
 
-_FORK_ONCE = """
+def _count_fork_warnings(body, env=None):
+    """Run body in a fresh interpreter and count the fork warnings it logs to stderr."""
+    return _run_and_count([sys.executable, "-c", textwrap.dedent(body)], env)
+
+
+def _count_fork_warnings_in_script(tmp_path, body, env=None):
+    """As _count_fork_warnings, but from a real script file.
+
+    The forkserver start method preloads __main__, which it cannot do for `python -c`. Only a
+    script on disk makes the forkserver process import arcticdb.
+    """
+    script = tmp_path / "fork_body.py"
+    script.write_text(textwrap.dedent(body))
+    return _run_and_count([sys.executable, str(script)], env)
+
+
+# The warning is only logged once ArcticDB has started IO threads
+_IMPORT_AND_WRITE = """
     import os
+    import sys
+    import tempfile
+    import pandas as pd
     import arcticdb
 
+    _lib = arcticdb.Arctic("lmdb://" + tempfile.mkdtemp()).get_library("arm", create_if_missing=True)
+    _lib.write("s", pd.DataFrame({"a": [1, 2, 3]}))
+"""
+
+_FORK_ONCE = _IMPORT_AND_WRITE + """
     pid = os.fork()
     if pid == 0:
-        os._exit(0)
+        sys.exit(0)
     os.waitpid(pid, 0)
 """
 
@@ -175,28 +199,24 @@ def test_fork_warning_logged():
 @FORK_SUPPORTED
 @FORK_WARNING_SUPPORTED
 def test_fork_warning_logged_for_pool():
-    assert _count_fork_warnings("""
-            import multiprocessing
-            import arcticdb
+    assert _count_fork_warnings(_IMPORT_AND_WRITE + """
+    import multiprocessing
 
-            with multiprocessing.get_context("fork").Pool(3) as pool:
-                assert pool.map(abs, [-1, -2, -3]) == [1, 2, 3]
-            """) == 1
+    with multiprocessing.get_context("fork").Pool(3) as pool:
+        assert pool.map(abs, [-1, -2, -3]) == [1, 2, 3]
+    """) == 1
 
 
 @FORK_SUPPORTED
 @FORK_WARNING_SUPPORTED
 def test_fork_warning_logged_once_per_process():
-    assert _count_fork_warnings("""
-            import os
-            import arcticdb
-
-            for _ in range(3):
-                pid = os.fork()
-                if pid == 0:
-                    os._exit(0)
-                os.waitpid(pid, 0)
-            """) == 1
+    assert _count_fork_warnings(_IMPORT_AND_WRITE + """
+    for _ in range(3):
+        pid = os.fork()
+        if pid == 0:
+            sys.exit(0)
+        os.waitpid(pid, 0)
+    """) == 1
 
 
 @FORK_SUPPORTED
@@ -208,16 +228,111 @@ def test_fork_warning_disabled_by_env_var():
 @FORK_SUPPORTED
 @FORK_WARNING_SUPPORTED
 def test_fork_warning_disabled_by_config():
-    assert _count_fork_warnings("""
-            import os
-            from arcticdb_ext import set_config_int
+    assert _count_fork_warnings(_IMPORT_AND_WRITE + """
+    from arcticdb_ext import set_config_int
 
-            set_config_int("Fork.WarnOnFork", 0)
-            pid = os.fork()
-            if pid == 0:
-                os._exit(0)
-            os.waitpid(pid, 0)
-            """) == 0
+    set_config_int("Fork.WarnOnFork", 0)
+    pid = os.fork()
+    if pid == 0:
+        sys.exit(0)
+    os.waitpid(pid, 0)
+    """) == 0
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_no_fork_warning_without_arcticdb_io():
+    """Creating a library and listing symbols starts no pool threads, so forking is safe."""
+    assert _count_fork_warnings("""
+    import os
+    import sys
+    import tempfile
+    import arcticdb
+
+    lib = arcticdb.Arctic("lmdb://" + tempfile.mkdtemp()).get_library("x", create_if_missing=True)
+    assert lib.list_symbols() == []
+
+    pid = os.fork()
+    if pid == 0:
+        sys.exit(0)
+    os.waitpid(pid, 0)
+    """) == 0
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_no_fork_warning_for_spawn_pool():
+    assert _count_fork_warnings(_IMPORT_AND_WRITE + """
+    import multiprocessing
+
+    with multiprocessing.get_context("spawn").Pool(2) as pool:
+        assert pool.map(abs, [-1, -2]) == [1, 2]
+    """) == 0
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_no_fork_warning_for_subprocess():
+    assert _count_fork_warnings(_IMPORT_AND_WRITE + """
+    import subprocess
+
+    subprocess.run([sys.executable, "-c", ""], check=True)
+    """) == 0
+
+
+# A forkserver preloads __main__, so the work has to sit under the guard for the forkserver process
+# not to run it. That is also how multiprocessing asks you to write a script.
+_POOL_IN_SCRIPT = """
+    import tempfile
+    import multiprocessing
+    import pandas as pd
+    import arcticdb
+
+    if __name__ == "__main__":
+        lib = arcticdb.Arctic("lmdb://" + tempfile.mkdtemp()).get_library("x", create_if_missing=True)
+        lib.write("s", pd.DataFrame({"a": [1, 2, 3]}))
+        with multiprocessing.get_context("__START_METHOD__").Pool(2) as pool:
+            assert pool.map(abs, [-1, -2]) == [1, 2]
+"""
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_no_fork_warning_for_forkserver_pool(tmp_path):
+    """The forkserver process forks every worker, but holds no ArcticDB threads of its own.
+
+    It imports __main__ to preload it, so it registers the atfork handler, but the __main__ guard
+    keeps the ArcticDB work out of it. The parent holds the threads and never forks.
+    """
+    body = _POOL_IN_SCRIPT.replace("__START_METHOD__", "forkserver")
+    assert _count_fork_warnings_in_script(tmp_path, body) == 0
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_logged_for_fork_pool_in_script(tmp_path):
+    """Positive control for test_no_fork_warning_for_forkserver_pool."""
+    body = _POOL_IN_SCRIPT.replace("__START_METHOD__", "fork")
+    assert _count_fork_warnings_in_script(tmp_path, body) == 1
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_logged_by_forkserver_doing_module_level_io(tmp_path):
+    """Known limitation, pinned deliberately.
+
+    Writing at module level rather than under the __main__ guard means the forkserver process runs
+    it too, so it holds live ArcticDB threads and warns as it forks each worker. The warning is
+    accurate about that process, but the user is already using forkserver.
+    """
+    body = _IMPORT_AND_WRITE + """
+    import multiprocessing
+
+    if __name__ == "__main__":
+        with multiprocessing.get_context("forkserver").Pool(2) as pool:
+            assert pool.map(abs, [-1, -2]) == [1, 2]
+    """
+    assert _count_fork_warnings_in_script(tmp_path, body) == 1
 
 
 def test_set_config_int_overrides_env_var_after_spawn(lmdb_version_store_v1, monkeypatch):

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -26,7 +26,8 @@ from tests.util.mark import SKIP_CONDA_MARK
 FORK_SUPPORTED = pytest.mark.skipif(sys.platform == "win32", reason="fork/forkserver not available on Windows")
 
 FORK_WARNING_SUPPORTED = pytest.mark.skipif(
-    sys.version_info < (3, 12), reason="The fork warning is only compiled in for Python 3.12+"
+    sys.version_info < (3, 12) or sys.platform == "darwin",
+    reason="The fork warning is only compiled in for Python 3.12+, and not on macOS",
 )
 
 FORK_WARNING = "fork() called in a process using ArcticDB"
@@ -185,7 +186,7 @@ _IMPORT_AND_WRITE = """
 _FORK_ONCE = _IMPORT_AND_WRITE + """
     pid = os.fork()
     if pid == 0:
-        sys.exit(0)
+        os._exit(0)
     os.waitpid(pid, 0)
 """
 
@@ -214,7 +215,7 @@ def test_fork_warning_logged_once_per_process():
     for _ in range(3):
         pid = os.fork()
         if pid == 0:
-            sys.exit(0)
+            os._exit(0)
         os.waitpid(pid, 0)
     """) == 1
 
@@ -234,7 +235,7 @@ def test_fork_warning_disabled_by_config():
     set_config_int("Fork.WarnOnFork", 0)
     pid = os.fork()
     if pid == 0:
-        sys.exit(0)
+        os._exit(0)
     os.waitpid(pid, 0)
     """) == 0
 
@@ -254,7 +255,7 @@ def test_no_fork_warning_without_arcticdb_io():
 
     pid = os.fork()
     if pid == 0:
-        sys.exit(0)
+        os._exit(0)
     os.waitpid(pid, 0)
     """) == 0
 
@@ -313,25 +314,6 @@ def test_no_fork_warning_for_forkserver_pool(tmp_path):
 def test_fork_warning_logged_for_fork_pool_in_script(tmp_path):
     """Positive control for test_no_fork_warning_for_forkserver_pool."""
     body = _POOL_IN_SCRIPT.replace("__START_METHOD__", "fork")
-    assert _count_fork_warnings_in_script(tmp_path, body) == 1
-
-
-@FORK_SUPPORTED
-@FORK_WARNING_SUPPORTED
-def test_fork_warning_logged_by_forkserver_doing_module_level_io(tmp_path):
-    """Known limitation, pinned deliberately.
-
-    Writing at module level rather than under the __main__ guard means the forkserver process runs
-    it too, so it holds live ArcticDB threads and warns as it forks each worker. The warning is
-    accurate about that process, but the user is already using forkserver.
-    """
-    body = _IMPORT_AND_WRITE + """
-    import multiprocessing
-
-    if __name__ == "__main__":
-        with multiprocessing.get_context("forkserver").Pool(2) as pool:
-            assert pool.map(abs, [-1, -2]) == [1, 2]
-    """
     assert _count_fork_warnings_in_script(tmp_path, body) == 1
 
 

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -7,7 +7,10 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import multiprocessing
+import os
+import subprocess
 import sys
+import textwrap
 import time
 from multiprocessing import Pool
 import numpy as np
@@ -21,6 +24,12 @@ from arcticdb.util.test import assert_frame_equal
 from tests.util.mark import SKIP_CONDA_MARK
 
 FORK_SUPPORTED = pytest.mark.skipif(sys.platform == "win32", reason="fork/forkserver not available on Windows")
+
+FORK_WARNING_SUPPORTED = pytest.mark.skipif(
+    sys.version_info < (3, 12), reason="The fork warning is only compiled in for Python 3.12+"
+)
+
+FORK_WARNING = "fork() called in a process using ArcticDB"
 
 
 def df(symbol):
@@ -135,6 +144,80 @@ def test_configs_propagated_to_child_process(request, store_fixture, start_metho
             p.map(_check_config_in_child, [(store, "TestPropagation", 12345)])
     finally:
         unset_config_int("TestPropagation")
+
+
+def _count_fork_warnings(body, env=None):
+    """Run body in a fresh interpreter and count the fork warnings it logs to stderr."""
+    child_env = dict(os.environ)
+    child_env.update(env or {})
+    proc = subprocess.run([sys.executable, "-c", textwrap.dedent(body)], capture_output=True, text=True, env=child_env)
+    assert proc.returncode == 0, proc.stderr
+    return proc.stderr.count(FORK_WARNING)
+
+
+_FORK_ONCE = """
+    import os
+    import arcticdb
+
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    os.waitpid(pid, 0)
+"""
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_logged():
+    assert _count_fork_warnings(_FORK_ONCE) == 1
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_logged_for_pool():
+    assert _count_fork_warnings("""
+            import multiprocessing
+            import arcticdb
+
+            with multiprocessing.get_context("fork").Pool(3) as pool:
+                assert pool.map(abs, [-1, -2, -3]) == [1, 2, 3]
+            """) == 1
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_logged_once_per_process():
+    assert _count_fork_warnings("""
+            import os
+            import arcticdb
+
+            for _ in range(3):
+                pid = os.fork()
+                if pid == 0:
+                    os._exit(0)
+                os.waitpid(pid, 0)
+            """) == 1
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_disabled_by_env_var():
+    assert _count_fork_warnings(_FORK_ONCE, env={"ARCTICDB_Fork_WarnOnFork_int": "0"}) == 0
+
+
+@FORK_SUPPORTED
+@FORK_WARNING_SUPPORTED
+def test_fork_warning_disabled_by_config():
+    assert _count_fork_warnings("""
+            import os
+            from arcticdb_ext import set_config_int
+
+            set_config_int("Fork.WarnOnFork", 0)
+            pid = os.fork()
+            if pid == 0:
+                os._exit(0)
+            os.waitpid(pid, 0)
+            """) == 0
 
 
 def test_set_config_int_overrides_env_var_after_spawn(lmdb_version_store_v1, monkeypatch):


### PR DESCRIPTION
Forking a process that uses ArcticDB is unsafe: `fork()` duplicates only the calling thread, so
the folly pools and the storage SDKs' background threads do not exist in the child, and any mutex
they held stays locked. `Arctic`, `Library` and `NativeVersionStore` objects created before the
fork must not be used afterwards in the child.

CPython 3.12 added a `DeprecationWarning` for forking a multi-threaded process, but it is
invisible in the case that matters. It is attributed to `multiprocessing/popen_fork.py` rather
than `__main__`, so the default warning filters drop it. Users doing exactly the wrong thing get
no diagnostic. This PR logs an ArcticDB warning instead.

## New runtime configuration: `Fork.WarnOnFork`

**User-facing.** Controls whether the warning is logged. Documented in
`docs/mkdocs/docs/runtime_config.md`.

| | |
|---|---|
| Default | `1` (enabled) |
| Disable in code | `set_config_int("Fork.WarnOnFork", 0)` |
| Disable by environment | `ARCTICDB_Fork_WarnOnFork_int=0` |

The warning is logged at most once per process however many times it forks, and only once
ArcticDB has started its background threads.

No public API changes, and no on-disk format changes.
