### PR TITLE
Docs 12669504345: Extend compact_data demo notebook

### DIFF
--- a/docs/mkdocs/docs/notebooks/ArcticDB_demo_compact_data.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_demo_compact_data.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !pip install arcticdb"
+    "!pip install arcticdb"
    ]
   },
   {

--- a/docs/mkdocs/docs/notebooks/ArcticDB_demo_compact_data.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_demo_compact_data.ipynb
@@ -16,14 +16,15 @@
    "source": [
     "# ArcticDB Data Compaction Demo\n",
     "\n",
-    "This demo notebook demonstrates the `compact_data` method for reslicing data on disk in order to optimise read performance, and the accompanying `compact_data_explain_plan` method.\n",
+    "This demo notebook demonstrates the `compact_data` and `compact_data_batch` methods for reslicing data on disk in order to optimise read performance, and the accompanying `compact_data_explain_plan` method. It also covers the `compact_data` argument to `append` and `append_batch`.\n",
     "\n",
-    "This is what you need to know about it:\n",
-    "* After running `compact_data` against a symbol, all chunks on disk are guaranteed to have a row-count within 33% of some target value.\n",
+    "* After running `compact_data` or `compact_data_batch` against a symbol, all chunks on disk are guaranteed to have a row-count within 33% of some target value.\n",
     "    * This target value defaults to the `rows_per_segment` library config setting if not specified.\n",
     "* The compaction operates on the latest live version of the symbol, and creates a new version unless the data is already suitably compacted.\n",
     "* The metadata from the latest live version is maintained by the `compact_data` method.\n",
-    "* `compact_data_explain_plan` is like a dry run of the compaction, showing what the effect of running `compact_data` would be. No actual data is read from or written to disk.\n",
+    "* `compact_data_explain_plan` is like a dry run of the compaction, showing what the effect of running `compact_data` or `compact_data_batch` would be. No actual data is read from or written to disk.\n",
+    "* Setting `compact_data=True` with `append` or `append_batch` is similar to appending the data with the flag set to `False` (the default), and then compacting the data with one of the standalone methods. Only one new version is created though.\n",
+    "    * In this case, the `rows_per_segment` is not specifiable, it will always be taken from the library config setting.\n",
     "\n",
     "For more information about the on-disk data format, see [this section](https://docs.arcticdb.io/latest/technical/on_disk_storage/) of the documentation, as well as the [documentation](https://docs.arcticdb.io/latest/api/arctic/#arcticdb.LibraryOptions) for the `rows_per_segment` library configuration option."
    ]
@@ -38,12 +39,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "844205d7-65af-4164-bdf5-1a6db15f8927",
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install arcticdb"
+    "# !pip install arcticdb"
    ]
   },
   {
@@ -104,6 +105,14 @@
     "lib = arctic.get_library(\"compact_data\", create_if_missing=True)\n",
     "# symbol\n",
     "sym = \"OHLCV_minutely\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d93835b3-c4d4-4bef-992b-e86daa19931c",
+   "metadata": {},
+   "source": [
+    "## The `compact_data` method"
    ]
   },
   {
@@ -183,7 +192,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "45.7 ms ± 1.72 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+      "61.1 ms ± 6.79 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -229,43 +238,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:00:00</th>\n",
-       "      <td>0.652239</td>\n",
-       "      <td>0.559158</td>\n",
-       "      <td>0.377035</td>\n",
-       "      <td>0.262168</td>\n",
-       "      <td>0.988915</td>\n",
+       "      <td>0.903196</td>\n",
+       "      <td>0.287042</td>\n",
+       "      <td>0.310028</td>\n",
+       "      <td>0.465643</td>\n",
+       "      <td>0.850770</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:01:00</th>\n",
-       "      <td>0.519549</td>\n",
-       "      <td>0.814606</td>\n",
-       "      <td>0.754541</td>\n",
-       "      <td>0.258416</td>\n",
-       "      <td>0.147980</td>\n",
+       "      <td>0.726307</td>\n",
+       "      <td>0.976634</td>\n",
+       "      <td>0.716546</td>\n",
+       "      <td>0.695378</td>\n",
+       "      <td>0.278450</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:02:00</th>\n",
-       "      <td>0.261307</td>\n",
-       "      <td>0.525803</td>\n",
-       "      <td>0.486785</td>\n",
-       "      <td>0.956356</td>\n",
-       "      <td>0.771978</td>\n",
+       "      <td>0.305082</td>\n",
+       "      <td>0.343486</td>\n",
+       "      <td>0.042017</td>\n",
+       "      <td>0.550290</td>\n",
+       "      <td>0.552388</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:03:00</th>\n",
-       "      <td>0.186911</td>\n",
-       "      <td>0.061975</td>\n",
-       "      <td>0.462259</td>\n",
-       "      <td>0.481657</td>\n",
-       "      <td>0.419798</td>\n",
+       "      <td>0.722134</td>\n",
+       "      <td>0.141257</td>\n",
+       "      <td>0.488456</td>\n",
+       "      <td>0.835750</td>\n",
+       "      <td>0.395513</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:04:00</th>\n",
-       "      <td>0.931898</td>\n",
-       "      <td>0.025461</td>\n",
-       "      <td>0.715260</td>\n",
-       "      <td>0.205572</td>\n",
-       "      <td>0.600472</td>\n",
+       "      <td>0.928394</td>\n",
+       "      <td>0.744513</td>\n",
+       "      <td>0.785123</td>\n",
+       "      <td>0.862236</td>\n",
+       "      <td>0.087003</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -277,43 +286,43 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:56:00</th>\n",
-       "      <td>0.017824</td>\n",
-       "      <td>0.529770</td>\n",
-       "      <td>0.020662</td>\n",
-       "      <td>0.079490</td>\n",
-       "      <td>0.902616</td>\n",
+       "      <td>0.376040</td>\n",
+       "      <td>0.019941</td>\n",
+       "      <td>0.372354</td>\n",
+       "      <td>0.176808</td>\n",
+       "      <td>0.978362</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:57:00</th>\n",
-       "      <td>0.986598</td>\n",
-       "      <td>0.380662</td>\n",
-       "      <td>0.423765</td>\n",
-       "      <td>0.822334</td>\n",
-       "      <td>0.373985</td>\n",
+       "      <td>0.476032</td>\n",
+       "      <td>0.130399</td>\n",
+       "      <td>0.674303</td>\n",
+       "      <td>0.730136</td>\n",
+       "      <td>0.248132</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:58:00</th>\n",
-       "      <td>0.083624</td>\n",
-       "      <td>0.424631</td>\n",
-       "      <td>0.749354</td>\n",
-       "      <td>0.270700</td>\n",
-       "      <td>0.977522</td>\n",
+       "      <td>0.409921</td>\n",
+       "      <td>0.260924</td>\n",
+       "      <td>0.186574</td>\n",
+       "      <td>0.393183</td>\n",
+       "      <td>0.574988</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:59:00</th>\n",
-       "      <td>0.642927</td>\n",
-       "      <td>0.110095</td>\n",
-       "      <td>0.376601</td>\n",
-       "      <td>0.399092</td>\n",
-       "      <td>0.289307</td>\n",
+       "      <td>0.573795</td>\n",
+       "      <td>0.151552</td>\n",
+       "      <td>0.268032</td>\n",
+       "      <td>0.535715</td>\n",
+       "      <td>0.904988</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 16:00:00</th>\n",
-       "      <td>0.323974</td>\n",
-       "      <td>0.906545</td>\n",
-       "      <td>0.268960</td>\n",
-       "      <td>0.921583</td>\n",
-       "      <td>0.735306</td>\n",
+       "      <td>0.914831</td>\n",
+       "      <td>0.002621</td>\n",
+       "      <td>0.224933</td>\n",
+       "      <td>0.740409</td>\n",
+       "      <td>0.669241</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -322,17 +331,17 @@
       ],
       "text/plain": [
        "                         open      high       low     close    volume\n",
-       "2000-01-03 08:00:00  0.652239  0.559158  0.377035  0.262168  0.988915\n",
-       "2000-01-03 08:01:00  0.519549  0.814606  0.754541  0.258416  0.147980\n",
-       "2000-01-03 08:02:00  0.261307  0.525803  0.486785  0.956356  0.771978\n",
-       "2000-01-03 08:03:00  0.186911  0.061975  0.462259  0.481657  0.419798\n",
-       "2000-01-03 08:04:00  0.931898  0.025461  0.715260  0.205572  0.600472\n",
+       "2000-01-03 08:00:00  0.903196  0.287042  0.310028  0.465643  0.850770\n",
+       "2000-01-03 08:01:00  0.726307  0.976634  0.716546  0.695378  0.278450\n",
+       "2000-01-03 08:02:00  0.305082  0.343486  0.042017  0.550290  0.552388\n",
+       "2000-01-03 08:03:00  0.722134  0.141257  0.488456  0.835750  0.395513\n",
+       "2000-01-03 08:04:00  0.928394  0.744513  0.785123  0.862236  0.087003\n",
        "...                       ...       ...       ...       ...       ...\n",
-       "2026-01-01 15:56:00  0.017824  0.529770  0.020662  0.079490  0.902616\n",
-       "2026-01-01 15:57:00  0.986598  0.380662  0.423765  0.822334  0.373985\n",
-       "2026-01-01 15:58:00  0.083624  0.424631  0.749354  0.270700  0.977522\n",
-       "2026-01-01 15:59:00  0.642927  0.110095  0.376601  0.399092  0.289307\n",
-       "2026-01-01 16:00:00  0.323974  0.906545  0.268960  0.921583  0.735306\n",
+       "2026-01-01 15:56:00  0.376040  0.019941  0.372354  0.176808  0.978362\n",
+       "2026-01-01 15:57:00  0.476032  0.130399  0.674303  0.730136  0.248132\n",
+       "2026-01-01 15:58:00  0.409921  0.260924  0.186574  0.393183  0.574988\n",
+       "2026-01-01 15:59:00  0.573795  0.151552  0.268032  0.535715  0.904988\n",
+       "2026-01-01 16:00:00  0.914831  0.002621  0.224933  0.740409  0.669241\n",
        "\n",
        "[3263104 rows x 5 columns]"
       ]
