### PR TITLE
Skip heavy CI matrix on docs-only changes

### DIFF
--- a/.github/workflows/analysis_workflow.yml
+++ b/.github/workflows/analysis_workflow.yml
@@ -43,10 +43,15 @@ on:
 
 jobs:
 
+  detect_changes:
+    uses: ./.github/workflows/detect_docs_only.yml
+
   get_commits_to_benchmark:
-    name: Get tag commits  
+    name: Get tag commits
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     runs-on: ubuntu-22.04
-    steps:  
+    steps:
       - name: Checkout code 
         uses: actions/checkout@v3.3.0
         with:
@@ -130,6 +135,8 @@ jobs:
           
   run-asv-check-script:
     name: Executes asv tests checks
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     timeout-minutes: 120
     runs-on: ubuntu-latest
     container:
@@ -244,6 +251,8 @@ jobs:
   # ========================= Sanitizers ========================
   sanitizer-address-leak-undefined:
     name: Tests with ASan+LSan+UBSan
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/build_steps.yml
     secrets: inherit
     permissions: {packages: write}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,9 @@ concurrency:
 
 jobs:
 
+  detect_changes:
+    uses: ./.github/workflows/detect_docs_only.yml
+
   storage_type:
     runs-on: ubuntu-latest
     env:
@@ -117,6 +120,8 @@ jobs:
           done
 
   cibw_docker_image:
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/cibw_docker_image.yml
     permissions: {packages: write}
     with:
@@ -502,10 +507,11 @@ jobs:
       persistent_storage: ${{ needs.storage_type.outputs.storage }}
 
   publish_pytest_data:
-    needs: [build-python-wheels-linux, build-python-wheels-windows, build-python-wheels-macos]
+    needs: [detect_changes, build-python-wheels-linux, build-python-wheels-windows, build-python-wheels-macos]
     if: |
       always() &&
-      !cancelled()
+      !cancelled() &&
+      needs.detect_changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/publish_pytest_data.yml
     secrets: inherit
     permissions: {contents: write}

--- a/.github/workflows/build_with_conda.yml
+++ b/.github/workflows/build_with_conda.yml
@@ -25,7 +25,12 @@ on:
       run_custom_pytest_command: {required: false, type: string,  default: '',    description: Run custom pytest command or additional arguments}
 
 jobs:
+  detect_changes:
+    uses: ./.github/workflows/detect_docs_only.yml
+
   linux_64:
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/compile_and_test_with_conda.yml
     secrets: inherit
     with:
@@ -40,6 +45,8 @@ jobs:
       run_custom_pytest_command: ${{format('{0}', inputs.run_custom_pytest_command)}}
 
   linux_aarch64:
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/compile_and_test_with_conda.yml
     secrets: inherit
     with:
@@ -53,6 +60,8 @@ jobs:
       run_custom_pytest_command: ${{format('{0}', inputs.run_custom_pytest_command)}}
 
   osx_arm64:
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/compile_and_test_with_conda.yml
     secrets: inherit
     with:
@@ -69,6 +78,8 @@ jobs:
       run_custom_pytest_command: ${{format('{0}', inputs.run_custom_pytest_command)}}
 
   win_64:
