### PR TITLE
[throwaway, do not merge] Test .cpp change triggers full CI

### DIFF
--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -219,3 +219,5 @@ struct formatter<A, std::enable_if_t<std::is_invocable_v<A>, char>> {
     }
 };
 } // namespace fmt
+
+// throwaway: verifying CI runs the full matrix for .cpp changes (test commit, not for merge)


### PR DESCRIPTION
Temporary PR to verify detect_docs_only.yml correctly does NOT skip the build/test matrix when a .cpp file changes. Will be closed without merging once verified.