### PR TITLE
Use seaweed default path

### DIFF
--- a/.github/workflows/benchmark_commits.yml
+++ b/.github/workflows/benchmark_commits.yml
@@ -38,9 +38,6 @@ jobs:
       ARCTICDB_REAL_S3_REGION: eu-west-1
       ARCTICDB_REAL_S3_ENDPOINT: s3.eu-west-1.amazonaws.com
       ASV_RESULTS_BUCKET: arcticdb-ci-benchmark-results
-      # Some benchmarks use SeaweedFS because it supports parallel writes.
-      SEAWEED_DATA_DIR: ${{ runner.temp }}/seaweedfs-asv # Set the directory where local seaweed data resides
-      SEAWEED_BIN_DIR: ${{ github.workspace }}/.seaweed-bin # Set the directory where the seaweed binary is installed
       VCPKG_NUGET_USER: ${{secrets.VCPKG_NUGET_USER || github.repository_owner}}
       VCPKG_NUGET_TOKEN: ${{secrets.VCPKG_NUGET_TOKEN || secrets.GITHUB_TOKEN}}
       VCPKG_MAN_NUGET_USER: ${{secrets.VCPKG_MAN_NUGET_USER}} # For forks to download pre-compiled dependencies from the Man repo
@@ -111,6 +108,7 @@ jobs:
           ./tooling_venv/bin/pip install "ArcticDB[Testing]" "pytz" "pandas<3"
 
       # Use a global seaweed to avoid to cost of starting and stopping the server for each benchmark.
+      # Some benchmarks use SeaweedFS because it supports parallel writes.
       - name: Start SeaweedFS
         shell: bash -el {0}
         run: build_tooling/start_seaweed.sh start
@@ -176,9 +174,7 @@ jobs:
       - name: Stop SeaweedFS
         if: always()
         shell: bash -el {0}
