### PR TITLE
Implement insertion strategy for merge update with row range index

### DIFF
--- a/cpp/arcticdb/pipeline/frame_utils.hpp
+++ b/cpp/arcticdb/pipeline/frame_utils.hpp
@@ -133,6 +133,21 @@ std::variant<position_t, convert::StringEncodingError> add_py_string_to_pool(
     }
 }
 
+template<util::type_descriptor_tag TDT>
+position_t write_py_string_to_pool_or_throw(
+        PyObject* const py_string_object, const size_t row_in_segment, const pipelines::RowRange& row_range,
+        std::optional<ScopedGILLock>& gil_lock, StringPool& new_string_pool, const std::string_view column_name
+) {
+    return util::variant_match(
+            add_py_string_to_pool<TDT::data_type()>(py_string_object, gil_lock, new_string_pool),
+            [](position_t offset) { return offset; },
+            [&](convert::StringEncodingError&& err) -> position_t {
+                err.row_index_in_slice_ = row_in_segment;
+                err.raise(column_name, row_range.first);
+            }
+    );
+}
+
 template<typename TagType, typename RawType>
 std::optional<convert::StringEncodingError> set_sequence_type(
         SegmentInMemory& seg, const entity::NativeTensor& tensor, size_t col, size_t rows_to_write, size_t row

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -904,6 +904,7 @@ struct MergeUpdateClause {
         [[nodiscard]] const std::vector<std::vector<size_t>>& matched_rows(size_t target_row_slice) const;
         [[nodiscard]] bool is_source_row_matched(size_t source_row) const;
         [[nodiscard]] bool has_matched_target_rows() const;
+        [[nodiscard]] util::BitSet unmatched_source_rows() const;
 
       private:
         /// For each row slice, for each source row, store all target rows that match it

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -72,21 +72,6 @@ void filter_selected_ranges_and_keys_and_reindex_entities(
 }
 
 template<util::type_descriptor_tag TDT>
-position_t write_py_string_to_pool_or_throw(
-        PyObject* const py_string_object, const size_t row_in_segment, const RowRange& row_range,
-        std::optional<ScopedGILLock>& gil_lock, StringPool& new_string_pool, const std::string_view column_name
-) {
-    return util::variant_match(
-            add_py_string_to_pool<TDT::data_type()>(py_string_object, gil_lock, new_string_pool),
-            [](position_t offset) { return offset; },
-            [&](convert::StringEncodingError&& err) -> position_t {
-                err.row_index_in_slice_ = row_in_segment;
-                err.raise(column_name, row_range.first);
-            }
-    );
-}
-
-template<util::type_descriptor_tag TDT>
 void rebuild_sequence_column_in_new_pool(
         Column& target_column, const StringPool& old_string_pool, StringPool& new_string_pool,
         const util::BitSet* target_rows_to_add_in_new_pool = nullptr
@@ -808,7 +793,7 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
     std::vector<ProcessingUnit> row_slices =
             must_structure_by_time_slice() ? split_by_row_slice(std::move(proc)) : std::vector{std::move(proc)};
     const std::pair<size_t, size_t> source_start_end = get_source_start_end(row_slices);
-    const MatchRecord matched = match(row_slices, source_start_end);
+    MatchRecord matched = match(row_slices, source_start_end);
     matched.validate_rows_to_update(strategy_);
     if (strategy_.update_only()) {
         if (!matched.has_matched_target_rows()) {
@@ -825,15 +810,48 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
                     std::move(*row_slice.row_ranges_),
                     std::move(*row_slice.col_ranges_),
                     std::vector<EntityFetchCount>(entity_count, 1),
-                    // Updating never inserts rows, but merge_slices_and_keys requires every emitted row range to
-                    // declare its inserted row count.
-                    std::vector(entity_count, MergeUpdateInsertedRowsEntity{0})
+                    std::vector(entity_count, MergeUpdateInsertedRowsComponent{0})
             );
             res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
         }
         return res;
     }
     const StreamDescriptor& target_descriptor = source_->desc(); // TODO: Not true for dynamic schema
+
+    if (target_descriptor.index().type() == IndexDescriptor::Type::ROWCOUNT) {
+        MergeUpdateNotMatchedSourceRowsComponent unmatched_source_rows_component(
+                std::make_shared<util::BitSet>(matched.unmatched_source_rows())
+        );
+        if (strategy_.update() && matched.has_matched_target_rows()) {
+            // Update is requested and there are matched rows.
+            std::vector<ProcessingUnit> new_row_slices = update(matched, std::move(row_slices), source_start_end);
+            util::check(
+                    new_row_slices.size() == 1,
+                    "Row range indexed data must produce exactly one row slice as a result of Merge Update"
+            );
+            std::vector<EntityId> res;
+            for (ProcessingUnit& row_slice : new_row_slices) {
+                const size_t entity_count = row_slice.segments_->size();
+                std::vector<EntityId> entts = component_manager_->add_entities(
+                        std::move(*row_slice.segments_),
+                        std::move(*row_slice.row_ranges_),
+                        std::move(*row_slice.col_ranges_),
+                        std::vector<EntityFetchCount>(entity_count, 1),
+                        std::vector(entity_count, MergeUpdateInsertedRowsComponent{0}),
+                        std::vector(entity_count, unmatched_source_rows_component)
+                );
+                res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
+            }
+            return res;
+        }
+        // Either there are no matched rows or this is insert only scenario. Either way we must not produce any
+        // output for the next clause (Write Clause) because this did nothing. However we must store the matched
+        // rows set so that after the pipeline ends insertion can be performed. Create a dummy entity holding
+        // only the set
+        component_manager_->add_entities(std::vector{std::move(unmatched_source_rows_component)});
+        return {};
+    }
+
     auto new_row_slices = update_and_insert(matched, target_descriptor, std::move(row_slices), source_start_end);
 
     std::vector<EntityId> res;
@@ -844,7 +862,7 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
                 std::move(*row_slice.row_ranges_),
                 std::move(*row_slice.col_ranges_),
                 std::vector<EntityFetchCount>(entity_count, 1),
-                std::vector(entity_count, MergeUpdateInsertedRowsEntity{matched.total_unmatched_source_rows()})
+                std::vector(entity_count, MergeUpdateInsertedRowsComponent{matched.total_unmatched_source_rows()})
         );
         res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
     }
@@ -994,10 +1012,6 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
         // merge_slices_and_keys keeps the existing data keys for row slices that are not re-emitted.
         return {};
     }
-    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
-            source_->desc().index().type() == IndexDescriptor::Type::TIMESTAMP,
-            "Merge update with insertion is implemented only for timeseries"
-    );
     const std::span<const timestamp> source_index = get_source_index(source_start_end);
     const StreamDescriptor source_descriptor = source_->desc();
     const size_t num_col_slices = row_slices.begin()->col_ranges_->size();