@@ -617,7 +626,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6784, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1779456252894183043)"
+       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6784, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1785934997582081646)"
       ]
      },
      "execution_count": 19,
@@ -655,7 +664,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "13.8 ms ± 1.16 ms per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+      "22.5 ms ± 1.07 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
      ]
     }
    ],
@@ -709,43 +718,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:00:00</th>\n",
-       "      <td>0.652239</td>\n",
-       "      <td>0.559158</td>\n",
-       "      <td>0.377035</td>\n",
-       "      <td>0.262168</td>\n",
-       "      <td>0.988915</td>\n",
+       "      <td>0.903196</td>\n",
+       "      <td>0.287042</td>\n",
+       "      <td>0.310028</td>\n",
+       "      <td>0.465643</td>\n",
+       "      <td>0.850770</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:01:00</th>\n",
-       "      <td>0.519549</td>\n",
-       "      <td>0.814606</td>\n",
-       "      <td>0.754541</td>\n",
-       "      <td>0.258416</td>\n",
-       "      <td>0.147980</td>\n",
+       "      <td>0.726307</td>\n",
+       "      <td>0.976634</td>\n",
+       "      <td>0.716546</td>\n",
+       "      <td>0.695378</td>\n",
+       "      <td>0.278450</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:02:00</th>\n",
-       "      <td>0.261307</td>\n",
-       "      <td>0.525803</td>\n",
-       "      <td>0.486785</td>\n",
-       "      <td>0.956356</td>\n",
-       "      <td>0.771978</td>\n",
+       "      <td>0.305082</td>\n",
+       "      <td>0.343486</td>\n",
+       "      <td>0.042017</td>\n",
+       "      <td>0.550290</td>\n",
+       "      <td>0.552388</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:03:00</th>\n",
-       "      <td>0.186911</td>\n",
-       "      <td>0.061975</td>\n",
-       "      <td>0.462259</td>\n",
-       "      <td>0.481657</td>\n",
-       "      <td>0.419798</td>\n",
+       "      <td>0.722134</td>\n",
+       "      <td>0.141257</td>\n",
+       "      <td>0.488456</td>\n",
+       "      <td>0.835750</td>\n",
+       "      <td>0.395513</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2000-01-03 08:04:00</th>\n",
-       "      <td>0.931898</td>\n",
-       "      <td>0.025461</td>\n",
-       "      <td>0.715260</td>\n",
-       "      <td>0.205572</td>\n",
-       "      <td>0.600472</td>\n",
+       "      <td>0.928394</td>\n",
+       "      <td>0.744513</td>\n",
+       "      <td>0.785123</td>\n",
+       "      <td>0.862236</td>\n",
+       "      <td>0.087003</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -757,43 +766,43 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:56:00</th>\n",
-       "      <td>0.017824</td>\n",
-       "      <td>0.529770</td>\n",
-       "      <td>0.020662</td>\n",
-       "      <td>0.079490</td>\n",
-       "      <td>0.902616</td>\n",
+       "      <td>0.376040</td>\n",
+       "      <td>0.019941</td>\n",
+       "      <td>0.372354</td>\n",
+       "      <td>0.176808</td>\n",
+       "      <td>0.978362</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:57:00</th>\n",
-       "      <td>0.986598</td>\n",
-       "      <td>0.380662</td>\n",
-       "      <td>0.423765</td>\n",
-       "      <td>0.822334</td>\n",
-       "      <td>0.373985</td>\n",
+       "      <td>0.476032</td>\n",
+       "      <td>0.130399</td>\n",
+       "      <td>0.674303</td>\n",
+       "      <td>0.730136</td>\n",
+       "      <td>0.248132</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:58:00</th>\n",
-       "      <td>0.083624</td>\n",
-       "      <td>0.424631</td>\n",
-       "      <td>0.749354</td>\n",
-       "      <td>0.270700</td>\n",
-       "      <td>0.977522</td>\n",
+       "      <td>0.409921</td>\n",
+       "      <td>0.260924</td>\n",
+       "      <td>0.186574</td>\n",
+       "      <td>0.393183</td>\n",
+       "      <td>0.574988</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 15:59:00</th>\n",
-       "      <td>0.642927</td>\n",
-       "      <td>0.110095</td>\n",
-       "      <td>0.376601</td>\n",
-       "      <td>0.399092</td>\n",
-       "      <td>0.289307</td>\n",
+       "      <td>0.573795</td>\n",
+       "      <td>0.151552</td>\n",
+       "      <td>0.268032</td>\n",
+       "      <td>0.535715</td>\n",
+       "      <td>0.904988</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2026-01-01 16:00:00</th>\n",
-       "      <td>0.323974</td>\n",
-       "      <td>0.906545</td>\n",
-       "      <td>0.268960</td>\n",
-       "      <td>0.921583</td>\n",
-       "      <td>0.735306</td>\n",
+       "      <td>0.914831</td>\n",
+       "      <td>0.002621</td>\n",
+       "      <td>0.224933</td>\n",
+       "      <td>0.740409</td>\n",
+       "      <td>0.669241</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -802,17 +811,17 @@
       ],
       "text/plain": [
        "                         open      high       low     close    volume\n",
-       "2000-01-03 08:00:00  0.652239  0.559158  0.377035  0.262168  0.988915\n",
-       "2000-01-03 08:01:00  0.519549  0.814606  0.754541  0.258416  0.147980\n",
-       "2000-01-03 08:02:00  0.261307  0.525803  0.486785  0.956356  0.771978\n",
-       "2000-01-03 08:03:00  0.186911  0.061975  0.462259  0.481657  0.419798\n",
-       "2000-01-03 08:04:00  0.931898  0.025461  0.715260  0.205572  0.600472\n",
+       "2000-01-03 08:00:00  0.903196  0.287042  0.310028  0.465643  0.850770\n",
+       "2000-01-03 08:01:00  0.726307  0.976634  0.716546  0.695378  0.278450\n",
+       "2000-01-03 08:02:00  0.305082  0.343486  0.042017  0.550290  0.552388\n",
+       "2000-01-03 08:03:00  0.722134  0.141257  0.488456  0.835750  0.395513\n",
+       "2000-01-03 08:04:00  0.928394  0.744513  0.785123  0.862236  0.087003\n",
        "...                       ...       ...       ...       ...       ...\n",
-       "2026-01-01 15:56:00  0.017824  0.529770  0.020662  0.079490  0.902616\n",
-       "2026-01-01 15:57:00  0.986598  0.380662  0.423765  0.822334  0.373985\n",
-       "2026-01-01 15:58:00  0.083624  0.424631  0.749354  0.270700  0.977522\n",
-       "2026-01-01 15:59:00  0.642927  0.110095  0.376601  0.399092  0.289307\n",
-       "2026-01-01 16:00:00  0.323974  0.906545  0.268960  0.921583  0.735306\n",
+       "2026-01-01 15:56:00  0.376040  0.019941  0.372354  0.176808  0.978362\n",
+       "2026-01-01 15:57:00  0.476032  0.130399  0.674303  0.730136  0.248132\n",
+       "2026-01-01 15:58:00  0.409921  0.260924  0.186574  0.393183  0.574988\n",
+       "2026-01-01 15:59:00  0.573795  0.151552  0.268032  0.535715  0.904988\n",
+       "2026-01-01 16:00:00  0.914831  0.002621  0.224933  0.740409  0.669241\n",
        "\n",
        "[3263104 rows x 5 columns]"
       ]