-        run: |
-          tail -20 "$SEAWEED_DATA_DIR/weed.log" || true
-          build_tooling/start_seaweed.sh stop
+        run: build_tooling/start_seaweed.sh stop
 
       - name: Clean up the test bucket
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,6 +143,8 @@ When upgrading a dependency like `sparrow` that has a custom port in vcpkg:
 
 C++ benchmark sources are in `cpp/arcticdb/*/test/benchmark_*.cpp`. ASV Python benchmarks live in `python/benchmarks/`. See [ASV Benchmarks Wiki](https://github.com/man-group/ArcticDB/wiki/Dev:-ASV-Benchmarks).
 
+Each time you change an ASV benchmark you must run this script `python/utils/asv_checks.py`
+
 ## Code Review Guidelines
 
 When writing or modifying code, follow the standards in [`docs/claude/PR_REVIEW_GUIDELINES.md`](docs/claude/PR_REVIEW_GUIDELINES.md). These cover API stability, memory safety, on-disk format compatibility, concurrency, testing, and other quality gates enforced during PR review.

--- a/build_tooling/start_seaweed.sh
+++ b/build_tooling/start_seaweed.sh
@@ -90,6 +90,7 @@ start() {
 }
 
 stop() {
+    tail -20 "$LOG_FILE" 2>/dev/null || true
     if [[ -f "$PID_FILE" ]] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
         kill "$(cat "$PID_FILE")"
         for _ in $(seq 1 30); do

--- a/build_tooling/start_seaweed.sh
+++ b/build_tooling/start_seaweed.sh
@@ -77,7 +77,10 @@ start() {
     fi
     download
     mkdir -p "$SEAWEED_DATA_DIR"
-    nohup "$SEAWEED_BIN_DIR/weed" server \
+    # AWS_* creds must not leak into weed: with them set the S3 gateway creates an admin
+    # identity from them and enables auth, rejecting the benchmarks' placeholder credentials
+    env -u AWS_ACCESS_KEY_ID -u AWS_SECRET_ACCESS_KEY \
+        nohup "$SEAWEED_BIN_DIR/weed" server \
         -dir="$SEAWEED_DATA_DIR" \
         -ip="$SEAWEED_IP" \
         -ip.bind="$SEAWEED_IP" \
@@ -103,10 +106,11 @@ start() {
             diagnostics
             exit 1
         fi
-        # Only check that both ports serve 
+        # S3 must answer 2xx: with auth disabled anonymous ListBuckets succeeds, so anything
+        # else (e.g. 403) means auth got enabled and the benchmarks' credentials would be rejected
         master_code=$(curl -s -o /dev/null -m 10 -w '%{http_code}' "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" 2>/dev/null || true)
         s3_code=$(curl -s -o /dev/null -m 10 -w '%{http_code}' "http://$SEAWEED_IP:$SEAWEED_S3_PORT" 2>/dev/null || true)
-        if [[ "$master_code" == 2* && "$s3_code" != "000" ]]; then
+        if [[ "$master_code" == 2* && "$s3_code" == 2* ]]; then
                     echo "SeaweedFS $SEAWEED_VERSION is up (master HTTP $master_code, s3 HTTP $s3_code). IP: $SEAWEED_IP, PID: $(cat $PID_FILE) master port :$SEAWEED_MASTER_PORT, filer port :$SEAWEED_FILER_PORT," \
                 "s3 port :$SEAWEED_S3_PORT, data in $SEAWEED_DATA_DIR"
             return

--- a/build_tooling/start_seaweed.sh
+++ b/build_tooling/start_seaweed.sh
@@ -40,6 +40,33 @@ download() {
     rm -f "$installer"
 }
 
+# Everything needed to tell why a probe failed, without a local SeaweedFS to reproduce against.
+# Each endpoint's status and (truncated) body are printed, so a probe that fails because the
+# response shape changed is distinguishable from one that fails because nothing is listening.
+diagnostics() {
+    echo "--- SeaweedFS diagnostics ---" >&2
+    echo "[version] $("$SEAWEED_BIN_DIR/weed" version 2>&1 | head -1)" >&2
+    echo "[data dir] $SEAWEED_DATA_DIR (log: $LOG_FILE)" >&2
+    local name path body
+    for probe in \
+        "master:$SEAWEED_MASTER_PORT/dir/status" \
+        "master-volumes:$SEAWEED_MASTER_PORT/vol/status" \
+        "s3-root:$SEAWEED_S3_PORT/" \
+        "filer:$SEAWEED_FILER_PORT/" \
+        "volume:$SEAWEED_VOLUME_PORT/status"; do
+        name="${probe%%:*}"
+        path="${probe#*:}"
+        body=$(curl -sS -m 10 -w '<http_code:%{http_code}>' "http://$SEAWEED_IP:$path" 2>&1 || true)
+        echo "[$name] http://$SEAWEED_IP:$path -> ${body:0:1500}" >&2
+    done
+    echo "[listening] $( (ss -ltn 2>/dev/null || netstat -ltn 2>/dev/null || true) |
+        grep -E ":($SEAWEED_MASTER_PORT|$SEAWEED_VOLUME_PORT|$SEAWEED_FILER_PORT|$SEAWEED_S3_PORT)\b" | tr '\n' ';')" >&2
+    echo "[log errors]" >&2
+    grep -E "^E" "$LOG_FILE" 2>/dev/null | tail -20 >&2 || true
+    echo "[log tail]" >&2
+    tail -50 "$LOG_FILE" >&2 2>/dev/null || true
+}
+
 start() {
     # A foreign server answering here would also answer the readiness probe below, making this
     # script report success while its own process dies on the port bind
@@ -72,20 +99,23 @@ start() {
     for _ in $(seq 1 120); do
         if ! kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
             rm -f "$PID_FILE"
-            echo "SeaweedFS process died on startup, last log lines:" >&2
-            tail -50 "$LOG_FILE" >&2
+            echo "SeaweedFS process died on startup" >&2
+            diagnostics
             exit 1
         fi
-        if curl -fsS "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" 2>/dev/null | grep -q '"DataNodes"' &&
-            curl -fsS "http://$SEAWEED_IP:$SEAWEED_S3_PORT" >/dev/null 2>&1; then
-                    echo "SeaweedFS $SEAWEED_VERSION is up. IP: $SEAWEED_IP, PID: $(cat $PID_FILE) master port :$SEAWEED_MASTER_PORT, filer port :$SEAWEED_FILER_PORT," \
+        # Only check that both ports serve 
+        master_code=$(curl -s -o /dev/null -m 10 -w '%{http_code}' "http://$SEAWEED_IP:$SEAWEED_MASTER_PORT/dir/status" 2>/dev/null || true)
+        s3_code=$(curl -s -o /dev/null -m 10 -w '%{http_code}' "http://$SEAWEED_IP:$SEAWEED_S3_PORT" 2>/dev/null || true)
+        if [[ "$master_code" == 2* && "$s3_code" != "000" ]]; then
+                    echo "SeaweedFS $SEAWEED_VERSION is up (master HTTP $master_code, s3 HTTP $s3_code). IP: $SEAWEED_IP, PID: $(cat $PID_FILE) master port :$SEAWEED_MASTER_PORT, filer port :$SEAWEED_FILER_PORT," \
                 "s3 port :$SEAWEED_S3_PORT, data in $SEAWEED_DATA_DIR"
             return
         fi
         sleep 1
     done
-    echo "SeaweedFS failed to start, last log lines:" >&2
-    tail -50 "$LOG_FILE" >&2
+    echo "SeaweedFS did not become ready in time" \
+        "(last master HTTP code: ${master_code:-none}, last s3 HTTP code: ${s3_code:-none})" >&2
+    diagnostics
     exit 1
 }
 
@@ -106,8 +136,9 @@ stop() {
 case "${1:-start}" in
     start) start ;;
     stop) stop ;;
+    status) diagnostics ;;
     *)
-        echo "Usage: $0 [start|stop]" >&2
+        echo "Usage: $0 [start|stop|status]" >&2
         exit 1
         ;;
 esac

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -1033,7 +1033,7 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "f4a967266cd6ea1d0d981ad126d561f2f00dbb8eeab69cc3e865dffa411e06f7"
@@ -1060,7 +1060,7 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "c0ae8f163bf19c07653b6f60ab6e995158aa563e662c2d8ccd347a5ba505688c"
@@ -1087,7 +1087,7 @@
                 "<Storage.AMAZON: 1>"
             ]
         ],
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "d362cfb67572e9f68968dfe29777803a15c4691f01653af49ea32bdb7c158b01"
@@ -1119,7 +1119,7 @@
         "repeat": 0,
         "rounds": 1,
         "sample_time": 0.1,
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "time",
         "unit": "seconds",
         "version": "9c67c6ac2385d57d12dc1d8d49b7a0d0711d60e36d0e7d6a99a23e5fcc7cfbb5",