+    needs: [detect_changes]
+    if: ${{ !cancelled() && needs.detect_changes.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/compile_and_test_with_conda.yml
     secrets: inherit
     with:
@@ -84,10 +95,11 @@ jobs:
       run_custom_pytest_command: ${{format('{0}', inputs.run_custom_pytest_command)}}
 
   publish_pytest_data:
-    needs: [linux_64, linux_aarch64, osx_arm64, win_64]
+    needs: [detect_changes, linux_64, linux_aarch64, osx_arm64, win_64]
     if: |
       always() &&
-      !cancelled()
+      !cancelled() &&
+      needs.detect_changes.outputs.docs_only != 'true'
     uses: ./.github/workflows/publish_pytest_data.yml
     secrets: inherit
     permissions:

--- a/.github/workflows/detect_docs_only.yml
+++ b/.github/workflows/detect_docs_only.yml
@@ -1,0 +1,82 @@
+name: Detect docs-only changes
+on:
+  workflow_call:
+    outputs:
+      docs_only:
+        description: "true if every changed file is docs/metadata and the build/test matrix can be skipped"
+        value: ${{ jobs.detect.outputs.docs_only }}
+
+permissions:
+  contents: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      docs_only: ${{ steps.check.outputs.docs_only }}
+    steps:
+      - name: Checkout (shallow)
+        if: |
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Fetch comparison commit (shallow)
+        if: |
+          github.event_name == 'pull_request' ||
+          (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          else
+            base_sha="${{ github.event.before }}"
+          fi
+          if [[ -n "$base_sha" ]] && [[ ! "$base_sha" =~ ^0+$ ]]; then
+            git fetch --depth=1 origin "$base_sha" || true
+          fi
+
+      - id: check
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+              echo "docs_only=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            base_sha="${{ github.event.before }}"
+
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -z "$base_sha" ]] || [[ "$base_sha" =~ ^0+$ ]] || ! git cat-file -e "$base_sha" 2>/dev/null; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed_files=$(git diff --no-renames --name-only "$base_sha" "${{ github.sha }}")
+          echo "Changed files:"
+          echo "$changed_files"
+
+          if [[ -z "$changed_files" ]]; then
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          non_docs_files=$(echo "$changed_files" | grep -Ev '(\.md$|\.ipynb$|^docs/|^LICENSE(\.[A-Za-z]+)?$|^\.gitignore$)' || true)
+
+          if [[ -z "$non_docs_files" ]]; then
+            echo "docs_only=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+          fi


### PR DESCRIPTION
## Summary

Doc-only PRs (e.g. a README.md line, a docs/ page) currently trigger the
full cross-platform build/test matrix in `build.yml` and
`build_with_conda.yml`, adding significant wait time for changes that
cannot affect build/test behaviour (see #3294 for an example).

This adds a `detect_docs_only.yml` reusable workflow that diffs the
changed files against the PR base / push `before` SHA and outputs
`docs_only=true` only when every changed file matches `*.md`, `*.ipynb`,
`docs/**`, `LICENSE*`, or `.gitignore`. It defaults to `docs_only=false` (full run)
for any event/state it can't confidently classify (schedule,
workflow_dispatch).

`cibw_docker_image` (build.yml) and `linux_64`/`linux_aarch64`/`osx_arm64`/`win_64`
(build_with_conda.yml) are gated on `docs_only != 'true'`; this cascades
through `needs:` to skip everything downstream (`common_config`,
`cpp-test-*`, `build-python-wheels-*`, the conda build/test jobs).
`publish_pytest_data` in both files gets the same guard added explicitly.

The two required status checks, `can_merge` and `can_merge_conda`, need
no changes — both already use `always() && !failure() && !cancelled()`,
and GitHub Actions treats a skipped dependency as neither failed nor
cancelled, so they still run (fast) and report green.

### Why not GitHub's built-in `paths-ignore` trigger filter?

GitHub Actions supports skipping a workflow entirely via
`on.push.paths-ignore` / `on.pull_request.paths-ignore`. We deliberately
didn't use it here, for two reasons specific to how `can_merge` and
`can_merge_conda` work as *required* status checks:

- When a workflow is skipped by `paths-ignore`, GitHub doesn't run it at
  all — it doesn't even report a "skipped" status for that workflow's
  jobs. For a required status check, GitHub treats "no report yet" as
  pending forever unless the check had *previously* reported success on
  that exact commit SHA on another branch (GitHub's documented
  workaround for this is to auto-pass paths-ignore'd required checks
  only when the SHA already succeeded elsewhere, which doesn't apply to
  a fresh PR commit). In practice this makes PRs get stuck waiting on a
  required check that will never post, unless every contributor
  remembers to special-case this — which is exactly the flakiness this
  PR is trying to avoid, not introduce.
- `build.yml` and `build_with_conda.yml` are themselves the workflows
  containing `can_merge`/`can_merge_conda`. Applying `paths-ignore` at
  the top of these files would skip the *entire* workflow, including
  those required-check jobs — there's no way to use `paths-ignore` to
  skip only the expensive inner jobs while still running the cheap
  required-check job. Reusable/matrix workflows compound this: `paths-ignore`
  interacts badly with `workflow_call` fan-out, where some matrix legs
  can report and others silently don't.

The `docs_only` output + `needs`/`if` gating pattern used here keeps
required-status-check reporting entirely within our control: the
workflow always runs, `can_merge`/`can_merge_conda` always execute and
report, and only the expensive middle of the job graph is conditionally
skipped.

## Test evidence

All tests below were done with throwaway PRs based on this branch (closed
without merging, branches deleted afterwards).

**1. Docs-only path (`docs_only=true`)** — PR #3297, a single added line
in `README.md` only:
- `detect_changes` ran and reported `docs_only=true`
  ([build.yml run](https://github.com/man-group/ArcticDB/actions/runs/30911898545),
  [build_with_conda.yml run](https://github.com/man-group/ArcticDB/actions/runs/30911896148)).
- `cibw_docker_image`, `common_config`, all `cpp-test-*` /
  `build-python-wheels-*` jobs, and all four conda platform jobs
  (`linux_64`, `linux_aarch64`, `osx_arm64`, `win_64`) showed as
  **Skipped**.
- Both required checks completed successfully in well under a minute:
  `can_merge` -> `COMPLETED SUCCESS`, `All conda jobs completed` ->
  `COMPLETED SUCCESS`.
- `run_linting_checks` and `storage_type` still ran normally, as
  intended (cheap, always-on checks).

**2. Non-docs path (`docs_only=false`), this PR** — this PR itself
only touches workflow YAML (`.github/workflows/*.yml`), so it exercises
the "not docs-only" branch:
- `detect_changes` ran and reported `docs_only=false`
  ([build.yml run](https://github.com/man-group/ArcticDB/actions/runs/30911789398),
  [build_with_conda.yml run](https://github.com/man-group/ArcticDB/actions/runs/30911786098)).
- `cibw_docker_image`, `common_config`, and the full `cpp-test-*` /
  `build-python-wheels-*` / conda matrix all queued and ran as normal --
  confirming no regression for ordinary (non-docs) PRs.

**3. A `.cpp`-only change (`docs_only=false`)** — PR #3298, a one-line
comment appended to `cpp/arcticdb/util/preconditions.hpp`:
- `detect_changes` logged the changed file as
  `cpp/arcticdb/util/preconditions.hpp` and reported `docs_only=false`.
- `cibw_docker_image`, `common_config`, and the full `cpp-test-*` /
  `build-python-wheels-*` / conda matrix all queued/ran (not skipped),
  confirming a source change is never misclassified as docs-only.
- Runs cancelled after confirming job state, to avoid burning CI time on
  a throwaway change.

**4. A `.py`-only change (`docs_only=false`)** — PR #3299, a one-line
comment appended to `python/arcticdb/version_store/library.py`:
- `detect_changes` logged the changed file as
  `python/arcticdb/version_store/library.py` and reported
  `docs_only=false`.
- `cibw_docker_image`, `common_config`, and the full `cpp-test-*` /
  `build-python-wheels-*` / conda matrix all queued/ran (not skipped).
- Runs cancelled after confirming job state, for the same reason as (3).
