### PR TITLE
Throwaway: verify non-docs detection after review fixes

### DIFF
--- a/cpp/arcticdb/util/preconditions.hpp
+++ b/cpp/arcticdb/util/preconditions.hpp
@@ -219,3 +219,4 @@ struct formatter<A, std::enable_if_t<std::is_invocable_v<A>, char>> {
     }
 };
 } // namespace fmt
+// throwaway test v2


### PR DESCRIPTION
Throwaway PR to verify `detect_docs_only.yml` still correctly classifies a .cpp change as `docs_only=false` using the new PR-files-API approach. Will be closed immediately after checking.