### PR TITLE
Generate schema output before processing in read_modify_write and refactor PipelineContext

### DIFF
--- a/cpp/arcticdb/entity/stream_descriptor.hpp
+++ b/cpp/arcticdb/entity/stream_descriptor.hpp
@@ -238,6 +238,8 @@ struct OutputSchema {
         default_values_.emplace(name, value);
     }
 
+    const ankerl::unordered_dense::map<std::string, Value>& default_values() const { return default_values_; }
+
   private:
     StreamDescriptor stream_descriptor_;
     std::optional<ankerl::unordered_dense::map<std::string, DataType>> column_types_;

--- a/cpp/arcticdb/entity/type_utils.cpp
+++ b/cpp/arcticdb/entity/type_utils.cpp
@@ -263,4 +263,13 @@ std::optional<entity::TypeDescriptor> promotable_type(
     return res;
 }
 
+std::string get_user_friendly_type_string(const entity::TypeDescriptor& type) {
+    return is_sequence_type(type.data_type()) ? fmt::format("TD<type=STRING, dim={}>", type.dimension_)
+                                              : fmt::format("{}", type);
+}
+
+std::string get_user_friendly_type_string(entity::DataType type) {
+    return get_user_friendly_type_string(entity::TypeDescriptor{type, entity::Dimension::Dim0});
+}
+
 } // namespace arcticdb

--- a/cpp/arcticdb/entity/type_utils.hpp
+++ b/cpp/arcticdb/entity/type_utils.hpp
@@ -41,10 +41,9 @@ enum class IntToFloatConversion {
         const entity::TypeDescriptor& left, const entity::TypeDescriptor& right
 );
 