@@ -951,43 +960,43 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>2003-11-03 08:00:00</th>\n",
-       "      <td>0.513891</td>\n",
-       "      <td>0.731586</td>\n",
-       "      <td>0.751961</td>\n",
-       "      <td>0.947970</td>\n",
-       "      <td>0.239459</td>\n",
+       "      <td>0.582366</td>\n",
+       "      <td>0.146977</td>\n",
+       "      <td>0.656918</td>\n",
+       "      <td>0.290471</td>\n",
+       "      <td>0.483627</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 08:01:00</th>\n",
-       "      <td>0.103845</td>\n",
-       "      <td>0.013911</td>\n",
-       "      <td>0.083932</td>\n",
-       "      <td>0.264079</td>\n",
-       "      <td>0.696063</td>\n",
+       "      <td>0.397897</td>\n",
+       "      <td>0.230768</td>\n",
+       "      <td>0.596099</td>\n",
+       "      <td>0.613895</td>\n",
+       "      <td>0.106646</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 08:02:00</th>\n",
-       "      <td>0.584501</td>\n",
-       "      <td>0.905620</td>\n",
-       "      <td>0.505111</td>\n",
-       "      <td>0.143124</td>\n",
-       "      <td>0.299208</td>\n",
+       "      <td>0.123893</td>\n",
+       "      <td>0.647533</td>\n",
+       "      <td>0.210100</td>\n",
+       "      <td>0.579464</td>\n",
+       "      <td>0.228911</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 08:03:00</th>\n",
-       "      <td>0.186388</td>\n",
-       "      <td>0.188366</td>\n",
-       "      <td>0.507724</td>\n",
-       "      <td>0.299007</td>\n",
-       "      <td>0.311037</td>\n",
+       "      <td>0.015324</td>\n",
+       "      <td>0.760227</td>\n",
+       "      <td>0.185393</td>\n",
+       "      <td>0.012468</td>\n",
+       "      <td>0.157286</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 08:04:00</th>\n",
-       "      <td>0.343084</td>\n",
-       "      <td>0.009887</td>\n",
-       "      <td>0.172661</td>\n",
-       "      <td>0.187550</td>\n",
-       "      <td>0.848564</td>\n",
+       "      <td>0.670147</td>\n",
+       "      <td>0.349669</td>\n",
+       "      <td>0.281271</td>\n",
+       "      <td>0.658520</td>\n",
+       "      <td>0.667422</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>...</th>\n",
@@ -999,43 +1008,43 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 15:56:00</th>\n",
-       "      <td>0.809524</td>\n",
-       "      <td>0.905820</td>\n",
-       "      <td>0.006144</td>\n",
-       "      <td>0.731492</td>\n",
-       "      <td>0.103905</td>\n",
+       "      <td>0.059694</td>\n",
+       "      <td>0.965551</td>\n",
+       "      <td>0.219874</td>\n",
+       "      <td>0.880971</td>\n",
+       "      <td>0.625992</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 15:57:00</th>\n",
-       "      <td>0.503292</td>\n",
-       "      <td>0.884031</td>\n",
-       "      <td>0.742494</td>\n",
-       "      <td>0.414768</td>\n",
-       "      <td>0.739807</td>\n",
+       "      <td>0.448745</td>\n",
+       "      <td>0.969533</td>\n",
+       "      <td>0.881961</td>\n",
+       "      <td>0.976806</td>\n",
+       "      <td>0.990011</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 15:58:00</th>\n",
-       "      <td>0.018958</td>\n",
-       "      <td>0.534203</td>\n",
-       "      <td>0.526111</td>\n",
-       "      <td>0.062234</td>\n",
-       "      <td>0.926631</td>\n",
+       "      <td>0.169475</td>\n",
+       "      <td>0.339409</td>\n",
+       "      <td>0.738013</td>\n",
+       "      <td>0.512463</td>\n",
+       "      <td>0.517097</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 15:59:00</th>\n",
-       "      <td>0.533881</td>\n",
-       "      <td>0.098154</td>\n",
-       "      <td>0.498576</td>\n",
-       "      <td>0.255710</td>\n",
-       "      <td>0.667218</td>\n",
+       "      <td>0.892093</td>\n",
+       "      <td>0.206302</td>\n",
+       "      <td>0.791956</td>\n",
+       "      <td>0.174379</td>\n",
+       "      <td>0.669368</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2003-11-03 16:00:00</th>\n",
-       "      <td>0.524923</td>\n",
-       "      <td>0.628789</td>\n",
-       "      <td>0.003717</td>\n",
-       "      <td>0.209919</td>\n",
-       "      <td>0.449783</td>\n",
+       "      <td>0.629526</td>\n",
+       "      <td>0.466912</td>\n",
+       "      <td>0.286768</td>\n",
+       "      <td>0.889151</td>\n",
+       "      <td>0.067524</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1044,17 +1053,17 @@
       ],
       "text/plain": [
        "                         open      high       low     close    volume\n",
-       "2003-11-03 08:00:00  0.513891  0.731586  0.751961  0.947970  0.239459\n",
-       "2003-11-03 08:01:00  0.103845  0.013911  0.083932  0.264079  0.696063\n",
-       "2003-11-03 08:02:00  0.584501  0.905620  0.505111  0.143124  0.299208\n",
-       "2003-11-03 08:03:00  0.186388  0.188366  0.507724  0.299007  0.311037\n",
-       "2003-11-03 08:04:00  0.343084  0.009887  0.172661  0.187550  0.848564\n",
+       "2003-11-03 08:00:00  0.582366  0.146977  0.656918  0.290471  0.483627\n",
+       "2003-11-03 08:01:00  0.397897  0.230768  0.596099  0.613895  0.106646\n",
+       "2003-11-03 08:02:00  0.123893  0.647533  0.210100  0.579464  0.228911\n",
+       "2003-11-03 08:03:00  0.015324  0.760227  0.185393  0.012468  0.157286\n",
+       "2003-11-03 08:04:00  0.670147  0.349669  0.281271  0.658520  0.667422\n",
        "...                       ...       ...       ...       ...       ...\n",
-       "2003-11-03 15:56:00  0.809524  0.905820  0.006144  0.731492  0.103905\n",
-       "2003-11-03 15:57:00  0.503292  0.884031  0.742494  0.414768  0.739807\n",
-       "2003-11-03 15:58:00  0.018958  0.534203  0.526111  0.062234  0.926631\n",
-       "2003-11-03 15:59:00  0.533881  0.098154  0.498576  0.255710  0.667218\n",
-       "2003-11-03 16:00:00  0.524923  0.628789  0.003717  0.209919  0.449783\n",
+       "2003-11-03 15:56:00  0.059694  0.965551  0.219874  0.880971  0.625992\n",
+       "2003-11-03 15:57:00  0.448745  0.969533  0.881961  0.976806  0.990011\n",
+       "2003-11-03 15:58:00  0.169475  0.339409  0.738013  0.512463  0.517097\n",
+       "2003-11-03 15:59:00  0.892093  0.206302  0.791956  0.174379  0.669368\n",
+       "2003-11-03 16:00:00  0.629526  0.466912  0.286768  0.889151  0.067524\n",
        "\n",
        "[481 rows x 5 columns]"
       ]