@@ -1099,11 +1113,6 @@ std::vector<ProcessingUnit> MergeUpdateClause::update(
         const MatchRecord& match_record, std::vector<ProcessingUnit>&& row_slices,
         std::pair<size_t, size_t> source_start_end
 ) const {
-    ARCTICDB_DEBUG_CHECK(
-            ErrorCode::E_ASSERTION_FAILURE,
-            strategy_.update_only(),
-            "MergeUpdateClause::update should only be called for prue updates without insertion"
-    );
     std::vector<ProcessingUnit> result;
     const StreamDescriptor& source_descriptor = source_->desc();
     const auto [source_start, source_end] = source_start_end;
@@ -1436,6 +1445,7 @@ void MergeUpdateClause::MatchRecord::clone_source_match(
 size_t MergeUpdateClause::MatchRecord::total_unmatched_source_rows() const {
     return std::ranges::count_if(source_row_matched_count_, [](const size_t count) { return count == 0; });
 }
+
 void MergeUpdateClause::MatchRecord::validate_rows_to_update(const MergeStrategy& strategy) const {
     // TODO: This can be inlined in the loop iterating over all columns to avoid iterating the source one more
     // time. The loop structure makes it not intuitive. The performance cost must be evaluated. Monday:
@@ -1472,5 +1482,15 @@ bool MergeUpdateClause::MatchRecord::is_source_row_matched(size_t source_row) co
 }
 
 bool MergeUpdateClause::MatchRecord::has_matched_target_rows() const { return total_matched_target_rows_count_ > 0; }
+
+[[nodiscard]] util::BitSet MergeUpdateClause::MatchRecord::unmatched_source_rows() const {
+    util::BitSet result(source_row_matched_count_.size());
+    for (size_t i = 0; i < source_row_matched_count_.size(); ++i) {
+        if (source_row_matched_count_[i] == 0) {
+            result.set(i);
+        }
+    }
+    return result;
+}
 
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -30,11 +30,19 @@ using namespace entt::literals;
 /// clause adding this entity and then after read_modify_write it reads it in order to compute the correct row ranges
 /// accounting for insertion. If any other piece of code adds this entity to the component manager the merge updates
 /// will iterate over them as well, producing wrong results. See merge_update_impl and Monday 12618296803
-struct MergeUpdateInsertedRowsEntity {
-    MergeUpdateInsertedRowsEntity() = default;
-    MergeUpdateInsertedRowsEntity(const size_t inserted_rows) : inserted_rows(inserted_rows) {}
+struct MergeUpdateInsertedRowsComponent {
+    MergeUpdateInsertedRowsComponent() = default;
+    MergeUpdateInsertedRowsComponent(const size_t inserted_rows) : inserted_rows(inserted_rows) {}
     operator size_t() const { return inserted_rows; }
     size_t inserted_rows = 0;
+};
+
+struct MergeUpdateNotMatchedSourceRowsComponent {
+    MergeUpdateNotMatchedSourceRowsComponent() = default;
+    MergeUpdateNotMatchedSourceRowsComponent(std::shared_ptr<util::BitSet> unmatched_source_rows) :
+        unmatched_source_rows(std::move(unmatched_source_rows)) {}
+    operator util::BitSet&() const { return *unmatched_source_rows; }
+    std::shared_ptr<util::BitSet> unmatched_source_rows;
 };
 
 class ComponentManager {
@@ -140,7 +148,7 @@ class ComponentManager {
     }
 
     template<typename ProcessComponents>
-    void process_entities(ProcessComponents&& process_fn) {
+    auto process_entities(ProcessComponents&& process_fn) const {
         using ArgTypes = util::function_arg_types<std::decay_t<ProcessComponents>>::args_t;
         // Derive the component tuple type (references stripped) without default-constructing it, as
         // the component types need not be default-constructible.

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -37,11 +37,16 @@ struct MergeUpdateInsertedRowsComponent {
     size_t inserted_rows = 0;
 };
 
+/// Used only by the MergeUpdateClause, and only for row-count indexed targets. After the pipeline finishes,
+/// write_inserted_row_range_data (via source_rows_to_insert_for_row_range_merge_update) intersects this component
+/// across *all* entities that carry it to decide which source rows to append. If any other piece of code adds this
+/// component the intersection will silently drop bits and rows will not be inserted. All instances added within a
+/// single merge must have the same size.
 struct MergeUpdateNotMatchedSourceRowsComponent {
     MergeUpdateNotMatchedSourceRowsComponent() = default;
     MergeUpdateNotMatchedSourceRowsComponent(std::shared_ptr<util::BitSet> unmatched_source_rows) :
         unmatched_source_rows(std::move(unmatched_source_rows)) {}
-    operator util::BitSet&() const { return *unmatched_source_rows; }
+    operator util::BitSet&() { return *unmatched_source_rows; }
     std::shared_ptr<util::BitSet> unmatched_source_rows;
 };
 

--- a/cpp/arcticdb/util/bitset.hpp
+++ b/cpp/arcticdb/util/bitset.hpp
@@ -25,6 +25,7 @@ using BitSetSizeType = bm::bvector<>::size_type;
 using BitIndex = bm::bvector<>::rs_index_type;
 
 template<typename functor>
+requires std::is_invocable_r_v<void, functor, size_t>
 struct BitSetVisitor {
     functor& f;
     int add_bits(BitSet::size_type off, const unsigned char* bits, unsigned n) {

--- a/cpp/arcticdb/util/bitset.hpp
+++ b/cpp/arcticdb/util/bitset.hpp
@@ -11,6 +11,7 @@
 #include <arcticdb/util/magic_num.hpp>
 
 #include <bitmagic/bm.h>
+#include <bitmagic/bmalgo.h>
 
 namespace arcticdb {
 
@@ -22,6 +23,23 @@ using BitMagicStart = SmallMagicNum<'M', 's'>;
 using BitMagicEnd = SmallMagicNum<'M', 'e'>;
 using BitSetSizeType = bm::bvector<>::size_type;
 using BitIndex = bm::bvector<>::rs_index_type;
+
+template<typename functor>
+struct BitSetVisitor {
+    functor& f;
+    int add_bits(BitSet::size_type off, const unsigned char* bits, unsigned n) {
+        for (unsigned i = 0; i < n; ++i) {
+            f(off + bits[i]);
+        }
+        return 0;
+    }
+    int add_range(BitSet::size_type off, BitSet::size_type n) {
+        for (BitSet::size_type i = 0; i < n; ++i) {
+            f(off + i);
+        }
+        return 0;
+    }
+};
 
 /// @brief Get the combined size of the magic words used as delimiters for the sparse bitmaps
 /// When sparse bitmaps are encoded we use two different magic words to mark the start and the end of the bitmap
@@ -50,10 +68,20 @@ void copy_packed_bits(const uint8_t* src, size_t src_bit_offset, size_t num_bits
 template<typename functor>
 requires std::is_invocable_r_v<void, functor, size_t>
 void iterate_over_set_positions(const bm::bvector<>& bv, size_t from, size_t to, functor&& f) {
-    // TODO: Investigate performance of `get_enumerator`. Maybe having an rs_index can speed it up.
-    for (auto en = bv.get_enumerator(from); *en < to; ++en) {
-        f(*en);
+    util::check(to >= from, "Invalid bit set iteration range: from {} to {}", from, to);
+    if (from == to) {
+        return;
     }
+    util::BitSetVisitor visitor{f};
+    // the range that bitmagic requires is inclusive
+    bm::for_each_bit_range(bv, from, to - 1, visitor);
+}
+
+template<typename functor>
+requires std::is_invocable_r_v<void, functor, size_t>
+void iterate_over_set_positions(const bm::bvector<>& bv, functor&& f) {
+    util::BitSetVisitor visitor{f};
+    bm::for_each_bit(bv, visitor);
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/merge_options.cpp
+++ b/cpp/arcticdb/version/merge_options.cpp
@@ -20,4 +20,6 @@ bool MergeStrategy::insert_only() const {
 bool MergeStrategy::insert() const { return not_matched_by_target == MergeAction::INSERT; }
 
 bool MergeStrategy::update() const { return matched == MergeAction::UPDATE; }
+
+bool MergeStrategy::update_and_insert() const { return update() && insert(); }
 } // namespace arcticdb

--- a/cpp/arcticdb/version/merge_options.hpp
+++ b/cpp/arcticdb/version/merge_options.hpp
@@ -15,10 +15,11 @@ struct MergeStrategy {
     MergeAction matched = MergeAction::DO_NOTHING;
     MergeAction not_matched_by_target = MergeAction::DO_NOTHING;
     bool operator==(const MergeStrategy&) const = default;
-    bool update_only() const;
-    bool insert_only() const;
-    bool insert() const;
-    bool update() const;
+    [[nodiscard]] bool update_only() const;
+    [[nodiscard]] bool insert_only() const;
+    [[nodiscard]] bool insert() const;
+    [[nodiscard]] bool update() const;
+    [[nodiscard]] bool update_and_insert() const;
 };
 
 } // namespace arcticdb

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -492,13 +492,14 @@ folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
             const Field& field = slice_descriptor.field(column_in_segment);
             const size_t source_field_pos = col_range.start() + column_in_segment;
             details::visit_scalar(field.type(), [&]<util::type_descriptor_tag TDT>(TDT) {
-                constexpr bool is_sequence = is_sequence_type(TDT::data_type());
-                using SourceRawType =
-                        std::conditional_t<is_sequence, PyObject* const, typename TDT::DataTypeTag::raw_type>;
+                using SourceRawType = std::conditional_t<
+                        is_sequence_type(TDT::data_type()),
+                        PyObject* const,
+                        typename TDT::DataTypeTag::raw_type>;
                 auto data_it = col_data.begin<TDT>();
                 std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
                 iterate_over_set_positions(*source_rows_to_insert, [&](size_t source_row) {
-                    if constexpr (is_sequence) {
+                    if constexpr (is_sequence_type(TDT::data_type())) {
                         *data_it = write_py_string_to_pool_or_throw<TDT>(
                                 source_data[source_row],
                                 source_row,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -42,6 +42,7 @@
 #include <arcticdb/util/format_date.hpp>
 #include <iterator>
 #include <aws/core/utils/stream/ResponseStream.h>
+#include <arcticdb/util/bitset.hpp>
 
 namespace arcticdb::version_store {
 
@@ -417,6 +418,13 @@ std::vector<SliceAndKey> merge_slices_and_keys(
                 }
             }
         }
+        while (new_slice_and_key_it != new_slices.end() && new_slice_and_key_it->slice().col_range == current_col_range
+        ) {
+            new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
+            new_slice_and_key_it->slice().row_range.second += total_inserted_rows;
+            merged_ranges_and_keys.emplace_back(std::move(*new_slice_and_key_it));
+            ++new_slice_and_key_it;
+        }
     }
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             new_slice_and_key_it == new_slices.end(), "Not all new slices were merged"
@@ -425,6 +433,104 @@ std::vector<SliceAndKey> merge_slices_and_keys(
             old_slice_and_key_it == old_slices.end(), "Not all old slices were merged"
     );
     return merged_ranges_and_keys;
+}
+
+std::optional<util::BitSet> source_rows_to_insert_for_row_range_merge_update(const ComponentManager& component_manager
+) {
+    std::optional<util::BitSet> rows_to_insert;
+    component_manager.process_entities([&](const MergeUpdateNotMatchedSourceRowsComponent& unmatched_source_rows) {
+        if (rows_to_insert) {
+            rows_to_insert->bit_and(*unmatched_source_rows.unmatched_source_rows);
+        } else {
+            rows_to_insert = *unmatched_source_rows.unmatched_source_rows;
+        }
+    });
+    return rows_to_insert;
+}
+
+std::vector<StreamDescriptor> split_rowrange_descriptor(
+        const StreamDescriptor& descriptor, const size_t column_slice_size
+) {
+    auto descriptors = util::reserve_vector<StreamDescriptor>(descriptor.field_count() / column_slice_size + 1);
+    for (size_t field_index = 0; field_index < descriptor.field_count(); ++field_index) {
+        if (field_index % column_slice_size == 0) {
+            descriptors.emplace_back();
+            descriptors.back().set_index(descriptor.index());
+            descriptors.back().set_id(descriptor.id());
+        }
+        descriptors.back().add_field(descriptor.field(field_index));
+    }
+    return descriptors;
+}
+
+folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
+        const InputFrame& source, const ComponentManager& component_manager, const StreamDescriptor& target_descriptor,
+        const size_t columns_per_slice, const IndexPartialKey& target_index_partial_key,
+        const size_t last_row_in_target, Store& store
+) {
+    const std::optional<util::BitSet> source_rows_to_insert =
+            source_rows_to_insert_for_row_range_merge_update(component_manager);
+    const size_t num_rows_to_insert = source_rows_to_insert ? source_rows_to_insert->count() : 0;
+    if (num_rows_to_insert == 0) {
+        return folly::makeFuture<std::vector<SliceAndKey>>(std::vector<SliceAndKey>{});
+    }
+    std::vector<StreamDescriptor> descriptors = split_rowrange_descriptor(target_descriptor, columns_per_slice);
+    const RowRange new_row_range{last_row_in_target, last_row_in_target + num_rows_to_insert};
+    auto write_data_keys_future = util::reserve_vector<folly::Future<SliceAndKey>>(descriptors.size());
+    for (size_t col_slice = 0; col_slice < descriptors.size(); ++col_slice) {
+        SegmentInMemory new_segment(
+                std::move(descriptors[col_slice]), num_rows_to_insert, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
+        );
+        const StreamDescriptor& slice_descriptor = new_segment.descriptor();
+        const ColRange col_range{
+                col_slice * columns_per_slice,
+                std::min((col_slice + 1) * columns_per_slice, target_descriptor.field_count())
+        };
+        for (size_t column_in_segment = 0; column_in_segment < slice_descriptor.field_count(); ++column_in_segment) {
+            std::optional<ScopedGILLock> gil_lock;
+            ColumnData col_data = new_segment.column_data(column_in_segment);
+            const Field& field = slice_descriptor.field(column_in_segment);
+            const size_t source_field_pos = col_range.start() + column_in_segment;
+            details::visit_scalar(field.type(), [&]<util::type_descriptor_tag TDT>(TDT) {
+                constexpr bool is_sequence = is_sequence_type(TDT::data_type());
+                using SourceRawType =
+                        std::conditional_t<is_sequence, PyObject* const, typename TDT::DataTypeTag::raw_type>;
+                auto data_it = col_data.begin<TDT>();
+                std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
+                iterate_over_set_positions(*source_rows_to_insert, [&](size_t source_row) {
+                    if constexpr (is_sequence) {
+                        *data_it = write_py_string_to_pool_or_throw<TDT>(
+                                source_data[source_row],
+                                source_row,
+                                RowRange{0, source.num_rows},
+                                gil_lock,
+                                new_segment.string_pool(),
+                                field.name()
+                        );
+                    } else {
+                        *data_it = source_data[source_row];
+                    }
+                    ++data_it;
+                });
+            });
+        }
+        new_segment.set_row_data(num_rows_to_insert - 1);
+        write_data_keys_future.push_back(store.compress_and_schedule_async_write(
+                std::make_tuple(
+                        PartialKey{
+                                .key_type = KeyType::TABLE_DATA,
+                                .version_id = target_index_partial_key.version_id,
+                                .stream_id = target_index_partial_key.id,
+                                .start_index = static_cast<timestamp>(new_row_range.first),
+                                .end_index = static_cast<timestamp>(new_row_range.second)
+                        },
+                        std::move(new_segment),
+                        FrameSlice(col_range, new_row_range)
+                ),
+                std::make_shared<DeDupMap>()
+        ));
+    }
+    return folly::collect(std::move(write_data_keys_future));
 }
 } // namespace
 
@@ -3152,11 +3258,6 @@ folly::Future<AtomKey> merge_update_impl(
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !write_options.dynamic_schema, "Cannot merge update with dynamic schema"
     );
-    internal::check<ErrorCode::E_NOT_IMPLEMENTED>(
-            strategy.not_matched_by_target != MergeAction::INSERT ||
-                    pipeline_context->descriptor().index().type() == IndexDescriptor::Type::TIMESTAMP,
-            "Merge update with INSERT strategy is not implemented for ROWRANGE indexes yet."
-    );
     const IndexDescriptor::Type index_type = pipeline_context->descriptor().index().type();
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             (index_type == IndexDescriptor::Type::TIMESTAMP &&
@@ -3182,37 +3283,70 @@ folly::Future<AtomKey> merge_update_impl(
                         store,
                         write_options,
                         source = std::move(source),
-                        target_partial_index_key](std::vector<SliceAndKey>&& data_keys_and_slices) {
-                ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
-                component_manager->process_entities([&](const MergeUpdateInsertedRowsEntity& inserted_rows,
-                                                        const std::shared_ptr<RowRange>& row_range) {
-                    inserted_rows_per_row_range.emplace(*row_range, inserted_rows);
-                });
-                std::vector<SliceAndKey> merged_ranges_and_keys = merge_slices_and_keys(
-                        std::move(pipeline_context->slice_and_keys_),
-                        std::move(data_keys_and_slices),
-                        std::move(inserted_rows_per_row_range)
-                );
-                pipeline_context->slice_and_keys_.clear();
-                const size_t row_count = merged_ranges_and_keys.empty()
-                                                 ? 0
-                                                 : merged_ranges_and_keys.back().slice().row_range.second -
-                                                           merged_ranges_and_keys.front().slice().row_range.first;
-                const TimeseriesDescriptor tsd = make_timeseries_descriptor(
-                        row_count,
-                        pipeline_context->descriptor(),
-                        pipeline_context->normalization(),
-                        std::make_optional(std::move(source->user_meta)),
-                        std::nullopt,
-                        write_options.bucketize_dynamic
-                );
-                return index::write_index(
-                        index_type_from_descriptor(pipeline_context->descriptor()),
-                        tsd,
-                        std::move(merged_ranges_and_keys),
                         target_partial_index_key,
-                        store
-                );
+                        strategy](std::vector<SliceAndKey>&& data_keys_and_slices) {
+                const StreamDescriptor& target_descriptor = pipeline_context->descriptor();
+                folly::SemiFuture<std::vector<SliceAndKey>> inserted_row_slices_fut =
+                        (target_descriptor.index().type() == IndexDescriptor::Type::ROWCOUNT && strategy.insert())
+                                ? write_inserted_row_range_data(
+                                          *source,
+                                          *component_manager,
+                                          target_descriptor,
+                                          write_options.column_group_size,
+                                          target_partial_index_key,
+                                          pipeline_context->last_row(),
+                                          *store
+                                  )
+                                : folly::makeSemiFuture(std::vector<SliceAndKey>{});
+                return std::move(inserted_row_slices_fut)
+                        .via(&async::cpu_executor())
+                        .thenValue([pipeline_context,
+                                    component_manager,
+                                    store,
+                                    write_options,
+                                    source,
+                                    target_partial_index_key,
+                                    data_keys_and_slices = std::move(data_keys_and_slices
+                                    )](std::vector<SliceAndKey>&& inserted_row_slices) mutable {
+                            ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
+                            component_manager->process_entities(
+                                    [&](const MergeUpdateInsertedRowsComponent& inserted_rows,
+                                        const std::shared_ptr<RowRange>& row_range) {
+                                        inserted_rows_per_row_range.emplace(*row_range, inserted_rows);
+                                    }
+                            );
+                            data_keys_and_slices.insert(
+                                    data_keys_and_slices.end(),
+                                    std::make_move_iterator(inserted_row_slices.begin()),
+                                    std::make_move_iterator(inserted_row_slices.end())
+                            );
+                            std::vector<SliceAndKey> merged_ranges_and_keys = merge_slices_and_keys(
+                                    std::move(pipeline_context->slice_and_keys_),
+                                    std::move(data_keys_and_slices),
+                                    std::move(inserted_rows_per_row_range)
+                            );
+                            pipeline_context->slice_and_keys_.clear();
+                            const size_t row_count =
+                                    merged_ranges_and_keys.empty()
+                                            ? 0
+                                            : merged_ranges_and_keys.back().slice().row_range.second -
+                                                      merged_ranges_and_keys.front().slice().row_range.first;
+                            const TimeseriesDescriptor tsd = make_timeseries_descriptor(
+                                    row_count,
+                                    pipeline_context->descriptor(),
+                                    pipeline_context->normalization(),
+                                    std::make_optional(std::move(source->user_meta)),
+                                    std::nullopt,
+                                    write_options.bucketize_dynamic
+                            );
+                            return index::write_index(
+                                    index_type_from_descriptor(pipeline_context->descriptor()),
+                                    tsd,
+                                    std::move(merged_ranges_and_keys),
+                                    target_partial_index_key,
+                                    store
+                            );
+                        });
             });
 }
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -451,7 +451,9 @@ std::optional<util::BitSet> source_rows_to_insert_for_row_range_merge_update(con
 std::vector<StreamDescriptor> split_rowrange_descriptor(
         const StreamDescriptor& descriptor, const size_t column_slice_size
 ) {
-    auto descriptors = util::reserve_vector<StreamDescriptor>(descriptor.field_count() / column_slice_size + 1);
+    auto descriptors = util::reserve_vector<StreamDescriptor>(
+            (descriptor.field_count() + column_slice_size - 1) / column_slice_size
+    );
     for (size_t field_index = 0; field_index < descriptor.field_count(); ++field_index) {
         if (field_index % column_slice_size == 0) {
             descriptors.emplace_back();

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -282,7 +282,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=8, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1784913472050154303)"
+       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=16, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1785928648523148767)"
       ]
      },
      "execution_count": 4,
@@ -2287,7 +2287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260724 20:17:52.543535 4443 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260805 14:17:29.207539 33604 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {
@@ -3220,6 +3220,495 @@
   },
   {
    "cell_type": "markdown",
+   "id": "rr0insert0intro",
+   "metadata": {},
+   "source": [
+    "## Insertion into Row-Range Indexed Data\n",
+    "\n",
+    "The insertion strategies also work when the data is **row-range indexed** — a DataFrame with a default `RangeIndex`. Because there is no meaningful index to match on, the `on` parameter is **required** and matching is performed purely on the columns it lists.\n",
+    "\n",
+    "Unmatched rows from `source` are **appended after all existing target rows, in source order**.\n",
+    "\n",
+    "#### Insert Only: `matched=\"do_nothing\"`, `not_matched_by_target=\"insert\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "rr1insert1code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A1</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C3</td>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  A1        10\n",
+       "1  B2        20\n",
+       "2  C3        30"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D4</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>E5</td>\n",
+       "      <td>50</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  B2       999\n",
+       "1  D4        40\n",
+       "2  E5        50"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge — new rows appended at the end\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A1</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C3</td>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>D4</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>E5</td>\n",
+       "      <td>50</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  A1        10\n",
+       "1  B2        20\n",
+       "2  C3        30\n",
+       "3  D4        40\n",
+       "4  E5        50"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Target: a product inventory with a default RangeIndex (row-range indexed)\n",
+    "inventory = pd.DataFrame({\n",
+    "    \"SKU\": [\"A1\", \"B2\", \"C3\"],\n",
+    "    \"Quantity\": [10, 20, 30],\n",
+    "})\n",
+    "lib.write(\"inventory_insert\", inventory)\n",
+    "print(\"Original data\")\n",
+    "display(lib.read(\"inventory_insert\").data)\n",
+    "\n",
+    "# Source: an existing SKU (B2) and two new ones (D4, E5)\n",
+    "new_stock = pd.DataFrame({\n",
+    "    \"SKU\": [\"B2\", \"D4\", \"E5\"],\n",
+    "    \"Quantity\": [999, 40, 50],\n",
+    "})\n",
+    "print(\"Source data\")\n",
+    "display(new_stock)\n",
+    "\n",
+    "# Insert only — matching SKU B2 is left unchanged, new SKUs are appended in source order\n",
+    "lib.merge_experimental(\n",
+    "    \"inventory_insert\",\n",
+    "    new_stock,\n",
+    "    strategy=MergeStrategy(matched=\"do_nothing\", not_matched_by_target=\"insert\"),\n",
+    "    on=[\"SKU\"]\n",
+    ")\n",
+    "print(\"Data after merge — new rows appended at the end\")\n",
+    "display(lib.read(\"inventory_insert\").data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rr2insert2md",
+   "metadata": {},
+   "source": [
+    "`SKU=\"B2\"` already existed in `target`, so with `matched=\"do_nothing\"` its source `Quantity` of `999` was ignored. The two new SKUs (`D4`, `E5`) were appended at the end in the order they appear in `source`, and the result was re-indexed with a fresh `RangeIndex`.\n",
+    "\n",
+    "#### Update and Insert: `matched=\"update\"`, `not_matched_by_target=\"insert\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "rr3insert3code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A1</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C3</td>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  A1        10\n",
+       "1  B2        20\n",
+       "2  C3        30"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D4</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>E5</td>\n",
+       "      <td>50</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  B2       999\n",
+       "1  D4        40\n",
+       "2  E5        50"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge — B2 updated in place, new rows appended\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A1</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C3</td>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>D4</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>E5</td>\n",
+       "      <td>50</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  A1        10\n",
+       "1  B2       999\n",
+       "2  C3        30\n",
+       "3  D4        40\n",
+       "4  E5        50"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Same target and source, this time updating matched rows as well as inserting new ones\n",
+    "lib.write(\"inventory_upsert\", inventory)\n",
+    "print(\"Original data\")\n",
+    "display(lib.read(\"inventory_upsert\").data)\n",
+    "print(\"Source data\")\n",
+    "display(new_stock)\n",
+    "\n",
+    "lib.merge_experimental(\n",
+    "    \"inventory_upsert\",\n",
+    "    new_stock,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"insert\"),\n",
+    "    on=[\"SKU\"]\n",
+    ")\n",
+    "print(\"Data after merge — B2 updated in place, new rows appended\")\n",
+    "display(lib.read(\"inventory_upsert\").data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rr4insert4md",
+   "metadata": {},
+   "source": [
+    "This time `matched=\"update\"` overwrote the `Quantity` of the existing `SKU=\"B2\"` row in place (from `20` to `999`), while the unmatched SKUs `D4` and `E5` were appended at the end as before."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "84815889-9efa-46ee-a143-2f6016949a5c",
    "metadata": {},
    "source": [
@@ -3228,8 +3717,7 @@
     "\n",
     "1. Both `target` and `source` must have a sorted index when using `pd.DatetimeIndex` or a `pd.MultiIndex` with a datetime first level.\n",
     "2. The library must use a static schema, and both `source` and `target` must share the same schema.\n",
-    "3. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses row-range matching (requires the `on` parameter).\n",
-    "4. For strategies with `not_matched_by_target=\"insert\"`, only datetime-indexed data is supported."
+    "3. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses row-range matching (requires the `on` parameter)."
    ]
   },
   {

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -282,7 +282,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=16, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1785928648523148767)"
+       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1786394374204517043)"
       ]
      },
      "execution_count": 4,
@@ -2287,7 +2287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260805 14:17:29.207539 33604 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260810 23:39:34.614978 81758 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {
@@ -2410,7 +2410,7 @@
     "Merge also works with `pd.MultiIndex` DataFrames. The behavior depends on the **first level** of the MultiIndex:\n",
     "\n",
     "- **Datetime first level**: The DataFrame is treated like a timeseries, meaning the first column will automatically be included in the `on` parameter and used for matching. The remaining index levels are treated as regular columns. They can be updated by the merge or included in `on` for additional matching.\n",
-    "- **Non-datetime first level**: The DataFrame is treated like a row-range-indexed DataFrame. The `on` parameter is **required** to be a non-empty list of columns. Matching is performed on the columns in the `on` parameter.\n",
+    "- **Non-datetime first level**: The DataFrame is treated like non-timeseries data. The `on` parameter is **required** to be a non-empty list of columns. Matching is performed on the columns in the `on` parameter.\n",
     "\n",
     "### Example: MultiIndex with Datetime First Level\n",
     "\n",
@@ -2952,7 +2952,7 @@
     "\n",
     "### Example: MultiIndex with Non-Datetime First Level\n",
     "\n",
-    "When the first level of the MultiIndex is not a datetime, the DataFrame is treated like a row-range-indexed DataFrame. The `on` parameter is required and all index levels become updatable columns."
+    "When the first level of the MultiIndex is not a datetime, the DataFrame is treated like non-timeseries data. The `on` parameter is required and all index levels become updatable columns."
    ]
   },
   {
@@ -3223,9 +3223,9 @@
    "id": "rr0insert0intro",
    "metadata": {},
    "source": [
-    "## Insertion into Row-Range Indexed Data\n",
+    "## Insertion into Non-Timeseries Data\n",
     "\n",
-    "The insertion strategies also work when the data is **row-range indexed** — a DataFrame with a default `RangeIndex`. Because there is no meaningful index to match on, the `on` parameter is **required** and matching is performed purely on the columns it lists.\n",
+    "The insertion strategies also work when the data is **non-timeseries** — a DataFrame with a default `RangeIndex`. Because there is no meaningful index to match on, the `on` parameter is **required** and matching is performed purely on the columns it lists.\n",
     "\n",
     "Unmatched rows from `source` are **appended after all existing target rows, in source order**.\n",
     "\n",
@@ -3438,7 +3438,7 @@
     }
    ],
    "source": [
-    "# Target: a product inventory with a default RangeIndex (row-range indexed)\n",
+    "# Target: a product inventory with a default RangeIndex (non-timeseries)\n",
     "inventory = pd.DataFrame({\n",
     "    \"SKU\": [\"A1\", \"B2\", \"C3\"],\n",
     "    \"Quantity\": [10, 20, 30],\n",
@@ -3704,7 +3704,228 @@
    "id": "rr4insert4md",
    "metadata": {},
    "source": [
-    "This time `matched=\"update\"` overwrote the `Quantity` of the existing `SKU=\"B2\"` row in place (from `20` to `999`), while the unmatched SKUs `D4` and `E5` were appended at the end as before."
+    "This time `matched=\"update\"` overwrote the `Quantity` of the existing `SKU=\"B2\"` row in place (from `20` to `999`), while the unmatched SKUs `D4` and `E5` were appended at the end as before.\n",
+    "\n",
+    "#### Update Only: `matched=\"update\"`, `not_matched_by_target=\"do_nothing\"`\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "rr5insert5code",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A1</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>20</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C3</td>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  A1        10\n",
+       "1  B2        20\n",
+       "2  C3        30"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Source data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>D4</td>\n",
+       "      <td>40</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>E5</td>\n",
+       "      <td>50</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  B2       999\n",
+       "1  D4        40\n",
+       "2  E5        50"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge — B2 updated in place, D4 and E5 not inserted\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SKU</th>\n",
+       "      <th>Quantity</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>A1</td>\n",
+       "      <td>10</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B2</td>\n",
+       "      <td>999</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>C3</td>\n",
+       "      <td>30</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  SKU  Quantity\n",
+       "0  A1        10\n",
+       "1  B2       999\n",
+       "2  C3        30"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Same target and source, but this time only updating matched rows — unmatched rows are not inserted\n",
+    "lib.write(\"inventory_update_only\", inventory)\n",
+    "print(\"Original data\")\n",
+    "display(lib.read(\"inventory_update_only\").data)\n",
+    "print(\"Source data\")\n",
+    "display(new_stock)\n",
+    "\n",
+    "lib.merge_experimental(\n",
+    "    \"inventory_update_only\",\n",
+    "    new_stock,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
+    "    on=[\"SKU\"]\n",
+    ")\n",
+    "print(\"Data after merge — B2 updated in place, D4 and E5 not inserted\")\n",
+    "display(lib.read(\"inventory_update_only\").data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rr6insert6md",
+   "metadata": {},
+   "source": [
+    "`matched=\"update\"` overwrote the `Quantity` of the existing `SKU=\"B2\"` row in place, the same as before. This time `not_matched_by_target=\"do_nothing\"` means the unmatched SKUs `D4` and `E5` are not inserted into `target`, so the row count is unchanged."
    ]
   },
   {
@@ -3717,7 +3938,7 @@
     "\n",
     "1. Both `target` and `source` must have a sorted index when using `pd.DatetimeIndex` or a `pd.MultiIndex` with a datetime first level.\n",
     "2. The library must use a static schema, and both `source` and `target` must share the same schema.\n",
-    "3. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses row-range matching (requires the `on` parameter)."
+    "3. For `pd.MultiIndex`, the behavior is determined by the first level: datetime first level uses datetime matching, non-datetime first level uses non-timeseries matching (requires the `on` parameter)."
    ]
   },
   {

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4398,8 +4398,6 @@ class NativeVersionStore:
             This API is under development and is subject to change. The API is not subject to semver and can change in
             minor or patch releases.
 
-            Only date time indexed symbols and sources are supported at the moment.
-
         Parameters
         ----------
         symbol : str
@@ -4407,9 +4405,6 @@ class NativeVersionStore:
         source : pandas.DataFrame or pandas.Series
             The new data to merge. In the case of timeseries, the index must be sorted.
         strategy : Optional[MergeStrategy], default=MergeStrategy(matched="update", not_matched_by_target="insert")
-            !!! warning
-                Strategies using insertion are implemented only for DatetimeIndex
-
             Determines how to handle matched and unmatched rows. Accepted strategies are:
                 - MergeStrategy(matched="update", not_matched_by_target="do_nothing"): Update matched rows, leave others unchanged.
                 - MergeStrategy(matched="do_nothing", not_matched_by_target="insert"): Insert unmatched rows from source.

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3498,8 +3498,6 @@ class Library:
             This API is under development and is subject to change. The API is not subject to semver and can change in
             minor or patch releases.
 
-            Only date time indexed symbols and sources are supported at the moment.
-
             Dynamic schema is not supported.
 
         Parameters
@@ -3509,9 +3507,6 @@ class Library:
         source : pandas.DataFrame or pandas.Series
             The new data to merge. In the case of timeseries, the index must be sorted.
         strategy : Optional[MergeStrategy], default=MergeStrategy(matched="update", not_matched_by_target="insert")
-            !!! warning
-                Strategies using insertion are implemented only for DatetimeIndex
-
             Determines how to handle matched and unmatched rows. Accepted strategies are:
                 - MergeStrategy(matched="update", not_matched_by_target="do_nothing"): Update matched rows, leave others unchanged.
                 - MergeStrategy(matched="do_nothing", not_matched_by_target="insert"): Insert unmatched rows from source.

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -270,6 +270,37 @@ def random_values_for_dtype(dtype, count):
     return np.random.randint(low, high, size=count, dtype=np.int64).astype(dtype)
 
 
+def assert_valid_index(index_df):
+    # Every column slice must be split into the exact same set of contiguous row ranges.
+    first_slice_row_ranges = None
+    current_col_range = None
+    current_row_ranges = []
+    prev_row_range = None
+
+    for start_col, end_col, start_row, end_row in zip(
+        index_df["start_col"], index_df["end_col"], index_df["start_row"], index_df["end_row"]
+    ):
+        col_range, row_range = (start_col, end_col), (start_row, end_row)
+        if current_col_range is None:
+            current_col_range = col_range
+        elif col_range != current_col_range:
+            assert col_range[0] == current_col_range[1]
+            if first_slice_row_ranges is None:
+                first_slice_row_ranges = current_row_ranges[:]
+            else:
+                assert current_row_ranges == first_slice_row_ranges
+            current_row_ranges, prev_row_range, current_col_range = [], None, col_range
+        if prev_row_range is not None:
+            assert row_range[0] == prev_row_range[1]
+        current_row_ranges.append(row_range)
+        prev_row_range = row_range
+
+    if first_slice_row_ranges is None:
+        first_slice_row_ranges = current_row_ranges
+    else:
+        assert current_row_ranges == first_slice_row_ranges
+
+
 def randomize_values(frame, positions, columns):
     if not len(positions) or not columns:
         return
@@ -360,5 +391,6 @@ def test_insert(s3_storage, strategy, index_type, data):
     )
     lib.write("symbol", target)
     lib.merge_experimental("symbol", source, strategy=strategy, on=on)
+    assert_valid_index(lib._dev_tools.library_tool().read_index("symbol"))
     result = lib.read("symbol").data
     assert_frame_equal(result, expected)

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -223,11 +223,16 @@ def test_rowrange_merge_update(s3_version_store_v1, merge_args):
 _MISSING = object()
 
 
-def match_keys(frame, on):
+def match_keys(frame, on, include_index=True):
+    # Datetime index matches on (index, *on). Row range index has no meaningful index to match on, so it matches on
+    # the "on" columns only.
     columns = [frame[col] for col in on]
     return pd.Series(
         [
-            (index, *(_MISSING if pd.isna(col.iat[pos]) else col.iat[pos] for col in columns))
+            (
+                *((index,) if include_index else ()),
+                *(_MISSING if pd.isna(col.iat[pos]) else col.iat[pos] for col in columns),
+            )
             for pos, index in enumerate(frame.index)
         ]
     )
@@ -276,9 +281,12 @@ def randomize_values(frame, positions, columns):
 
 
 @st.composite
-def merge_insert_dataframes(draw, column_names, column_dtypes, min_date, max_date, on, strategy):
-    merged = draw(dataframe(column_names, column_dtypes, min_date, max_date)).sort_index()
-    keys = match_keys(merged, on)
+def merge_insert_dataframes(
+    draw, column_names, column_dtypes, min_date, max_date, on, strategy, index_type=DataframeStrategyIndexType.DATETIME
+):
+    rowrange = index_type == DataframeStrategyIndexType.ROWRANGE
+    merged = draw(dataframe(column_names, column_dtypes, min_date, max_date, index_type=index_type)).sort_index()
+    keys = match_keys(merged, on, include_index=not rowrange)
     is_inserted = generate_rows_to_insert(draw, keys)
     is_matched = generate_matched_rows(draw, keys, is_inserted)
     is_source = is_inserted | is_matched
@@ -292,47 +300,59 @@ def merge_insert_dataframes(draw, column_names, column_dtypes, min_date, max_dat
         # matched=do_nothing: merge ignores source, so randomize source to prove the merge doesn't use it.
         randomize_values(source, np.flatnonzero(is_matched[is_source]), non_on_columns)
 
-    # Reorder so inserted rows follow the target rows sharing their timestamp
-    order = sorted(range(len(merged)), key=lambda i: (merged.index[i], bool(is_inserted[i])))
-    expected = merged.iloc[order]
+    if rowrange:
+        # Row range index has no ordering key: unmatched rows are appended after all target rows in source order and
+        # the result is re-indexed with a fresh RangeIndex. A stable sort by the inserted flag keeps target rows in
+        # their original order followed by the inserted rows in theirs. target/source are slices of a RangeIndex, so
+        # they need a fresh contiguous RangeIndex before being written/merged.
+        order = sorted(range(len(merged)), key=lambda i: bool(is_inserted[i]))
+        expected = merged.iloc[order]
+        for frame in (target, source, expected):
+            frame.index = pd.RangeIndex(len(frame))
+            frame.index.name = "index"
+    else:
+        # Reorder so inserted rows follow the target rows sharing their timestamp
+        order = sorted(range(len(merged)), key=lambda i: (merged.index[i], bool(is_inserted[i])))
+        expected = merged.iloc[order]
 
     return target, source, expected
 
 
 @st.composite
-def merge_insert_arguments(draw, strategy):
-    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True))
-    target, source, expected = draw(merge_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on, strategy))
+def merge_insert_arguments(draw, strategy, index_type=DataframeStrategyIndexType.DATETIME):
+    # Row range index cannot match on the index, so at least one "on" column is required.
+    on_min_size = 1 if index_type == DataframeStrategyIndexType.ROWRANGE else 0
+    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True, min_size=on_min_size))
+    target, source, expected = draw(
+        merge_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on, strategy, index_type=index_type)
+    )
     rows_per_segment = draw(st.integers(1, len(expected)))
     cols_per_segment = draw(st.integers(1, len(COL_NAMES)))
     return target, source, expected, strategy, on, cols_per_segment, rows_per_segment
 
 
+@pytest.mark.parametrize(
+    "index_type",
+    [DataframeStrategyIndexType.DATETIME, DataframeStrategyIndexType.ROWRANGE],
+    ids=["datetime", "rowrange"],
+)
+@pytest.mark.parametrize(
+    "strategy",
+    [
+        MergeStrategy(matched="do_nothing", not_matched_by_target="insert"),
+        MergeStrategy(matched="update", not_matched_by_target="insert"),
+    ],
+    ids=["do_nothing", "update"],
+)
 @use_of_function_scoped_fixtures_in_hypothesis_checked
-@given(merge_args=merge_insert_arguments(MergeStrategy(matched="do_nothing", not_matched_by_target="insert")))
+@given(data=st.data())
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
-def test_datetime_insert(s3_storage, merge_args):
-    target, source, expected, strategy, on, cols_per_segment, rows_per_segment = merge_args
-    ac = s3_storage.create_arctic()
-    name = "test_datetime_insert"
-    if name in ac.list_libraries():
-        ac.delete_library(name)
-    lib = ac.create_library(
-        name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
+def test_insert(s3_storage, strategy, index_type, data):
+    target, source, expected, _, on, cols_per_segment, rows_per_segment = data.draw(
+        merge_insert_arguments(strategy, index_type=index_type)
     )
-    lib.write("symbol", target)
-    lib.merge_experimental("symbol", source, strategy=strategy, on=on)
-    result = lib.read("symbol").data
-    assert_frame_equal(result, expected)
-
-
-@use_of_function_scoped_fixtures_in_hypothesis_checked
-@given(merge_args=merge_insert_arguments(MergeStrategy(matched="update", not_matched_by_target="insert")))
-@settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
-def test_datetime_update_insert(s3_storage, merge_args):
-    target, source, expected, strategy, on, cols_per_segment, rows_per_segment = merge_args
     ac = s3_storage.create_arctic()
-    name = "test_datetime_update_insert"
+    name = f"test_insert_{index_type.value}_{strategy.matched}"
     if name in ac.list_libraries():
         ac.delete_library(name)
     lib = ac.create_library(

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -3026,6 +3026,144 @@ class TestMergeRowrangeUpdate:
         generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["my_index"])
 
 
+class TestMergeRowrangeInsert:
+    """Row count indexed merge with strategy do_nothing/insert: unmatched source rows are appended to the target in
+    source order; matched source rows are left untouched (no in-place rewrite)."""
+
+    def setup_method(self):
+        self.strategy = MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
+
+    def test_basic_append_unmatched(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+        # a=1 matches (do_nothing leaves it untouched), a=99 and a=100 are unmatched and appended in source order.
+        source = pd.DataFrame({"a": [1, 99, 100], "b": [10.0, 99.0, 100.0]})
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 2, 3, 99, 100], "b": [1.0, 2.0, 3.0, 99.0, 100.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_none_matched_appends_all(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+        source = pd.DataFrame({"a": [10, 20], "b": [10.0, 20.0]})
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 2, 3, 10, 20], "b": [1.0, 2.0, 3.0, 10.0, 20.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_all_matched_writes_no_new_data_keys(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+        source = pd.DataFrame({"a": [3, 1, 2], "b": [30.0, 10.0, 20.0]})
+        lib.write("sym", target)
+        lt = lib._dev_tools.library_tool()
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        # do_nothing on matched means no row slice is rewritten, and every source row matched means nothing is
+        # inserted, so no new data key is created.
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
+        assert_frame_equal(lib.read("sym").data, target)
+
+    def test_match_in_one_row_slice_only_suppresses_insert(self, lmdb_library_factory):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=2))
+        target = pd.DataFrame({"a": [1, 2, 3, 4], "b": [1.0, 2.0, 3.0, 4.0]})  # row slices [0,2) and [2,4)
+        # a=3 lives in the second row slice, so only that slice's processing unit matches it. The matched bitsets are
+        # ORed across all units, so a=3 must NOT be inserted even though the first slice's unit did not match it.
+        source = pd.DataFrame({"a": [3, 5], "b": [30.0, 50.0]})
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 50.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_duplicate_unmatched_source_rows_both_inserted(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1], "b": [1.0]})
+        source = pd.DataFrame({"a": [7, 7], "b": [70.0, 71.0]})
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 7, 7], "b": [1.0, 70.0, 71.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_string_columns_inserted(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2], "s": ["x", "y"]})
+        # Non-ASCII string exercises the GIL/string-pool path in build_row_range_insert_segments.
+        source = pd.DataFrame({"a": [1, 3, 4], "s": ["x", "café", None]})
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 2, 3, 4], "s": ["x", "y", "café", None]})
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_column_sliced_insert(self, lmdb_library_factory):
+        lib = lmdb_library_factory(arcticdb.LibraryOptions(columns_per_segment=2))
+        target = pd.DataFrame({"a": [1, 2], "b": [1.0, 2.0], "c": [10, 20]})  # column slices [a, b] and [c]
+        source = pd.DataFrame({"a": [1, 3], "b": [1.0, 30.0], "c": [10, 300]})
+        lib.write("sym", target)
+        lt = lib._dev_tools.library_tool()
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2  # 1 row slice x 2 column slices
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 30.0], "c": [10, 20, 300]})
+        assert_frame_equal(lib.read("sym").data, expected)
+        # One insert segment is appended per column slice; do_nothing leaves the matched rows untouched.
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
+
+
+class TestMergeRowrangeUpdateAndInsert:
+    """Row count indexed merge with strategy update/insert: matched source rows update the target in place and
+    unmatched source rows are appended in source order."""
+
+    def setup_method(self):
+        self.strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
+
+    def test_update_matched_and_append_unmatched(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["x", "y", "z"]})
+        source = pd.DataFrame({"a": [1, 99, 3, 100], "b": [10.0, 99.0, 30.0, 100.0], "c": ["X", "N", "Z", "M"]})
+        # a=1 updates row 0, a=3 updates row 2; a=99 and a=100 are unmatched and appended in source order.
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 99, 100],
+                "b": [10.0, 2.0, 30.0, 99.0, 100.0],
+                "c": ["X", "y", "Z", "N", "M"],
+            }
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_only_matches_no_insert_segment(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
+        source = pd.DataFrame({"a": [1, 2], "b": [10.0, 20.0]})
+        lib.write("sym", target)
+        lt = lib._dev_tools.library_tool()
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        expected = pd.DataFrame({"a": [1, 2, 3], "b": [10.0, 20.0, 3.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+        # The update rewrites the single row slice (one new data key); nothing is inserted.
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
+
+    def test_multiple_on_columns(self, lmdb_library):
+        lib = lmdb_library
+        target = pd.DataFrame({"a": [1, 2], "b": ["x", "y"], "c": [1.0, 2.0]})
+        source = pd.DataFrame({"a": [1, 3], "b": ["x", "q"], "c": [10.0, 30.0]})
+        # (a=1, b="x") matches row 0 and updates c; (a=3, b="q") is unmatched and appended.
+        lib.write("sym", target)
+        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a", "b"])
+        expected = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "q"], "c": [10.0, 2.0, 30.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+
+    def test_ambiguous_multi_match_raises(self, lmdb_library):
+        lib = lmdb_library
+        # Two source rows match the same target row on "a"; an update strategy cannot resolve which value wins.
+        target = pd.DataFrame({"a": [1, 2], "b": [1.0, 2.0]})
+        source = pd.DataFrame({"a": [1, 1], "b": [10.0, 11.0]})
+        lib.write("sym", target)
+        with pytest.raises(UserInputException):
+            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+
+
 class TestMergeMultiindexUpdate:
     """MultiIndex with datetime first level behaves like datetime-indexed merge.
     MultiIndex without datetime first level behaves like row-range-indexed merge."""

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -2642,6 +2642,7 @@ class TestMergeRowrangeCommon:
         assert_vit_equals_except_data(merge_vit, read_vit)
 
         lt = lib._dev_tools.library_tool()
+        # +1 for the never-pruned v0 key, +1 per write path exercised (UPDATE rewrites in place, INSERT appends).
         expected_data_keys = (
             3 if strategy.not_matched_by_target == MergeAction.INSERT and strategy.matched == MergeAction.UPDATE else 2
         )
@@ -3025,13 +3026,18 @@ class TestMergeRowrangeInsert:
     def setup_method(self):
         self.strategy = MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
 
-    def test_basic_append_unmatched(self, lmdb_library):
-        lib = lmdb_library
+    def test_basic_append_unmatched(self, in_memory_store_factory):
+        lib = in_memory_store_factory()
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         # a=1 matches (do_nothing leaves it untouched), a=99 and a=100 are unmatched and appended in source order.
         source = pd.DataFrame({"a": [1, 99, 100], "b": [10.0, 99.0, 100.0]})
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        stats = qs.get_query_stats()
+        # a single-column-slice target's unmatched rows are appended as exactly one new data segment.
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
         expected = pd.DataFrame({"a": [1, 2, 3, 99, 100], "b": [1.0, 2.0, 3.0, 99.0, 100.0]})
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -3108,13 +3114,18 @@ class TestMergeRowrangeUpdateAndInsert:
     def setup_method(self):
         self.strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
 
-    def test_update_matched_and_append_unmatched(self, lmdb_library):
-        lib = lmdb_library
+    def test_update_matched_and_append_unmatched(self, in_memory_store_factory):
+        lib = in_memory_store_factory(dynamic_strings=True)
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0], "c": ["x", "y", "z"]})
         source = pd.DataFrame({"a": [1, 99, 3, 100], "b": [10.0, 99.0, 30.0, 100.0], "c": ["X", "N", "Z", "M"]})
         # a=1 updates row 0, a=3 updates row 2; a=99 and a=100 are unmatched and appended in source order.
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        stats = qs.get_query_stats()
+        # update one segment in place and append one segment for insertion
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected = pd.DataFrame(
             {
                 "a": [1, 2, 3, 99, 100],

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -25,6 +25,8 @@ from arcticdb.version_store._store import normalize_merge_action
 from typing import Union, List, Optional
 import arcticdb.toolbox.query_stats as qs
 
+from arcticdb_ext.version_store import MergeAction
+
 pytestmark = pytest.mark.merge_update
 
 
@@ -82,14 +84,8 @@ def test_normalize_merge_action(action):
     "strategy",
     (
         MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
-        pytest.param(
-            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
-            marks=pytest.mark.xfail(reason="Insert is not implemented"),
-        ),
-        pytest.param(
-            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
-            marks=pytest.mark.xfail(reason="Insert is not implemented"),
-        ),
+        MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+        MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
     ),
 )
 class TestMergeTimeseriesCommon:
@@ -2618,14 +2614,8 @@ class TestMergeUpdateInsertIndexSpansMultipleSegmentsChain:
     "strategy",
     (
         MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING),
-        pytest.param(
-            MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
-            marks=pytest.mark.xfail(reason="Insert is not implemented"),
-        ),
-        pytest.param(
-            MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
-            marks=pytest.mark.xfail(reason="Insert is not implemented"),
-        ),
+        MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT),
+        MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT),
     ),
 )
 class TestMergeRowrangeCommon:
@@ -2652,8 +2642,10 @@ class TestMergeRowrangeCommon:
         assert_vit_equals_except_data(merge_vit, read_vit)
 
         lt = lib._dev_tools.library_tool()
-
-        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
+        expected_data_keys = (
+            3 if strategy.not_matched_by_target == MergeAction.INSERT and strategy.matched == MergeAction.UPDATE else 2
+        )
+        assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == expected_data_keys
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_INDEX, "sym")) == 2
         assert len(lt.find_keys_for_symbol(KeyType.VERSION, "sym")) == 2
 


### PR DESCRIPTION
#### Reference Issues/PRs

New data is always appended as a singe segment.

If the strategy allows update the update code path is reused without any changes.

The MatchRecord already has information about all matched source rows. Now it can emit an ordered vector containing all source rows that are not matched. Each processing unit emits such an entity similar to how each processing unit emits `MergeUpdateInsertedRowsComponent` tracking the number of inserted rows when datetime index is used. At the end of the processing all such sets are intersected. The result is a set of the rows which must be inserted.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