-inline std::string get_user_friendly_type_string(const entity::TypeDescriptor& type) {
-    return is_sequence_type(type.data_type()) ? fmt::format("TD<type=STRING, dim={}>", type.dimension_)
-                                              : fmt::format("{}", type);
-}
+std::string get_user_friendly_type_string(const entity::TypeDescriptor& type);
+
+std::string get_user_friendly_type_string(entity::DataType type);
 
 } // namespace arcticdb
 

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -23,11 +23,9 @@ struct FrameSliceMap {
     std::shared_ptr<PipelineContext> context_;
 
     FrameSliceMap(std::shared_ptr<PipelineContext> context, bool dynamic_schema) : context_(std::move(context)) {
-        const StreamDescriptor& descriptor = context_->on_disk_descriptor();
+        const StreamDescriptor& descriptor = context_->output_descriptor();
         const auto true_index_field_count = descriptor.index().field_count();
-        const auto required_fields_count = context_->has_normalization()
-                                                   ? index::required_fields_count(descriptor, context_->normalization())
-                                                   : index::required_fields_count(descriptor);
+        const auto required_fields_count = context_->output_required_fields_count();
         std::optional<size_t> min_col_index;
         for (const auto& context_row : *context_) {
             const auto& row_range = context_row.slice_and_key().slice_.row_range;

--- a/cpp/arcticdb/pipeline/frame_slice_map.hpp
+++ b/cpp/arcticdb/pipeline/frame_slice_map.hpp
@@ -23,7 +23,7 @@ struct FrameSliceMap {
     std::shared_ptr<PipelineContext> context_;
 
     FrameSliceMap(std::shared_ptr<PipelineContext> context, bool dynamic_schema) : context_(std::move(context)) {
-        const entity::StreamDescriptor& descriptor = context_->descriptor();
+        const StreamDescriptor& descriptor = context_->on_disk_descriptor();
         const auto true_index_field_count = descriptor.index().field_count();
         const auto required_fields_count = context_->has_normalization()
                                                    ? index::required_fields_count(descriptor, context_->normalization())

--- a/cpp/arcticdb/pipeline/frame_utils.cpp
+++ b/cpp/arcticdb/pipeline/frame_utils.cpp
@@ -48,8 +48,8 @@ TimeseriesDescriptor timeseries_descriptor_from_pipeline_context(
 ) {
     return make_timeseries_descriptor(
             pipeline_context->total_rows_,
-            pipeline_context->descriptor(),
-            pipeline_context->normalization(),
+            pipeline_context->output_descriptor(),
+            pipeline_context->output_normalization(),
             pipeline_context->release_opt_user_defined_metadata(),
             std::move(next_key),
             bucketize_dynamic

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -12,7 +12,7 @@
 
 namespace arcticdb::pipelines {
 
-PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key) : desc_(frame.descriptor()) {
+PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key) : on_disk_descriptor_(frame.descriptor()) {
     SliceAndKey sk{FrameSlice{frame}, key};
     slice_and_keys_.emplace_back(std::move(sk));
     util::BitSet bitset(1);
@@ -20,7 +20,7 @@ PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key) : d
     fetch_index_ = std::move(bitset);
     ensure_vectors();
 
-    generate_filtered_field_descriptors(*this, {});
+    generate_filtered_field_descriptors({});
     string_pools_[0] = frame.string_pool_ptr();
     auto map = std::make_shared<ColumnMap>(frame.descriptor().field_count());
     map->set_from_descriptor(frame.descriptor());
@@ -30,8 +30,60 @@ PipelineContext::PipelineContext(SegmentInMemory& frame, const AtomKey& key) : d
 }
 
 void PipelineContext::set_selected_columns(const std::optional<std::vector<std::string>>& columns) {
-    util::check(static_cast<bool>(desc_), "Descriptor not set in set_selected_columns");
-    selected_columns_ = requested_column_bitset_including_index(*desc_, columns);
+    util::check(static_cast<bool>(on_disk_descriptor_), "Descriptor not set in set_selected_columns");
+    selected_columns_ = requested_column_bitset_including_index(*on_disk_descriptor_, columns);
+}
+
+void PipelineContext::generate_string_coerced_descriptor(const ReadOptions& read_options) {
+    const bool force_strings_to_object = opt_false(read_options.force_strings_to_object());
+    const bool force_strings_to_fixed = opt_false(read_options.force_strings_to_fixed());
+    if (!force_strings_to_object && !force_strings_to_fixed)
+        return;
+
+    StreamDescriptor desc = *on_disk_descriptor_;
+    if (force_strings_to_object) {
+        auto& fields = desc.fields();
+        for (Field& field_desc : fields) {
+            if (field_desc.type().data_type() == DataType::ASCII_FIXED64)
+                set_data_type(DataType::ASCII_DYNAMIC64, field_desc.mutable_type());
+
+            if (field_desc.type().data_type() == DataType::UTF_FIXED64)
+                set_data_type(DataType::UTF_DYNAMIC64, field_desc.mutable_type());
+        }
+    } else if (force_strings_to_fixed) {
+        auto& fields = desc.fields();
+        for (Field& field_desc : fields) {
+            if (field_desc.type().data_type() == DataType::ASCII_DYNAMIC64)
+                set_data_type(DataType::ASCII_FIXED64, field_desc.mutable_type());
+
+            if (field_desc.type().data_type() == DataType::UTF_DYNAMIC64)
+                set_data_type(DataType::UTF_FIXED64, field_desc.mutable_type());
+        }
+    }
+    util::check(
+            desc.field_count() == on_disk_descriptor_->field_count(),
+            "Coerced descriptor field count {} does not match on-disk descriptor field count {}",
+            desc.field_count(),
+            on_disk_descriptor_->field_count()
+    );
+    string_coerced_descriptor_ = std::move(desc);
+}
+
+void PipelineContext::generate_filtered_field_descriptors(const std::optional<std::vector<std::string>>& columns) {
+    if (columns.has_value()) {
+        const ankerl::unordered_dense::set<std::string_view> column_set{std::begin(*columns), std::end(*columns)};
+
+        filter_columns_ = std::make_shared<FieldCollection>();
+        ARCTICDB_DEBUG(log::version(), "Context descriptor: {}", *on_disk_descriptor_);
+        for (const auto& field : on_disk_descriptor_->fields()) {
+            if (column_set.find(field.name()) != column_set.end())
+                filter_columns_->add_field(field.type(), field.name());
+        }
+
+        filter_columns_set_ = std::unordered_set<std::string_view>{};
+        for (const auto& field : *filter_columns_)
+            filter_columns_set_->insert(field.name());
+    }
 }
 
 bool PipelineContext::only_index_columns_selected() const {
@@ -40,7 +92,7 @@ bool PipelineContext::only_index_columns_selected() const {
     if (overall_column_bitset_->count() == 0)
         return true;
     // For RangeIndex, field_count() == 0, so bit 0 is a data column, not an index column.
-    if (desc_ && desc_->index().field_count() == 0)
+    if (on_disk_descriptor_ && on_disk_descriptor_->index().field_count() == 0)
         return false;
     return overall_column_bitset_->count() == 1 && (*overall_column_bitset_)[0];
 }
@@ -88,6 +140,47 @@ void PipelineContext::set_normalization(arcticdb::proto::descriptors::Normalizat
 arcticdb::proto::descriptors::NormalizationMetadata PipelineContext::release_normalization() {
     util::check(tsd_.has_value(), "No normalization metadata defined");
     return std::move(*tsd_->mutable_proto().mutable_normalization());
+}
+
+const StreamDescriptor& PipelineContext::on_disk_descriptor() const {
+    util::check(
+            on_disk_descriptor_, "Trying to read on disk descriptor from the processing pipeline but it is not set"
+    );
+    return *on_disk_descriptor_;
+}
+StreamDescriptor& PipelineContext::on_disk_descriptor() {
+    return const_cast<StreamDescriptor&>(static_cast<const PipelineContext&>(*this).on_disk_descriptor());
+}
+[[nodiscard]] bool PipelineContext::has_on_disk_descriptor() const { return on_disk_descriptor_.has_value(); }
+
+void PipelineContext::set_on_disk_descriptor(StreamDescriptor&& desc) { on_disk_descriptor_ = std::move(desc); }
+
+void PipelineContext::set_on_disk_descriptor(const StreamDescriptor& desc) { on_disk_descriptor_ = desc; }
+
+[[nodiscard]] bool PipelineContext::are_string_fields_coerced() const { return string_coerced_descriptor_.has_value(); }
+
+void PipelineContext::set_output_schema(OutputSchema&& output_schema) { output_schema_ = std::move(output_schema); }
+
+const StreamDescriptor& PipelineContext::output_descriptor() const {
+    if (output_schema_) {
+        return output_schema_->stream_descriptor();
+    }
+    if (string_coerced_descriptor_) {
+        return *string_coerced_descriptor_;
+    }
+    return on_disk_descriptor();
+}
+
+const proto::descriptors::NormalizationMetadata& PipelineContext::output_normalization() const {
+    return output_schema_ ? output_schema_->norm_metadata_ : normalization();
+}
+
+const ankerl::unordered_dense::map<std::string, Value>& PipelineContext::output_default_values() const {
+    if (output_schema_) {
+        return output_schema_->default_values();
+    }
+    static const ankerl::unordered_dense::map<std::string, Value> empty_default_values;
+    return empty_default_values;
 }
 
 const StringPool& PipelineContextRow::string_pool() const { return *parent_->string_pools_[index_]; }

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -8,6 +8,7 @@
 
 #include <arcticdb/pipeline/pipeline_context.hpp>
 #include <arcticdb/pipeline/read_pipeline.hpp>
+#include <arcticdb/pipeline/index_utils.hpp>
 #include <arcticdb/column_store/column_map.hpp>
 
 namespace arcticdb::pipelines {
@@ -173,6 +174,13 @@ const StreamDescriptor& PipelineContext::output_descriptor() const {
 
 const proto::descriptors::NormalizationMetadata& PipelineContext::output_normalization() const {
     return output_schema_ ? output_schema_->norm_metadata_ : normalization();
+}
+
+uint32_t PipelineContext::output_required_fields_count() const {
+    if (output_schema_ || tsd_) {
+        return index::required_fields_count(output_descriptor(), output_normalization());
+    }
+    return index::required_fields_count(output_descriptor());
 }
 
 const ankerl::unordered_dense::map<std::string, Value>& PipelineContext::output_default_values() const {

--- a/cpp/arcticdb/pipeline/pipeline_context.cpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.cpp
@@ -75,8 +75,8 @@ void PipelineContext::generate_filtered_field_descriptors(const std::optional<st
         const ankerl::unordered_dense::set<std::string_view> column_set{std::begin(*columns), std::end(*columns)};
 
         filter_columns_ = std::make_shared<FieldCollection>();
-        ARCTICDB_DEBUG(log::version(), "Context descriptor: {}", *on_disk_descriptor_);
-        for (const auto& field : on_disk_descriptor_->fields()) {
+        ARCTICDB_DEBUG(log::version(), "Context descriptor: {}", output_descriptor());
+        for (const auto& field : output_descriptor().fields()) {
             if (column_set.find(field.name()) != column_set.end())
                 filter_columns_->add_field(field.type(), field.name());
         }

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -159,6 +159,10 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     const proto::descriptors::NormalizationMetadata& output_normalization() const;
 
+    /// Number of leading required (index) fields in the output, accounting for multi-index/series normalization.
+    /// Returns the count with no normalization applied when the context carries neither an output schema nor a TSD.
+    uint32_t output_required_fields_count() const;
+
     const ankerl::unordered_dense::map<std::string, Value>& output_default_values() const;
 
     void set_selected_columns(const std::optional<std::vector<std::string>>& columns);

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -12,6 +12,7 @@
 #include <arcticdb/entity/index_range.hpp>
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/pipeline/read_options.hpp>
 #include <arcticdb/util/bitset.hpp>
 #include <memory>
 
@@ -97,22 +98,15 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     PipelineContext() = default;
 
-    explicit PipelineContext(StreamDescriptor desc) : desc_(std::move(desc)) {}
+    explicit PipelineContext(StreamDescriptor desc) : on_disk_descriptor_(std::move(desc)) {}
 
     explicit PipelineContext(SegmentInMemory& frame, const AtomKey& key);
 
     PipelineContext(const PipelineContext& other) = delete;
     PipelineContext& operator=(const PipelineContext& other) = delete;
 
-    // StreamDescriptor that can mutated for modifying operations. At the end of the pipeline,
-    // the modified descriptor can be written out to storage, otherwise this'll match what was read from storage.
-    std::optional<StreamDescriptor> desc_;
-    // If user requests strings to be returned in a different format (e.g. fixed rather than dynamic) than they were
-    // written in, desc_ will be modified such that the return matches what's requested, and this'll be set to the
-    // original value. It's only set in this edge case.
-    std::optional<StreamDescriptor> orig_desc_;
     // When there are staged segments this holds the combined stream descriptor for all staged segments
-    // This can be different than desc_ in case dynamic schema is used. Otherwise they must be the same.
+    // This can be different than on_disk_descriptor_ in case dynamic schema is used. Otherwise they must be the same.
     std::optional<StreamDescriptor> staged_descriptor_;
     StreamId stream_id_;
     VersionId version_id_ = 0;
@@ -138,9 +132,6 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     std::optional<SegmentInMemory> multi_key_;
     std::vector<unsigned char> compacted_;
     std::optional<size_t> incompletes_after_;
-    /// Used to override the default values of types when the NullValueReducer fills missing segments. For example, in
-    /// the sum unordered aggregation and the sum resampling clause, the value must 0 even if the output type is float.
-    ankerl::unordered_dense::map<std::string, Value> default_values_;
     bool bucketize_dynamic_ = false;
 
     PipelineContextRow operator[](size_t num) { return PipelineContextRow{shared_from_this(), num}; }
@@ -163,16 +154,18 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     size_t calc_rows() const { return last_row() - first_row(); }
 
-    const StreamDescriptor& descriptor() const {
-        util::check(static_cast<bool>(desc_), "Stream descriptor not found in pipeline context");
-        return *desc_;
-    }
+    /// The descriptor of the dataframe that will be presented to the user.
+    const StreamDescriptor& output_descriptor() const;
 
-    void set_descriptor(StreamDescriptor&& desc) { desc_ = std::move(desc); }
+    const proto::descriptors::NormalizationMetadata& output_normalization() const;
 
-    void set_descriptor(const StreamDescriptor& desc) { desc_ = desc; }
+    const ankerl::unordered_dense::map<std::string, Value>& output_default_values() const;
 
     void set_selected_columns(const std::optional<std::vector<std::string>>& columns);
+
+    void generate_string_coerced_descriptor(const ReadOptions& read_options);
+
+    void generate_filtered_field_descriptors(const std::optional<std::vector<std::string>>& columns);
 
     IndexRange index_range() const {
         if (slice_and_keys_.empty())
@@ -184,7 +177,7 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
     friend void swap(PipelineContext& left, PipelineContext& right) noexcept {
         using std::swap;
 
-        swap(left.desc_, right.desc_);
+        swap(left.on_disk_descriptor_, right.on_disk_descriptor_);
         swap(left.slice_and_keys_, right.slice_and_keys_);
         swap(left.stream_id_, right.stream_id_);
         swap(left.version_id_, right.version_id_);
@@ -200,6 +193,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
         swap(left.filter_columns_set_, right.filter_columns_set_);
         swap(left.compacted_, right.compacted_);
         swap(left.staged_descriptor_, right.staged_descriptor_);
+        swap(left.output_schema_, right.output_schema_);
+        swap(left.string_coerced_descriptor_, right.string_coerced_descriptor_);
     }
 
     using iterator = PipelineContextIterator<PipelineContextRow>;
@@ -256,12 +251,29 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     std::optional<proto::descriptors::UserDefinedMetadata> release_opt_user_defined_metadata();
 
+    const StreamDescriptor& on_disk_descriptor() const;
+    StreamDescriptor& on_disk_descriptor();
+    [[nodiscard]] bool has_on_disk_descriptor() const;
+    void set_on_disk_descriptor(StreamDescriptor&& desc);
+    void set_on_disk_descriptor(const StreamDescriptor& desc);
+    [[nodiscard]] bool are_string_fields_coerced() const;
+    void set_output_schema(OutputSchema&& output_schema);
+
   private:
     // Carries the normalization metadata and user metadata for the pipeline. On indexed reads it is initialised from
     // the existing on-disk version (the compact path additionally relies on its descriptor, total rows and sorted
     // state being those of the existing version); on writes / incompletes / joins it is created solely to carry the
     // working normalization metadata.
     std::optional<TimeseriesDescriptor> tsd_;
+    /// The descriptor of the data on disk.
+    std::optional<StreamDescriptor> on_disk_descriptor_;
+    /// Mutated version of the on_disk_descriptor, where all string columns respect the user defined options in
+    /// ReadOptions::force_strings_to_fixed_ and ReadOptions::force_strings_to_objects_
+    std::optional<StreamDescriptor> string_coerced_descriptor_;
+    /// Holds the schema of the output produced by the processing pipeline. This is what will be returned to the user
+    /// after the pipeline runs. Computed by applying the modify_schema methods of all clauses in order they appear in
+    /// the pipeline.
+    std::optional<OutputSchema> output_schema_;
 };
 
 } // namespace arcticdb::pipelines

--- a/cpp/arcticdb/pipeline/pipeline_context.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_context.hpp
@@ -159,8 +159,8 @@ struct PipelineContext : public std::enable_shared_from_this<PipelineContext> {
 
     const proto::descriptors::NormalizationMetadata& output_normalization() const;
 
-    /// Number of leading required (index) fields in the output, accounting for multi-index/series normalization.
-    /// Returns the count with no normalization applied when the context carries neither an output schema nor a TSD.
+    /// Number of leading required fields in the output, accounting for multi-index/series normalization. Returns the
+    /// count with no normalization applied when the context carries neither an output schema nor a TSD.
     uint32_t output_required_fields_count() const;
 
     const ankerl::unordered_dense::map<std::string, Value>& output_default_values() const;

--- a/cpp/arcticdb/pipeline/pipeline_utils.hpp
+++ b/cpp/arcticdb/pipeline/pipeline_utils.hpp
@@ -133,7 +133,7 @@ inline std::pair<std::shared_ptr<PipelineContext>, std::shared_ptr<std::any>> pr
     pipeline_context->fetch_index_ = std::move(bitset);
     pipeline_context->ensure_vectors();
 
-    generate_filtered_field_descriptors(pipeline_context, {});
+    pipeline_context->generate_filtered_field_descriptors({});
     pipeline_context->begin()->set_string_pool(frame_and_desc.frame_.string_pool_ptr());
     auto descriptor = std::make_shared<StreamDescriptor>(frame_and_desc.frame_.descriptor());
     pipeline_context->begin()->set_descriptor(std::move(descriptor));

--- a/cpp/arcticdb/pipeline/query.hpp
+++ b/cpp/arcticdb/pipeline/query.hpp
@@ -136,7 +136,7 @@ inline FilterQuery<index::IndexSegmentReader> create_dynamic_col_filter(
             // we use raw_hashes for each col
             // A FrameSlice stores (hash_bucket, total_buckets) at the time of writing that slice
             // so a column will exist inside a slice iff col_hash % total_buckets == hash_bucket
-            cols_hashes.insert(bucketize(pipeline->desc_->field(*col).name(), std::nullopt));
+            cols_hashes.insert(bucketize(pipeline->on_disk_descriptor().field(*col).name(), std::nullopt));
             ++col;
         }
 

--- a/cpp/arcticdb/pipeline/read_frame.cpp
+++ b/cpp/arcticdb/pipeline/read_frame.cpp
@@ -83,13 +83,13 @@ std::pair<StreamDescriptor, BlockConfigPerColumn> get_filtered_descriptor_and_bl
         const std::shared_ptr<PipelineContext>& context, const ReadOptions& read_options
 ) {
     return get_filtered_descriptor_and_block_config(
-            context->descriptor().clone(), read_options, context->filter_columns_
+            context->output_descriptor().clone(), read_options, context->filter_columns_
     );
 }
 
 void handle_modified_descriptor(const std::shared_ptr<PipelineContext>& context, SegmentInMemory& output) {
-    if (context->orig_desc_) {
-        for (const auto& field : context->orig_desc_.value().fields()) {
+    if (context->are_string_fields_coerced()) {
+        for (const auto& field : context->on_disk_descriptor().fields()) {
             auto col_index = output.column_index(field.name());
             if (!col_index)
                 continue;
@@ -992,7 +992,8 @@ struct ReduceColumnTask : async::BaseTask {
         const auto column_data = slice_map_->columns_.find(frame_field.name());
         const auto& name = frame_field.name();
         const std::optional<Value> default_value = [&]() -> std::optional<Value> {
-            if (auto it = context_->default_values_.find(std::string(name)); it != context_->default_values_.end()) {
+            const auto& default_values = context_->output_default_values();
+            if (auto it = default_values.find(std::string(name)); it != default_values.end()) {
                 return it->second;
             }
             return {};

--- a/cpp/arcticdb/pipeline/read_pipeline.hpp
+++ b/cpp/arcticdb/pipeline/read_pipeline.hpp
@@ -116,38 +116,13 @@ std::optional<util::BitSet> overall_column_bitset(
         const std::optional<util::BitSet>& requested_columns
 );
 
-inline void generate_filtered_field_descriptors(
-        PipelineContext& context, const std::optional<std::vector<std::string>>& columns
-) {
-    if (columns.has_value()) {
-        const ankerl::unordered_dense::set<std::string_view> column_set{std::begin(*columns), std::end(*columns)};
-
-        context.filter_columns_ = std::make_shared<FieldCollection>();
-        const auto& desc = context.descriptor();
-        ARCTICDB_DEBUG(log::version(), "Context descriptor: {}", desc);
-        for (const auto& field : desc.fields()) {
-            if (column_set.find(field.name()) != column_set.end())
-                context.filter_columns_->add_field(field.type(), field.name());
-        }
-
-        context.filter_columns_set_ = std::unordered_set<std::string_view>{};
-        for (const auto& field : *context.filter_columns_)
-            context.filter_columns_set_->insert(field.name());
-    }
-}
-
-inline void generate_filtered_field_descriptors(
-        std::shared_ptr<PipelineContext>& context, const std::optional<std::vector<std::string>>& columns
-) {
-    generate_filtered_field_descriptors(*context, columns);
-}
-
 inline void get_column_bitset_in_context(
         const ReadQuery& query, const std::shared_ptr<PipelineContext>& pipeline_context
 ) {
     pipeline_context->set_selected_columns(query.columns);
-    pipeline_context->overall_column_bitset_ =
-            overall_column_bitset(pipeline_context->descriptor(), query.clauses_, pipeline_context->selected_columns_);
+    pipeline_context->overall_column_bitset_ = overall_column_bitset(
+            pipeline_context->on_disk_descriptor(), query.clauses_, pipeline_context->selected_columns_
+    );
 }
 
 template<class ContainerType>

--- a/cpp/arcticdb/pipeline/test/test_frame_allocation.cpp
+++ b/cpp/arcticdb/pipeline/test/test_frame_allocation.cpp
@@ -39,7 +39,7 @@ TEST(OutputFrame, AllocateChunked) {
             }
     );
 
-    context->set_descriptor(desc);
+    context->set_on_disk_descriptor(std::move(desc));
     auto read_options = ReadOptions{};
     read_options.set_output_format(OutputFormat::ARROW);
     auto frame = allocate_frame(context, read_options);

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -269,7 +269,7 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
             user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
                     std::holds_alternative<DataType>(left_type), "Unexpected bitset input to {}", operation_type_
             );
-            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res](auto tag) {
+            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, &operation](auto tag) {
                 using type_info = ScalarTypeInfo<decltype(tag)>;
                 if constexpr (is_numeric_type(type_info::data_type)) {
                     if (operation_type_ == OperationType::ABS) {
@@ -286,7 +286,9 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     }
                 } else {
                     user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                            "Unexpected data type {} input to {}", type_info::data_type, operation_type_
+                            "Cannot perform unary operation {} ({})",
+                            unary_operation_to_string(operation_type_, operation.left_->label_),
+                            get_user_friendly_type_string(type_info::TDT::type_descriptor())
                     );
                 }
             });
@@ -335,74 +337,86 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                     "Unexpected value set input to {}",
                     operation_type_
             );
-            details::visit_type(std::get<DataType>(left_type), [operation_type_, &res, right_type](auto left_tag) {
-                using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
-                details::visit_type(std::get<DataType>(right_type), [operation_type_, &res](auto right_tag) {
-                    using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
-                    if constexpr (is_numeric_type(left_type_info::data_type) &&
-                                  is_numeric_type(right_type_info::data_type)) {
-                        switch (operation_type_) {
-                        case OperationType::ADD: {
-                            using TargetType = typename binary_operation_promoted_type<
-                                    typename left_type_info::RawType,
-                                    typename right_type_info::RawType,
-                                    std::remove_reference_t<PlusOperator>>::type;
-                            res = data_type_from_raw_type<TargetType>();
-                            break;
-                        }
-                        case OperationType::SUB: {
-                            using TargetType = typename binary_operation_promoted_type<
-                                    typename left_type_info::RawType,
-                                    typename right_type_info::RawType,
-                                    std::remove_reference_t<MinusOperator>>::type;
-                            res = data_type_from_raw_type<TargetType>();
-                            break;
-                        }
-                        case OperationType::MUL: {
-                            using TargetType = typename binary_operation_promoted_type<
-                                    typename left_type_info::RawType,
-                                    typename right_type_info::RawType,
-                                    std::remove_reference_t<TimesOperator>>::type;
-                            res = data_type_from_raw_type<TargetType>();
-                            break;
-                        }
-                        case OperationType::DIV: {
-                            using TargetType = typename binary_operation_promoted_type<
-                                    typename left_type_info::RawType,
-                                    typename right_type_info::RawType,
-                                    std::remove_reference_t<DivideOperator>>::type;
-                            res = data_type_from_raw_type<TargetType>();
-                            break;
-                        }
-                        case OperationType::POW: {
-                            if constexpr (!is_integer_type(right_type_info::data_type)) {
-                                user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                                        "POW operator does not support floating point exponents, got {}",
-                                        right_type_info::data_type
-                                );
-                            }
+            details::visit_type(
+                    std::get<DataType>(left_type),
+                    [operation_type_, &res, right_type, &operation](auto left_tag) {
+                        using left_type_info = ScalarTypeInfo<decltype(left_tag)>;
+                        details::visit_type(
+                                std::get<DataType>(right_type),
+                                [operation_type_, &res, &operation](auto right_tag) {
+                                    using right_type_info = ScalarTypeInfo<decltype(right_tag)>;
+                                    if constexpr (is_numeric_type(left_type_info::data_type) &&
+                                                  is_numeric_type(right_type_info::data_type)) {
+                                        switch (operation_type_) {
+                                        case OperationType::ADD: {
+                                            using TargetType = typename binary_operation_promoted_type<
+                                                    typename left_type_info::RawType,
+                                                    typename right_type_info::RawType,
+                                                    std::remove_reference_t<PlusOperator>>::type;
+                                            res = data_type_from_raw_type<TargetType>();
+                                            break;
+                                        }
+                                        case OperationType::SUB: {
+                                            using TargetType = typename binary_operation_promoted_type<
+                                                    typename left_type_info::RawType,
+                                                    typename right_type_info::RawType,
+                                                    std::remove_reference_t<MinusOperator>>::type;
+                                            res = data_type_from_raw_type<TargetType>();
+                                            break;
+                                        }
+                                        case OperationType::MUL: {
+                                            using TargetType = typename binary_operation_promoted_type<
+                                                    typename left_type_info::RawType,
+                                                    typename right_type_info::RawType,
+                                                    std::remove_reference_t<TimesOperator>>::type;
+                                            res = data_type_from_raw_type<TargetType>();
+                                            break;
+                                        }
+                                        case OperationType::DIV: {
+                                            using TargetType = typename binary_operation_promoted_type<
+                                                    typename left_type_info::RawType,
+                                                    typename right_type_info::RawType,
+                                                    std::remove_reference_t<DivideOperator>>::type;
+                                            res = data_type_from_raw_type<TargetType>();
+                                            break;
+                                        }
+                                        case OperationType::POW: {
+                                            if constexpr (!is_integer_type(right_type_info::data_type)) {
+                                                user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                                                        "POW operator does not support floating point exponents, got "
+                                                        "{}",
+                                                        right_type_info::data_type
+                                                );
+                                            }
 
-                            using TargetType = typename binary_operation_promoted_type<
-                                    typename left_type_info::RawType,
-                                    typename right_type_info::RawType,
-                                    std::remove_reference_t<PowOperator>>::type;
-                            res = data_type_from_raw_type<TargetType>();
-                            break;
-                        }
+                                            using TargetType = typename binary_operation_promoted_type<
+                                                    typename left_type_info::RawType,
+                                                    typename right_type_info::RawType,
+                                                    std::remove_reference_t<PowOperator>>::type;
+                                            res = data_type_from_raw_type<TargetType>();
+                                            break;
+                                        }
 
-                        default:
-                            internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unexpected binary operator");
-                        }
-                    } else {
-                        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
-                                "Unexpected data types {} {} input to {}",
-                                left_type_info::data_type,
-                                right_type_info::data_type,
-                                operation_type_
+                                        default:
+                                            internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unexpected binary operator"
+                                            );
+                                        }
+                                    } else {
+                                        user_input::raise<ErrorCode::E_INVALID_USER_ARGUMENT>(
+                                                "Non-numeric operand provided to binary operation: {}",
+                                                binary_operation_with_types_to_string(
+                                                        operation.left_->label_,
+                                                        left_type_info::TDT::type_descriptor(),
+                                                        operation_type_,
+                                                        operation.right_->label_,
+                                                        right_type_info::TDT::type_descriptor()
+                                                )
+                                        );
+                                    }
+                                }
                         );
                     }
-                });
-            });
+            );
             break;
         case OperationType::EQ:
         case OperationType::NE:
@@ -433,10 +447,14 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                             (is_sequence_type(std::get<DataType>(left_type)) &&
                              is_sequence_type(std::get<DataType>(right_type)) &&
                              (operation_type_ == OperationType::EQ || operation_type_ == OperationType::NE)),
-                    "Unexpected data types {} {} input to {}",
-                    std::get<DataType>(left_type),
-                    std::get<DataType>(right_type),
-                    operation_type_
+                    "Invalid comparison {}",
+                    binary_operation_with_types_to_string(
+                            operation.left_->label_,
+                            TypeDescriptor{std::get<DataType>(left_type), Dimension::Dim0},
+                            operation_type_,
+                            operation.right_->label_,
+                            TypeDescriptor{std::get<DataType>(right_type), Dimension::Dim0}
+                    )
             );
             break;
         case OperationType::REGEX_MATCH:
@@ -486,10 +504,11 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                          is_sequence_type(std::get<DataType>(right_type))) ||
                                 (is_numeric_type(std::get<DataType>(left_type)) &&
                                  is_numeric_type(std::get<DataType>(right_type))),
-                        "Unexpected data types {} {} input to {}",
-                        std::get<DataType>(left_type),
-                        std::get<DataType>(right_type),
-                        operation_type_
+                        "Cannot check membership '{}' of {} {} in set of {}",
+                        operation_type_,
+                        operation.left_->label_,
+                        get_user_friendly_type_string(std::get<DataType>(left_type)),
+                        get_user_friendly_type_string(std::get<DataType>(right_type))
                 );
             } // else - Empty value set compatible with all data types
             break;

--- a/cpp/arcticdb/processing/expression_node.cpp
+++ b/cpp/arcticdb/processing/expression_node.cpp
@@ -504,7 +504,7 @@ std::variant<BitSetTag, DataType> ExpressionNode::compute(
                          is_sequence_type(std::get<DataType>(right_type))) ||
                                 (is_numeric_type(std::get<DataType>(left_type)) &&
                                  is_numeric_type(std::get<DataType>(right_type))),
-                        "Cannot check membership '{}' of {} {} in set of {}",
+                        "Cannot check membership '{}' of {} ({}) in set of {}",
                         operation_type_,
                         operation.left_->label_,
                         get_user_friendly_type_string(std::get<DataType>(left_type)),

--- a/cpp/arcticdb/processing/operation_dispatch_binary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.cpp
@@ -172,4 +172,28 @@ VariantData dispatch_binary(const VariantData& left, const VariantData& right, O
     }
 }
 
+std::string binary_operation_with_types_to_string(
+        std::string_view left, const TypeDescriptor& type_left, OperationType func, std::string_view right,
+        const TypeDescriptor& type_right, bool arguments_reversed
+) {
+    if (arguments_reversed) {
+        return fmt::format(
+                "{} ({}) {} {} ({})",
+                right,
+                get_user_friendly_type_string(type_right),
+                func,
+                left,
+                get_user_friendly_type_string(type_left)
+        );
+    }
+    return fmt::format(
+            "{} ({}) {} {} ({})",
+            left,
+            get_user_friendly_type_string(type_left),
+            func,
+            right,
+            get_user_friendly_type_string(type_right)
+    );
+}
+
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.cpp
@@ -172,28 +172,4 @@ VariantData dispatch_binary(const VariantData& left, const VariantData& right, O
     }
 }
 
-std::string binary_operation_with_types_to_string(
-        std::string_view left, const TypeDescriptor& type_left, OperationType func, std::string_view right,
-        const TypeDescriptor& type_right, bool arguments_reversed
-) {
-    if (arguments_reversed) {
-        return fmt::format(
-                "{} ({}) {} {} ({})",
-                right,
-                get_user_friendly_type_string(type_right),
-                func,
-                left,
-                get_user_friendly_type_string(type_left)
-        );
-    }
-    return fmt::format(
-            "{} ({}) {} {} ({})",
-            left,
-            get_user_friendly_type_string(type_left),
-            func,
-            right,
-            get_user_friendly_type_string(type_right)
-    );
-}
-
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -50,7 +50,7 @@ inline std::string binary_operation_column_name(
 }
 
 template<typename Func>
-inline std::string binary_operation_with_types_to_string(
+std::string binary_operation_with_types_to_string(
         std::string_view left, const TypeDescriptor& type_left, Func&& func, std::string_view right,
         const TypeDescriptor& type_right, bool arguments_reversed = false
 ) {
@@ -73,6 +73,11 @@ inline std::string binary_operation_with_types_to_string(
             get_user_friendly_type_string(type_right)
     );
 }
+
+std::string binary_operation_with_types_to_string(
+        std::string_view left, const TypeDescriptor& type_left, OperationType func, std::string_view right,
+        const TypeDescriptor& type_right, bool arguments_reversed = false
+);
 
 template<typename Func>
 VariantData binary_membership(const ColumnWithStrings& column_with_strings, ValueSet& value_set, Func&& func) {

--- a/cpp/arcticdb/processing/operation_dispatch_binary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_binary.hpp
@@ -74,11 +74,6 @@ std::string binary_operation_with_types_to_string(
     );
 }
 
-std::string binary_operation_with_types_to_string(
-        std::string_view left, const TypeDescriptor& type_left, OperationType func, std::string_view right,
-        const TypeDescriptor& type_right, bool arguments_reversed = false
-);
-
 template<typename Func>
 VariantData binary_membership(const ColumnWithStrings& column_with_strings, ValueSet& value_set, Func&& func) {
     if (is_empty_type(column_with_strings.column_->type().data_type())) {

--- a/cpp/arcticdb/processing/operation_dispatch_unary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.cpp
@@ -82,8 +82,4 @@ VariantData dispatch_unary(const VariantData& left, OperationType operation) {
     }
 }
 
-std::string unary_operation_to_string(OperationType func, std::string_view operand_str) {
-    return fmt::format("{}({})", func, operand_str);
-}
-
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_unary.cpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.cpp
@@ -82,4 +82,8 @@ VariantData dispatch_unary(const VariantData& left, OperationType operation) {
     }
 }
 
+std::string unary_operation_to_string(OperationType func, std::string_view operand_str) {
+    return fmt::format("{}({})", func, operand_str);
+}
+
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -35,8 +35,6 @@ std::string unary_operation_to_string(Func&& func, std::string_view operand_str)
     return fmt::format("{}({})", func, operand_str);
 }
 
-std::string unary_operation_to_string(OperationType func, std::string_view operand_str);
-
 template<typename Func>
 VariantData unary_operator(const Value& val, Func&& func) {
     auto output = std::make_unique<Value>();

--- a/cpp/arcticdb/processing/operation_dispatch_unary.hpp
+++ b/cpp/arcticdb/processing/operation_dispatch_unary.hpp
@@ -31,9 +31,11 @@ VariantData unary_boolean(FullResult, OperationType operation);
 VariantData visit_unary_boolean(const VariantData& left, OperationType operation);
 
 template<typename Func>
-inline std::string unary_operation_to_string(Func&& func, std::string_view operand_str) {
+std::string unary_operation_to_string(Func&& func, std::string_view operand_str) {
     return fmt::format("{}({})", func, operand_str);
 }
+
+std::string unary_operation_to_string(OperationType func, std::string_view operand_str);
 
 template<typename Func>
 VariantData unary_operator(const Value& val, Func&& func) {

--- a/cpp/arcticdb/stream/test/test_incompletes.cpp
+++ b/cpp/arcticdb/stream/test/test_incompletes.cpp
@@ -36,7 +36,7 @@ TEST(Append, Simple) {
     async::TaskScheduler scheduler{5};
 
     pipeline_context->slice_and_keys_ = arcticdb::get_incomplete(store, stream_id, range, 0, false, false);
-    generate_filtered_field_descriptors(pipeline_context, {});
+    pipeline_context->generate_filtered_field_descriptors({});
 
     auto read_options = ReadOptions{};
     read_options.set_output_format(OutputFormat::NATIVE);

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1511,8 +1511,7 @@ std::shared_ptr<PipelineContext> setup_join_pipeline_context(
 ) {
     auto output_schema = modify_schema(clauses.front()->join_schemas(std::move(input_schemas)), clauses);
     auto pipeline_context = std::make_shared<PipelineContext>();
-    pipeline_context->set_on_disk_descriptor(output_schema.stream_descriptor());
-    pipeline_context->set_normalization(std::move(output_schema.norm_metadata_));
+    pipeline_context->set_output_schema(std::move(output_schema));
     return pipeline_context;
 }
 

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1511,7 +1511,7 @@ std::shared_ptr<PipelineContext> setup_join_pipeline_context(
 ) {
     auto output_schema = modify_schema(clauses.front()->join_schemas(std::move(input_schemas)), clauses);
     auto pipeline_context = std::make_shared<PipelineContext>();
-    pipeline_context->set_descriptor(output_schema.stream_descriptor());
+    pipeline_context->set_on_disk_descriptor(output_schema.stream_descriptor());
     pipeline_context->set_normalization(std::move(output_schema.norm_metadata_));
     return pipeline_context;
 }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -1222,7 +1222,7 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
 
     auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
     SegmentReader reader = [base_reader = std::move(base_reader),
-                            pipeline_desc = pipeline_context->descriptor(),
+                            pipeline_desc = pipeline_context->on_disk_descriptor(),
                             processing_config](pipelines::RangesAndKey&& rk) {
         const bool is_incomplete = rk.is_incomplete();
         return base_reader(std::move(rk))

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -57,35 +57,6 @@ namespace arcticdb::version_store {
 
 namespace ranges = std::ranges;
 
-static void modify_descriptor(
-        const std::shared_ptr<pipelines::PipelineContext>& pipeline_context, const ReadOptions& read_options
-) {
-
-    if (opt_false(read_options.force_strings_to_object()) || opt_false(read_options.force_strings_to_fixed()))
-        pipeline_context->orig_desc_ = pipeline_context->desc_;
-
-    auto& desc = *pipeline_context->desc_;
-    if (opt_false(read_options.force_strings_to_object())) {
-        auto& fields = desc.fields();
-        for (Field& field_desc : fields) {
-            if (field_desc.type().data_type() == DataType::ASCII_FIXED64)
-                set_data_type(DataType::ASCII_DYNAMIC64, field_desc.mutable_type());
-
-            if (field_desc.type().data_type() == DataType::UTF_FIXED64)
-                set_data_type(DataType::UTF_DYNAMIC64, field_desc.mutable_type());
-        }
-    } else if (opt_false(read_options.force_strings_to_fixed())) {
-        auto& fields = desc.fields();
-        for (Field& field_desc : fields) {
-            if (field_desc.type().data_type() == DataType::ASCII_DYNAMIC64)
-                set_data_type(DataType::ASCII_FIXED64, field_desc.mutable_type());
-
-            if (field_desc.type().data_type() == DataType::UTF_DYNAMIC64)
-                set_data_type(DataType::UTF_FIXED64, field_desc.mutable_type());
-        }
-    }
-}
-
 std::tuple<IndexPartialKey, SlicingPolicy> get_partial_key_and_slicing_policy(
         const std::shared_ptr<Store>& store, const WriteOptions& options, const InputFrame& frame, VersionId version_id,
         bool validate_index
@@ -1123,106 +1094,6 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
     });
 }
 
-void set_output_descriptors(
-        const ProcessingUnit& proc, const std::vector<std::shared_ptr<Clause>>& clauses,
-        const std::shared_ptr<PipelineContext>& pipeline_context
-) {
-    std::optional<std::string> index_column;
-    for (auto clause = clauses.rbegin(); clause != clauses.rend(); ++clause) {
-        bool should_break = util::variant_match(
-                (*clause)->clause_info().index_,
-                [](const KeepCurrentIndex&) { return false; },
-                [&](const KeepCurrentTopLevelIndex&) {
-                    if (pipeline_context->normalization().df().common().has_multi_index()) {
-                        const auto& multi_index = pipeline_context->normalization().df().common().multi_index();
-                        auto name = multi_index.name();
-                        auto tz = multi_index.tz();
-                        bool fake_name{false};
-                        for (auto pos : multi_index.fake_field_pos()) {
-                            if (pos == 0) {
-                                fake_name = true;
-                                break;
-                            }
-                        }
-                        auto mutable_index =
-                                pipeline_context->mutable_normalization().mutable_df()->mutable_common()->mutable_index(
-                                );
-                        mutable_index->set_tz(tz);
-                        mutable_index->set_is_physically_stored(true);
-                        mutable_index->set_name(name);
-                        mutable_index->set_fake_name(fake_name);
-                    }
-                    return true;
-                },
-                [&](const NewIndex& new_index) {
-                    index_column = new_index;
-                    auto mutable_index =
-                            pipeline_context->mutable_normalization().mutable_df()->mutable_common()->mutable_index();
-                    mutable_index->set_name(new_index);
-                    mutable_index->clear_fake_name();
-                    mutable_index->set_is_physically_stored(true);
-                    return true;
-                }
-        );
-        if (should_break) {
-            break;
-        }
-    }
-    std::optional<StreamDescriptor> new_stream_descriptor;
-    if (proc.segments_.has_value() && !proc.segments_->empty()) {
-        new_stream_descriptor = std::make_optional<StreamDescriptor>();
-        new_stream_descriptor->set_index(proc.segments_->at(0)->descriptor().index());
-        for (size_t idx = 0; idx < new_stream_descriptor->index().field_count(); idx++) {
-            new_stream_descriptor->add_field(proc.segments_->at(0)->descriptor().field(idx));
-        }
-    }
-    if (new_stream_descriptor.has_value() && proc.segments_.has_value()) {
-        std::vector<std::shared_ptr<FieldCollection>> fields;
-        for (const auto& segment : *proc.segments_) {
-            fields.push_back(segment->descriptor().fields_ptr());
-        }
-        new_stream_descriptor = merge_descriptors(*new_stream_descriptor, fields, std::vector<std::string>{});
-    }
-    if (new_stream_descriptor.has_value()) {
-        // Finding and erasing fields from the FieldCollection contained in StreamDescriptor is O(n) in number of fields
-        // So maintain map from field names to types in the new_stream_descriptor to make these operations O(1)
-        // Cannot use set of FieldRef as the name in the output might match the input, but with a different type after
-        // processing
-        std::unordered_map<std::string_view, TypeDescriptor> new_fields;
-        for (const auto& field : new_stream_descriptor->fields()) {
-            new_fields.emplace(field.name(), field.type());
-        }
-        // Columns might be in a different order to the original dataframe, so reorder here
-        auto original_stream_descriptor = pipeline_context->descriptor();
-        StreamDescriptor final_stream_descriptor{original_stream_descriptor.id()};
-        final_stream_descriptor.set_index(new_stream_descriptor->index());
-        // Erase field from new_fields as we add them to final_stream_descriptor, as all fields left in new_fields
-        // after these operations were created by the processing pipeline, and so should be appended
-        // Index columns should always appear first
-        if (index_column.has_value()) {
-            const auto nh = new_fields.extract(*index_column);
-            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                    !nh.empty(), "New index column not found in processing pipeline"
-            );
-            final_stream_descriptor.add_field(FieldRef{nh.mapped(), nh.key()});
-        }
-        for (const auto& field : original_stream_descriptor.fields()) {
-            if (const auto nh = new_fields.extract(field.name()); nh) {
-                final_stream_descriptor.add_field(FieldRef{nh.mapped(), nh.key()});
-            }
-        }
-        // Iterate through new_stream_descriptor->fields() rather than remaining new_fields to preserve ordering
-        // e.g. if there were two projections then users will expect the column produced by the first one to appear
-        // first in the output df
-        for (const auto& field : new_stream_descriptor->fields()) {
-            if (new_fields.contains(field.name())) {
-                final_stream_descriptor.add_field(field);
-            }
-        }
-        pipeline_context->set_descriptor(final_stream_descriptor);
-    }
-}
-
 std::shared_ptr<std::unordered_set<std::string>> columns_to_decode(
         const std::shared_ptr<PipelineContext>& pipeline_context
 ) {
@@ -1237,8 +1108,8 @@ std::shared_ptr<std::unordered_set<std::string>> columns_to_decode(
         auto en = pipeline_context->overall_column_bitset_->first();
         auto en_end = pipeline_context->overall_column_bitset_->end();
         while (en < en_end) {
-            ARCTICDB_DEBUG(log::version(), "Adding field {}", pipeline_context->desc_->field(*en).name());
-            res->insert(std::string(pipeline_context->desc_->field(*en++).name()));
+            ARCTICDB_DEBUG(log::version(), "Adding field {}", pipeline_context->on_disk_descriptor().field(*en).name());
+            res->insert(std::string(pipeline_context->on_disk_descriptor().field(*en++).name()));
         }
     }
     return res;
@@ -1262,7 +1133,7 @@ std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_con
 }
 
 static StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
-    const StreamDescriptor& desc = pipeline_context.descriptor();
+    const StreamDescriptor& desc = pipeline_context.output_descriptor();
     // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
     // it to constrain the initial set of columns. If dynamic schema is used and only certain columns must be read we
     // use the whole descriptor and at the end of the read return only the ones that were selected. This is because
@@ -1318,16 +1189,6 @@ static OutputSchema generate_output_schema(PipelineContext& pipeline_context, co
     return output_schema;
 }
 
-static void generate_output_schema_and_save_to_pipeline(
-        PipelineContext& pipeline_context, const ReadQuery& read_query
-) {
-    OutputSchema schema = generate_output_schema(pipeline_context, read_query);
-    auto&& [descriptor, norm_meta, default_values] = schema.release();
-    pipeline_context.set_descriptor(std::forward<StreamDescriptor>(descriptor));
-    pipeline_context.set_normalization(std::forward<proto::descriptors::NormalizationMetadata>(norm_meta));
-    pipeline_context.default_values_ = std::forward<decltype(default_values)>(default_values);
-}
-
 folly::Future<std::vector<EntityId>> read_and_schedule_processing(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
         const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
@@ -1336,7 +1197,7 @@ folly::Future<std::vector<EntityId>> read_and_schedule_processing(
     const ProcessingConfig processing_config{
             opt_false(read_options.dynamic_schema()),
             pipeline_context->rows_,
-            pipeline_context->descriptor().index().type()
+            pipeline_context->on_disk_descriptor().index().type()
     };
     for (auto& clause : read_query->clauses_) {
         clause->set_processing_config(processing_config);
@@ -1406,9 +1267,9 @@ folly::Future<std::vector<SliceAndKey>> read_process_and_collect(
         const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options
 ) {
     auto component_manager = std::make_shared<ComponentManager>();
+    pipeline_context->set_output_schema(generate_output_schema(*pipeline_context, *read_query));
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
             .thenValue([component_manager, pipeline_context, read_query](std::vector<EntityId>&& processed_entity_ids) {
-                generate_output_schema_and_save_to_pipeline(*pipeline_context, *read_query);
                 auto proc = gather_entities<
                         std::shared_ptr<SegmentInMemory>,
                         std::shared_ptr<RowRange>,
@@ -1491,13 +1352,13 @@ void check_can_perform_processing(
     }
 
     // To keep
-    if (pipeline_context->desc_) {
+    if (pipeline_context->has_on_disk_descriptor()) {
         util::check(
-                pipeline_context->descriptor().index().type() == IndexDescriptor::Type::TIMESTAMP ||
+                pipeline_context->on_disk_descriptor().index().type() == IndexDescriptor::Type::TIMESTAMP ||
                         !std::holds_alternative<IndexRange>(read_query.row_filter),
                 "Cannot apply date range filter to symbol with non-timestamp index"
         );
-        const auto sorted_value = pipeline_context->descriptor().sorted();
+        const auto sorted_value = pipeline_context->on_disk_descriptor().sorted();
         sorting::check<ErrorCode::E_UNSORTED_DATA>(
                 sorted_value == SortedValue::UNKNOWN || sorted_value == SortedValue::ASCENDING ||
                         !std::holds_alternative<IndexRange>(read_query.row_filter),
@@ -1545,7 +1406,7 @@ static void read_indexed_keys_to_pipeline(
     const auto& tsd = index_segment_reader.tsd();
     read_query.convert_to_positive_row_filter(static_cast<int64_t>(tsd.total_rows()));
     const bool bucketize_dynamic = index_segment_reader.bucketize_dynamic();
-    pipeline_context->desc_ = tsd.as_stream_descriptor();
+    pipeline_context->set_on_disk_descriptor(tsd.as_stream_descriptor());
 
     const bool dynamic_schema = opt_false(read_options.dynamic_schema());
     auto queries = get_column_bitset_and_query_functions<index::IndexSegmentReader>(
@@ -1650,7 +1511,7 @@ static std::variant<bool, CompactionError> read_incompletes_to_pipeline(
         // - in case of static schema: populate the descriptor and column_bitset
         add_index_columns_to_query(read_query, seg.index_descriptor());
         if (!flags.dynamic_schema) {
-            pipeline_context->desc_ = seg.descriptor();
+            pipeline_context->set_on_disk_descriptor(seg.descriptor());
             get_column_bitset_in_context(read_query, pipeline_context);
         }
     }
@@ -1667,13 +1528,13 @@ static std::variant<bool, CompactionError> read_incompletes_to_pipeline(
 
     // We need to check that the index names match regardless of the dynamic schema setting
     // A more detailed check is done later in the do_compact function
-    if (pipeline_context->desc_) {
+    if (pipeline_context->has_on_disk_descriptor()) {
         schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                index_names_match(staged_desc, *pipeline_context->desc_),
+                index_names_match(staged_desc, pipeline_context->on_disk_descriptor()),
                 "The index names in the staged stream descriptor {} are not identical to that of the stream descriptor "
                 "on storage {}",
                 staged_desc,
-                *pipeline_context->desc_
+                pipeline_context->on_disk_descriptor()
         );
     }
 
@@ -1682,12 +1543,13 @@ static std::variant<bool, CompactionError> read_incompletes_to_pipeline(
         pipeline_context->staged_descriptor_ = merge_descriptors(
                 seg.descriptor(), incomplete_segments, read_query.columns, std::nullopt, flags.convert_int_to_float
         );
-        if (pipeline_context->desc_) {
+        if (pipeline_context->has_on_disk_descriptor()) {
             const std::array staged_fields_ptr = {pipeline_context->staged_descriptor_->fields_ptr()};
-            pipeline_context->desc_ =
-                    merge_descriptors(*pipeline_context->desc_, staged_fields_ptr, read_query.columns);
+            pipeline_context->set_on_disk_descriptor(
+                    merge_descriptors(pipeline_context->on_disk_descriptor(), staged_fields_ptr, read_query.columns)
+            );
         } else {
-            pipeline_context->desc_ = pipeline_context->staged_descriptor_;
+            pipeline_context->set_on_disk_descriptor(*pipeline_context->staged_descriptor_);
         }
     } else {
         ARCTICDB_DEBUG(log::version(), "read_incompletes_to_pipeline: Static schema");
@@ -1701,25 +1563,25 @@ static std::variant<bool, CompactionError> read_incompletes_to_pipeline(
                 first_incomplete_seg.descriptor().uncompressed_bytes(),
                 first_incomplete_seg.index_descriptor()
         );
-        if (pipeline_context->desc_) {
+        if (pipeline_context->has_on_disk_descriptor()) {
             schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-                    columns_match(*pipeline_context->desc_, staged_desc, flags.convert_int_to_float),
+                    columns_match(pipeline_context->on_disk_descriptor(), staged_desc, flags.convert_int_to_float),
                     "When static schema is used the staged stream descriptor {} must equal the stream descriptor on "
                     "storage {}",
                     staged_desc,
-                    *pipeline_context->desc_
+                    pipeline_context->on_disk_descriptor()
             );
         }
         pipeline_context->staged_descriptor_ = staged_desc;
-        pipeline_context->desc_ = staged_desc;
+        pipeline_context->set_on_disk_descriptor(staged_desc);
     }
 
-    modify_descriptor(pipeline_context, read_options);
+    pipeline_context->generate_string_coerced_descriptor(read_options);
     if (flags.convert_int_to_float) {
-        stream::convert_descriptor_types(*pipeline_context->staged_descriptor_);
+        convert_descriptor_types(*pipeline_context->staged_descriptor_);
     }
 
-    generate_filtered_field_descriptors(pipeline_context, read_query.columns);
+    pipeline_context->generate_filtered_field_descriptors(read_query.columns);
     pipeline_context->total_rows_ = pipeline_context->calc_rows();
     return true;
 }
@@ -1736,7 +1598,7 @@ static void check_incompletes_index_ranges_dont_overlap(
       - that the earliest timestamp in an incomplete segment is greater than the latest timestamp existing in the
         symbol in the case of a parallel append
      */
-    if (pipeline_context->descriptor().index().type() == IndexDescriptorImpl::Type::TIMESTAMP) {
+    if (pipeline_context->on_disk_descriptor().index().type() == IndexDescriptorImpl::Type::TIMESTAMP) {
         std::optional<timestamp> last_existing_index_value;
         if (append_to_existing) {
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -2046,8 +1908,9 @@ struct CopyToBufferTask : async::BaseTask {
                     continue;
                 }
                 const std::optional<Value>& default_value = [&]() -> std::optional<Value> {
-                    const auto it = pipeline_context_->default_values_.find(std::string{field_name});
-                    if (it != pipeline_context_->default_values_.end()) {
+                    const auto& default_values = pipeline_context_->output_default_values();
+                    const auto it = default_values.find(std::string{field_name});
+                    if (it != default_values.end()) {
                         return it->second;
                     }
                     return {};
@@ -2073,8 +1936,9 @@ folly::Future<folly::Unit> copy_segments_to_frame(
         const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
         SegmentInMemory frame, std::shared_ptr<std::any> handler_data, const ReadOptions& read_options
 ) {
-    const auto required_fields_count =
-            pipelines::index::required_fields_count(pipeline_context->descriptor(), pipeline_context->normalization());
+    const auto required_fields_count = pipelines::index::required_fields_count(
+            pipeline_context->output_descriptor(), pipeline_context->output_normalization()
+    );
     std::vector<folly::Future<folly::Unit>> copy_tasks;
     DecodePathData shared_data;
     for (auto context_row : folly::enumerate(*pipeline_context)) {
@@ -2389,14 +2253,14 @@ VersionedItem collate_and_write(
     util::check(keys.size() == slices.size(), "Mismatch between slices size and key size");
     TimeseriesDescriptor tsd;
 
-    tsd.set_stream_descriptor(pipeline_context->descriptor());
+    tsd.set_stream_descriptor(pipeline_context->on_disk_descriptor());
     tsd.set_total_rows(pipeline_context->total_rows_);
     auto& tsd_proto = tsd.mutable_proto();
     tsd_proto.mutable_normalization()->CopyFrom(pipeline_context->normalization());
     if (user_meta)
         tsd_proto.mutable_user_meta()->CopyFrom(*user_meta);
 
-    auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
+    auto index = stream::index_type_from_descriptor(pipeline_context->on_disk_descriptor());
     return util::variant_match(index, [&store, &pipeline_context, &slices, &keys, &append_after, &tsd](auto idx) {
         using IndexType = decltype(idx);
         index::IndexWriter<IndexType> writer(
@@ -2534,9 +2398,9 @@ static SortedValue compute_sorted_status(const std::optional<SortedValue>& initi
 
 std::variant<VersionedItem, CompactionError> sort_merge_impl(
         const std::shared_ptr<Store>& store, const StreamId& stream_id,
-        const std::optional<arcticdb::proto::descriptors::UserDefinedMetadata>& user_meta,
-        const UpdateInfo& update_info, const CompactIncompleteParameters& compaction_parameters,
-        const WriteOptions& write_options, std::shared_ptr<PipelineContext>& pipeline_context
+        const std::optional<proto::descriptors::UserDefinedMetadata>& user_meta, const UpdateInfo& update_info,
+        const CompactIncompleteParameters& compaction_parameters, const WriteOptions& write_options,
+        std::shared_ptr<PipelineContext>& pipeline_context
 ) {
     auto read_query = ReadQuery{};
 
@@ -2548,7 +2412,7 @@ std::variant<VersionedItem, CompactionError> sort_merge_impl(
     const bool append_to_existing = compaction_parameters.append_ && update_info.previous_index_key_.has_value();
     // Cache this before calling read_incompletes_to_pipeline as it changes the descripor
     const std::optional<SortedValue> initial_index_sorted_status =
-            append_to_existing ? std::optional{pipeline_context->desc_->sorted()} : std::nullopt;
+            append_to_existing ? std::optional{pipeline_context->on_disk_descriptor().sorted()} : std::nullopt;
     const ReadIncompletesFlags read_incomplete_flags{
             .convert_int_to_float = compaction_parameters.convert_int_to_float_,
             .via_iteration = compaction_parameters.via_iteration_,
@@ -2579,7 +2443,7 @@ std::variant<VersionedItem, CompactionError> sort_merge_impl(
     std::vector<FrameSlice> slices;
     std::vector<folly::Future<VariantKey>> fut_vec;
     auto semaphore = std::make_shared<folly::NativeSemaphore>(n_segments_live_during_compaction());
-    auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
+    auto index = stream::index_type_from_descriptor(pipeline_context->on_disk_descriptor());
     util::variant_match(
             index,
             [&](const stream::TimeseriesIndex& timeseries_index) {
@@ -2592,7 +2456,7 @@ std::variant<VersionedItem, CompactionError> sort_merge_impl(
                         timeseries_index,
                         SparseColumnPolicy{},
                         stream_id,
-                        pipeline_context->descriptor(),
+                        pipeline_context->on_disk_descriptor(),
                         write_options.dynamic_schema
                 }));
                 ReadOptions read_options;
@@ -2618,7 +2482,7 @@ std::variant<VersionedItem, CompactionError> sort_merge_impl(
                 }
                 pipeline_context->total_rows_ = num_versioned_rows + get_slice_rowcounts(segments);
 
-                auto index = index_type_from_descriptor(pipeline_context->descriptor());
+                auto index = index_type_from_descriptor(pipeline_context->on_disk_descriptor());
                 stream::SegmentAggregator<TimeseriesIndex, DynamicSchema, RowCountSegmentPolicy, SparseColumnPolicy>
                         aggregator{
                                 [&slices](FrameSlice&& slice) { slices.emplace_back(std::move(slice)); },
@@ -2663,7 +2527,7 @@ std::variant<VersionedItem, CompactionError> sort_merge_impl(
                     aggregator.add_segment(std::move(segment), sk.slice(), compaction_parameters.convert_int_to_float_);
                 }
                 aggregator.commit();
-                pipeline_context->desc_->set_sorted(compute_sorted_status(initial_index_sorted_status));
+                pipeline_context->on_disk_descriptor().set_sorted(compute_sorted_status(initial_index_sorted_status));
             },
             [&](const auto&) {
                 util::raise_rte(
@@ -2696,7 +2560,7 @@ std::variant<VersionedItem, CompactionError> compact_incomplete_impl(
     const bool append_to_existing = compaction_parameters.append_ && update_info.previous_index_key_.has_value();
     // Cache this before calling read_incompletes_to_pipeline as it changes the descriptor.
     const std::optional<SortedValue> initial_index_sorted_status =
-            append_to_existing ? std::optional{pipeline_context->desc_->sorted()} : std::nullopt;
+            append_to_existing ? std::optional{pipeline_context->on_disk_descriptor().sorted()} : std::nullopt;
     const ReadIncompletesFlags read_incomplete_flags{
             .convert_int_to_float = compaction_parameters.convert_int_to_float_,
             .via_iteration = compaction_parameters.via_iteration_,
@@ -2762,7 +2626,8 @@ std::variant<VersionedItem, CompactionError> compact_incomplete_impl(
                                 compaction_options
                         );
                 if constexpr (std::is_same_v<IndexType, TimeseriesIndex>) {
-                    pipeline_context->desc_->set_sorted(compute_sorted_status(initial_index_sorted_status));
+                    pipeline_context->on_disk_descriptor().set_sorted(compute_sorted_status(initial_index_sorted_status)
+                    );
                 }
                 return compaction_result;
             });
@@ -2817,7 +2682,7 @@ PredefragmentationInfo get_pre_defragmentation_info(
             compaction_start_info = {slice.row_range.start(), segment_idx};
 
         if (slice.col_range.start() ==
-            pipeline_context->descriptor().index().field_count()) { // where data column starts
+            pipeline_context->on_disk_descriptor().index().field_count()) { // where data column starts
             first_col_segment_idx.emplace_back(slice.row_range.start(), segment_idx);
             if (new_segment_row_size == 0)
                 ++num_to_segments_after_compact;
@@ -2868,7 +2733,7 @@ VersionedItem defragment_symbol_data_impl(
 
     // in the new index segment, we will start appending after this value
     std::vector<FrameSlice> slices;
-    const auto index = index_type_from_descriptor(pre_defragmentation_info.pipeline_context->descriptor());
+    const auto index = index_type_from_descriptor(pre_defragmentation_info.pipeline_context->on_disk_descriptor());
     auto policies = std::make_tuple(
             index,
             options.dynamic_schema ? VariantSchema{DynamicSchema::default_schema(index, stream_id)}
@@ -2983,7 +2848,7 @@ void set_row_id_if_index_only(
         const PipelineContext& pipeline_context, SegmentInMemory& frame, const ReadQuery& read_query
 ) {
     if (read_query.columns && read_query.columns->empty() &&
-        pipeline_context.descriptor().index().type() == IndexDescriptor::Type::ROWCOUNT) {
+        pipeline_context.output_descriptor().index().type() == IndexDescriptor::Type::ROWCOUNT) {
         frame.set_row_id(static_cast<ssize_t>(pipeline_context.rows_ - 1));
     }
 }
@@ -3036,8 +2901,8 @@ std::shared_ptr<PipelineContext> setup_pipeline_context(
         );
     }
 
-    modify_descriptor(pipeline_context, read_options);
-    generate_filtered_field_descriptors(pipeline_context, read_query.columns);
+    pipeline_context->generate_string_coerced_descriptor(read_options);
+    pipeline_context->generate_filtered_field_descriptors(read_query.columns);
     return pipeline_context;
 }
 
@@ -3144,12 +3009,12 @@ folly::Future<std::vector<SliceAndKey>> read_modify_write_data_keys(
     read_query->clauses_.push_back(std::make_shared<Clause>(
             WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
     ));
+    pipeline_context->set_output_schema(generate_output_schema(*pipeline_context, *read_query));
 
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
             .thenValue([component_manager = std::move(component_manager),
                         pipeline_context,
                         read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
-                generate_output_schema_and_save_to_pipeline(*pipeline_context, *read_query);
                 std::vector<folly::Future<SliceAndKey>> write_segments_futures;
                 ranges::transform(
                         std::get<0>(component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(
@@ -3193,14 +3058,14 @@ folly::Future<VersionedItem> read_modify_write_impl(
                                                            data_keys_and_slices.front().slice().row_range.first;
                 const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                         row_count,
-                        pipeline_context->descriptor(),
-                        pipeline_context->normalization(),
+                        pipeline_context->output_descriptor(),
+                        pipeline_context->output_normalization(),
                         std::move(user_meta_proto),
                         std::nullopt,
                         write_options.bucketize_dynamic
                 );
                 return index::write_index(
-                        index_type_from_descriptor(pipeline_context->descriptor()),
+                        index_type_from_descriptor(pipeline_context->output_descriptor()),
                         tsd,
                         std::move(data_keys_and_slices),
                         target_partial_index_key,
@@ -3216,7 +3081,6 @@ folly::Future<AtomKey> merge_update_impl(
         std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto read_query = std::make_shared<ReadQuery>();
-    const StreamDescriptor& source_descriptor = source->desc();
     auto merge_update_clause = std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source));
     read_query->clauses_.push_back(merge_update_clause);
     VersionIdentifier resolved = VersionedItem{*update_info.previous_index_key_};
@@ -3234,14 +3098,14 @@ folly::Future<AtomKey> merge_update_impl(
         } else if (strategy.update_only()) {
             const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                     0,
-                    pipeline_context->descriptor(),
-                    pipeline_context->release_normalization(),
+                    pipeline_context->output_descriptor(),
+                    pipeline_context->output_normalization(),
                     std::move(source->user_meta),
                     std::nullopt,
                     write_options.bucketize_dynamic
             );
             return index::write_index(
-                    index_type_from_descriptor(pipeline_context->descriptor()),
+                    index_type_from_descriptor(pipeline_context->output_descriptor()),
                     tsd,
                     std::vector<SliceAndKey>{},
                     target_partial_index_key,
@@ -3249,22 +3113,15 @@ folly::Future<AtomKey> merge_update_impl(
             );
         }
     }
-    // TODO: Rely on modify_schema for this https://man312219.monday.com/boards/7852509418/pulses/10997979275
-    schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
-            columns_match(pipeline_context->descriptor(), source_descriptor),
-            "Cannot perform merge update when the source and target schema are not the same.\nSource schema: "
-            "{}\nTarget schema: {}",
-            source_descriptor,
-            pipeline_context->descriptor()
-    );
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             !write_options.dynamic_schema, "Cannot merge update with dynamic schema"
     );
-    const IndexDescriptor::Type index_type = pipeline_context->descriptor().index().type();
+    const IndexDescriptor::Type index_type = pipeline_context->on_disk_descriptor().index().type();
+
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
             (index_type == IndexDescriptor::Type::TIMESTAMP &&
-             (pipeline_context->descriptor().sorted() == SortedValue::ASCENDING ||
-              pipeline_context->descriptor().sorted() == SortedValue::UNKNOWN)) ||
+             (pipeline_context->on_disk_descriptor().sorted() == SortedValue::ASCENDING ||
+              pipeline_context->on_disk_descriptor().sorted() == SortedValue::UNKNOWN)) ||
                     index_type == IndexDescriptor::Type::ROWCOUNT,
             "Merge update supports only ascending indexed data and row count indexed data"
     );
@@ -3287,7 +3144,7 @@ folly::Future<AtomKey> merge_update_impl(
                         source = std::move(source),
                         target_partial_index_key,
                         strategy](std::vector<SliceAndKey>&& data_keys_and_slices) {
-                const StreamDescriptor& target_descriptor = pipeline_context->descriptor();
+                const StreamDescriptor& target_descriptor = pipeline_context->output_descriptor();
                 folly::SemiFuture<std::vector<SliceAndKey>> inserted_row_slices_fut =
                         (target_descriptor.index().type() == IndexDescriptor::Type::ROWCOUNT && strategy.insert())
                                 ? write_inserted_row_range_data(
@@ -3335,14 +3192,14 @@ folly::Future<AtomKey> merge_update_impl(
                                                       merged_ranges_and_keys.front().slice().row_range.first;
                             const TimeseriesDescriptor tsd = make_timeseries_descriptor(
                                     row_count,
-                                    pipeline_context->descriptor(),
-                                    pipeline_context->normalization(),
+                                    pipeline_context->output_descriptor(),
+                                    pipeline_context->output_normalization(),
                                     std::make_optional(std::move(source->user_meta)),
                                     std::nullopt,
                                     write_options.bucketize_dynamic
                             );
                             return index::write_index(
-                                    index_type_from_descriptor(pipeline_context->descriptor()),
+                                    index_type_from_descriptor(pipeline_context->output_descriptor()),
                                     tsd,
                                     std::move(merged_ranges_and_keys),
                                     target_partial_index_key,
@@ -3527,7 +3384,7 @@ static std::shared_ptr<TimeseriesDescriptor> compact_data_tsd(
     if (!compact_data_frame.has_value()) {
         return std::make_shared<TimeseriesDescriptor>(make_timeseries_descriptor(
                 existing_tsd.total_rows(),
-                *pipeline_context.desc_,
+                pipeline_context.on_disk_descriptor(),
                 pipeline_context.normalization(),
                 pipeline_context.release_opt_user_defined_metadata(),
                 std::nullopt,
@@ -3648,7 +3505,8 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                                                     }
                                                 }
                                                 return index::write_index(
-                                                        index_type_from_descriptor(pipeline_context->descriptor()),
+                                                        index_type_from_descriptor(pipeline_context->output_descriptor()
+                                                        ),
                                                         *tsd,
                                                         std::move(slices_and_keys),
                                                         target_partial_index_key,

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -249,14 +249,14 @@ template<
         const std::shared_ptr<Store>& store, std::optional<size_t> segment_size, const CompactionOptions& options
 ) {
     CompactionResult result;
-    auto index = stream::index_type_from_descriptor(pipeline_context->descriptor());
+    auto index = stream::index_type_from_descriptor(pipeline_context->on_disk_descriptor());
 
     std::vector<folly::Future<VariantKey>> write_futures;
 
     auto semaphore = std::make_shared<folly::NativeSemaphore>(n_segments_live_during_compaction());
     stream::SegmentAggregator<IndexType, SchemaType, SegmentationPolicy, DensityPolicy> aggregator{
             [&slices](pipelines::FrameSlice&& slice) { slices.emplace_back(std::move(slice)); },
-            SchemaType{pipeline_context->descriptor(), index},
+            SchemaType{pipeline_context->on_disk_descriptor(), index},
             [&write_futures, &store, &pipeline_context, &semaphore](SegmentInMemory&& segment) {
                 auto local_index_start = IndexType::start_value_for_segment(segment);
                 auto local_index_end = pipelines::end_index_generator(IndexType::end_value_for_segment(segment));
@@ -324,7 +324,7 @@ template<
                 segment.descriptor().uncompressed_bytes()
         );
 
-        if (!index_names_match(segment.descriptor(), pipeline_context->descriptor())) {
+        if (!index_names_match(segment.descriptor(), pipeline_context->on_disk_descriptor())) {
             auto written_keys = folly::collect(write_futures).get();
             remove_written_keys(store.get(), std::move(written_keys));
             return Error{
@@ -332,7 +332,7 @@ template<
                     fmt::format(
                             "Index names in segment {} and pipeline context {} do not match",
                             segment.descriptor(),
-                            pipeline_context->descriptor()
+                            pipeline_context->on_disk_descriptor()
                     )
             };
         }
@@ -346,7 +346,7 @@ template<
         if constexpr (std::is_same_v<SchemaType, FixedSchema>) {
             if (options.perform_schema_checks) {
                 CheckOutcome outcome = check_schema_matches_incomplete(
-                        segment.descriptor(), pipeline_context->descriptor(), options.convert_int_to_float
+                        segment.descriptor(), pipeline_context->on_disk_descriptor(), options.convert_int_to_float
                 );
                 if (std::holds_alternative<Error>(outcome)) {
                     auto written_keys = folly::collect(write_futures).get();

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -504,7 +504,7 @@ def test_resampling_non_timeseries(lmdb_version_store_v1):
     df = pd.DataFrame({"col": np.arange(10)})
     lib.write(sym, df)
     q = QueryBuilder().resample("1min").agg({"col": "sum"})
-    with pytest.raises(UserInputException):
+    with pytest.raises(SchemaException):
         lib.read(sym, query_builder=q)
     q = (
         QueryBuilder()
@@ -512,7 +512,7 @@ def test_resampling_non_timeseries(lmdb_version_store_v1):
         .resample("1min")
         .agg({"col": "sum"})
     )
-    with pytest.raises(UserInputException) as e:
+    with pytest.raises(SchemaException) as e:
         lib.read(sym, query_builder=q)
     assert "std::length_error(vector::reserve)" not in str(e.value)
 

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -47,7 +47,7 @@ def test_filter_column_not_present(lmdb_version_store_v1, any_output_format):
     q = q[q["b"] < 5]
     symbol = "test_filter_column_not_present"
     lib.write(symbol, df)
-    with pytest.raises(InternalException):
+    with pytest.raises(SchemaException):
         _ = lib.read(symbol, query_builder=q)
 
 
@@ -448,8 +448,9 @@ def test_df_query_wrong_type(lmdb_version_store_v1, any_output_format):
     str_vals = np.array(["2", "3", "4", "5"])
     q = QueryBuilder()
     q = q[q["col1"].isin(str_vals)]
+
     with pytest.raises(
-        UserInputException, match="Cannot check membership 'IS IN' of col1.*type=INT.*in set of.*type=STRING"
+        UserInputException, match="Cannot check membership 'ISIN' of .*col1.*type=INT.*in set of.*type=STRING"
     ):
         lib.read(sym, query_builder=q)
 
@@ -457,25 +458,26 @@ def test_df_query_wrong_type(lmdb_version_store_v1, any_output_format):
     q = q[q["col1"] / q["col_str"] == 3]
     with pytest.raises(
         UserInputException,
-        match="Non-numeric column provided to binary operation: col1.*type=INT.*/.*col_str.*type=STRING",
+        match="Non-numeric operand provided to binary operation: .*col1.*type=INT.*DIV.*col_str.*type=STRING",
     ):
         lib.read(sym, query_builder=q)
 
     q = QueryBuilder()
     q = q[q["col1"] + "1" == 3]
     with pytest.raises(
-        UserInputException, match='Non-numeric type provided to binary operation: col1.*type=INT.*\+ "1".*type=STRING'
+        UserInputException,
+        match='Non-numeric operand provided to binary operation: .*col1.*type=INT.*ADD.*"1".*type=STRING',
     ):
         lib.read(sym, query_builder=q)
 
     q = QueryBuilder()
     q = q[-q["col_str"] == 3]
-    with pytest.raises(UserInputException, match="Cannot perform unary operation -\(col_str\).*type=STRING"):
+    with pytest.raises(UserInputException, match="Cannot perform unary operation NEG\(.*col_str.*\).*type=STRING"):
         lib.read(sym, query_builder=q)
 
     q = QueryBuilder()
     q = q[q["col1"] - 1 >= "1"]
-    with pytest.raises(UserInputException, match='Invalid comparison.*col1 - 1.*type=INT.*>=.*"1".*type=STRING'):
+    with pytest.raises(UserInputException, match='Invalid comparison.*col1.* SUB .*1.*type=INT.*GE.*"1".*type=STRING'):
         lib.read(sym, query_builder=q)
 
     q = QueryBuilder()
@@ -483,7 +485,7 @@ def test_df_query_wrong_type(lmdb_version_store_v1, any_output_format):
     # check that ((1 + (col1 * col2)) + col3) is generated as a column name and shown in the error message
     with pytest.raises(
         UserInputException,
-        match="Invalid comparison.*\(1 \+ \(col1 \* col2\)\) - col3.*type=INT.*==.*col_str .*type=STRING",
+        match="Invalid comparison.*\(.*1.* ADD \(.*col1.* MUL .*col2.*\)\) SUB .*col3.*type=INT.*EQ.*col_str.* .*type=STRING",
     ):
         lib.read(sym, query_builder=q)
 
@@ -1074,9 +1076,9 @@ def test_filter_string_less_than(lmdb_version_store_v1, any_output_format):
     lib.write(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", df, dynamic_strings=False)
     q = QueryBuilder()
     q = q[q["a"] < "row2"]
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{DYNAMIC_STRINGS_SUFFIX}", query_builder=q).data
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", query_builder=q).data
 
 
@@ -1089,9 +1091,9 @@ def test_filter_string_less_than_equal(lmdb_version_store_v1, any_output_format)
     lib.write(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", df, dynamic_strings=False)
     q = QueryBuilder()
     q = q[q["a"] <= "row2"]
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{DYNAMIC_STRINGS_SUFFIX}", query_builder=q).data
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", query_builder=q).data
 
 
@@ -1104,9 +1106,9 @@ def test_filter_string_greater_than(lmdb_version_store_v1, any_output_format):
     lib.write(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", df, dynamic_strings=False)
     q = QueryBuilder()
     q = q[q["a"] > "row2"]
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{DYNAMIC_STRINGS_SUFFIX}", query_builder=q).data
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", query_builder=q).data
 
 
@@ -1119,9 +1121,9 @@ def test_filter_string_greater_than_equal(lmdb_version_store_v1, any_output_form
     lib.write(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", df, dynamic_strings=False)
     q = QueryBuilder()
     q = q[q["a"] >= "row2"]
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{DYNAMIC_STRINGS_SUFFIX}", query_builder=q).data
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(f"{base_symbol}_{FIXED_STRINGS_SUFFIX}", query_builder=q).data
 
 

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -10,7 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from arcticdb_ext.exceptions import InternalException, UserInputException
+from arcticdb_ext.exceptions import SchemaException, UserInputException
 from arcticdb.exceptions import ArcticNativeException
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal, make_dynamic, regularize_dataframe
@@ -26,7 +26,7 @@ def test_project_column_not_present(lmdb_version_store_v1, any_output_format):
     q = q.apply("new", q["b"] + 1)
     symbol = "test_project_column_not_present"
     lib.write(symbol, df)
-    with pytest.raises(InternalException):
+    with pytest.raises(SchemaException):
         _ = lib.read(symbol, query_builder=q)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_ternary.py
+++ b/python/tests/unit/arcticdb/version_store/test_ternary.py
@@ -149,13 +149,13 @@ def test_project_ternary_fixed_width_strings(version_store_factory):
     # Column/value
     q = QueryBuilder()
     q = q.apply("new_col", where(q["conditional"], q["width_1"], "hello"))
-    with pytest.raises(SchemaException):
+    with pytest.raises(UserInputException):
         lib.read(symbol, query_builder=q)
 
     # Column/column
     q = QueryBuilder()
     q = q.apply("new_col", where(q["conditional"], q["width_1"], q["width_2"]))
-    with pytest.raises(SchemaException):
+    with pytest.raises(UserInputException):
         lib.read(symbol, query_builder=q)
 
 
@@ -978,7 +978,7 @@ def test_filter_ternary_invalid_conditions(lmdb_version_store_v1, any_output_for
     # Non-bool column
     q = QueryBuilder()
     q = q[where(q["conditional"], q["conditional"] < 0, q["conditional"] >= 0)]
-    with pytest.raises(InternalException):
+    with pytest.raises(UserInputException):
         lib.read(symbol, query_builder=q)
 
     # Value


### PR DESCRIPTION
This commit implements two changes.

Monday: 10997979275

## Generate the output schema before the processing pipeline is run in `read_modify_write`

Currently `read_modify_write` calls `generate_output_schema_and_save_to_pipeline` **after** the pipeline ends. This is the functions that applies modify schema to compute the output schema and performs the checks for schema validity for all clauses. This is wasteful for two reasons:
1. It'll run the pipeline anyway even if modify_schema forbids it and only at the it will check the preconditions
2. If write clause is part of the pipeline it'll write the segments and throw, orphaning the written segments

merge_update needs to know the output schema in advance. This will be important for the implementation of dynamic schema.

This PR moved this computation before the pipeline is run.

## Refactor `PipelineContext`

The `PipelineContext` now holds the output schema and `merge_update` can use it (will be needed for dynamic schema in future).

The `PipelineContext` holds multiple descriptors, some of which poorly named which makes the working with the context confusing and error prone. The descriptors are now renamed and made private. For most of the part this is renaming

`orig_desc_` -> `on_disk_descriptor_`
`desc_` -> `string_coerced_descriptor_`

The string coerced descriptor is used at run time to produce different string types. On the type of the string is changed, names, positions and count of the fields stays the same.

A new utility method for getting the output schema is added which uses 3 way fallback. If the processing pipeline set the output schema it's the result descriptor, if during a read string coercion was required it's the correct user facing output, otherwise return the on disk descriptor.