@@ -1155,7 +1164,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6786, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1779456264058020828)"
+       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6786, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1785934999543172806)"
       ]
      },
      "execution_count": 29,
@@ -1234,7 +1243,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6787, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1779456264292791517)"
+       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6787, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1785934999760942648)"
       ]
      },
      "execution_count": 32,
@@ -1284,7 +1293,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6788, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1779456264576206308)"
+       "VersionedItem(symbol='OHLCV_minutely', library='compact_data', data=n/a, version=6788, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1785934999959716837)"
       ]
      },
      "execution_count": 34,
@@ -1294,6 +1303,242 @@
    ],
    "source": [
     "lib.compact_data(sym, rows_per_segment=10_000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec1e0ceb-116d-46dd-bc80-38259cf02058",
+   "metadata": {},
+   "source": [
+    "## The `compact_data_batch` method\n",
+    "\n",
+    "This is identical to the `compact_data` method, but operates on a collection of symbols"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "3ccd3f52-205d-45ab-9c48-eb094660fce5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "VersionedItem(symbol='non-fragmented', library='compact_data', data=n/a, version=0, metadata=None, host='LMDB(path=/users/is/aowens/source/man.arcticdb/arcticdb_link/docs/mkdocs/docs/notebooks/arcticdb_compact_data)', timestamp=1785935145603435349)"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Generate 10 symbols of fragmented minutely OHLCV volume data\n",
+    "syms = [f\"{sym}_{i}\" for i in range(10)]\n",
+    "for day in days:\n",
+    "    df = generate_day_data(day)\n",
+    "    lib.append_batch([adb.WritePayload(sym, df) for sym in syms])\n",
+    "\n",
+    "# Also add one non-fragmented symbol\n",
+    "df = pd.DataFrame({\"col\": np.arange(1_000_000)})\n",
+    "lib.write(\"non-fragmented\", df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9779d714-fab3-4360-8f08-5bfcbf5bb7b9",
+   "metadata": {},
+   "source": [
+    "### This reads 67,840 data keys:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "da8f6f41-e7bc-47a8-a3ee-7e2700145648",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "443 ms ± 25.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "lib.read_batch(syms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "de331f92-d93d-4d35-9734-4ac48ca0318c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "res = lib.compact_data_batch(syms + [\"non-fragmented\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "16faaef8-a141-4c4b-9886-72b783b25004",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The non-fragmented symbol is still on version 0, as it did not need compacting\n",
+    "res[10].version"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e8b2aed1-d4ac-4a90-ad9f-b7edfbdcf7b2",
+   "metadata": {},
+   "source": [
+    "### This reads 330 data keys:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "89904069-2abd-4d7c-aae6-6dee4d37a423",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "112 ms ± 8.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%timeit\n",
+    "lib.read_batch(syms)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "917beab3-7bf0-4d4d-a389-77db16dd386f",
+   "metadata": {},
+   "source": [
+    "## The `compact_data` argument to `append` and `append_batch`\n",
+    "\n",
+    "Does the compaction in-line as part of the append"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "cdccda8d-fda6-401b-abc1-47991de95cfb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "After 500 appends there are 3 data keys\n",
+      "After 1000 appends there are 7 data keys\n",
+      "After 1500 appends there are 10 data keys\n",
+      "After 2000 appends there are 14 data keys\n",
+      "After 2500 appends there are 17 data keys\n",
+      "After 3000 appends there are 21 data keys\n",
+      "After 3500 appends there are 25 data keys\n",
+      "After 4000 appends there are 28 data keys\n",
+      "After 4500 appends there are 32 data keys\n",
+      "After 5000 appends there are 35 data keys\n",
+      "After 5500 appends there are 39 data keys\n",
+      "After 6000 appends there are 43 data keys\n",
+      "After 6500 appends there are 46 data keys\n"
+     ]
+    }
+   ],
+   "source": [
+    "lib.delete(sym)\n",
+    "lib_tool = lib._dev_tools.library_tool()\n",
+    "# Where previously 1 data key would be created on every call to append, now they are compacted together\n",
+    "for idx, day in enumerate(days):\n",
+    "    df = generate_day_data(day)\n",
+    "    lib.append(sym, df, compact_data=True)\n",
+    "    if (idx + 1) % 500 == 0:\n",
+    "        print(f\"After {idx + 1} appends there are {len(lib_tool.read_index(sym))} data keys\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2147fbc-b074-4356-ace5-d1760b9ab5c5",
+   "metadata": {},
+   "source": [
+    "### Note that if the data is fragmented, and then `append` or `append_batch` is called with `compact_data=True` then the whole symbol will be compacted. This can take longer and use a lot more memory than if the majority of the data is already well compacted."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "ece628ee-be7f-4337-a065-5bef7873c882",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Before compaction there are 6783 data keys\n",
+      "After append with compact_data=True there are 33 data keys\n"
+     ]
+    }
+   ],
+   "source": [
+    "lib.delete(sym)\n",
+    "for day in days[:-1]:\n",
+    "    df = generate_day_data(day)\n",
+    "    lib.append(sym, df, compact_data=False)\n",
+    "print(f\"Before compaction there are {len(lib_tool.read_index(sym))} data keys\")\n",
+    "df = generate_day_data(days[-1])\n",
+    "lib.append(sym, df, compact_data=True)\n",
+    "print(f\"After append with compact_data=True there are {len(lib_tool.read_index(sym))} data keys\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5363910e-b183-4d34-9c7b-1cf267fea94d",
+   "metadata": {},
+   "source": [
+    "### The argument works in exactly the same way with `append_batch`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "334bdbcb-8e67-481f-a3d8-17e416e102fd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "There is 1 data key for each symbol\n"
+     ]
+    }
+   ],
+   "source": [
+    "df = generate_day_data(days[0])\n",
+    "lib.write_batch([adb.WritePayload(sym, df) for sym in syms])\n",
+    "df = generate_day_data(days[1])\n",
+    "lib.append_batch([adb.WritePayload(sym, df) for sym in syms], compact_data=True)\n",
+    "print(f\"There is {len(lib_tool.read_index(syms[0]))} data key for each symbol\")"
    ]
   }
  ],


### PR DESCRIPTION
#### Reference Issues/PRs
[12669504345](https://man312219.monday.com/boards/7852509418/pulses/12669504345)

#### What does this implement or fix?
Extends the `compact_data` demo notebook to include `compact_data_batch`, and the `compact_data` argument to `append` and `append_batch`.