### PR TITLE
[throwaway, do not merge] Test .py change triggers full CI

### DIFF
--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3553,3 +3553,5 @@ class Library:
             raise ArcticInvalidApiUsageException(
                 "mode must be one of StagedDataFinalizeMethod.WRITE, StagedDataFinalizeMethod.APPEND, 'write', 'append'"
             )
+
+# throwaway: verifying CI runs the full matrix for .py changes (test commit, not for merge)


### PR DESCRIPTION
Temporary PR to verify detect_docs_only.yml correctly does NOT skip the build/test matrix when a .py file changes. Will be closed without merging once verified.