@@ -1152,7 +1152,7 @@
         "repeat": 0,
         "rounds": 1,
         "sample_time": 0.1,
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "time",
         "unit": "seconds",
         "version": "a93ba8dc7f258d45759f62c1d3d2a48bcf6ea4d091a58f36008ed020b4eeefb9",
@@ -1185,7 +1185,7 @@
         "repeat": 0,
         "rounds": 1,
         "sample_time": 0.1,
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "time",
         "unit": "seconds",
         "version": "64aec41d93970093050e6a4b50565a81f071487c2b3a63f9e6fabe9afe0b0f7f",
@@ -1218,7 +1218,7 @@
         "repeat": 0,
         "rounds": 1,
         "sample_time": 0.1,
-        "setup_cache_key": "basic_functions:313",
+        "setup_cache_key": "basic_functions:310",
         "type": "time",
         "unit": "seconds",
         "version": "f2cdd6b45cd2d49f2358097a18969b2ad5f2efc6cf26a854ab889d6b23fc4c4f",
@@ -2120,7 +2120,7 @@
         "warmup_time": 0.5
     },
     "compact_data.AppendCompactDataNumericDynamicSchema.peakmem_append_compact_data": {
-        "code": "class AppendCompactDataNumericDynamicSchema:\n    def peakmem_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        columns = rng.choice(self.COLUMN_NAMES, self.NUM_COLUMNS // 2, replace=False)\n        self.append_df = pd.DataFrame({column: np.arange(append_rows) for column in columns})\n        self._setup(self.lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class AppendCompactDataNumericDynamicSchema:\n    def peakmem_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        columns = rng.choice(self.COLUMN_NAMES, self.NUM_COLUMNS // 2, replace=False)\n        self.append_df = pd.DataFrame({column: np.arange(append_rows) for column in columns})\n        self._setup(lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "compact_data.AppendCompactDataNumericDynamicSchema.peakmem_append_compact_data",
         "param_names": [
             "num_symbols",
@@ -2141,13 +2141,13 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "compact_data:430",
+        "setup_cache_key": "compact_data:427",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "ef9a24a988741ffb5729c46d7e75bc83ebb7cd3757890eea3160303f1f1053a8"
+        "version": "ba4165befb708b8f7f58643cda9872d9cb793aad070c02999d2cc7114fa42ec9"
     },
     "compact_data.AppendCompactDataNumericDynamicSchema.time_append_compact_data": {
-        "code": "class AppendCompactDataNumericDynamicSchema:\n    def time_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        columns = rng.choice(self.COLUMN_NAMES, self.NUM_COLUMNS // 2, replace=False)\n        self.append_df = pd.DataFrame({column: np.arange(append_rows) for column in columns})\n        self._setup(self.lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class AppendCompactDataNumericDynamicSchema:\n    def time_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        columns = rng.choice(self.COLUMN_NAMES, self.NUM_COLUMNS // 2, replace=False)\n        self.append_df = pd.DataFrame({column: np.arange(append_rows) for column in columns})\n        self._setup(lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "compact_data.AppendCompactDataNumericDynamicSchema.time_append_compact_data",
         "number": 1,
@@ -2173,14 +2173,14 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:430",
+        "setup_cache_key": "compact_data:427",
         "type": "time",
         "unit": "seconds",
-        "version": "e8851c6ceb9da5f5c4ae5526de0225ead5f6f2d221165ea2772afeb4112a7220",
+        "version": "213d83968732a37caeb4a6199db291b7ff4720e1ba81da9b8f9d335bf863e675",
         "warmup_time": 0
     },
     "compact_data.AppendCompactDataNumericStaticSchema.peakmem_append_compact_data": {
-        "code": "class AppendCompactDataNumericStaticSchema:\n    def peakmem_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": np.arange(i * append_rows, (i + 1) * append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(self.lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class AppendCompactDataNumericStaticSchema:\n    def peakmem_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": np.arange(i * append_rows, (i + 1) * append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "compact_data.AppendCompactDataNumericStaticSchema.peakmem_append_compact_data",
         "param_names": [
             "num_symbols",
@@ -2202,13 +2202,13 @@
                 "1000000"
             ]
         ],
-        "setup_cache_key": "compact_data:332",
+        "setup_cache_key": "compact_data:329",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "85ec2af75fa362379363f90d807083ca4f66a1043a89122b6152e5c109e8535c"
+        "version": "1581bf5cf4f523b1dba5029cd77944e091eb35ea35bb67e679bda577d5e5ace3"
     },
     "compact_data.AppendCompactDataNumericStaticSchema.time_append_compact_data": {
-        "code": "class AppendCompactDataNumericStaticSchema:\n    def time_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": np.arange(i * append_rows, (i + 1) * append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(self.lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class AppendCompactDataNumericStaticSchema:\n    def time_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": np.arange(i * append_rows, (i + 1) * append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "compact_data.AppendCompactDataNumericStaticSchema.time_append_compact_data",
         "number": 1,
@@ -2235,14 +2235,14 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:332",
+        "setup_cache_key": "compact_data:329",
         "type": "time",
         "unit": "seconds",
-        "version": "98b2898dbb3b3750ffc35b30d035311796631e6d863708fb5c505b4dc59a6a1b",
+        "version": "fec1a6b2e52e6380a99b1666c49b3461b4fb24f28221b495f60e1be274bb9023",
         "warmup_time": 0
     },
     "compact_data.AppendCompactDataStringsStaticSchema.peakmem_append_compact_data": {
-        "code": "class AppendCompactDataStringsStaticSchema:\n    def peakmem_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": rng.choice(self.unique_strings, append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(self.lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class AppendCompactDataStringsStaticSchema:\n    def peakmem_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": rng.choice(self.unique_strings, append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "name": "compact_data.AppendCompactDataStringsStaticSchema.peakmem_append_compact_data",
         "param_names": [
             "num_symbols",
@@ -2264,13 +2264,13 @@
                 "1000000"
             ]
         ],
-        "setup_cache_key": "compact_data:381",
+        "setup_cache_key": "compact_data:378",
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "01966458fac955b928515db294e7f868a08bff9312199ee1b5b3a32cf5128259"
+        "version": "7a58c10ef4b2a352df474a8f1904d021f721652d3837e10680d47d47c3d275b6"
     },
     "compact_data.AppendCompactDataStringsStaticSchema.time_append_compact_data": {
-        "code": "class AppendCompactDataStringsStaticSchema:\n    def time_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": rng.choice(self.unique_strings, append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(self.lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
+        "code": "class AppendCompactDataStringsStaticSchema:\n    def time_append_compact_data(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append(num_symbols)\n\n    def setup(self, num_symbols, existing_data_fragmented, append_rows):\n        self.append_df = pd.DataFrame(\n            {f\"col_{i}\": rng.choice(self.unique_strings, append_rows) for i in range(self.NUM_COLUMNS)}\n        )\n        self._setup(lib_name(existing_data_fragmented))\n\n    def setup_cache(self):\n        start = time.time()\n        self._setup_cache()\n        self.logger.info(f\"SETUP_CACHE TIME: {time.time() - start}\")",
         "min_run_count": 2,
         "name": "compact_data.AppendCompactDataStringsStaticSchema.time_append_compact_data",
         "number": 1,
@@ -2297,10 +2297,10 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:381",
+        "setup_cache_key": "compact_data:378",
         "type": "time",
         "unit": "seconds",
-        "version": "a049f0099f95d04ec69d08ebabcd44d596eff4fe34034ad6d9da0b3fbd1e2f94",
+        "version": "8665815997d55eb8deeb5b37f5eafc228bc6aed867aee9a5f0e5171296cbbd26",
         "warmup_time": 0
     },
     "compact_data.CompactDataNumericDynamicSchema.peakmem_compact_data": {
@@ -2815,7 +2815,7 @@
         "warmup_time": 0.1
     },
     "merge_functions.MergeThinDatetime.peakmem_merge": {
-        "code": "class MergeThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeThinDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -2849,10 +2849,10 @@
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "cbfab97f86b2e4dcf663168cbc55298e56ae941d902c8cb6a3fd79ba3814f707"
+        "version": "bda038e7ac799f351dadb49a529e87aa2762d0993fa7b3f2fb5534f80d20c5d6"
     },
     "merge_functions.MergeThinDatetime.time_merge": {
-        "code": "class MergeThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinDatetime.time_merge",
         "number": 1,
@@ -2891,11 +2891,11 @@
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "a34ddbececbef9f6234500dd1f6efb2ed19e12e0620f1b29f93a7f0066501523",
+        "version": "5fa0f07cbaf18da0b38b5fa5a212bd62af352193686538be081fad7bfd09497f",
         "warmup_time": 0
     },
     "merge_functions.MergeThinRowRange.peakmem_merge": {
-        "code": "class MergeThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeThinRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -2922,10 +2922,10 @@
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "83ce0f1d857f8367a41b0eda0ae44c9b09680e06d7402639b4e2715e9f3fcaec"
+        "version": "aa4096cc5f46058c309c21eb33ebaabc2e84d6e07560aac829027da71086ea6b"
     },
     "merge_functions.MergeThinRowRange.time_merge": {
-        "code": "class MergeThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinRowRange.time_merge",
         "number": 1,
@@ -2957,11 +2957,11 @@
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "32cb2f20ab4c79563a5aea377ad6caabb8fd7230fd759389d42d242bd13a5bad",
+        "version": "256a83ebc7be8dd867cee611d7e3e1fafe2e35dc4ccc40358530caf35984706f",
         "warmup_time": 0
     },
     "merge_functions.MergeThinStringDatetime.peakmem_merge": {
-        "code": "class MergeThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeThinStringDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3000,10 +3000,10 @@
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "9a4715db7915ea7b2b73942e7a0a2cd83c063e074c67547ec1ed44288513c101"
+        "version": "4deaada28c22d2cd8a4edfb8d8d9c558ab7b4c68bd9c3bc81cf099cdd90d2585"
     },
     "merge_functions.MergeThinStringDatetime.time_merge": {
-        "code": "class MergeThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinStringDatetime.time_merge",
         "number": 1,
@@ -3047,11 +3047,11 @@
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "7aa19f2e81803ed621ab348a8958540af05e64898025e41dc25844a5919a2ecf",
+        "version": "cfc2523da2cb2b2cc7892532ef9027eeeaf039dd512c09875e6cc054fd3e977b",
         "warmup_time": 0
     },
     "merge_functions.MergeThinStringRowRange.peakmem_merge": {
-        "code": "class MergeThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeThinStringRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3083,10 +3083,10 @@
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "ad7361d4bf2af736b0a1463d93711c64694b195cf605818d11da012a3ac03699"
+        "version": "16b046fab8ab2ff6a54e7b6c1b6bca4b1f3518b5a093be95fc3b02422b00a2ec"
     },
     "merge_functions.MergeThinStringRowRange.time_merge": {
-        "code": "class MergeThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                lib_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(lib_name, target)\n                self._precompute_sources(lib_name, target)",
+        "code": "class MergeThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinStringRowRange.time_merge",
         "number": 1,
@@ -3123,11 +3123,11 @@
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "22ccdef99021933f2dc537f4d6ba6d6b71b4541cc80997b54aaf359d16a045ef",
+        "version": "5b1ad5a07078537f4b40748fd746b8053078bd52e4f3ff7d2c141470c7ccb6a7",
         "warmup_time": 0
     },
     "merge_functions.MergeWideDatetime.peakmem_merge": {
-        "code": "class MergeWideDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeWideDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeWideDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3156,10 +3156,10 @@
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "28ef558b79b92e01a385d0ecec377258a6201802c6eedcb369c0075a56f116d9"
+        "version": "5f3a5dffc5a5810c9c7edad0c697800df32682f9c4ec49442c6e85cca031184b"
     },
     "merge_functions.MergeWideDatetime.time_merge": {
-        "code": "class MergeWideDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeWideDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "min_run_count": 2,
         "name": "merge_functions.MergeWideDatetime.time_merge",
         "number": 1,
@@ -3193,11 +3193,11 @@
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "8d0da60fabfacd13ca11c1699891ed2cd5d1c600e01f01603881e627290d590b",
+        "version": "4d658e12e079c00f5d468ed7a82c1b2facd8de1b98e5388b569c1737a3d82607",
         "warmup_time": 0
     },
     "merge_functions.MergeWideRowRange.peakmem_merge": {
-        "code": "class MergeWideRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeWideRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeWideRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3224,10 +3224,10 @@
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "c4c62f623fa4e712d1f56e9441cca2abdd0b4ccc2ca88d3d80e6f46ef0c28b2f"
+        "version": "f33e277e4413aa7b086be54628ec33080037cbdf369f347c5dd190ffca5a6fff"
     },
     "merge_functions.MergeWideRowRange.time_merge": {
-        "code": "class MergeWideRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            lib_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(lib_name, target)\n            self._precompute_sources(lib_name, target)",
+        "code": "class MergeWideRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "min_run_count": 2,
         "name": "merge_functions.MergeWideRowRange.time_merge",
         "number": 1,
@@ -3259,7 +3259,7 @@
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "717843d0191fbcd48ec7704510ce9f6683963afc0159987528abafd57c63479d",
+        "version": "8be4bc6bfde5a0e7db280ac5e667e58f53c945de9de79a16e0965936c6b6f547",
         "warmup_time": 0
     },
     "modification_functions.DeleteBatchSymbols.time_delete_batch_symbols": {

--- a/python/benchmarks/basic_functions.py
+++ b/python/benchmarks/basic_functions.py
@@ -274,9 +274,6 @@ class BatchWrite:
         self.logger.info(f"SETUP_CACHE TIME: {time.time() - start}")
         return lib_for_storage
 
-    def _lib_name(self, rows):
-        return f"lib_{rows}"
-
     def _setup_cache(self):
         lib_for_storage = create_libraries_across_storages(STORAGES)
         return lib_for_storage

--- a/python/benchmarks/compact_data.py
+++ b/python/benchmarks/compact_data.py
@@ -278,9 +278,6 @@ class AppendCompactDataBase:
         self.CONNECTION_STRING_BASE = f"lmdb://{self.LMDB_BASE_DIR}"
         self.CONNECTION_STRING = f"lmdb://{self.LMDB_DIR}"
 
-    def lib_name(self, *args):
-        return "_".join(f"{arg}" for arg in args)
-
     def _setup_cache_base(self, ac, lib_name, dfs):
         ac.delete_library(lib_name)
         lib = ac.create_library(lib_name, LibraryOptions(dynamic_schema=self.DYNAMIC_SCHEMA))
@@ -344,13 +341,13 @@ class AppendCompactDataNumericStaticSchema(AppendCompactDataBase):
                 dfs = [df[i * 10_000 : (i + 1) * 10_000] for i in range(num_rows // 10_000)]
             else:
                 dfs = [df]
-            self._setup_cache_base(ac, self.lib_name(existing_data_fragmented), dfs)
+            self._setup_cache_base(ac, lib_name(existing_data_fragmented), dfs)
 
     def setup(self, num_symbols, existing_data_fragmented, append_rows):
         self.append_df = pd.DataFrame(
             {f"col_{i}": np.arange(i * append_rows, (i + 1) * append_rows) for i in range(self.NUM_COLUMNS)}
         )
-        self._setup(self.lib_name(existing_data_fragmented))
+        self._setup(lib_name(existing_data_fragmented))
 
     def teardown(self, num_symbols, existing_data_fragmented, append_rows):
         self._teardown()
@@ -393,13 +390,13 @@ class AppendCompactDataStringsStaticSchema(AppendCompactDataBase):
                 dfs = [df[i * 10_000 : (i + 1) * 10_000] for i in range(num_rows // 10_000)]
             else:
                 dfs = [df]
-            self._setup_cache_base(ac, self.lib_name(existing_data_fragmented), dfs)
+            self._setup_cache_base(ac, lib_name(existing_data_fragmented), dfs)
 
     def setup(self, num_symbols, existing_data_fragmented, append_rows):
         self.append_df = pd.DataFrame(
             {f"col_{i}": rng.choice(self.unique_strings, append_rows) for i in range(self.NUM_COLUMNS)}
         )
-        self._setup(self.lib_name(existing_data_fragmented))
+        self._setup(lib_name(existing_data_fragmented))
 
     def teardown(self, num_symbols, existing_data_fragmented, append_rows):
         self._teardown()
@@ -443,12 +440,12 @@ class AppendCompactDataNumericDynamicSchema(AppendCompactDataBase):
             for _ in range(num_row_slices):
                 columns = rng.choice(self.COLUMN_NAMES, self.NUM_COLUMNS // 2, replace=False)
                 dfs.append(pd.DataFrame({column: np.arange(num_rows // num_row_slices) for column in columns}))
-            self._setup_cache_base(ac, self.lib_name(existing_data_fragmented), dfs)
+            self._setup_cache_base(ac, lib_name(existing_data_fragmented), dfs)
 
     def setup(self, num_symbols, existing_data_fragmented, append_rows):
         columns = rng.choice(self.COLUMN_NAMES, self.NUM_COLUMNS // 2, replace=False)
         self.append_df = pd.DataFrame({column: np.arange(append_rows) for column in columns})
-        self._setup(self.lib_name(existing_data_fragmented))
+        self._setup(lib_name(existing_data_fragmented))
 
     def teardown(self, num_symbols, existing_data_fragmented, append_rows):
         self._teardown()

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -267,9 +267,9 @@ class MergeThinDatetime(MergeBase):
             num_rows, num_value_cols = scenario
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
-            lib_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(lib_name, target)
-            self._precompute_sources(lib_name, target)
+            library_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(library_name, target)
+            self._precompute_sources(library_name, target)
 
     def setup(self, scenario, strategy, on_count, source_size, matched_slices):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
@@ -307,9 +307,9 @@ class MergeThinRowRange(MergeBase):
             num_rows, num_value_cols = scenario
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
-            lib_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(lib_name, target)
-            self._precompute_sources(lib_name, target)
+            library_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(library_name, target)
+            self._precompute_sources(library_name, target)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
@@ -360,9 +360,9 @@ class MergeThinStringDatetime(MergeBase):
                 # One target per pool size; per-size prefixes let setup copy only the variant being merged.
                 self.target_prefix = f"target_{num_unique_strings}"
                 self.source_prefix = f"source_{num_unique_strings}"
-                lib_name = lib_name(*scenario, self.INDEX_KIND)
-                self._write_cache_target(lib_name, target)
-                self._precompute_sources(lib_name, target)
+                library_name = lib_name(*scenario, self.INDEX_KIND)
+                self._write_cache_target(library_name, target)
+                self._precompute_sources(library_name, target)
 
     def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
         self.target_prefix = f"target_{num_unique_strings}"
@@ -416,9 +416,9 @@ class MergeThinStringRowRange(MergeBase):
                 # One target per pool size; per-size prefixes let setup copy only the variant being merged.
                 self.target_prefix = f"target_{num_unique_strings}"
                 self.source_prefix = f"source_{num_unique_strings}"
-                lib_name = lib_name(*scenario, self.INDEX_KIND)
-                self._write_cache_target(lib_name, target)
-                self._precompute_sources(lib_name, target)
+                library_name = lib_name(*scenario, self.INDEX_KIND)
+                self._write_cache_target(library_name, target)
+                self._precompute_sources(library_name, target)
 
     def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):
         self.target_prefix = f"target_{num_unique_strings}"
@@ -459,9 +459,9 @@ class MergeWideDatetime(MergeBase):
             num_rows, num_value_cols = scenario
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
-            lib_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(lib_name, target)
-            self._precompute_sources(lib_name, target)
+            library_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(library_name, target)
+            self._precompute_sources(library_name, target)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
@@ -499,9 +499,9 @@ class MergeWideRowRange(MergeBase):
             num_rows, num_value_cols = scenario
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
-            lib_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(lib_name, target)
-            self._precompute_sources(lib_name, target)
+            library_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(library_name, target)
+            self._precompute_sources(library_name, target)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)


### PR DESCRIPTION
#### Reference Issues/PRs

This makes seaweed use the default paths it has for downloading the binary and for storing the data. Defaults are used on the CI. It's configurable for local runs.

This also fixes a bug introduced in #3279. #3279 extracted lib_name as a helper function but the name clashed with a local variable.
#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
