### PR TITLE
Throwaway: verify docs-only detection after review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,4 @@ Interested in learning more about ArcticDB? Head over to our [blog](https://medi
 
 Do you have any questions or issues? Chat to us and other users through our dedicated Slack Workspace - sign up for Slack access on [our website](https://arcticdb.io).
 
+<!-- throwaway test v2 -->


### PR DESCRIPTION
Throwaway PR to verify `detect_docs_only.yml` still correctly classifies a docs-only change as `docs_only=true` using the new PR-files-API approach (no full checkout). Will be closed immediately after checking.