### PR TITLE
1 - Column stats write side re-write

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1096,6 +1096,7 @@ if(${TEST})
             pipeline/test/test_frame_allocation.cpp
             pipeline/test/test_rollback.cpp
             pipeline/test/test_value.cpp
+            pipeline/test/test_column_stats_build_segment.cpp
             pipeline/test/test_column_stats_data.cpp
             pipeline/test/test_column_stats_dispatch.cpp
             pipeline/test/test_column_stats_dispatch_range_vs_range.cpp

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -266,6 +266,7 @@ set(arcticdb_srcs
         log/trace.hpp
         pipeline/column_mapping.hpp
         pipeline/column_name_resolution.hpp
+        pipeline/column_stats_types.hpp
         pipeline/column_stats.hpp
         pipeline/column_stats_filter.hpp
         pipeline/column_stats_dispatch.hpp

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -1,45 +1,35 @@
 #include <arcticdb/pipeline/column_stats.hpp>
-#include <arcticdb/pipeline/index_fields.hpp>
 #include <arcticdb/processing/aggregation_interface.hpp>
 #include <arcticdb/processing/unsorted_aggregation.hpp>
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
+#include <algorithm>
+#include <tuple>
+
 namespace arcticdb {
 
-SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& segments) {
-    SegmentInMemory merged(Sparsity::PERMITTED);
-    merged.init_column_map();
-    merged.descriptor().set_index(IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+namespace {
+struct StatColumn {
+    std::string name;
+    ColumnStatTypeInternal type;
+    size_t data_col_offset;
+    TypeDescriptor type_descriptor;
+};
 
-    // Maintain the order of the columns in the input segments
-    ankerl::unordered_dense::map<std::string, size_t> field_name_to_index;
-    std::vector<TypeDescriptor> type_descriptors;
-    std::vector<std::string> field_names;
-    std::vector<arcticc::pb2::column_stats_pb2::ColumnStatsType> stat_types;
-    std::vector<size_t> data_col_offsets;
-    for (auto& segment : segments) {
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
-        auto metadata = segment.metadata();
-        util::check(metadata != nullptr, "Column stats segment has no metadata");
-        bool unpacked = metadata->UnpackTo(&header);
-        util::check(unpacked, "Could not unpack column stats metadata?");
-
-        // Build reverse lookup: stats_seg_offset -> (data_col_offset, type)
-        ankerl::unordered_dense::map<uint32_t, std::pair<uint32_t, arcticc::pb2::column_stats_pb2::ColumnStatsType>>
-                offset_lookup;
-        for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
-            for (const auto& entry : entry_list.entries()) {
-                offset_lookup[entry.stats_seg_offset()] = {data_col_offset, entry.type()};
-            }
-        }
-
-        for (const auto& [idx, field] : folly::enumerate(segment.descriptor().fields())) {
-            auto new_type = field.type();
-
-            if (auto it = field_name_to_index.find(std::string{field.name()}); it != field_name_to_index.end()) {
-                auto& merged_type = type_descriptors.at(field_name_to_index.at(std::string{field.name()}));
+// Distinct stat columns in first-appearance order, each widened to a type that can hold every
+// component's value for it. Dynamic schema can give a different type per row slice.
+std::vector<StatColumn> collect_stat_columns(
+        const std::vector<ColumnStatsComponent>& components,
+        ankerl::unordered_dense::map<std::string, size_t>& name_to_index
+) {
+    std::vector<StatColumn> stat_columns;
+    for (const auto& component : components) {
+        for (const auto& stat : component.stats) {
+            auto new_type = make_scalar_type(stat.value.data_type());
+            if (auto it = name_to_index.find(stat.segment_column_name); it != name_to_index.end()) {
+                auto& merged_type = stat_columns.at(it->second).type_descriptor;
                 auto opt_common_type = has_valid_common_type(merged_type, new_type);
                 internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                         opt_common_type.has_value(),
@@ -50,45 +40,87 @@ SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& 
                 );
                 merged_type = *opt_common_type;
             } else {
-                type_descriptors.emplace_back(new_type);
-                field_name_to_index.emplace(field.name(), type_descriptors.size() - 1);
-                field_names.emplace_back(field.name());
-                auto end_index_offset = static_cast<size_t>(index::Fields::end_index);
-                if (idx > end_index_offset) {
-                    // Skip start_index and end_index which are not statistics
-                    auto& [dcol, stype] = offset_lookup.at(idx);
-                    stat_types.emplace_back(stype);
-                    data_col_offsets.emplace_back(dcol);
-                }
+                name_to_index.emplace(stat.segment_column_name, stat_columns.size());
+                stat_columns.emplace_back(
+                        StatColumn{stat.segment_column_name, stat.type, stat.data_col_offset, new_type}
+                );
             }
         }
     }
+    return stat_columns;
+}
 
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader merged_header;
-    merged_header.set_version(1); // see column_stats.proto for explanation of the versioning scheme
-    auto end_index_offset = static_cast<size_t>(index::Fields::end_index);
-    size_t stat_idx = 0;
-    for (const auto& [idx, type_descriptor] : folly::enumerate(type_descriptors)) {
-        merged.add_column(FieldRef{type_descriptor, field_names.at(idx)}, 0, AllocationType::DYNAMIC);
-        if (idx > end_index_offset) {
-            auto& entry_list = (*merged_header.mutable_stats_by_column())[data_col_offsets.at(stat_idx)];
-            auto* new_entry = entry_list.add_entries();
-            new_entry->set_stats_seg_offset(idx);
-            new_entry->set_type(stat_types.at(stat_idx));
-            ++stat_idx;
+// has_valid_common_type guarantees the target represents the source exactly, so a static_cast is
+// faithful. The source type is needed to interpret Value's raw bytes, hence the nested visit.
+void set_stat_value(Column& column, size_t row, const Value& value) {
+    details::visit_type(column.type().data_type(), [&column, row, &value](auto target_tag) {
+        using TargetRaw = typename ScalarTypeInfo<decltype(target_tag)>::RawType;
+        details::visit_type(value.data_type(), [&column, row, &value](auto source_tag) {
+            using SourceRaw = typename ScalarTypeInfo<decltype(source_tag)>::RawType;
+            column.set_scalar<TargetRaw>(static_cast<ssize_t>(row), static_cast<TargetRaw>(value.get<SourceRaw>()));
+        });
+    });
+}
+} // namespace
+
+SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& components) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            !components.empty(), "build_column_stats_segment requires at least one component"
+    );
+    std::sort(components.begin(), components.end(), [](const auto& left, const auto& right) {
+        return std::tie(left.start_index, left.end_index) < std::tie(right.start_index, right.end_index);
+    });
+
+    ankerl::unordered_dense::map<std::string, size_t> name_to_index;
+    const auto stat_columns = collect_stat_columns(components, name_to_index);
+
+    const auto last_row = static_cast<ssize_t>(components.size()) - 1;
+    SegmentInMemory seg(Sparsity::PERMITTED);
+    seg.init_column_map();
+    seg.descriptor().set_index(IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
+
+    auto start_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto end_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    for (const auto& component : components) {
+        start_index_col->push_back<NumericIndex>(component.start_index);
+        end_index_col->push_back<NumericIndex>(component.end_index);
+    }
+    start_index_col->set_row_data(last_row);
+    end_index_col->set_row_data(last_row);
+    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_index_col);
+    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_index_col);
+
+    std::vector<std::shared_ptr<Column>> columns;
+    columns.reserve(stat_columns.size());
+    for (const auto& stat_column : stat_columns) {
+        columns.emplace_back(std::make_shared<Column>(stat_column.type_descriptor, Sparsity::PERMITTED));
+    }
+    // set_scalar creates and backfills the sparse map where a stat is missing from a row slice
+    for (const auto& [row, component] : folly::enumerate(components)) {
+        for (const auto& stat : component.stats) {
+            set_stat_value(*columns.at(name_to_index.at(stat.segment_column_name)), row, stat.value);
         }
     }
-    for (auto& segment : segments) {
-        merged.append(segment);
+
+    const auto stats_offset_base = seg.descriptor().field_count();
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    header.set_version(1); // see column_stats.proto for explanation of the versioning scheme
+    for (const auto& [idx, stat_column] : folly::enumerate(stat_columns)) {
+        columns.at(idx)->set_row_data(last_row);
+        seg.add_column(FieldRef{stat_column.type_descriptor, stat_column.name}, columns.at(idx));
+        auto* new_entry = (*header.mutable_stats_by_column())[stat_column.data_col_offset].add_entries();
+        new_entry->set_stats_seg_offset(stats_offset_base + idx);
+        new_entry->set_type(stat_column.type);
     }
-    merged.set_compacted(true);
-    merged.sort(start_index_column_name);
+
+    seg.set_row_id(last_row);
+    seg.set_compacted(true);
 
     google::protobuf::Any any;
-    bool packed = any.PackFrom(merged_header);
-    util::check(packed, "Failed to pack merged_header in to Any?");
-    merged.set_metadata(std::move(any));
-    return merged;
+    bool packed = any.PackFrom(header);
+    util::check(packed, "Failed to pack header in to Any?");
+    seg.set_metadata(std::move(any));
+    return seg;
 }
 
 std::string type_to_operator_string(ColumnStatTypeInternal type) {

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -3,10 +3,12 @@
 #include <arcticdb/processing/unsorted_aggregation.hpp>
 #include <arcticdb/entity/timeseries_descriptor.hpp>
 #include <arcticdb/entity/type_utils.hpp>
+#include <arcticdb/column_store/column_algorithms.hpp>
 #include <arcticdb/util/preconditions.hpp>
 
 #include <algorithm>
 #include <tuple>
+#include <unordered_set>
 
 namespace arcticdb {
 
@@ -18,40 +20,44 @@ struct StatColumn {
     TypeDescriptor type_descriptor;
 };
 
-// Distinct stat columns in first-appearance order, each widened to a type that can hold every
-// component's value for it. Dynamic schema can give a different type per row slice.
+bool is_count_stat(ColumnStatTypeInternal type) {
+    return type == ColumnStatTypeInternal::NAN_COUNT_V1 || type == ColumnStatTypeInternal::NULL_COUNT_V1;
+}
+
+// Distinct stat columns in first-appearance order. MIN/MAX take their type from the descriptor
+// (deterministic regardless of which row slices this create covers); nan/null counts are always
+// UINT64.
 std::vector<StatColumn> collect_stat_columns(
-        const std::vector<ColumnStatsComponent>& components,
+        const std::vector<ColumnStatsRow>& components, const StreamDescriptor& descriptor,
         ankerl::unordered_dense::map<std::string, size_t>& name_to_index
 ) {
     std::vector<StatColumn> stat_columns;
     for (const auto& component : components) {
         for (const auto& stat : component.stats) {
-            auto new_type = make_scalar_type(stat.value.data_type());
-            if (auto it = name_to_index.find(stat.segment_column_name); it != name_to_index.end()) {
-                auto& merged_type = stat_columns.at(it->second).type_descriptor;
-                auto opt_common_type = has_valid_common_type(merged_type, new_type);
-                internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                        opt_common_type.has_value(),
-                        "No valid common type between {} and {} in {}",
-                        merged_type,
-                        new_type,
-                        __FUNCTION__
-                );
-                merged_type = *opt_common_type;
-            } else {
-                name_to_index.emplace(stat.segment_column_name, stat_columns.size());
-                stat_columns.emplace_back(
-                        StatColumn{stat.segment_column_name, stat.type, stat.data_col_offset, new_type}
-                );
+            if (name_to_index.contains(stat.segment_column_name)) {
+                continue;
             }
+            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                    stat.data_col_offset < descriptor.field_count(),
+                    "Column stats data_col_offset {} is out of range for a descriptor with {} fields. Use "
+                    "drop_column_stats_experimental and recreate the column stats.",
+                    stat.data_col_offset,
+                    descriptor.field_count()
+            );
+            const auto resolved_type = is_count_stat(stat.type) ? make_scalar_type(DataType::UINT64)
+                                                                : descriptor.field(stat.data_col_offset).type();
+            name_to_index.emplace(stat.segment_column_name, stat_columns.size());
+            stat_columns.emplace_back(
+                    StatColumn{stat.segment_column_name, stat.type, stat.data_col_offset, resolved_type}
+            );
         }
     }
     return stat_columns;
 }
 
-// has_valid_common_type guarantees the target represents the source exactly, so a static_cast is
-// faithful. The source type is needed to interpret Value's raw bytes, hence the nested visit.
+// The target is the descriptor's field type, which merge_descriptors resolved as a common type over
+// every slice's type for that column, so the static_cast is OK. The source type is needed to
+// interpret Value's raw bytes, hence the nested visit.
 void set_stat_value(Column& column, size_t row, const Value& value) {
     details::visit_type(column.type().data_type(), [&column, row, &value](auto target_tag) {
         using TargetRaw = typename ScalarTypeInfo<decltype(target_tag)>::RawType;
@@ -63,16 +69,36 @@ void set_stat_value(Column& column, size_t row, const Value& value) {
 }
 } // namespace
 
-SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& components) {
+SegmentInMemory build_column_stats_segment(
+        std::vector<ColumnStatsRow>&& components, const StreamDescriptor& descriptor
+) {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             !components.empty(), "build_column_stats_segment requires at least one component"
     );
     std::sort(components.begin(), components.end(), [](const auto& left, const auto& right) {
         return std::tie(left.start_row, left.end_row) < std::tie(right.start_row, right.end_row);
     });
+    for (size_t i = 0; i < components.size(); ++i) {
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                components.at(i).end_row > components.at(i).start_row,
+                "Column stats component has empty row range [{}, {})",
+                components.at(i).start_row,
+                components.at(i).end_row
+        );
+        if (i > 0) {
+            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                    components.at(i).start_row > components.at(i - 1).start_row,
+                    "Column stats components must have strictly increasing start_row, got [{}, {}) after [{}, {})",
+                    components.at(i).start_row,
+                    components.at(i).end_row,
+                    components.at(i - 1).start_row,
+                    components.at(i - 1).end_row
+            );
+        }
+    }
 
     ankerl::unordered_dense::map<std::string, size_t> name_to_index;
-    const auto stat_columns = collect_stat_columns(components, name_to_index);
+    const auto stat_columns = collect_stat_columns(components, descriptor, name_to_index);
 
     const auto last_row = static_cast<ssize_t>(components.size()) - 1;
     SegmentInMemory seg(Sparsity::PERMITTED);
@@ -136,6 +162,84 @@ std::string type_to_operator_string(ColumnStatTypeInternal type) {
     default:
         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unknown column stat type requested");
     }
+}
+
+std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& segment) {
+    if (segment.row_count() == 0) {
+        return {};
+    }
+
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            segment.metadata(), "Column stats segment is missing its header metadata"
+    );
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            segment.metadata()->UnpackTo(&header), "Failed to unpack column stats header from segment metadata"
+    );
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            header.version() == 1,
+            "Column stats header version {} is not understood by this client. Use "
+            "drop_column_stats_experimental and recreate the column stats before downgrading.",
+            header.version()
+    );
+
+    const auto& fields = segment.fields();
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            fields.size() >= 2 && fields.at(start_row_column_offset).name() == start_row_column_name &&
+                    fields.at(end_row_column_offset).name() == end_row_column_name,
+            "Column stats segment does not have start_row/end_row columns at the expected offsets"
+    );
+
+    const auto& start_row_col = segment.column(start_row_column_offset);
+    const auto& end_row_col = segment.column(end_row_column_offset);
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            !start_row_col.is_sparse() && !end_row_col.is_sparse() &&
+                    static_cast<size_t>(start_row_col.row_count()) == segment.row_count() &&
+                    static_cast<size_t>(end_row_col.row_count()) == segment.row_count(),
+            "Column stats start_row/end_row columns must be dense and cover every row of the segment"
+    );
+
+    std::vector<ColumnStatsRow> components(segment.row_count());
+    for (size_t row = 0; row < segment.row_count(); ++row) {
+        components.at(row).start_row =
+                *segment.scalar_at<uint64_t>(static_cast<position_t>(row), start_row_column_offset);
+        components.at(row).end_row = *segment.scalar_at<uint64_t>(static_cast<position_t>(row), end_row_column_offset);
+    }
+
+    for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
+        for (const auto& entry : entry_list.entries()) {
+            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                    entry.type() != ColumnStatTypeInternal::UNKNOWN,
+                    "Column stats header entry for data column {} has an unrecognised stat type - you need to upgrade your ArcticDB client",
+                    data_col_offset
+            );
+            const auto stats_seg_offset = entry.stats_seg_offset();
+            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                    stats_seg_offset > end_row_column_offset && stats_seg_offset < fields.size(),
+                    "Column stats header entry stats_seg_offset {} is out of range for a segment with {} fields",
+                    stats_seg_offset,
+                    fields.size()
+            );
+
+            const auto field_name = fields.at(stats_seg_offset).name();
+
+            const auto& column = segment.column(stats_seg_offset);
+            const std::string segment_column_name{field_name};
+            details::visit_type(column.type().data_type(), [&]([[maybe_unused]] auto tag) {
+                using type_info = ScalarTypeInfo<decltype(tag)>;
+                for_each_enumerated<typename type_info::TDT>(column, [&](const auto& it) {
+                    components.at(static_cast<size_t>(it.idx()))
+                            .stats.emplace_back(ColumnStatValue{
+                                    segment_column_name,
+                                    entry.type(),
+                                    data_col_offset,
+                                    Value{it.value(), type_info::data_type}
+                            });
+                });
+            });
+        }
+    }
+    return components;
 }
 
 std::string type_to_name(ColumnStatType type) {
@@ -287,64 +391,6 @@ ColumnStats::ColumnStats(const TimeseriesDescriptor& tsd) {
         offset_to_stat_info_.emplace(field_index, NameAndStatTypes{std::move(field_name), {ColumnStatType::MINMAX}});
     }
     offset_to_stat_info_set_ = true;
-}
-
-namespace {
-std::unordered_set<ColumnStatTypeInternal> external_to_internal(ColumnStatType type) {
-    switch (type) {
-    case ColumnStatType::MINMAX:
-        return {ColumnStatTypeInternal::MIN_V1,
-                ColumnStatTypeInternal::MAX_V1,
-                ColumnStatTypeInternal::NAN_COUNT_V1,
-                ColumnStatTypeInternal::NULL_COUNT_V1};
-    default:
-        internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unknown column stat type");
-    }
-}
-} // namespace
-
-std::vector<std::string> ColumnStats::drop(const ColumnStats& to_drop, bool warn_if_missing) {
-    util::check(offset_to_stat_info_set_, "Expect this->offset to stat info to be set");
-    util::check(to_drop.offset_to_stat_info_set_, "Expect to_drop.offset to stat info to be set");
-    std::vector<std::string> dropped_names;
-    for (const auto& [offset, name_and_stat_types] : to_drop.offset_to_stat_info_) {
-        if (auto it = offset_to_stat_info_.find(offset); it == offset_to_stat_info_.end()) {
-            if (warn_if_missing) {
-                log::version().warn(
-                        "Requested column stats drop but column '{}' does not have any column stats",
-                        name_and_stat_types.mangled_name
-                );
-            }
-        } else {
-            for (const auto& column_stat_type : name_and_stat_types.column_stats) {
-                bool none_erased = it->second.column_stats.erase(column_stat_type) == 0;
-                if (none_erased) {
-                    if (warn_if_missing) {
-                        log::version().warn(
-                                "Requested column stats drop but column '{}' does not have the specified column stat "
-                                "'{}'",
-                                name_and_stat_types.mangled_name,
-                                type_to_name(column_stat_type)
-                        );
-                    }
-                } else {
-                    for (const auto& internal_type : external_to_internal(column_stat_type)) {
-                        dropped_names.emplace_back(
-                                to_segment_column_name(name_and_stat_types.mangled_name, internal_type)
-                        );
-                    }
-                }
-            }
-        }
-    }
-    for (auto it = offset_to_stat_info_.begin(); it != offset_to_stat_info_.end();) {
-        if (it->second.column_stats.empty()) {
-            it = offset_to_stat_info_.erase(it);
-        } else {
-            ++it;
-        }
-    }
-    return dropped_names;
 }
 
 std::unordered_map<std::string, std::unordered_set<std::string>> ColumnStats::to_map() const {

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -24,9 +24,6 @@ bool is_count_stat(ColumnStatTypeInternal type) {
     return type == ColumnStatTypeInternal::NAN_COUNT_V1 || type == ColumnStatTypeInternal::NULL_COUNT_V1;
 }
 
-// Distinct stat columns in first-appearance order. MIN/MAX take their type from the descriptor
-// (deterministic regardless of which row slices this create covers); nan/null counts are always
-// UINT64.
 std::vector<StatColumn> collect_stat_columns(
         const std::vector<ColumnStatsRow>& components, const StreamDescriptor& descriptor,
         ankerl::unordered_dense::map<std::string, size_t>& name_to_index
@@ -76,7 +73,7 @@ SegmentInMemory build_column_stats_segment(
             !components.empty(), "build_column_stats_segment requires at least one component"
     );
     std::sort(components.begin(), components.end(), [](const auto& left, const auto& right) {
-        return std::tie(left.start_row, left.end_row) < std::tie(right.start_row, right.end_row);
+        return left.start_row < right.start_row;
     });
     for (size_t i = 0; i < components.size(); ++i) {
         internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -130,7 +127,7 @@ SegmentInMemory build_column_stats_segment(
 
     const auto stats_offset_base = seg.descriptor().field_count();
     arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
-    header.set_version(1); // see column_stats.proto for explanation of the versioning scheme
+    header.set_version(CURRENT_COLUMN_STATS_HEADER_VERSION);
     for (const auto& [idx, stat_column] : folly::enumerate(stat_columns)) {
         columns.at(idx)->set_row_data(last_row);
         seg.add_column(FieldRef{stat_column.type_descriptor, stat_column.name}, columns.at(idx));
@@ -176,12 +173,9 @@ std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& s
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             segment.metadata()->UnpackTo(&header), "Failed to unpack column stats header from segment metadata"
     );
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            header.version() == 1,
-            "Column stats header version {} is not understood by this client. Use "
-            "drop_column_stats_experimental and recreate the column stats before downgrading.",
-            header.version()
-    );
+    // decode_column_stats_segment is only used for creating/extending column stats, so it is OK to fatally
+    // error on an unrecognised header version here
+    validate_column_stats_header_version(header, ColumnStatsHeaderVersionMismatchAction::Raise);
 
     const auto& fields = segment.fields();
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -210,7 +204,8 @@ std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& s
         for (const auto& entry : entry_list.entries()) {
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
                     entry.type() != ColumnStatTypeInternal::UNKNOWN,
-                    "Column stats header entry for data column {} has an unrecognised stat type - you need to upgrade your ArcticDB client",
+                    "Column stats header entry for data column {} has an unrecognised stat type - you need to upgrade "
+                    "your ArcticDB client",
                     data_col_offset
             );
             const auto stats_seg_offset = entry.stats_seg_offset();
@@ -262,15 +257,22 @@ std::string to_segment_column_name(const std::string& column, ColumnStatTypeInte
     return fmt::format("{}({})", type_to_operator_string(type), column);
 }
 
-void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header) {
-    auto version = header.version();
-    if (version > 1) {
-        log::version().warn(
-                "This client only understands column stats version 1 but has encountered version={}. Upgrade your "
-                "ArcticDB "
-                "installation.",
+void validate_column_stats_header_version(
+        const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, ColumnStatsHeaderVersionMismatchAction action
+) {
+    const auto version = header.version();
+    if (version > CURRENT_COLUMN_STATS_HEADER_VERSION) {
+        const auto message = fmt::format(
+                "This client only understands column stats version {} but has encountered version={}. Upgrade your "
+                "ArcticDB installation.",
+                CURRENT_COLUMN_STATS_HEADER_VERSION,
                 version
         );
+        if (action == ColumnStatsHeaderVersionMismatchAction::Raise) {
+            internal::raise<ErrorCode::E_ASSERTION_FAILURE>(message);
+        } else {
+            log::version().warn(message);
+        }
     }
 }
 
@@ -278,7 +280,7 @@ ColumnStats::ColumnStats(
         const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, const TimeseriesDescriptor& tsd
 ) {
     using namespace arcticc::pb2::column_stats_pb2;
-    validate_column_stats_header_version(header);
+    validate_column_stats_header_version(header, ColumnStatsHeaderVersionMismatchAction::Warn);
 
     for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
         for (const auto& entry : entry_list.entries()) {

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -68,7 +68,7 @@ SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& c
             !components.empty(), "build_column_stats_segment requires at least one component"
     );
     std::sort(components.begin(), components.end(), [](const auto& left, const auto& right) {
-        return std::tie(left.start_index, left.end_index) < std::tie(right.start_index, right.end_index);
+        return std::tie(left.start_row, left.end_row) < std::tie(right.start_row, right.end_row);
     });
 
     ankerl::unordered_dense::map<std::string, size_t> name_to_index;
@@ -79,16 +79,16 @@ SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& c
     seg.init_column_map();
     seg.descriptor().set_index(IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
 
-    auto start_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    auto end_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto start_row_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::NOT_PERMITTED);
+    auto end_row_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::NOT_PERMITTED);
     for (const auto& component : components) {
-        start_index_col->push_back<NumericIndex>(component.start_index);
-        end_index_col->push_back<NumericIndex>(component.end_index);
+        start_row_col->push_back<uint64_t>(component.start_row);
+        end_row_col->push_back<uint64_t>(component.end_row);
     }
-    start_index_col->set_row_data(last_row);
-    end_index_col->set_row_data(last_row);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_index_col);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_index_col);
+    start_row_col->set_row_data(last_row);
+    end_row_col->set_row_data(last_row);
+    seg.add_column(scalar_field(DataType::UINT64, start_row_column_name), start_row_col);
+    seg.add_column(scalar_field(DataType::UINT64, end_row_column_name), end_row_col);
 
     std::vector<std::shared_ptr<Column>> columns;
     columns.reserve(stat_columns.size());

--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -20,18 +20,35 @@ struct StatColumn {
     TypeDescriptor type_descriptor;
 };
 
+// Identifies a stat column
+struct StatKey {
+    ColumnStatTypeInternal type;
+    size_t data_col_offset;
+
+    friend bool operator==(const StatKey& left, const StatKey& right) {
+        return left.type == right.type && left.data_col_offset == right.data_col_offset;
+    }
+};
+
+struct StatKeyHash {
+    size_t operator()(const StatKey& key) const noexcept {
+        return folly::hash::hash_combine(key.type, key.data_col_offset);
+    }
+};
+
 bool is_count_stat(ColumnStatTypeInternal type) {
     return type == ColumnStatTypeInternal::NAN_COUNT_V1 || type == ColumnStatTypeInternal::NULL_COUNT_V1;
 }
 
 std::vector<StatColumn> collect_stat_columns(
-        const std::vector<ColumnStatsRow>& components, const StreamDescriptor& descriptor,
-        ankerl::unordered_dense::map<std::string, size_t>& name_to_index
+        const std::vector<ColumnStatsRow>& column_stats_rows, const StreamDescriptor& descriptor,
+        ankerl::unordered_dense::map<StatKey, size_t, StatKeyHash>& stat_key_to_index
 ) {
     std::vector<StatColumn> stat_columns;
-    for (const auto& component : components) {
-        for (const auto& stat : component.stats) {
-            if (name_to_index.contains(stat.segment_column_name)) {
+    for (const auto& column_stats_row : column_stats_rows) {
+        for (const auto& stat : column_stats_row.stats) {
+            const StatKey stat_key{stat.type, stat.data_col_offset};
+            if (stat_key_to_index.contains(stat_key)) {
                 continue;
             }
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -43,10 +60,9 @@ std::vector<StatColumn> collect_stat_columns(
             );
             const auto resolved_type = is_count_stat(stat.type) ? make_scalar_type(DataType::UINT64)
                                                                 : descriptor.field(stat.data_col_offset).type();
-            name_to_index.emplace(stat.segment_column_name, stat_columns.size());
-            stat_columns.emplace_back(
-                    StatColumn{stat.segment_column_name, stat.type, stat.data_col_offset, resolved_type}
-            );
+            auto name = to_segment_column_name(descriptor.field(stat.data_col_offset).name(), stat.type);
+            stat_key_to_index.emplace(stat_key, stat_columns.size());
+            stat_columns.emplace_back(StatColumn{std::move(name), stat.type, stat.data_col_offset, resolved_type});
         }
     }
     return stat_columns;
@@ -67,47 +83,61 @@ void set_stat_value(Column& column, size_t row, const Value& value) {
 } // namespace
 
 SegmentInMemory build_column_stats_segment(
-        std::vector<ColumnStatsRow>&& components, const StreamDescriptor& descriptor
+        std::vector<ColumnStatsRow>&& column_stats_rows, const StreamDescriptor& descriptor
 ) {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            !components.empty(), "build_column_stats_segment requires at least one component"
+            !column_stats_rows.empty(), "build_column_stats_segment requires at least one component"
     );
-    std::sort(components.begin(), components.end(), [](const auto& left, const auto& right) {
-        return left.start_row < right.start_row;
+    std::sort(column_stats_rows.begin(), column_stats_rows.end(), [](const auto& left, const auto& right) {
+        return left.row_range.start() < right.row_range.start();
     });
-    for (size_t i = 0; i < components.size(); ++i) {
+
+    auto start_row_col = std::make_shared<Column>(
+            make_scalar_type(DataType::UINT64),
+            column_stats_rows.size(),
+            AllocationType::PRESIZED,
+            Sparsity::NOT_PERMITTED
+    );
+    auto end_row_col = std::make_shared<Column>(
+            make_scalar_type(DataType::UINT64),
+            column_stats_rows.size(),
+            AllocationType::PRESIZED,
+            Sparsity::NOT_PERMITTED
+    );
+    using RowTDT = ScalarTagType<DataTypeTag<DataType::UINT64>>;
+    auto start_row_data = start_row_col->data();
+    auto end_row_data = end_row_col->data();
+    auto start_it = start_row_data.begin<RowTDT>();
+    auto end_it = end_row_data.begin<RowTDT>();
+    for (size_t i = 0; i < column_stats_rows.size(); ++i, ++start_it, ++end_it) {
         internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                components.at(i).end_row > components.at(i).start_row,
+                column_stats_rows.at(i).row_range.end() > column_stats_rows.at(i).row_range.start(),
                 "Column stats component has empty row range [{}, {})",
-                components.at(i).start_row,
-                components.at(i).end_row
+                column_stats_rows.at(i).row_range.start(),
+                column_stats_rows.at(i).row_range.end()
         );
         if (i > 0) {
             internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                    components.at(i).start_row > components.at(i - 1).start_row,
+                    column_stats_rows.at(i).row_range.start() > column_stats_rows.at(i - 1).row_range.start(),
                     "Column stats components must have strictly increasing start_row, got [{}, {}) after [{}, {})",
-                    components.at(i).start_row,
-                    components.at(i).end_row,
-                    components.at(i - 1).start_row,
-                    components.at(i - 1).end_row
+                    column_stats_rows.at(i).row_range.start(),
+                    column_stats_rows.at(i).row_range.end(),
+                    column_stats_rows.at(i - 1).row_range.start(),
+                    column_stats_rows.at(i - 1).row_range.end()
             );
         }
+        *start_it = column_stats_rows.at(i).row_range.start();
+        *end_it = column_stats_rows.at(i).row_range.end();
     }
 
-    ankerl::unordered_dense::map<std::string, size_t> name_to_index;
-    const auto stat_columns = collect_stat_columns(components, descriptor, name_to_index);
+    ankerl::unordered_dense::map<StatKey, size_t, StatKeyHash> stat_key_to_index;
+    const auto stat_columns = collect_stat_columns(column_stats_rows, descriptor, stat_key_to_index);
 
-    const auto last_row = static_cast<ssize_t>(components.size()) - 1;
+    const auto last_row = static_cast<ssize_t>(column_stats_rows.size()) - 1;
     SegmentInMemory seg(Sparsity::PERMITTED);
     seg.init_column_map();
     seg.descriptor().set_index(IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0});
 
-    auto start_row_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::NOT_PERMITTED);
-    auto end_row_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::NOT_PERMITTED);
-    for (const auto& component : components) {
-        start_row_col->push_back<uint64_t>(component.start_row);
-        end_row_col->push_back<uint64_t>(component.end_row);
-    }
     start_row_col->set_row_data(last_row);
     end_row_col->set_row_data(last_row);
     seg.add_column(scalar_field(DataType::UINT64, start_row_column_name), start_row_col);
@@ -119,9 +149,10 @@ SegmentInMemory build_column_stats_segment(
         columns.emplace_back(std::make_shared<Column>(stat_column.type_descriptor, Sparsity::PERMITTED));
     }
     // set_scalar creates and backfills the sparse map where a stat is missing from a row slice
-    for (const auto& [row, component] : folly::enumerate(components)) {
-        for (const auto& stat : component.stats) {
-            set_stat_value(*columns.at(name_to_index.at(stat.segment_column_name)), row, stat.value);
+    for (const auto& [row, column_stats_row] : folly::enumerate(column_stats_rows)) {
+        for (const auto& stat : column_stats_row.stats) {
+            const StatKey stat_key{stat.type, stat.data_col_offset};
+            set_stat_value(*columns.at(stat_key_to_index.at(stat_key)), row, stat.value);
         }
     }
 
@@ -193,11 +224,12 @@ std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& s
             "Column stats start_row/end_row columns must be dense and cover every row of the segment"
     );
 
-    std::vector<ColumnStatsRow> components(segment.row_count());
+    std::vector<ColumnStatsRow> column_stats_rows(segment.row_count());
     for (size_t row = 0; row < segment.row_count(); ++row) {
-        components.at(row).start_row =
-                *segment.scalar_at<uint64_t>(static_cast<position_t>(row), start_row_column_offset);
-        components.at(row).end_row = *segment.scalar_at<uint64_t>(static_cast<position_t>(row), end_row_column_offset);
+        column_stats_rows.at(row).row_range = pipelines::RowRange{
+                *start_row_col.scalar_at<uint64_t>(static_cast<position_t>(row)),
+                *end_row_col.scalar_at<uint64_t>(static_cast<position_t>(row))
+        };
     }
 
     for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
@@ -216,25 +248,19 @@ std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& s
                     fields.size()
             );
 
-            const auto field_name = fields.at(stats_seg_offset).name();
-
             const auto& column = segment.column(stats_seg_offset);
-            const std::string segment_column_name{field_name};
             details::visit_type(column.type().data_type(), [&]([[maybe_unused]] auto tag) {
                 using type_info = ScalarTypeInfo<decltype(tag)>;
                 for_each_enumerated<typename type_info::TDT>(column, [&](const auto& it) {
-                    components.at(static_cast<size_t>(it.idx()))
+                    column_stats_rows.at(static_cast<size_t>(it.idx()))
                             .stats.emplace_back(ColumnStatValue{
-                                    segment_column_name,
-                                    entry.type(),
-                                    data_col_offset,
-                                    Value{it.value(), type_info::data_type}
+                                    entry.type(), data_col_offset, Value{it.value(), type_info::data_type}
                             });
                 });
             });
         }
     }
-    return components;
+    return column_stats_rows;
 }
 
 std::string type_to_name(ColumnStatType type) {
@@ -253,7 +279,7 @@ std::optional<ColumnStatType> name_to_type(const std::string& name) {
     return std::nullopt;
 }
 
-std::string to_segment_column_name(const std::string& column, ColumnStatTypeInternal type) {
+std::string to_segment_column_name(std::string_view column, ColumnStatTypeInternal type) {
     return fmt::format("{}({})", type_to_operator_string(type), column);
 }
 
@@ -420,22 +446,9 @@ std::optional<Clause> ColumnStats::clause() const {
         for (const auto& column_stat_type : name_and_stat_types.column_stats) {
             switch (column_stat_type) {
             case ColumnStatType::MINMAX:
-                index_generation_aggregators->emplace_back(MinMaxAggregator(
-                        ColumnName(name_and_stat_types.mangled_name),
-                        offset,
-                        ColumnName(
-                                to_segment_column_name(name_and_stat_types.mangled_name, ColumnStatTypeInternal::MIN_V1)
-                        ),
-                        ColumnName(
-                                to_segment_column_name(name_and_stat_types.mangled_name, ColumnStatTypeInternal::MAX_V1)
-                        ),
-                        ColumnName(to_segment_column_name(
-                                name_and_stat_types.mangled_name, ColumnStatTypeInternal::NAN_COUNT_V1
-                        )),
-                        ColumnName(to_segment_column_name(
-                                name_and_stat_types.mangled_name, ColumnStatTypeInternal::NULL_COUNT_V1
-                        ))
-                ));
+                index_generation_aggregators->emplace_back(
+                        MinMaxAggregator(ColumnName(name_and_stat_types.mangled_name), offset)
+                );
                 break;
             default:
                 internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unrecognised ColumnStatType");

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -2,6 +2,7 @@
 
 #include <arcticdb/pipeline/column_name_resolution.hpp>
 #include <arcticdb/processing/clause.hpp>
+#include <arcticdb/pipeline/column_stats_types.hpp>
 #include <arcticdb/pipeline/index_fields.hpp>
 #include <column_stats.pb.h>
 #include <ankerl/unordered_dense.h>
@@ -13,12 +14,10 @@
 
 namespace arcticdb {
 
-SegmentInMemory merge_column_stats_segments(const std::vector<SegmentInMemory>& segments);
+SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& components);
 
 // User facing types - eg users are only allowed to create min and max together, not one or the other
 enum class ColumnStatType { MINMAX };
-// Total universe of column stats we support - min and max are treated separately here
-using ColumnStatTypeInternal = arcticc::pb2::column_stats_pb2::ColumnStatsType;
 
 static const char* const start_index_column_name = "start_index";
 static constexpr size_t start_index_column_offset = 0;

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/pipeline/column_name_resolution.hpp>
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/pipeline/column_stats_types.hpp>
@@ -14,7 +15,11 @@
 
 namespace arcticdb {
 
-SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& components);
+SegmentInMemory build_column_stats_segment(
+        std::vector<ColumnStatsRow>&& components, const StreamDescriptor& descriptor
+);
+
+std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& segment);
 
 // User facing types - eg users are only allowed to create min and max together, not one or the other
 enum class ColumnStatType { MINMAX };
@@ -43,9 +48,6 @@ class ColumnStats {
     explicit ColumnStats(
             const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, const TimeseriesDescriptor& tsd
     );
-
-    // Returns the segment column names of the dropped stats (e.g. "v1_MIN(col)", "v1_MAX(col)")
-    std::vector<std::string> drop(const ColumnStats& to_drop, bool warn_if_missing = true);
 
     std::unordered_map<std::string, std::unordered_set<std::string>> to_map() const;
     std::optional<Clause> clause() const;

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -19,10 +19,10 @@ SegmentInMemory build_column_stats_segment(std::vector<ColumnStatsComponent>&& c
 // User facing types - eg users are only allowed to create min and max together, not one or the other
 enum class ColumnStatType { MINMAX };
 
-static const char* const start_index_column_name = "start_index";
-static constexpr size_t start_index_column_offset = 0;
-static const char* const end_index_column_name = "end_index";
-static constexpr size_t end_index_column_offset = 1;
+static const char* const start_row_column_name = "start_row";
+static constexpr size_t start_row_column_offset = 0;
+static const char* const end_row_column_name = "end_row";
+static constexpr size_t end_row_column_offset = 1;
 
 struct NameAndStatTypes {
     std::string mangled_name;

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -38,7 +38,15 @@ struct NameAndStatTypes {
     }
 };
 
-void validate_column_stats_header_version(const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header);
+// The version of the ColumnStatsHeader written by this build. See column_stats.proto for an
+// explanation of the header versioning scheme.
+static constexpr uint32_t CURRENT_COLUMN_STATS_HEADER_VERSION = 1;
+
+enum class ColumnStatsHeaderVersionMismatchAction { Warn, Raise };
+
+void validate_column_stats_header_version(
+        const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, ColumnStatsHeaderVersionMismatchAction action
+);
 
 std::string to_segment_column_name(const std::string& column, ColumnStatTypeInternal type);
 

--- a/cpp/arcticdb/pipeline/column_stats.hpp
+++ b/cpp/arcticdb/pipeline/column_stats.hpp
@@ -10,13 +10,14 @@
 #include <map>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace arcticdb {
 
 SegmentInMemory build_column_stats_segment(
-        std::vector<ColumnStatsRow>&& components, const StreamDescriptor& descriptor
+        std::vector<ColumnStatsRow>&& column_stats_rows, const StreamDescriptor& descriptor
 );
 
 std::vector<ColumnStatsRow> decode_column_stats_segment(const SegmentInMemory& segment);
@@ -48,7 +49,7 @@ void validate_column_stats_header_version(
         const arcticc::pb2::column_stats_pb2::ColumnStatsHeader& header, ColumnStatsHeaderVersionMismatchAction action
 );
 
-std::string to_segment_column_name(const std::string& column, ColumnStatTypeInternal type);
+std::string to_segment_column_name(std::string_view column, ColumnStatTypeInternal type);
 
 class ColumnStats {
   public:

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -310,7 +310,7 @@ ColumnStatsData::ColumnStatsData(
     util::check(metadata != nullptr, "Column stats segment has no metadata");
     bool unpacked = metadata->UnpackTo(&header);
     util::check(unpacked, "Could not unpack ColumnStatsHeader from column stats segment metadata");
-    validate_column_stats_header_version(header);
+    validate_column_stats_header_version(header, ColumnStatsHeaderVersionMismatchAction::Warn);
 
     segment.init_column_map();
     const auto& fields = segment.descriptor().fields();
@@ -488,7 +488,7 @@ SegmentInMemory partial_decode_column_stats_segment(
     ColumnStatsHeader header;
     bool unpacked = maybe_metadata->UnpackTo(&header);
     util::check(unpacked, "Could not unpack ColumnStatsHeader from column stats segment metadata");
-    validate_column_stats_header_version(header);
+    validate_column_stats_header_version(header, ColumnStatsHeaderVersionMismatchAction::Warn);
 
     std::unordered_set<std::string> retain_field_names;
     retain_field_names.insert(start_row_column_name);

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -246,40 +246,41 @@ std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
 
 } // anonymous namespace
 
-std::pair<size_t, size_t> ColumnStatsData::calculate_start_and_end_indices(
-        const std::optional<std::pair<timestamp, timestamp>>& date_range, const size_t segment_row_count,
-        const Column& start_index_col, const Column& end_index_col
+std::pair<size_t, size_t> ColumnStatsData::parse_row_ranges(
+        const std::optional<pipelines::RowRange>& window, const size_t segment_row_count, const Column& start_row_col,
+        const Column& end_row_col
 ) {
-    // Construct start_indices and end_indices with date range pruning.
+    // Build the row range lookup, skipping row slices outside the window.
     // Also construct the interval [first_kept, last_kept_excl) to quickly skip stats for row ranges
     // we are not interested in when we read the statistics themselves.
     size_t first_kept = segment_row_count;
     size_t last_kept_excl = 0;
-    start_indices_.reserve(segment_row_count);
-    end_indices_.reserve(segment_row_count);
-    using TsTDT = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    auto start_data = start_index_col.data();
-    auto end_data = end_index_col.data();
-    auto start_it = start_data.begin<TsTDT>();
-    auto end_it = end_data.begin<TsTDT>();
-    timestamp prev_start = 0;
+    row_range_to_row_.reserve(segment_row_count);
+    using RowTDT = ScalarTagType<DataTypeTag<DataType::UINT64>>;
+    auto start_data = start_row_col.data();
+    auto end_data = end_row_col.data();
+    auto start_it = start_data.begin<RowTDT>();
+    auto end_it = end_data.begin<RowTDT>();
+    uint64_t prev_start = 0;
     for (size_t r = 0; r < segment_row_count; ++r, ++start_it, ++end_it) {
-        const timestamp start_index_ts = *start_it;
-        const timestamp end_index_ts = *end_it;
+        const uint64_t start_row = *start_it;
+        const uint64_t end_row = *end_it;
         if (r > 0) {
             util::check(
-                    start_index_ts >= prev_start,
-                    "Column stats segment start_index must be monotonically increasing "
+                    start_row > prev_start,
+                    "Column stats segment start_row must be strictly monotonically increasing "
                     "(violated at row {})",
                     r
             );
         }
-        prev_start = start_index_ts;
-        if (date_range.has_value()) {
-            if (start_index_ts > date_range->second) {
+        prev_start = start_row;
+        if (window.has_value()) {
+            // Sorted on start_row, so once a slice starts at or after the window nothing later can
+            // intersect it.
+            if (start_row >= window->second) {
                 break;
             }
-            if (end_index_ts < date_range->first) {
+            if (end_row <= window->first) {
                 continue;
             }
         }
@@ -287,32 +288,17 @@ std::pair<size_t, size_t> ColumnStatsData::calculate_start_and_end_indices(
             first_kept = r;
         }
         last_kept_excl = r + 1;
-        start_indices_.push_back(start_index_ts);
-        end_indices_.push_back(end_index_ts);
+        // r - first_kept is the same convention load_stats_by_column uses to index the value vectors
+        auto [_, inserted] = row_range_to_row_.emplace(pipelines::RowRange{start_row, end_row}, r - first_kept);
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                inserted, "Duplicate row range [{}, {}) in column stats segment at row {}", start_row, end_row, r
+        );
     }
     return std::make_pair(first_kept, last_kept_excl);
 }
 
-void ColumnStatsData::drop_duplicate_rows() {
-    index_to_row_.reserve(num_rows_);
-    std::unordered_set<std::pair<timestamp, timestamp>, util::PairHasher> duplicate_keys;
-    for (size_t r = 0; r < num_rows_; ++r) {
-        auto key = std::make_pair(start_indices_.at(r), end_indices_.at(r));
-        if (auto [_, inserted] = index_to_row_.emplace(key, r); !inserted) {
-            // Duplicate (start_index, end_index) — can happen with timestamp indices when multiple
-            // segments span the same time range.
-            duplicate_keys.insert(key);
-        }
-    }
-    for (const auto& key : duplicate_keys) {
-        log::version().debug("Duplicate key detected in column stats - dropping {}", key);
-        index_to_row_.erase(key);
-    }
-}
-
 ColumnStatsData::ColumnStatsData(
-        SegmentInMemory&& segment, const TimeseriesDescriptor& tsd,
-        std::optional<std::pair<timestamp, timestamp>> date_range
+        SegmentInMemory&& segment, const TimeseriesDescriptor& tsd, const std::optional<pipelines::RowRange>& window
 ) {
     using namespace arcticc::pb2::column_stats_pb2;
     if (segment.row_count() == 0) {
@@ -330,30 +316,28 @@ ColumnStatsData::ColumnStatsData(
     const auto& fields = segment.descriptor().fields();
     const auto segment_row_count = segment.row_count();
 
-    const auto& start_index_col = segment.column(start_index_column_offset);
-    const auto& end_index_col = segment.column(end_index_column_offset);
-    if (start_index_col.is_sparse() || end_index_col.is_sparse() ||
-        static_cast<size_t>(start_index_col.row_count()) != segment_row_count ||
-        static_cast<size_t>(end_index_col.row_count()) != segment_row_count) {
-        log::version().warn("Saw column stats row without start_index or end_index, discarding all column stats");
+    const auto& start_row_col = segment.column(start_row_column_offset);
+    const auto& end_row_col = segment.column(end_row_column_offset);
+    if (start_row_col.is_sparse() || end_row_col.is_sparse() ||
+        static_cast<size_t>(start_row_col.row_count()) != segment_row_count ||
+        static_cast<size_t>(end_row_col.row_count()) != segment_row_count) {
+        log::version().warn("Saw column stats row without start_row or end_row, discarding all column stats");
         return;
     }
 
     std::vector<StatsMetadataForColumn> stats_metadata = calculate_stats_metadata(segment, tsd, header, fields);
 
-    auto [first_kept, last_kept_excl] =
-            calculate_start_and_end_indices(date_range, segment_row_count, start_index_col, end_index_col);
-    num_rows_ = start_indices_.size();
+    auto [first_kept, last_kept_excl] = parse_row_ranges(window, segment_row_count, start_row_col, end_row_col);
+    num_rows_ = last_kept_excl > first_kept ? last_kept_excl - first_kept : 0;
     if (num_rows_ == 0) {
         return;
     }
 
     stats_by_column_ = load_stats_by_column(segment, stats_metadata, first_kept, last_kept_excl, num_rows_);
-    drop_duplicate_rows();
 }
 
-std::optional<size_t> ColumnStatsData::find_row(timestamp start_index, timestamp end_index) const {
-    if (auto it = index_to_row_.find({start_index, end_index}); it != index_to_row_.end()) {
+std::optional<size_t> ColumnStatsData::find_row(const pipelines::RowRange& row_range) const {
+    if (auto it = row_range_to_row_.find(row_range); it != row_range_to_row_.end()) {
         return it->second;
     }
     return std::nullopt;
@@ -412,9 +396,6 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
             res->invert();
         }
 
-        auto start_index_col = isr.column(Fields::start_index).begin<stream::TimeseriesIndex::TypeDescTag>();
-        auto end_index_col = isr.column(Fields::end_index).begin<stream::TimeseriesIndex::TypeDescTag>();
-
         StatsRowIndices row_indices;
         row_indices.reserve(isr.size());
         [[maybe_unused]] size_t total_count = 0; // for debug logging only, unused in release build
@@ -425,9 +406,7 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
                 continue;
             }
             total_count++;
-            timestamp start_idx = *(start_index_col + row);
-            timestamp end_idx = *(end_index_col + row);
-            row_indices.emplace_back(column_stats_data.find_row(start_idx, end_idx));
+            row_indices.emplace_back(column_stats_data.find_row(slice_row_range_at(isr, row)));
         }
         util::check(row_indices.size() == isr.size(), "Expected row_indices.size() == isr.size()");
 
@@ -512,8 +491,8 @@ SegmentInMemory partial_decode_column_stats_segment(
     validate_column_stats_header_version(header);
 
     std::unordered_set<std::string> retain_field_names;
-    retain_field_names.insert(start_index_column_name);
-    retain_field_names.insert(end_index_column_name);
+    retain_field_names.insert(start_row_column_name);
+    retain_field_names.insert(end_row_column_name);
     for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
         std::string col_name{tsd.fields().at(data_col_offset).name()};
         if (!columns_of_interest.contains(col_name)) {
@@ -524,8 +503,8 @@ SegmentInMemory partial_decode_column_stats_segment(
         }
     }
 
-    // Preserve the order so start_index lands at offset 0 and end_index at offset 1, matching the
-    // start_index_column_offset / end_index_column_offset constants used downstream.
+    // Preserve the order so start_row lands at offset 0 and end_row at offset 1, matching the
+    // start_row_column_offset / end_row_column_offset constants used downstream.
     StreamDescriptor partial_desc;
     partial_desc.set_index(column_stats_segment.descriptor().index());
     for (const auto& field : column_stats_segment.descriptor().fields()) {
@@ -534,9 +513,9 @@ SegmentInMemory partial_decode_column_stats_segment(
         }
     }
     util::check(
-            partial_desc.fields().size() >= 2 && partial_desc.fields(0).name() == start_index_column_name &&
-                    partial_desc.fields(1).name() == end_index_column_name,
-            "Expected start_index/end_index at the front of the column stats segment"
+            partial_desc.fields().size() >= 2 && partial_desc.fields(0).name() == start_row_column_name &&
+                    partial_desc.fields(1).name() == end_row_column_name,
+            "Expected start_row/end_row at the front of the column stats segment"
     );
 
     SegmentInMemory partial(std::move(partial_desc), 0, AllocationType::DYNAMIC);
@@ -546,6 +525,54 @@ SegmentInMemory partial_decode_column_stats_segment(
     return partial;
 }
 
+namespace {
+// Restrict which rows in the column stats segment we parse.
+// This is a single RowRange spanning all the row ranges that survived build_row_read_query_filters,
+// narrowed by a DateRangeClause if the query had one. Empty if nothing survived.
+pipelines::RowRange row_window_of_interest(
+        const index::IndexSegmentReader& isr, const util::BitSet& surviving,
+        const std::optional<std::pair<timestamp, timestamp>>& date_range
+) {
+    using namespace pipelines;
+    std::optional<RowRange> window;
+    auto extend_to = [&window, &isr](size_t row) {
+        const auto slice_row_range = slice_row_range_at(isr, row);
+        if (window.has_value()) {
+            window = RowRange{
+                    std::min(window->first, slice_row_range.first), std::max(window->second, slice_row_range.second)
+            };
+        } else {
+            window = slice_row_range;
+        }
+    };
+
+    // A DateRangeClause prunes ranges_and_keys in structure_for_processing, which runs after
+    // filter_index, so it is not yet reflected in the bitset.
+    if (date_range.has_value() && isr.has_timestamp_index()) {
+        using TsTDT = stream::TimeseriesIndex::TypeDescTag;
+        const IndexRange date_filter{date_range->first, date_range->second};
+        auto start_index_it = isr.column(index::Fields::start_index).begin<TsTDT>();
+        auto end_index_it = isr.column(index::Fields::end_index).begin<TsTDT>();
+        for (size_t row = 0; row < isr.size(); ++row) {
+            if (!surviving.get_bit(row)) {
+                continue;
+            }
+            const IndexRange slice_index_range{*(start_index_it + row), *(end_index_it + row)};
+            if (is_slice_in_index_range(slice_index_range, date_filter, true)) {
+                extend_to(row);
+            }
+        }
+    } else {
+        for (size_t row = 0; row < isr.size(); ++row) {
+            if (surviving.get_bit(row)) {
+                extend_to(row);
+            }
+        }
+    }
+    return window.value_or(RowRange{0, 0});
+}
+} // namespace
+
 FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
         std::shared_ptr<Segment> column_stats_compressed, const TimeseriesDescriptor& tsd,
         ColumnStatsQueryMetadata&& query_metadata
@@ -554,11 +581,26 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
             query_metadata.should_try_column_stats_read(),
             "Should not try to create column stats filter if !should_try_column_stats_read()"
     );
-    SegmentInMemory partial_segment =
-            partial_decode_column_stats_segment(*column_stats_compressed, tsd, query_metadata.columns_of_interest);
-    ColumnStatsData column_stats{std::move(partial_segment), tsd, query_metadata.date_range};
-    ExpressionContext expression_context = *query_metadata.filter_expression;
-    return create_column_stats_filter(std::move(column_stats), std::move(expression_context));
+    return [column_stats_compressed = std::move(column_stats_compressed),
+            tsd,
+            query_metadata = std::move(query_metadata
+            )](const index::IndexSegmentReader& isr, std::unique_ptr<util::BitSet>&& input) mutable {
+        std::unique_ptr<util::BitSet> surviving;
+        if (input) {
+            surviving = std::move(input);
+        } else {
+            surviving = std::make_unique<util::BitSet>(static_cast<util::BitSetSizeType>(isr.size()));
+            surviving->invert();
+        }
+
+        auto window = row_window_of_interest(isr, *surviving, query_metadata.date_range);
+        SegmentInMemory partial_segment =
+                partial_decode_column_stats_segment(*column_stats_compressed, tsd, query_metadata.columns_of_interest);
+        ColumnStatsData column_stats{std::move(partial_segment), tsd, window};
+        ExpressionContext expression_context = *query_metadata.filter_expression;
+        auto filter = create_column_stats_filter(std::move(column_stats), std::move(expression_context));
+        return filter(isr, std::move(surviving));
+    };
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -25,17 +25,6 @@
 
 namespace arcticdb {
 
-namespace util {
-
-struct PairHasher {
-    template<typename T1, typename T2>
-    std::size_t operator()(const std::pair<T1, T2>& p) const {
-        return folly::hash::hash_combine(p.first, p.second);
-    }
-};
-
-} // namespace util
-
 struct ColumnStatsValues {
     std::optional<Value> min;
     std::optional<Value> max;
@@ -81,20 +70,21 @@ class ColumnStatsData {
      * @param segment The column stats segment.
      * @param tsd     The original symbol's TSD, used to resolve data_col_offsets in the column stats
      *                header back to user column names.
-     * @param date_range Date range to load stats for.
+     * @param window  Range of data rows to load stats for. Stats for row slices that do not
+     *                intersect it are not parsed, and find_row will not find them.
      */
     explicit ColumnStatsData(
             SegmentInMemory&& segment, const TimeseriesDescriptor& tsd,
-            std::optional<std::pair<timestamp, timestamp>> date_range = std::nullopt
+            const std::optional<pipelines::RowRange>& window = std::nullopt
     );
 
     ARCTICDB_MOVE_ONLY_DEFAULT(ColumnStatsData)
 
     /**
-     * Find the row index for a given row-slice identified by start_index and end_index.
+     * Find the row index for the row slice covering the given range of data rows.
      * Returns nullopt if no matching stats found.
      */
-    std::optional<size_t> find_row(timestamp start_index, timestamp end_index) const;
+    std::optional<size_t> find_row(const pipelines::RowRange& row_range) const;
 
     bool empty() const { return num_rows_ == 0; }
 
@@ -107,20 +97,15 @@ class ColumnStatsData {
     ) const;
 
   private:
-    std::pair<size_t, size_t> calculate_start_and_end_indices(
-            const std::optional<std::pair<timestamp, timestamp>>& date_range, size_t segment_row_count,
-            const Column& start_index_col, const Column& end_index_col
+    std::pair<size_t, size_t> parse_row_ranges(
+            const std::optional<pipelines::RowRange>& window, size_t segment_row_count, const Column& start_row_col,
+            const Column& end_row_col
     );
 
-    void drop_duplicate_rows();
-
     size_t num_rows_{0};
-    std::vector<timestamp> start_indices_; // size = num_rows_
-    std::vector<timestamp> end_indices_;   // size = num_rows_
     std::unordered_map<std::string, StatsForColumn> stats_by_column_;
 
-    // (start_index, end_index) -> row index. The index values are rowcounts for string-indexed symbols.
-    std::unordered_map<std::pair<timestamp, timestamp>, size_t, util::PairHasher> index_to_row_;
+    std::unordered_map<pipelines::RowRange, size_t, pipelines::RowRange::Hasher> row_range_to_row_;
 };
 
 struct ColumnStatsQueryMetadata {
@@ -156,7 +141,7 @@ FilterQuery<index::IndexSegmentReader> create_column_stats_filter(
  * Create a column stats filter from compressed column stats bytes.
  *
  * Partially decodes the column stats segment so only the stats columns referenced by the query's
- * filter clauses are loaded; rows outside the intersection of any DateRangeClause are pruned.
+ * filter clauses are loaded.
  *
  * Precondition: query_metadata.should_try_column_stats_read() == true.
  */

--- a/cpp/arcticdb/pipeline/column_stats_types.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_types.hpp
@@ -34,7 +34,7 @@ struct ColumnStatValue {
 /// One per row slice. Added to the ComponentManager as a standalone entity by
 /// ColumnStatsGenerationClause::process and read back by create_column_stats_impl via
 /// process_entities, which scans the whole registry — no other code may add this component.
-struct ColumnStatsComponent {
+struct ColumnStatsRow {
     uint64_t start_row;
     uint64_t end_row;
     std::vector<ColumnStatValue> stats;

--- a/cpp/arcticdb/pipeline/column_stats_types.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_types.hpp
@@ -35,8 +35,8 @@ struct ColumnStatValue {
 /// ColumnStatsGenerationClause::process and read back by create_column_stats_impl via
 /// process_entities, which scans the whole registry — no other code may add this component.
 struct ColumnStatsComponent {
-    entity::NumericIndex start_index;
-    entity::NumericIndex end_index;
+    uint64_t start_row;
+    uint64_t end_row;
     std::vector<ColumnStatValue> stats;
 };
 

--- a/cpp/arcticdb/pipeline/column_stats_types.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_types.hpp
@@ -1,0 +1,43 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <arcticdb/entity/index_range.hpp>
+#include <arcticdb/pipeline/value.hpp>
+#include <column_stats.pb.h>
+
+#include <string>
+#include <vector>
+
+// Kept free of processing/ and column_stats.hpp so that aggregation_interface.hpp can name the
+// aggregator return type: column_stats.hpp includes processing/clause.hpp, which includes
+// aggregation_interface.hpp.
+namespace arcticdb {
+
+// Total universe of column stats we support - min and max are treated separately here
+using ColumnStatTypeInternal = arcticc::pb2::column_stats_pb2::ColumnStatsType;
+
+struct ColumnStatValue {
+    // to_segment_column_name(<name of the column at data_col_offset>, type), e.g. "v1_MIN(col)"
+    std::string segment_column_name;
+    ColumnStatTypeInternal type;
+    size_t data_col_offset;
+    Value value;
+};
+
+/// One per row slice. Added to the ComponentManager as a standalone entity by
+/// ColumnStatsGenerationClause::process and read back by create_column_stats_impl via
+/// process_entities, which scans the whole registry — no other code may add this component.
+struct ColumnStatsComponent {
+    entity::NumericIndex start_index;
+    entity::NumericIndex end_index;
+    std::vector<ColumnStatValue> stats;
+};
+
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/column_stats_types.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_types.hpp
@@ -15,12 +15,8 @@
 #include <string>
 #include <vector>
 
-// Kept free of processing/ and column_stats.hpp so that aggregation_interface.hpp can name the
-// aggregator return type: column_stats.hpp includes processing/clause.hpp, which includes
-// aggregation_interface.hpp.
 namespace arcticdb {
 
-// Total universe of column stats we support - min and max are treated separately here
 using ColumnStatTypeInternal = arcticc::pb2::column_stats_pb2::ColumnStatsType;
 
 struct ColumnStatValue {
@@ -33,7 +29,7 @@ struct ColumnStatValue {
 
 /// One per row slice. Added to the ComponentManager as a standalone entity by
 /// ColumnStatsGenerationClause::process and read back by create_column_stats_impl via
-/// process_entities, which scans the whole registry — no other code may add this component.
+/// process_entities
 struct ColumnStatsRow {
     uint64_t start_row;
     uint64_t end_row;

--- a/cpp/arcticdb/pipeline/column_stats_types.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_types.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/entity/index_range.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/pipeline/value.hpp>
 #include <column_stats.pb.h>
 
@@ -20,19 +21,15 @@ namespace arcticdb {
 using ColumnStatTypeInternal = arcticc::pb2::column_stats_pb2::ColumnStatsType;
 
 struct ColumnStatValue {
-    // to_segment_column_name(<name of the column at data_col_offset>, type), e.g. "v1_MIN(col)"
-    std::string segment_column_name;
     ColumnStatTypeInternal type;
     size_t data_col_offset;
     Value value;
 };
 
 /// One per row slice. Added to the ComponentManager as a standalone entity by
-/// ColumnStatsGenerationClause::process and read back by create_column_stats_impl via
-/// process_entities
+/// ColumnStatsGenerationClause::process and read back by create_column_stats_impl
 struct ColumnStatsRow {
-    uint64_t start_row;
-    uint64_t end_row;
+    pipelines::RowRange row_range;
     std::vector<ColumnStatValue> stats;
 };
 

--- a/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
@@ -7,9 +7,15 @@
  */
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <arcticdb/entity/type_utils.hpp>
+#include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
+#include <arcticdb/pipeline/frame_slice.hpp>
 #include <google/protobuf/any.pb.h>
+
+#include <algorithm>
+#include <unordered_set>
 
 namespace arcticdb {
 
@@ -22,8 +28,8 @@ ColumnStatValue min_stat(T value, DataType data_type, const char* name = "v1_MIN
     return ColumnStatValue{name, ColumnStatTypeInternal::MIN_V1, price_data_col_offset, Value{value, data_type}};
 }
 
-ColumnStatsComponent component(uint64_t start_row, uint64_t end_row, std::vector<ColumnStatValue> stats) {
-    return ColumnStatsComponent{start_row, end_row, std::move(stats)};
+ColumnStatsRow component(uint64_t start_row, uint64_t end_row, std::vector<ColumnStatValue> stats) {
+    return ColumnStatsRow{start_row, end_row, std::move(stats)};
 }
 
 position_t column_index(const SegmentInMemory& seg, std::string_view name) {
@@ -31,14 +37,53 @@ position_t column_index(const SegmentInMemory& seg, std::string_view name) {
     EXPECT_TRUE(idx.has_value()) << "column " << name << " missing";
     return static_cast<position_t>(*idx);
 }
+
+StreamDescriptor make_descriptor(DataType price_type = DataType::INT64, DataType volume_type = DataType::UINT64) {
+    StreamDescriptor desc{"sym"};
+    desc.add_scalar_field(DataType::UINT64, "index");
+    desc.add_scalar_field(price_type, "price");
+    desc.add_scalar_field(volume_type, "volume");
+    return desc;
+}
+
+bool stat_values_equal(const ColumnStatValue& left, const ColumnStatValue& right) {
+    return left.segment_column_name == right.segment_column_name && left.type == right.type &&
+           left.data_col_offset == right.data_col_offset && left.value == right.value;
+}
+
+// Stat order within a component reflects protobuf map iteration order over stats_by_column, which
+// is unspecified, so comparisons sort by segment_column_name first.
+void expect_components_equal(std::vector<ColumnStatsRow> actual, std::vector<ColumnStatsRow> expected) {
+    auto by_name = [](const ColumnStatValue& l, const ColumnStatValue& r) {
+        return l.segment_column_name < r.segment_column_name;
+    };
+    for (auto& c : actual) {
+        std::sort(c.stats.begin(), c.stats.end(), by_name);
+    }
+    for (auto& c : expected) {
+        std::sort(c.stats.begin(), c.stats.end(), by_name);
+    }
+    ASSERT_EQ(actual.size(), expected.size());
+    for (size_t i = 0; i < actual.size(); ++i) {
+        EXPECT_EQ(actual.at(i).start_row, expected.at(i).start_row) << "component " << i;
+        EXPECT_EQ(actual.at(i).end_row, expected.at(i).end_row) << "component " << i;
+        ASSERT_EQ(actual.at(i).stats.size(), expected.at(i).stats.size()) << "component " << i;
+        for (size_t j = 0; j < actual.at(i).stats.size(); ++j) {
+            EXPECT_TRUE(stat_values_equal(actual.at(i).stats.at(j), expected.at(i).stats.at(j)))
+                    << "component " << i << " stat " << j;
+        }
+    }
+}
 } // namespace
 
 TEST(ColumnStatsBuildSegmentTest, IndexColumnsAndRowOrder) {
+    auto desc = make_descriptor();
     // Deliberately out of index order
     auto seg = build_column_stats_segment(
             {component(300, 399, {min_stat<int64_t>(3, DataType::INT64)}),
              component(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
-             component(200, 299, {min_stat<int64_t>(2, DataType::INT64)})}
+             component(200, 299, {min_stat<int64_t>(2, DataType::INT64)})},
+            desc
     );
 
     ASSERT_EQ(seg.row_count(), 3);
@@ -54,23 +99,27 @@ TEST(ColumnStatsBuildSegmentTest, IndexColumnsAndRowOrder) {
 }
 
 TEST(ColumnStatsBuildSegmentTest, HeaderOffsetsMatchColumnPositions) {
-    auto seg = build_column_stats_segment({component(
-            100,
-            199,
-            {min_stat<int64_t>(1, DataType::INT64),
-             ColumnStatValue{
-                     "v1_MAX(price)",
-                     ColumnStatTypeInternal::MAX_V1,
-                     price_data_col_offset,
-                     Value{int64_t{9}, DataType::INT64}
-             },
-             ColumnStatValue{
-                     "v1_MIN(volume)",
-                     ColumnStatTypeInternal::MIN_V1,
-                     volume_data_col_offset,
-                     Value{uint64_t{5}, DataType::UINT64}
-             }}
-    )});
+    auto desc = make_descriptor();
+    auto seg = build_column_stats_segment(
+            {component(
+                    100,
+                    199,
+                    {min_stat<int64_t>(1, DataType::INT64),
+                     ColumnStatValue{
+                             "v1_MAX(price)",
+                             ColumnStatTypeInternal::MAX_V1,
+                             price_data_col_offset,
+                             Value{int64_t{9}, DataType::INT64}
+                     },
+                     ColumnStatValue{
+                             "v1_MIN(volume)",
+                             ColumnStatTypeInternal::MIN_V1,
+                             volume_data_col_offset,
+                             Value{uint64_t{5}, DataType::UINT64}
+                     }}
+            )},
+            desc
+    );
 
     ASSERT_TRUE(seg.metadata());
     arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
@@ -96,58 +145,46 @@ TEST(ColumnStatsBuildSegmentTest, HeaderOffsetsMatchColumnPositions) {
     EXPECT_EQ(entries, 3);
 }
 
-// Dynamic schema can give a different type per row slice for the same stat. The column must widen
-// to the common type and every value must survive the cast.
-TEST(ColumnStatsBuildSegmentTest, WidensToCommonTypeUnsignedIntegers) {
-    auto seg = build_column_stats_segment(
-            {component(100, 199, {min_stat<uint8_t>(7, DataType::UINT8)}),
-             component(200, 299, {min_stat<uint16_t>(1000, DataType::UINT16)})}
-    );
-
-    const auto col = column_index(seg, "v1_MIN(price)");
-    const auto expected_type =
-            has_valid_common_type(make_scalar_type(DataType::UINT8), make_scalar_type(DataType::UINT16));
-    ASSERT_TRUE(expected_type.has_value());
-    EXPECT_EQ(seg.column(col).type(), *expected_type);
-    EXPECT_EQ(seg.scalar_at<uint16_t>(0, col), 7);
-    EXPECT_EQ(seg.scalar_at<uint16_t>(1, col), 1000);
-}
-
-TEST(ColumnStatsBuildSegmentTest, WidensToCommonTypeMixedSignIntegers) {
-    auto seg = build_column_stats_segment(
-            {component(100, 199, {min_stat<uint16_t>(1000, DataType::UINT16)}),
-             component(200, 299, {min_stat<int32_t>(-1002, DataType::INT32)})}
-    );
-
-    const auto col = column_index(seg, "v1_MIN(price)");
-    const auto expected_type =
-            has_valid_common_type(make_scalar_type(DataType::UINT16), make_scalar_type(DataType::INT32));
-    ASSERT_TRUE(expected_type.has_value());
-    EXPECT_EQ(seg.column(col).type(), *expected_type);
-    EXPECT_EQ(seg.scalar_at<int32_t>(0, col), 1000);
-    EXPECT_EQ(seg.scalar_at<int32_t>(1, col), -1002);
-}
-
-TEST(ColumnStatsBuildSegmentTest, WidensToCommonTypeFloats) {
-    auto seg = build_column_stats_segment(
-            {component(100, 199, {min_stat<float>(1.5F, DataType::FLOAT32)}),
-             component(200, 299, {min_stat<double>(2.25, DataType::FLOAT64)})}
-    );
-
-    const auto col = column_index(seg, "v1_MIN(price)");
-    EXPECT_EQ(seg.column(col).type(), make_scalar_type(DataType::FLOAT64));
-    EXPECT_EQ(seg.scalar_at<double>(0, col), 1.5);
-    EXPECT_EQ(seg.scalar_at<double>(1, col), 2.25);
+// The descriptor decides the stat column's on-disk type, not the row slices contributing to this
+// particular create — otherwise a partial create over a subset of slices could write a narrower
+// type than a whole-symbol create, making the on-disk type depend on creation order.
+TEST(ColumnStatsBuildSegmentTest, StatColumnTypeComesFromDescriptor) {
+    {
+        auto desc = make_descriptor(DataType::UINT16);
+        auto seg = build_column_stats_segment(
+                {component(100, 199, {min_stat<uint8_t>(7, DataType::UINT8)}),
+                 component(200, 299, {min_stat<uint16_t>(1000, DataType::UINT16)})},
+                desc
+        );
+        const auto col = column_index(seg, "v1_MIN(price)");
+        EXPECT_EQ(seg.column(col).type(), make_scalar_type(DataType::UINT16));
+        EXPECT_EQ(seg.scalar_at<uint16_t>(0, col), 7);
+        EXPECT_EQ(seg.scalar_at<uint16_t>(1, col), 1000);
+    }
+    {
+        auto desc = make_descriptor(DataType::INT32);
+        auto seg = build_column_stats_segment(
+                {component(100, 199, {min_stat<uint16_t>(1000, DataType::UINT16)}),
+                 component(200, 299, {min_stat<int16_t>(-1002, DataType::INT16)})},
+                desc
+        );
+        const auto col = column_index(seg, "v1_MIN(price)");
+        EXPECT_EQ(seg.column(col).type(), make_scalar_type(DataType::INT32));
+        EXPECT_EQ(seg.scalar_at<int32_t>(0, col), 1000);
+        EXPECT_EQ(seg.scalar_at<int32_t>(1, col), -1002);
+    }
 }
 
 // A stat missing from some row slices stays sparse, with the absent rows marked absent rather than
 // shifting the values of the rows that do have it.
 TEST(ColumnStatsBuildSegmentTest, StatAbsentFromSomeComponentsIsSparse) {
+    auto desc = make_descriptor();
     auto seg = build_column_stats_segment(
             {component(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
              component(200, 299, {}),
              component(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
-             component(400, 499, {})}
+             component(400, 499, {})},
+            desc
     );
 
     ASSERT_EQ(seg.row_count(), 4);
@@ -162,18 +199,100 @@ TEST(ColumnStatsBuildSegmentTest, StatAbsentFromSomeComponentsIsSparse) {
     EXPECT_EQ(seg.scalar_at<uint64_t>(3, 1), 499);
 }
 
-TEST(ColumnStatsBuildSegmentTest, NoCommonTypeRaises) {
+TEST(ColumnStatsBuildSegmentTest, DuplicateRowRangeRaises) {
+    auto desc = make_descriptor();
     EXPECT_THROW(
             build_column_stats_segment(
-                    {component(100, 199, {min_stat<uint64_t>(1, DataType::UINT64)}),
-                     component(200, 299, {min_stat<int64_t>(-1, DataType::INT64)})}
+                    {component(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
+                     component(100, 199, {min_stat<int64_t>(2, DataType::INT64)})},
+                    desc
             ),
             InternalException
     );
 }
 
+TEST(ColumnStatsBuildSegmentTest, NonMonotonicRowRangeRaises) {
+    auto desc = make_descriptor();
+    EXPECT_THROW(
+            build_column_stats_segment(
+                    {component(0, 5, {min_stat<int64_t>(1, DataType::INT64)}),
+                     component(0, 3, {min_stat<int64_t>(2, DataType::INT64)})},
+                    desc
+            ),
+            InternalException
+    );
+}
+
+TEST(ColumnStatsBuildSegmentTest, DataColOffsetOutOfRangeRaises) {
+    auto desc = make_descriptor();
+    EXPECT_THROW(build_column_stats_segment(
+            {component(
+                    100,
+                    199,
+                    {ColumnStatValue{
+                            "v1_MIN(bogus)", ColumnStatTypeInternal::MIN_V1, 999, Value{int64_t{1}, DataType::INT64}
+                    }}
+            )},
+            desc
+    ), InternalException);
+}
+
 TEST(ColumnStatsBuildSegmentTest, EmptyComponentsRaises) {
-    EXPECT_THROW(build_column_stats_segment({}), InternalException);
+    auto desc = make_descriptor();
+    EXPECT_THROW(build_column_stats_segment({}, desc), InternalException);
+}
+
+TEST(ColumnStatsBuildSegmentTest, RoundTripsSingleTypeComponents) {
+    auto desc = make_descriptor();
+    std::vector components{
+            component(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
+            component(200, 299, {}),
+            component(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
+            component(400, 499, {})
+    };
+    auto expected = components;
+    auto seg = build_column_stats_segment(std::move(components), desc);
+    auto decoded = decode_column_stats_segment(seg);
+    expect_components_equal(std::move(decoded), std::move(expected));
+}
+
+TEST(ColumnStatsBuildSegmentTest, EmptySegmentDecodesToNoComponents) {
+    SegmentInMemory empty_seg;
+    EXPECT_TRUE(decode_column_stats_segment(empty_seg).empty());
+}
+
+TEST(ColumnStatsBuildSegmentTest, FutureHeaderVersionRaises) {
+    auto desc = make_descriptor();
+    auto seg = build_column_stats_segment({component(100, 199, {min_stat<int64_t>(1, DataType::INT64)})}, desc);
+
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    ASSERT_TRUE(seg.metadata()->UnpackTo(&header));
+    header.set_version(99);
+    google::protobuf::Any any;
+    ASSERT_TRUE(any.PackFrom(header));
+    seg.reset_metadata();
+    seg.set_metadata(std::move(any));
+
+    EXPECT_THROW(decode_column_stats_segment(seg), InternalException);
+}
+
+TEST(ColumnStatsBuildSegmentTest, HeaderOffsetOutOfRangeRaises) {
+    auto desc = make_descriptor();
+    auto seg = build_column_stats_segment({component(100, 199, {min_stat<int64_t>(1, DataType::INT64)})}, desc);
+
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    ASSERT_TRUE(seg.metadata()->UnpackTo(&header));
+    for (auto& [data_col_offset, entry_list] : *header.mutable_stats_by_column()) {
+        for (auto& entry : *entry_list.mutable_entries()) {
+            entry.set_stats_seg_offset(999);
+        }
+    }
+    google::protobuf::Any any;
+    ASSERT_TRUE(any.PackFrom(header));
+    seg.reset_metadata();
+    seg.set_metadata(std::move(any));
+
+    EXPECT_THROW(decode_column_stats_segment(seg), InternalException);
 }
 
 } // namespace arcticdb

--- a/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
@@ -225,16 +225,22 @@ TEST(ColumnStatsBuildSegmentTest, NonMonotonicRowRangeRaises) {
 
 TEST(ColumnStatsBuildSegmentTest, DataColOffsetOutOfRangeRaises) {
     auto desc = make_descriptor();
-    EXPECT_THROW(build_column_stats_segment(
-            {component(
-                    100,
-                    199,
-                    {ColumnStatValue{
-                            "v1_MIN(bogus)", ColumnStatTypeInternal::MIN_V1, 999, Value{int64_t{1}, DataType::INT64}
-                    }}
-            )},
-            desc
-    ), InternalException);
+    EXPECT_THROW(
+            build_column_stats_segment(
+                    {component(
+                            100,
+                            199,
+                            {ColumnStatValue{
+                                    "v1_MIN(bogus)",
+                                    ColumnStatTypeInternal::MIN_V1,
+                                    999,
+                                    Value{int64_t{1}, DataType::INT64}
+                            }}
+                    )},
+                    desc
+            ),
+            InternalException
+    );
 }
 
 TEST(ColumnStatsBuildSegmentTest, EmptyComponentsRaises) {

--- a/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
@@ -12,9 +12,11 @@
 #include <arcticdb/entity/stream_descriptor.hpp>
 #include <arcticdb/pipeline/column_stats.hpp>
 #include <arcticdb/pipeline/frame_slice.hpp>
+#include <arcticdb/util/preconditions.hpp>
 #include <google/protobuf/any.pb.h>
 
 #include <algorithm>
+#include <tuple>
 #include <unordered_set>
 
 namespace arcticdb {
@@ -24,17 +26,17 @@ constexpr size_t price_data_col_offset = 1;
 constexpr size_t volume_data_col_offset = 2;
 
 template<typename T>
-ColumnStatValue min_stat(T value, DataType data_type, const char* name = "v1_MIN(price)") {
-    return ColumnStatValue{name, ColumnStatTypeInternal::MIN_V1, price_data_col_offset, Value{value, data_type}};
+ColumnStatValue min_stat(T value, DataType data_type) {
+    return ColumnStatValue{ColumnStatTypeInternal::MIN_V1, price_data_col_offset, Value{value, data_type}};
 }
 
-ColumnStatsRow component(uint64_t start_row, uint64_t end_row, std::vector<ColumnStatValue> stats) {
-    return ColumnStatsRow{start_row, end_row, std::move(stats)};
+ColumnStatsRow column_stats_row(uint64_t start_row, uint64_t end_row, std::vector<ColumnStatValue> stats) {
+    return ColumnStatsRow{pipelines::RowRange{start_row, end_row}, std::move(stats)};
 }
 
 position_t column_index(const SegmentInMemory& seg, std::string_view name) {
     auto idx = seg.column_index(name);
-    EXPECT_TRUE(idx.has_value()) << "column " << name << " missing";
+    util::check(idx.has_value(), "column {} missing", name);
     return static_cast<position_t>(*idx);
 }
 
@@ -47,26 +49,25 @@ StreamDescriptor make_descriptor(DataType price_type = DataType::INT64, DataType
 }
 
 bool stat_values_equal(const ColumnStatValue& left, const ColumnStatValue& right) {
-    return left.segment_column_name == right.segment_column_name && left.type == right.type &&
-           left.data_col_offset == right.data_col_offset && left.value == right.value;
+    return left.type == right.type && left.data_col_offset == right.data_col_offset && left.value == right.value;
 }
 
-// Stat order within a component reflects protobuf map iteration order over stats_by_column, which
-// is unspecified, so comparisons sort by segment_column_name first.
-void expect_components_equal(std::vector<ColumnStatsRow> actual, std::vector<ColumnStatsRow> expected) {
-    auto by_name = [](const ColumnStatValue& l, const ColumnStatValue& r) {
-        return l.segment_column_name < r.segment_column_name;
+// Stat order within a column stats row reflects protobuf map iteration order over stats_by_column, which
+// is unspecified, so comparisons sort by (type, data_col_offset) first.
+void expect_column_stats_rows_equal(std::vector<ColumnStatsRow> actual, std::vector<ColumnStatsRow> expected) {
+    auto by_key = [](const ColumnStatValue& l, const ColumnStatValue& r) {
+        return std::tie(l.type, l.data_col_offset) < std::tie(r.type, r.data_col_offset);
     };
     for (auto& c : actual) {
-        std::sort(c.stats.begin(), c.stats.end(), by_name);
+        std::sort(c.stats.begin(), c.stats.end(), by_key);
     }
     for (auto& c : expected) {
-        std::sort(c.stats.begin(), c.stats.end(), by_name);
+        std::sort(c.stats.begin(), c.stats.end(), by_key);
     }
     ASSERT_EQ(actual.size(), expected.size());
     for (size_t i = 0; i < actual.size(); ++i) {
-        EXPECT_EQ(actual.at(i).start_row, expected.at(i).start_row) << "component " << i;
-        EXPECT_EQ(actual.at(i).end_row, expected.at(i).end_row) << "component " << i;
+        EXPECT_EQ(actual.at(i).row_range.start(), expected.at(i).row_range.start()) << "component " << i;
+        EXPECT_EQ(actual.at(i).row_range.end(), expected.at(i).row_range.end()) << "component " << i;
         ASSERT_EQ(actual.at(i).stats.size(), expected.at(i).stats.size()) << "component " << i;
         for (size_t j = 0; j < actual.at(i).stats.size(); ++j) {
             EXPECT_TRUE(stat_values_equal(actual.at(i).stats.at(j), expected.at(i).stats.at(j)))
@@ -80,9 +81,9 @@ TEST(ColumnStatsBuildSegmentTest, IndexColumnsAndRowOrder) {
     auto desc = make_descriptor();
     // Deliberately out of index order
     auto seg = build_column_stats_segment(
-            {component(300, 399, {min_stat<int64_t>(3, DataType::INT64)}),
-             component(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
-             component(200, 299, {min_stat<int64_t>(2, DataType::INT64)})},
+            {column_stats_row(300, 399, {min_stat<int64_t>(3, DataType::INT64)}),
+             column_stats_row(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
+             column_stats_row(200, 299, {min_stat<int64_t>(2, DataType::INT64)})},
             desc
     );
 
@@ -101,18 +102,14 @@ TEST(ColumnStatsBuildSegmentTest, IndexColumnsAndRowOrder) {
 TEST(ColumnStatsBuildSegmentTest, HeaderOffsetsMatchColumnPositions) {
     auto desc = make_descriptor();
     auto seg = build_column_stats_segment(
-            {component(
+            {column_stats_row(
                     100,
                     199,
                     {min_stat<int64_t>(1, DataType::INT64),
                      ColumnStatValue{
-                             "v1_MAX(price)",
-                             ColumnStatTypeInternal::MAX_V1,
-                             price_data_col_offset,
-                             Value{int64_t{9}, DataType::INT64}
+                             ColumnStatTypeInternal::MAX_V1, price_data_col_offset, Value{int64_t{9}, DataType::INT64}
                      },
                      ColumnStatValue{
-                             "v1_MIN(volume)",
                              ColumnStatTypeInternal::MIN_V1,
                              volume_data_col_offset,
                              Value{uint64_t{5}, DataType::UINT64}
@@ -152,8 +149,8 @@ TEST(ColumnStatsBuildSegmentTest, StatColumnTypeComesFromDescriptor) {
     {
         auto desc = make_descriptor(DataType::UINT16);
         auto seg = build_column_stats_segment(
-                {component(100, 199, {min_stat<uint8_t>(7, DataType::UINT8)}),
-                 component(200, 299, {min_stat<uint16_t>(1000, DataType::UINT16)})},
+                {column_stats_row(100, 199, {min_stat<uint8_t>(7, DataType::UINT8)}),
+                 column_stats_row(200, 299, {min_stat<uint16_t>(1000, DataType::UINT16)})},
                 desc
         );
         const auto col = column_index(seg, "v1_MIN(price)");
@@ -164,8 +161,8 @@ TEST(ColumnStatsBuildSegmentTest, StatColumnTypeComesFromDescriptor) {
     {
         auto desc = make_descriptor(DataType::INT32);
         auto seg = build_column_stats_segment(
-                {component(100, 199, {min_stat<uint16_t>(1000, DataType::UINT16)}),
-                 component(200, 299, {min_stat<int16_t>(-1002, DataType::INT16)})},
+                {column_stats_row(100, 199, {min_stat<uint16_t>(1000, DataType::UINT16)}),
+                 column_stats_row(200, 299, {min_stat<int16_t>(-1002, DataType::INT16)})},
                 desc
         );
         const auto col = column_index(seg, "v1_MIN(price)");
@@ -180,10 +177,10 @@ TEST(ColumnStatsBuildSegmentTest, StatColumnTypeComesFromDescriptor) {
 TEST(ColumnStatsBuildSegmentTest, StatAbsentFromSomeComponentsIsSparse) {
     auto desc = make_descriptor();
     auto seg = build_column_stats_segment(
-            {component(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
-             component(200, 299, {}),
-             component(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
-             component(400, 499, {})},
+            {column_stats_row(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
+             column_stats_row(200, 299, {}),
+             column_stats_row(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
+             column_stats_row(400, 499, {})},
             desc
     );
 
@@ -203,8 +200,8 @@ TEST(ColumnStatsBuildSegmentTest, DuplicateRowRangeRaises) {
     auto desc = make_descriptor();
     EXPECT_THROW(
             build_column_stats_segment(
-                    {component(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
-                     component(100, 199, {min_stat<int64_t>(2, DataType::INT64)})},
+                    {column_stats_row(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
+                     column_stats_row(100, 199, {min_stat<int64_t>(2, DataType::INT64)})},
                     desc
             ),
             InternalException
@@ -215,8 +212,8 @@ TEST(ColumnStatsBuildSegmentTest, NonMonotonicRowRangeRaises) {
     auto desc = make_descriptor();
     EXPECT_THROW(
             build_column_stats_segment(
-                    {component(0, 5, {min_stat<int64_t>(1, DataType::INT64)}),
-                     component(0, 3, {min_stat<int64_t>(2, DataType::INT64)})},
+                    {column_stats_row(0, 5, {min_stat<int64_t>(1, DataType::INT64)}),
+                     column_stats_row(0, 3, {min_stat<int64_t>(2, DataType::INT64)})},
                     desc
             ),
             InternalException
@@ -227,15 +224,10 @@ TEST(ColumnStatsBuildSegmentTest, DataColOffsetOutOfRangeRaises) {
     auto desc = make_descriptor();
     EXPECT_THROW(
             build_column_stats_segment(
-                    {component(
+                    {column_stats_row(
                             100,
                             199,
-                            {ColumnStatValue{
-                                    "v1_MIN(bogus)",
-                                    ColumnStatTypeInternal::MIN_V1,
-                                    999,
-                                    Value{int64_t{1}, DataType::INT64}
-                            }}
+                            {ColumnStatValue{ColumnStatTypeInternal::MIN_V1, 999, Value{int64_t{1}, DataType::INT64}}}
                     )},
                     desc
             ),
@@ -250,16 +242,16 @@ TEST(ColumnStatsBuildSegmentTest, EmptyComponentsRaises) {
 
 TEST(ColumnStatsBuildSegmentTest, RoundTripsSingleTypeComponents) {
     auto desc = make_descriptor();
-    std::vector components{
-            component(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
-            component(200, 299, {}),
-            component(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
-            component(400, 499, {})
+    std::vector column_stats_rows{
+            column_stats_row(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
+            column_stats_row(200, 299, {}),
+            column_stats_row(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
+            column_stats_row(400, 499, {})
     };
-    auto expected = components;
-    auto seg = build_column_stats_segment(std::move(components), desc);
+    auto expected = column_stats_rows;
+    auto seg = build_column_stats_segment(std::move(column_stats_rows), desc);
     auto decoded = decode_column_stats_segment(seg);
-    expect_components_equal(std::move(decoded), std::move(expected));
+    expect_column_stats_rows_equal(std::move(decoded), std::move(expected));
 }
 
 TEST(ColumnStatsBuildSegmentTest, EmptySegmentDecodesToNoComponents) {
@@ -269,7 +261,7 @@ TEST(ColumnStatsBuildSegmentTest, EmptySegmentDecodesToNoComponents) {
 
 TEST(ColumnStatsBuildSegmentTest, FutureHeaderVersionRaises) {
     auto desc = make_descriptor();
-    auto seg = build_column_stats_segment({component(100, 199, {min_stat<int64_t>(1, DataType::INT64)})}, desc);
+    auto seg = build_column_stats_segment({column_stats_row(100, 199, {min_stat<int64_t>(1, DataType::INT64)})}, desc);
 
     arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
     ASSERT_TRUE(seg.metadata()->UnpackTo(&header));
@@ -284,7 +276,7 @@ TEST(ColumnStatsBuildSegmentTest, FutureHeaderVersionRaises) {
 
 TEST(ColumnStatsBuildSegmentTest, HeaderOffsetOutOfRangeRaises) {
     auto desc = make_descriptor();
-    auto seg = build_column_stats_segment({component(100, 199, {min_stat<int64_t>(1, DataType::INT64)})}, desc);
+    auto seg = build_column_stats_segment({column_stats_row(100, 199, {min_stat<int64_t>(1, DataType::INT64)})}, desc);
 
     arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
     ASSERT_TRUE(seg.metadata()->UnpackTo(&header));

--- a/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
@@ -22,8 +22,8 @@ ColumnStatValue min_stat(T value, DataType data_type, const char* name = "v1_MIN
     return ColumnStatValue{name, ColumnStatTypeInternal::MIN_V1, price_data_col_offset, Value{value, data_type}};
 }
 
-ColumnStatsComponent component(timestamp start, timestamp end, std::vector<ColumnStatValue> stats) {
-    return ColumnStatsComponent{start, end, std::move(stats)};
+ColumnStatsComponent component(uint64_t start_row, uint64_t end_row, std::vector<ColumnStatValue> stats) {
+    return ColumnStatsComponent{start_row, end_row, std::move(stats)};
 }
 
 position_t column_index(const SegmentInMemory& seg, std::string_view name) {
@@ -42,13 +42,13 @@ TEST(ColumnStatsBuildSegmentTest, IndexColumnsAndRowOrder) {
     );
 
     ASSERT_EQ(seg.row_count(), 3);
-    EXPECT_EQ(column_index(seg, start_index_column_name), 0);
-    EXPECT_EQ(column_index(seg, end_index_column_name), 1);
+    EXPECT_EQ(column_index(seg, start_row_column_name), 0);
+    EXPECT_EQ(column_index(seg, end_row_column_name), 1);
 
     const auto min_col = column_index(seg, "v1_MIN(price)");
-    for (auto&& [row, expected_start] : folly::enumerate(std::vector<timestamp>{100, 200, 300})) {
-        EXPECT_EQ(seg.scalar_at<timestamp>(static_cast<position_t>(row), 0), expected_start);
-        EXPECT_EQ(seg.scalar_at<timestamp>(static_cast<position_t>(row), 1), expected_start + 99);
+    for (auto&& [row, expected_start] : folly::enumerate(std::vector<uint64_t>{100, 200, 300})) {
+        EXPECT_EQ(seg.scalar_at<uint64_t>(static_cast<position_t>(row), 0), expected_start);
+        EXPECT_EQ(seg.scalar_at<uint64_t>(static_cast<position_t>(row), 1), expected_start + 99);
         EXPECT_EQ(seg.scalar_at<int64_t>(static_cast<position_t>(row), min_col), static_cast<int64_t>(row) + 1);
     }
 }
@@ -157,9 +157,9 @@ TEST(ColumnStatsBuildSegmentTest, StatAbsentFromSomeComponentsIsSparse) {
     EXPECT_FALSE(seg.scalar_at<int64_t>(1, col).has_value());
     EXPECT_EQ(seg.scalar_at<int64_t>(2, col), 33);
     EXPECT_FALSE(seg.scalar_at<int64_t>(3, col).has_value());
-    // The index columns stay dense across all rows
-    EXPECT_EQ(seg.scalar_at<timestamp>(3, 0), 400);
-    EXPECT_EQ(seg.scalar_at<timestamp>(3, 1), 499);
+    // The row-range columns stay dense across all rows
+    EXPECT_EQ(seg.scalar_at<uint64_t>(3, 0), 400);
+    EXPECT_EQ(seg.scalar_at<uint64_t>(3, 1), 499);
 }
 
 TEST(ColumnStatsBuildSegmentTest, NoCommonTypeRaises) {

--- a/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_build_segment.cpp
@@ -1,0 +1,179 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <arcticdb/entity/type_utils.hpp>
+#include <arcticdb/pipeline/column_stats.hpp>
+#include <google/protobuf/any.pb.h>
+
+namespace arcticdb {
+
+namespace {
+constexpr size_t price_data_col_offset = 1;
+constexpr size_t volume_data_col_offset = 2;
+
+template<typename T>
+ColumnStatValue min_stat(T value, DataType data_type, const char* name = "v1_MIN(price)") {
+    return ColumnStatValue{name, ColumnStatTypeInternal::MIN_V1, price_data_col_offset, Value{value, data_type}};
+}
+
+ColumnStatsComponent component(timestamp start, timestamp end, std::vector<ColumnStatValue> stats) {
+    return ColumnStatsComponent{start, end, std::move(stats)};
+}
+
+position_t column_index(const SegmentInMemory& seg, std::string_view name) {
+    auto idx = seg.column_index(name);
+    EXPECT_TRUE(idx.has_value()) << "column " << name << " missing";
+    return static_cast<position_t>(*idx);
+}
+} // namespace
+
+TEST(ColumnStatsBuildSegmentTest, IndexColumnsAndRowOrder) {
+    // Deliberately out of index order
+    auto seg = build_column_stats_segment(
+            {component(300, 399, {min_stat<int64_t>(3, DataType::INT64)}),
+             component(100, 199, {min_stat<int64_t>(1, DataType::INT64)}),
+             component(200, 299, {min_stat<int64_t>(2, DataType::INT64)})}
+    );
+
+    ASSERT_EQ(seg.row_count(), 3);
+    EXPECT_EQ(column_index(seg, start_index_column_name), 0);
+    EXPECT_EQ(column_index(seg, end_index_column_name), 1);
+
+    const auto min_col = column_index(seg, "v1_MIN(price)");
+    for (auto&& [row, expected_start] : folly::enumerate(std::vector<timestamp>{100, 200, 300})) {
+        EXPECT_EQ(seg.scalar_at<timestamp>(static_cast<position_t>(row), 0), expected_start);
+        EXPECT_EQ(seg.scalar_at<timestamp>(static_cast<position_t>(row), 1), expected_start + 99);
+        EXPECT_EQ(seg.scalar_at<int64_t>(static_cast<position_t>(row), min_col), static_cast<int64_t>(row) + 1);
+    }
+}
+
+TEST(ColumnStatsBuildSegmentTest, HeaderOffsetsMatchColumnPositions) {
+    auto seg = build_column_stats_segment({component(
+            100,
+            199,
+            {min_stat<int64_t>(1, DataType::INT64),
+             ColumnStatValue{
+                     "v1_MAX(price)",
+                     ColumnStatTypeInternal::MAX_V1,
+                     price_data_col_offset,
+                     Value{int64_t{9}, DataType::INT64}
+             },
+             ColumnStatValue{
+                     "v1_MIN(volume)",
+                     ColumnStatTypeInternal::MIN_V1,
+                     volume_data_col_offset,
+                     Value{uint64_t{5}, DataType::UINT64}
+             }}
+    )});
+
+    ASSERT_TRUE(seg.metadata());
+    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    ASSERT_TRUE(seg.metadata()->UnpackTo(&header));
+    EXPECT_EQ(header.version(), 1);
+
+    const std::unordered_map<ColumnStatTypeInternal, std::string> operator_for_type{
+            {ColumnStatTypeInternal::MIN_V1, "v1_MIN"}, {ColumnStatTypeInternal::MAX_V1, "v1_MAX"}
+    };
+    const std::unordered_map<size_t, std::string> column_for_offset{
+            {price_data_col_offset, "price"}, {volume_data_col_offset, "volume"}
+    };
+
+    size_t entries = 0;
+    for (const auto& [data_col_offset, entry_list] : header.stats_by_column()) {
+        for (const auto& entry : entry_list.entries()) {
+            const auto expected =
+                    fmt::format("{}({})", operator_for_type.at(entry.type()), column_for_offset.at(data_col_offset));
+            EXPECT_EQ(seg.descriptor().field(entry.stats_seg_offset()).name(), expected);
+            ++entries;
+        }
+    }
+    EXPECT_EQ(entries, 3);
+}
+
+// Dynamic schema can give a different type per row slice for the same stat. The column must widen
+// to the common type and every value must survive the cast.
+TEST(ColumnStatsBuildSegmentTest, WidensToCommonTypeUnsignedIntegers) {
+    auto seg = build_column_stats_segment(
+            {component(100, 199, {min_stat<uint8_t>(7, DataType::UINT8)}),
+             component(200, 299, {min_stat<uint16_t>(1000, DataType::UINT16)})}
+    );
+
+    const auto col = column_index(seg, "v1_MIN(price)");
+    const auto expected_type =
+            has_valid_common_type(make_scalar_type(DataType::UINT8), make_scalar_type(DataType::UINT16));
+    ASSERT_TRUE(expected_type.has_value());
+    EXPECT_EQ(seg.column(col).type(), *expected_type);
+    EXPECT_EQ(seg.scalar_at<uint16_t>(0, col), 7);
+    EXPECT_EQ(seg.scalar_at<uint16_t>(1, col), 1000);
+}
+
+TEST(ColumnStatsBuildSegmentTest, WidensToCommonTypeMixedSignIntegers) {
+    auto seg = build_column_stats_segment(
+            {component(100, 199, {min_stat<uint16_t>(1000, DataType::UINT16)}),
+             component(200, 299, {min_stat<int32_t>(-1002, DataType::INT32)})}
+    );
+
+    const auto col = column_index(seg, "v1_MIN(price)");
+    const auto expected_type =
+            has_valid_common_type(make_scalar_type(DataType::UINT16), make_scalar_type(DataType::INT32));
+    ASSERT_TRUE(expected_type.has_value());
+    EXPECT_EQ(seg.column(col).type(), *expected_type);
+    EXPECT_EQ(seg.scalar_at<int32_t>(0, col), 1000);
+    EXPECT_EQ(seg.scalar_at<int32_t>(1, col), -1002);
+}
+
+TEST(ColumnStatsBuildSegmentTest, WidensToCommonTypeFloats) {
+    auto seg = build_column_stats_segment(
+            {component(100, 199, {min_stat<float>(1.5F, DataType::FLOAT32)}),
+             component(200, 299, {min_stat<double>(2.25, DataType::FLOAT64)})}
+    );
+
+    const auto col = column_index(seg, "v1_MIN(price)");
+    EXPECT_EQ(seg.column(col).type(), make_scalar_type(DataType::FLOAT64));
+    EXPECT_EQ(seg.scalar_at<double>(0, col), 1.5);
+    EXPECT_EQ(seg.scalar_at<double>(1, col), 2.25);
+}
+
+// A stat missing from some row slices stays sparse, with the absent rows marked absent rather than
+// shifting the values of the rows that do have it.
+TEST(ColumnStatsBuildSegmentTest, StatAbsentFromSomeComponentsIsSparse) {
+    auto seg = build_column_stats_segment(
+            {component(100, 199, {min_stat<int64_t>(11, DataType::INT64)}),
+             component(200, 299, {}),
+             component(300, 399, {min_stat<int64_t>(33, DataType::INT64)}),
+             component(400, 499, {})}
+    );
+
+    ASSERT_EQ(seg.row_count(), 4);
+    const auto col = column_index(seg, "v1_MIN(price)");
+    EXPECT_TRUE(seg.column(col).is_sparse());
+    EXPECT_EQ(seg.scalar_at<int64_t>(0, col), 11);
+    EXPECT_FALSE(seg.scalar_at<int64_t>(1, col).has_value());
+    EXPECT_EQ(seg.scalar_at<int64_t>(2, col), 33);
+    EXPECT_FALSE(seg.scalar_at<int64_t>(3, col).has_value());
+    // The index columns stay dense across all rows
+    EXPECT_EQ(seg.scalar_at<timestamp>(3, 0), 400);
+    EXPECT_EQ(seg.scalar_at<timestamp>(3, 1), 499);
+}
+
+TEST(ColumnStatsBuildSegmentTest, NoCommonTypeRaises) {
+    EXPECT_THROW(
+            build_column_stats_segment(
+                    {component(100, 199, {min_stat<uint64_t>(1, DataType::UINT64)}),
+                     component(200, 299, {min_stat<int64_t>(-1, DataType::INT64)})}
+            ),
+            InternalException
+    );
+}
+
+TEST(ColumnStatsBuildSegmentTest, EmptyComponentsRaises) {
+    EXPECT_THROW(build_column_stats_segment({}), InternalException);
+}
+
+} // namespace arcticdb

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -6,16 +6,16 @@
 
 namespace arcticdb {
 // Helper to build a column stats SegmentInMemory with the expected schema:
-//   col 0: "start_index" (NANOSECONDS_UTC64)
-//   col 1: "end_index"   (NANOSECONDS_UTC64)
+//   col 0: "start_row" (UINT64)
+//   col 1: "end_row"   (UINT64)
 //   col 2: "v1_MIN(price)" (INT64)
 //   col 3: "v1_MAX(price)" (INT64)
 //
-// Each entry in |rows| is (start_index, end_index, min_price, max_price).
-// If a row's start_index is std::nullopt, that row has an absent start_index
+// Each entry in |rows| is (start_row, end_row, min_price, max_price).
+// If a row's start_row is std::nullopt, that row has an absent start_row
 struct StatsSegmentRow {
-    std::optional<timestamp> start_index;
-    std::optional<timestamp> end_index;
+    std::optional<uint64_t> start_row;
+    std::optional<uint64_t> end_row;
     int64_t min_price;
     int64_t max_price;
 };
@@ -38,19 +38,19 @@ TimeseriesDescriptor build_test_tsd() {
 SegmentInMemory build_stats_segment(const std::vector<StatsSegmentRow>& rows) {
     using namespace arcticc::pb2::column_stats_pb2;
 
-    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
     auto min_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto max_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
 
     for (const auto& row : rows) {
-        if (row.start_index.has_value()) {
-            start_col->push_back<timestamp>(*row.start_index);
+        if (row.start_row.has_value()) {
+            start_col->push_back<uint64_t>(*row.start_row);
         } else {
             start_col->mark_absent_rows(1);
         }
-        if (row.end_index.has_value()) {
-            end_col->push_back<timestamp>(*row.end_index);
+        if (row.end_row.has_value()) {
+            end_col->push_back<uint64_t>(*row.end_row);
         } else {
             end_col->mark_absent_rows(1);
         }
@@ -66,8 +66,8 @@ SegmentInMemory build_stats_segment(const std::vector<StatsSegmentRow>& rows) {
 
     SegmentInMemory seg;
     seg.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_col);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_col);
+    seg.add_column(scalar_field(DataType::UINT64, start_row_column_name), start_col);
+    seg.add_column(scalar_field(DataType::UINT64, end_row_column_name), end_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MIN(price)"), min_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MAX(price)"), max_col);
     seg.set_row_data(last_row);
@@ -102,37 +102,37 @@ TEST(ColumnStatsDataTest, FindStatsAllRowsPresent) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    auto row0 = data.find_row(100, 200);
+    auto row0 = data.find_row({100, 200});
     ASSERT_TRUE(row0.has_value());
     auto v0 = stats_for(data, "price", *row0);
     ASSERT_EQ(v0.min->get<int64_t>(), 10);
     ASSERT_EQ(v0.max->get<int64_t>(), 20);
 
-    auto row2 = data.find_row(500, 600);
+    auto row2 = data.find_row({500, 600});
     ASSERT_TRUE(row2.has_value());
     auto v2 = stats_for(data, "price", *row2);
     ASSERT_EQ(v2.min->get<int64_t>(), 50);
     ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
 
-// A malformed row (absent start_index) causes the entire ColumnStatsData to be discarded,
+// A malformed row (absent start_row) causes the entire ColumnStatsData to be discarded,
 // even if valid rows were already parsed.
 TEST(ColumnStatsDataTest, MalformedMiddleRowDiscardsAll) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},          // valid
-            {std::nullopt, 400, 30, 40}, // malformed — absent start_index
+            {std::nullopt, 400, 30, 40}, // malformed — absent start_row
             {500, 600, 50, 60},          // never reached
     });
 
     auto tsd = build_test_tsd();
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_TRUE(data.empty());
-    ASSERT_FALSE(data.find_row(100, 200).has_value());
-    ASSERT_FALSE(data.find_row(500, 600).has_value());
+    ASSERT_FALSE(data.find_row({100, 200}).has_value());
+    ASSERT_FALSE(data.find_row({500, 600}).has_value());
 }
 
-// Absent end_index also triggers discard.
-TEST(ColumnStatsDataTest, MalformedEndIndexDiscardsAll) {
+// Absent end_row also triggers discard.
+TEST(ColumnStatsDataTest, MalformedEndRowDiscardsAll) {
     auto seg = build_stats_segment({
             {100, std::nullopt, 10, 20},
     });
@@ -150,7 +150,7 @@ TEST(ColumnStatsDataTest, FindStatsNonExistentIndex) {
 
     auto tsd = build_test_tsd();
     ColumnStatsData data(std::move(seg), tsd);
-    ASSERT_FALSE(data.find_row(999, 888).has_value());
+    ASSERT_FALSE(data.find_row({999, 888}).has_value());
 }
 
 // An empty segment produces empty ColumnStatsData.
@@ -160,29 +160,23 @@ TEST(ColumnStatsDataTest, EmptySegment) {
     auto tsd = build_test_tsd();
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_TRUE(data.empty());
-    ASSERT_FALSE(data.find_row(0, 0).has_value());
+    ASSERT_FALSE(data.find_row({0, 0}).has_value());
 }
 
-// Two row-slices with the same (start_index, end_index) but different min/max stats.
-// This can happen with timestamp-indexed symbols when two segments span identical timestamp ranges
-// (e.g. segments where all rows share the same timestamp).
-// Both entries are dropped from the lookup so that find_row returns nullopt, forcing the
-// segments to be read without pruning rather than using the wrong stats.
-TEST(ColumnStatsDataTest, DuplicateIndexPairDropsBothRows) {
+// Row ranges are unique per row slice, so a repeated one means a corrupt segment. Unlike the
+// (start_index, end_index) key this replaced, there is no legitimate way to produce one, so say so
+// rather than silently dropping both rows.
+TEST(ColumnStatsDataTest, DuplicateRowRangeThrows) {
     auto seg = build_stats_segment({
-            {100, 200, 10, 20}, // row 0: price in [10, 20]
-            {100, 200, 50, 60}, // row 1: same index range, price in [50, 60]
+            {100, 200, 10, 20},
+            {100, 200, 50, 60},
     });
 
     auto tsd = build_test_tsd();
-    ColumnStatsData data(std::move(seg), tsd);
-    ASSERT_FALSE(data.empty());
-
-    // Neither row is reachable via find_row because the key is ambiguous.
-    ASSERT_FALSE(data.find_row(100, 200).has_value());
+    ASSERT_THROW(ColumnStatsData(std::move(seg), tsd), InternalException);
 }
 
-TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows) {
+TEST(ColumnStatsDataTest, WindowPrunesNonIntersectingRows) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},
             {300, 400, 30, 40},
@@ -191,26 +185,28 @@ TEST(ColumnStatsDataTest, DateRangePrunesNonOverlappingRows) {
     });
 
     auto tsd = build_test_tsd();
-    ColumnStatsData data(std::move(seg), tsd, std::make_pair<timestamp, timestamp>(250, 650));
+    ColumnStatsData data(std::move(seg), tsd, pipelines::RowRange{250, 650});
     ASSERT_FALSE(data.empty());
 
-    ASSERT_FALSE(data.find_row(100, 200).has_value());
-    ASSERT_FALSE(data.find_row(700, 800).has_value());
+    ASSERT_FALSE(data.find_row({100, 200}).has_value());
+    ASSERT_FALSE(data.find_row({700, 800}).has_value());
 
-    auto row1 = data.find_row(300, 400);
+    auto row1 = data.find_row({300, 400});
     ASSERT_TRUE(row1.has_value());
     auto v1 = stats_for(data, "price", *row1);
     ASSERT_EQ(v1.min->get<int64_t>(), 30);
     ASSERT_EQ(v1.max->get<int64_t>(), 40);
 
-    auto row2 = data.find_row(500, 600);
+    auto row2 = data.find_row({500, 600});
     ASSERT_TRUE(row2.has_value());
     auto v2 = stats_for(data, "price", *row2);
     ASSERT_EQ(v2.min->get<int64_t>(), 50);
     ASSERT_EQ(v2.max->get<int64_t>(), 60);
 }
 
-TEST(ColumnStatsDataTest, DateRangeBoundariesAreInclusive) {
+// Row ranges are half-open, so a slice is of interest iff it overlaps the window: touching it at
+// either end is not enough.
+TEST(ColumnStatsDataTest, WindowBoundariesAreHalfOpen) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},
             {300, 400, 30, 40},
@@ -219,46 +215,30 @@ TEST(ColumnStatsDataTest, DateRangeBoundariesAreInclusive) {
     });
 
     auto tsd = build_test_tsd();
-    ColumnStatsData data(std::move(seg), tsd, std::make_pair<timestamp, timestamp>(200, 500));
+    ColumnStatsData data(std::move(seg), tsd, pipelines::RowRange{200, 500});
     ASSERT_FALSE(data.empty());
 
-    ASSERT_TRUE(data.find_row(100, 200).has_value());
-    ASSERT_TRUE(data.find_row(300, 400).has_value());
-    ASSERT_TRUE(data.find_row(500, 600).has_value());
-    ASSERT_FALSE(data.find_row(700, 800).has_value());
+    ASSERT_FALSE(data.find_row({100, 200}).has_value()); // ends exactly where the window starts
+    ASSERT_TRUE(data.find_row({300, 400}).has_value());
+    ASSERT_FALSE(data.find_row({500, 600}).has_value()); // starts exactly where the window ends
+    ASSERT_FALSE(data.find_row({700, 800}).has_value());
 }
 
-// Duplicate keys are dropped but non-duplicate keys in the same segment are unaffected.
-TEST(ColumnStatsDataTest, DuplicateIndexPairDoesNotAffectOtherRows) {
+// An empty window is what row_window_of_interest returns when no row slice survived the preceding
+// queries. Nothing is parsed, and nothing is prunable, which is moot because nothing is left.
+TEST(ColumnStatsDataTest, EmptyWindowParsesNothing) {
     auto seg = build_stats_segment({
-            {100, 300, 10, 20}, // row 0: unique key
-            {300, 400, 30, 40}, // row 1: duplicate key (first)
-            {300, 400, 50, 60}, // row 2: duplicate key (second)
-            {400, 600, 70, 80}, // row 3: unique key
+            {100, 200, 10, 20},
+            {300, 400, 30, 40},
     });
 
     auto tsd = build_test_tsd();
-    ColumnStatsData data(std::move(seg), tsd);
-    ASSERT_FALSE(data.empty());
-
-    // Unique rows are still reachable.
-    auto row0 = data.find_row(100, 300);
-    ASSERT_TRUE(row0.has_value());
-    auto v0 = stats_for(data, "price", *row0);
-    ASSERT_EQ(v0.min->get<int64_t>(), 10);
-    ASSERT_EQ(v0.max->get<int64_t>(), 20);
-
-    auto row3 = data.find_row(400, 600);
-    ASSERT_TRUE(row3.has_value());
-    auto v3 = stats_for(data, "price", *row3);
-    ASSERT_EQ(v3.min->get<int64_t>(), 70);
-    ASSERT_EQ(v3.max->get<int64_t>(), 80);
-
-    // Duplicate key is not reachable.
-    ASSERT_FALSE(data.find_row(300, 400).has_value());
+    ColumnStatsData data(std::move(seg), tsd, pipelines::RowRange{0, 0});
+    ASSERT_TRUE(data.empty());
+    ASSERT_FALSE(data.find_row({100, 200}).has_value());
 }
 
-TEST(ColumnStatsDataTest, NonMonotonicStartIndexThrows) {
+TEST(ColumnStatsDataTest, NonMonotonicStartRowThrows) {
     auto seg = build_stats_segment({
             {100, 200, 10, 20},
             {300, 400, 30, 40},
@@ -269,39 +249,6 @@ TEST(ColumnStatsDataTest, NonMonotonicStartIndexThrows) {
     ASSERT_THROW(ColumnStatsData(std::move(seg), tsd), InternalException);
 }
 
-// Writers only sort on start_index, so when two rows share a start_index their end_indexes
-// can appear in any order. Like normal reads, ColumnStatsData must accept this rather than throwing,
-// even though this suggests an out of order index.
-TEST(ColumnStatsDataTest, NonMonotonicEndIndexesAllowed) {
-    auto seg = build_stats_segment({
-            {100, 300, 10, 20},
-            {100, 200, 30, 40},
-            {200, 400, 50, 60},
-    });
-
-    auto tsd = build_test_tsd();
-    ColumnStatsData data(std::move(seg), tsd);
-    ASSERT_FALSE(data.empty());
-
-    auto row0 = data.find_row(100, 300);
-    ASSERT_TRUE(row0.has_value());
-    auto v0 = stats_for(data, "price", *row0);
-    ASSERT_EQ(v0.min->get<int64_t>(), 10);
-    ASSERT_EQ(v0.max->get<int64_t>(), 20);
-
-    auto row1 = data.find_row(100, 200);
-    ASSERT_TRUE(row1.has_value());
-    auto v1 = stats_for(data, "price", *row1);
-    ASSERT_EQ(v1.min->get<int64_t>(), 30);
-    ASSERT_EQ(v1.max->get<int64_t>(), 40);
-
-    auto row2 = data.find_row(200, 400);
-    ASSERT_TRUE(row2.has_value());
-    auto v2 = stats_for(data, "price", *row2);
-    ASSERT_EQ(v2.min->get<int64_t>(), 50);
-    ASSERT_EQ(v2.max->get<int64_t>(), 60);
-}
-
 // Build a two-column stats segment where "volume" is absent (sparse) for certain rows.
 // Verify that values_for_column reports column_absent = true for those entries.
 TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
@@ -309,8 +256,8 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
 
     // Two data columns: price (offset 1) and volume (offset 2) in the TSD.
     // Stats segment layout:
-    //   col 0: start_index
-    //   col 1: end_index
+    //   col 0: start_row
+    //   col 1: end_row
     //   col 2: v1_MIN(price)
     //   col 3: v1_MAX(price)
     //   col 4: v1_MIN(volume)
@@ -319,24 +266,24 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     // Row 0: price=[10,20], volume=[100,200]  (both present)
     // Row 1: price=[30,40], volume absent      (sparse)
 
-    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
     auto min_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto max_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto min_vol_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto max_vol_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
 
     // Row 0: all present
-    start_col->push_back<timestamp>(100);
-    end_col->push_back<timestamp>(200);
+    start_col->push_back<uint64_t>(100);
+    end_col->push_back<uint64_t>(200);
     min_price_col->push_back<int64_t>(10);
     max_price_col->push_back<int64_t>(20);
     min_vol_col->push_back<int64_t>(100);
     max_vol_col->push_back<int64_t>(200);
 
     // Row 1: volume absent
-    start_col->push_back<timestamp>(300);
-    end_col->push_back<timestamp>(400);
+    start_col->push_back<uint64_t>(300);
+    end_col->push_back<uint64_t>(400);
     min_price_col->push_back<int64_t>(30);
     max_price_col->push_back<int64_t>(40);
     min_vol_col->mark_absent_rows(1);
@@ -345,8 +292,8 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     ssize_t last_row = 1;
     SegmentInMemory seg;
     seg.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_col);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_col);
+    seg.add_column(scalar_field(DataType::UINT64, start_row_column_name), start_col);
+    seg.add_column(scalar_field(DataType::UINT64, end_row_column_name), end_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MIN(price)"), min_price_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MAX(price)"), max_price_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MIN(volume)"), min_vol_col);
@@ -387,7 +334,7 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     ColumnStatsData data(std::move(seg), tsd);
     ASSERT_FALSE(data.empty());
 
-    auto row0 = data.find_row(100, 200);
+    auto row0 = data.find_row({100, 200});
     ASSERT_TRUE(row0.has_value());
     auto p0 = stats_for(data, "price", *row0);
     ASSERT_TRUE(p0.min.has_value());
@@ -399,7 +346,7 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     ASSERT_EQ(v0.min->get<int64_t>(), 100);
     ASSERT_FALSE(v0.column_absent);
 
-    auto row1 = data.find_row(300, 400);
+    auto row1 = data.find_row({300, 400});
     ASSERT_TRUE(row1.has_value());
     auto p1 = stats_for(data, "price", *row1);
     ASSERT_TRUE(p1.min.has_value());
@@ -419,8 +366,8 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     using namespace arcticc::pb2::column_stats_pb2;
 
     // Stats segment layout:
-    //   col 0: start_index
-    //   col 1: end_index
+    //   col 0: start_row
+    //   col 1: end_row
     //   col 2: v1_MIN(price)
     //   col 3: v1_MAX(price)
     //   col 4: v1_NAN_COUNT(price)
@@ -429,24 +376,24 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     // Row 0: price=[10,20]            (real values)
     // Row 1: price all null           (no MIN/MAX, null_count=3)
 
-    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
+    auto start_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+    auto end_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
     auto min_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto max_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
     auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
 
     // Row 0: real values present, no nulls
-    start_col->push_back<timestamp>(100);
-    end_col->push_back<timestamp>(200);
+    start_col->push_back<uint64_t>(100);
+    end_col->push_back<uint64_t>(200);
     min_price_col->push_back<int64_t>(10);
     max_price_col->push_back<int64_t>(20);
     nan_count_col->push_back<uint64_t>(0);
     null_count_col->push_back<uint64_t>(0);
 
     // Row 1: all null - min/max absent, counts present
-    start_col->push_back<timestamp>(300);
-    end_col->push_back<timestamp>(400);
+    start_col->push_back<uint64_t>(300);
+    end_col->push_back<uint64_t>(400);
     min_price_col->mark_absent_rows(1);
     max_price_col->mark_absent_rows(1);
     nan_count_col->push_back<uint64_t>(0);
@@ -455,8 +402,8 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     ssize_t last_row = 1;
     SegmentInMemory seg;
     seg.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_col);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_col);
+    seg.add_column(scalar_field(DataType::UINT64, start_row_column_name), start_col);
+    seg.add_column(scalar_field(DataType::UINT64, end_row_column_name), end_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MIN(price)"), min_price_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MAX(price)"), max_price_col);
     seg.add_column(scalar_field(DataType::UINT64, "v1_NAN_COUNT(price)"), nan_count_col);
@@ -486,7 +433,7 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     ColumnStatsData data(std::move(seg), build_test_tsd());
     ASSERT_FALSE(data.empty());
 
-    auto row0 = data.find_row(100, 200);
+    auto row0 = data.find_row({100, 200});
     ASSERT_TRUE(row0.has_value());
     auto v0 = stats_for(data, "price", *row0);
     ASSERT_TRUE(v0.min.has_value());
@@ -495,7 +442,7 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     ASSERT_EQ(v0.max->get<int64_t>(), 20);
     ASSERT_FALSE(v0.column_absent);
 
-    auto row1 = data.find_row(300, 400);
+    auto row1 = data.find_row({300, 400});
     ASSERT_TRUE(row1.has_value());
     auto v1 = stats_for(data, "price", *row1);
     ASSERT_FALSE(v1.min.has_value());

--- a/cpp/arcticdb/processing/aggregation_interface.hpp
+++ b/cpp/arcticdb/processing/aggregation_interface.hpp
@@ -61,9 +61,7 @@ struct IColumnStatsAggregatorData {
     template<class Base>
     struct Interface : Base {
         void aggregate(const ColumnWithStrings& input_column) { folly::poly_call<0>(*this, input_column); }
-        std::vector<ColumnStatValue> finalize(const std::vector<ColumnName>& output_column_names) const {
-            return folly::poly_call<1>(*this, output_column_names);
-        }
+        std::vector<ColumnStatValue> finalize() const { return folly::poly_call<1>(*this); }
     };
 
     template<class T>
@@ -76,12 +74,11 @@ struct IColumnStatsAggregator {
     template<class Base>
     struct Interface : Base {
         [[nodiscard]] ColumnName get_input_column_name() const { return folly::poly_call<0>(*this); };
-        [[nodiscard]] std::vector<ColumnName> get_output_column_names() const { return folly::poly_call<1>(*this); };
-        [[nodiscard]] ColumnStatsAggregatorData get_aggregator_data() const { return folly::poly_call<2>(*this); }
+        [[nodiscard]] ColumnStatsAggregatorData get_aggregator_data() const { return folly::poly_call<1>(*this); }
     };
 
     template<class T>
-    using Members = folly::PolyMembers<&T::get_input_column_name, &T::get_output_column_names, &T::get_aggregator_data>;
+    using Members = folly::PolyMembers<&T::get_input_column_name, &T::get_aggregator_data>;
 };
 
 using ColumnStatsAggregator = folly::Poly<IColumnStatsAggregator>;

--- a/cpp/arcticdb/processing/aggregation_interface.hpp
+++ b/cpp/arcticdb/processing/aggregation_interface.hpp
@@ -10,6 +10,7 @@
 
 #include <folly/Poly.h>
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/pipeline/column_stats_types.hpp>
 
 namespace arcticdb {
 
@@ -60,7 +61,7 @@ struct IColumnStatsAggregatorData {
     template<class Base>
     struct Interface : Base {
         void aggregate(const ColumnWithStrings& input_column) { folly::poly_call<0>(*this, input_column); }
-        SegmentInMemory finalize(const std::vector<ColumnName>& output_column_names) const {
+        std::vector<ColumnStatValue> finalize(const std::vector<ColumnName>& output_column_names) const {
             return folly::poly_call<1>(*this, output_column_names);
         }
     };

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -830,7 +830,7 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
                     std::holds_alternative<NumericIndex>(proc.atom_keys_->at(0)->end_index()),
             "Cannot build column stats over string-indexed symbol"
     );
-    ColumnStatsComponent component{.start_row = row_range.first, .end_row = row_range.second, .stats = {}};
+    ColumnStatsRow component{.start_row = row_range.first, .end_row = row_range.second, .stats = {}};
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
         auto finalized = agg_data->finalize(column_stats_aggregators_->at(agg_data.index).get_output_column_names());
         component.stats.insert(

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -834,41 +834,21 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
             std::holds_alternative<NumericIndex>(start_index) && std::holds_alternative<NumericIndex>(end_index),
             "Cannot build column stats over string-indexed symbol"
     );
-    auto start_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    auto end_index_col = std::make_shared<Column>(make_scalar_type(DataType::NANOSECONDS_UTC64), Sparsity::PERMITTED);
-    start_index_col->template push_back<NumericIndex>(std::get<NumericIndex>(start_index));
-    end_index_col->template push_back<NumericIndex>(std::get<NumericIndex>(end_index));
-    start_index_col->set_row_data(0);
-    end_index_col->set_row_data(0);
-
-    SegmentInMemory seg;
-    seg.descriptor().set_index(IndexDescriptorImpl(IndexDescriptorImpl::Type::ROWCOUNT, 0));
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, start_index_column_name), start_index_col);
-    seg.add_column(scalar_field(DataType::NANOSECONDS_UTC64, end_index_column_name), end_index_col);
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader merged_header;
+    ColumnStatsComponent component{
+            .start_index = std::get<NumericIndex>(start_index),
+            .end_index = std::get<NumericIndex>(end_index),
+            .stats = {}
+    };
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
         auto finalized = agg_data->finalize(column_stats_aggregators_->at(agg_data.index).get_output_column_names());
-        auto offset_base = seg.descriptor().field_count();
-        util::check(finalized.metadata(), "Expect finalized to have metadata, ColumnStatsGenerationClause::process");
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader sub_header;
-        bool unpacked = finalized.metadata()->UnpackTo(&sub_header);
-        util::check(unpacked, "Could not unpack meta to a ColumnStatsHeader in ColumnStatsGenerationClause#process");
-        for (const auto& [data_col_offset, entry_list] : sub_header.stats_by_column()) {
-            auto& merged_entry_list = (*merged_header.mutable_stats_by_column())[data_col_offset];
-            for (const auto& entry : entry_list.entries()) {
-                auto* new_entry = merged_entry_list.add_entries();
-                new_entry->set_stats_seg_offset(entry.stats_seg_offset() + offset_base);
-                new_entry->set_type(entry.type());
-            }
-        }
-        seg.concatenate(std::move(finalized));
+        component.stats.insert(
+                component.stats.end(),
+                std::make_move_iterator(finalized.begin()),
+                std::make_move_iterator(finalized.end())
+        );
     }
-    google::protobuf::Any any;
-    bool packed = any.PackFrom(merged_header);
-    util::check(packed, "Failed to pack merged_header into Any in ColumnStatsGenerationClause#process");
-    seg.set_metadata(std::move(any));
-    seg.set_row_id(0);
-    return push_entities(*component_manager_, ProcessingUnit(std::move(seg)));
+    component_manager_->add_entities(std::vector{std::move(component)});
+    return {};
 }
 
 std::vector<std::vector<size_t>> RowRangeClause::structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -823,16 +823,16 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
                 "Expected all data segments in one processing unit to have the same row range"
         );
     }
-    ColumnStatsRow component{.start_row = row_range.first, .end_row = row_range.second, .stats = {}};
+    ColumnStatsRow column_stats_row{.row_range = row_range, .stats = {}};
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
-        auto finalized = agg_data->finalize(column_stats_aggregators_->at(agg_data.index).get_output_column_names());
-        component.stats.insert(
-                component.stats.end(),
+        auto finalized = agg_data->finalize();
+        column_stats_row.stats.insert(
+                column_stats_row.stats.end(),
                 std::make_move_iterator(finalized.begin()),
                 std::make_move_iterator(finalized.end())
         );
     }
-    return component_manager_->add_entities(std::vector{std::move(component)});
+    return component_manager_->add_entities(std::vector{std::move(column_stats_row)});
 }
 
 std::vector<std::vector<size_t>> RowRangeClause::structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -803,13 +803,6 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
         aggregators_data.emplace_back(agg.get_aggregator_data());
     }
 
-    ankerl::unordered_dense::set<IndexValue> start_indexes;
-    ankerl::unordered_dense::set<IndexValue> end_indexes;
-
-    for (const auto& key : proc.atom_keys_.value()) {
-        start_indexes.insert(key->start_index());
-        end_indexes.insert(key->end_index());
-    }
     for (auto agg_data : folly::enumerate(aggregators_data)) {
         auto input_column_name = column_stats_aggregators_->at(agg_data.index).get_input_column_name();
         auto input_column = proc.get(input_column_name);
@@ -824,21 +817,20 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
         }
     }
 
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            start_indexes.size() == 1 && end_indexes.size() == 1,
-            "Expected all data segments in one processing unit to have same start and end indexes"
-    );
-    auto start_index = *start_indexes.begin();
-    auto end_index = *end_indexes.begin();
+    const auto& row_ranges = proc.row_ranges_.value();
+    const auto& row_range = *row_ranges.at(0);
+    for (const auto& other : row_ranges) {
+        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                other->first == row_range.first && other->second == row_range.second,
+                "Expected all data segments in one processing unit to have the same row range"
+        );
+    }
     schema::check<ErrorCode::E_UNSUPPORTED_INDEX_TYPE>(
-            std::holds_alternative<NumericIndex>(start_index) && std::holds_alternative<NumericIndex>(end_index),
+            std::holds_alternative<NumericIndex>(proc.atom_keys_->at(0)->start_index()) &&
+                    std::holds_alternative<NumericIndex>(proc.atom_keys_->at(0)->end_index()),
             "Cannot build column stats over string-indexed symbol"
     );
-    ColumnStatsComponent component{
-            .start_index = std::get<NumericIndex>(start_index),
-            .end_index = std::get<NumericIndex>(end_index),
-            .stats = {}
-    };
+    ColumnStatsComponent component{.start_row = row_range.first, .end_row = row_range.second, .stats = {}};
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
         auto finalized = agg_data->finalize(column_stats_aggregators_->at(agg_data.index).get_output_column_names());
         component.stats.insert(

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -789,11 +789,9 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
     internal::check<ErrorCode::E_INVALID_ARGUMENT>(
             !entity_ids.empty(), "ColumnStatsGenerationClause::process does not make sense with no processing units"
     );
-    auto proc = gather_entities<
-            std::shared_ptr<SegmentInMemory>,
-            std::shared_ptr<RowRange>,
-            std::shared_ptr<ColRange>,
-            std::shared_ptr<AtomKey>>(*component_manager_, std::move(entity_ids));
+    auto proc = gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
+            *component_manager_, std::move(entity_ids)
+    );
     std::vector<ColumnStatsAggregatorData> aggregators_data;
     internal::check<ErrorCode::E_INVALID_ARGUMENT>(
             static_cast<bool>(column_stats_aggregators_),
@@ -825,11 +823,6 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
                 "Expected all data segments in one processing unit to have the same row range"
         );
     }
-    schema::check<ErrorCode::E_UNSUPPORTED_INDEX_TYPE>(
-            std::holds_alternative<NumericIndex>(proc.atom_keys_->at(0)->start_index()) &&
-                    std::holds_alternative<NumericIndex>(proc.atom_keys_->at(0)->end_index()),
-            "Cannot build column stats over string-indexed symbol"
-    );
     ColumnStatsRow component{.start_row = row_range.first, .end_row = row_range.second, .stats = {}};
     for (const auto& agg_data : folly::enumerate(aggregators_data)) {
         auto finalized = agg_data->finalize(column_stats_aggregators_->at(agg_data.index).get_output_column_names());
@@ -839,8 +832,7 @@ std::vector<EntityId> ColumnStatsGenerationClause::process(std::vector<EntityId>
                 std::make_move_iterator(finalized.end())
         );
     }
-    component_manager_->add_entities(std::vector{std::move(component)});
-    return {};
+    return component_manager_->add_entities(std::vector{std::move(component)});
 }
 
 std::vector<std::vector<size_t>> RowRangeClause::structure_for_processing(std::vector<RangesAndKey>& ranges_and_keys) {

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -84,36 +84,21 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
     });
 }
 
-std::vector<ColumnStatValue> MinMaxAggregatorData::finalize(const std::vector<ColumnName>& output_column_names) const {
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            output_column_names.size() == 4,
-            "Expected 4 output column names in MinMaxAggregatorData::finalize, but got {}",
-            output_column_names.size()
-    );
+std::vector<ColumnStatValue> MinMaxAggregatorData::finalize() const {
     std::vector<ColumnStatValue> res;
     if (min_.has_value()) {
         res.reserve(4);
-        res.emplace_back(ColumnStatValue{
-                output_column_names.at(0).value, ColumnStatTypeInternal::MIN_V1, data_col_offset_, *min_
-        });
-        res.emplace_back(ColumnStatValue{
-                output_column_names.at(1).value, ColumnStatTypeInternal::MAX_V1, data_col_offset_, *max_
-        });
+        res.emplace_back(ColumnStatValue{ColumnStatTypeInternal::MIN_V1, data_col_offset_, *min_});
+        res.emplace_back(ColumnStatValue{ColumnStatTypeInternal::MAX_V1, data_col_offset_, *max_});
     } else if (null_count_ == 0) {
         // The column is absent from this slice entirely, so there is nothing to record
         return res;
     }
+    res.emplace_back(
+            ColumnStatValue{ColumnStatTypeInternal::NAN_COUNT_V1, data_col_offset_, Value{nan_count_, DataType::UINT64}}
+    );
     res.emplace_back(ColumnStatValue{
-            output_column_names.at(2).value,
-            ColumnStatTypeInternal::NAN_COUNT_V1,
-            data_col_offset_,
-            Value{nan_count_, DataType::UINT64}
-    });
-    res.emplace_back(ColumnStatValue{
-            output_column_names.at(3).value,
-            ColumnStatTypeInternal::NULL_COUNT_V1,
-            data_col_offset_,
-            Value{null_count_, DataType::UINT64}
+            ColumnStatTypeInternal::NULL_COUNT_V1, data_col_offset_, Value{null_count_, DataType::UINT64}
     });
     return res;
 }

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -84,74 +84,38 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
     });
 }
 
-SegmentInMemory MinMaxAggregatorData::finalize(const std::vector<ColumnName>& output_column_names) const {
+std::vector<ColumnStatValue> MinMaxAggregatorData::finalize(const std::vector<ColumnName>& output_column_names) const {
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
             output_column_names.size() == 4,
             "Expected 4 output column names in MinMaxAggregatorData::finalize, but got {}",
             output_column_names.size()
     );
-    SegmentInMemory seg;
-    arcticc::pb2::column_stats_pb2::ColumnStatsHeader header;
+    std::vector<ColumnStatValue> res;
     if (min_.has_value()) {
-        details::visit_type(min_->data_type(), [&output_column_names, &seg, &header, this](auto col_tag) {
-            using RawType = typename ScalarTypeInfo<decltype(col_tag)>::RawType;
-            auto min_col = std::make_shared<Column>(make_scalar_type(min_->data_type()), Sparsity::PERMITTED);
-            min_col->push_back<RawType>(min_->get<RawType>());
-
-            auto max_col = std::make_shared<Column>(make_scalar_type(max_->data_type()), Sparsity::PERMITTED);
-            max_col->push_back<RawType>(max_->get<RawType>());
-
-            auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-            nan_count_col->push_back<uint64_t>(nan_count_);
-
-            auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-            null_count_col->push_back<uint64_t>(null_count_);
-
-            auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset_];
-            auto* min_entry = entry_list.add_entries();
-            min_entry->set_stats_seg_offset(0);
-            min_entry->set_type(arcticc::pb2::column_stats_pb2::MIN_V1);
-            auto* max_entry = entry_list.add_entries();
-            max_entry->set_stats_seg_offset(1);
-            max_entry->set_type(arcticc::pb2::column_stats_pb2::MAX_V1);
-            auto* nan_entry = entry_list.add_entries();
-            nan_entry->set_stats_seg_offset(2);
-            nan_entry->set_type(arcticc::pb2::column_stats_pb2::NAN_COUNT_V1);
-            auto* null_entry = entry_list.add_entries();
-            null_entry->set_stats_seg_offset(3);
-            null_entry->set_type(arcticc::pb2::column_stats_pb2::NULL_COUNT_V1);
-
-            seg.add_column(scalar_field(min_col->type().data_type(), output_column_names[0].value), min_col);
-            seg.add_column(scalar_field(max_col->type().data_type(), output_column_names[1].value), max_col);
-            seg.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
-            seg.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
+        res.reserve(4);
+        res.emplace_back(ColumnStatValue{
+                output_column_names.at(0).value, ColumnStatTypeInternal::MIN_V1, data_col_offset_, *min_
         });
-    } else if (null_count_ > 0) { // The whole col in the slice is null
-        auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-        nan_count_col->push_back<uint64_t>(nan_count_);
-
-        auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-        null_count_col->push_back<uint64_t>(null_count_);
-
-        auto& entry_list = (*header.mutable_stats_by_column())[data_col_offset_];
-
-        auto* nan_entry = entry_list.add_entries();
-        nan_entry->set_stats_seg_offset(0);
-        nan_entry->set_type(arcticc::pb2::column_stats_pb2::NAN_COUNT_V1);
-
-        auto* null_entry = entry_list.add_entries();
-        null_entry->set_stats_seg_offset(1);
-        null_entry->set_type(arcticc::pb2::column_stats_pb2::NULL_COUNT_V1);
-
-        seg.add_column(scalar_field(DataType::UINT64, output_column_names[2].value), nan_count_col);
-        seg.add_column(scalar_field(DataType::UINT64, output_column_names[3].value), null_count_col);
+        res.emplace_back(ColumnStatValue{
+                output_column_names.at(1).value, ColumnStatTypeInternal::MAX_V1, data_col_offset_, *max_
+        });
+    } else if (null_count_ == 0) {
+        // The column is absent from this slice entirely, so there is nothing to record
+        return res;
     }
-
-    google::protobuf::Any any;
-    bool packed = any.PackFrom(header);
-    util::check(packed, "Failed to pack header in to Any?");
-    seg.set_metadata(std::move(any));
-    return seg;
+    res.emplace_back(ColumnStatValue{
+            output_column_names.at(2).value,
+            ColumnStatTypeInternal::NAN_COUNT_V1,
+            data_col_offset_,
+            Value{nan_count_, DataType::UINT64}
+    });
+    res.emplace_back(ColumnStatValue{
+            output_column_names.at(3).value,
+            ColumnStatTypeInternal::NULL_COUNT_V1,
+            data_col_offset_,
+            Value{null_count_, DataType::UINT64}
+    });
+    return res;
 }
 
 namespace {

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <arcticdb/entity/types.hpp>
+#include <arcticdb/pipeline/column_stats_types.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 
 namespace arcticdb {
@@ -19,7 +20,7 @@ class MinMaxAggregatorData {
     ARCTICDB_MOVE_COPY_DEFAULT(MinMaxAggregatorData)
 
     void aggregate(const ColumnWithStrings& input_column);
-    SegmentInMemory finalize(const std::vector<ColumnName>& output_column_names) const;
+    std::vector<ColumnStatValue> finalize(const std::vector<ColumnName>& output_column_names) const;
 
   private:
     std::optional<Value> min_;

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -20,7 +20,7 @@ class MinMaxAggregatorData {
     ARCTICDB_MOVE_COPY_DEFAULT(MinMaxAggregatorData)
 
     void aggregate(const ColumnWithStrings& input_column);
-    std::vector<ColumnStatValue> finalize(const std::vector<ColumnName>& output_column_names) const;
+    std::vector<ColumnStatValue> finalize() const;
 
   private:
     std::optional<Value> min_;
@@ -32,36 +32,18 @@ class MinMaxAggregatorData {
 
 class MinMaxAggregator {
   public:
-    explicit MinMaxAggregator(
-            ColumnName column_name, size_t data_col_offset, ColumnName output_column_name_min,
-            ColumnName output_column_name_max, ColumnName output_column_name_nan_count,
-            ColumnName output_column_name_null_count
-    ) :
+    explicit MinMaxAggregator(ColumnName column_name, size_t data_col_offset) :
         column_name_(std::move(column_name)),
-        data_col_offset_(data_col_offset),
-        output_column_name_min_(std::move(output_column_name_min)),
-        output_column_name_max_(std::move(output_column_name_max)),
-        output_column_name_nan_count_(std::move(output_column_name_nan_count)),
-        output_column_name_null_count_(std::move(output_column_name_null_count)) {}
+        data_col_offset_(data_col_offset) {}
 
     ARCTICDB_MOVE_COPY_DEFAULT(MinMaxAggregator)
 
     [[nodiscard]] ColumnName get_input_column_name() const { return column_name_; }
-    [[nodiscard]] std::vector<ColumnName> get_output_column_names() const {
-        return {output_column_name_min_,
-                output_column_name_max_,
-                output_column_name_nan_count_,
-                output_column_name_null_count_};
-    }
     [[nodiscard]] MinMaxAggregatorData get_aggregator_data() const { return MinMaxAggregatorData(data_col_offset_); }
 
   private:
     ColumnName column_name_;
     size_t data_col_offset_;
-    ColumnName output_column_name_min_;
-    ColumnName output_column_name_max_;
-    ColumnName output_column_name_nan_count_;
-    ColumnName output_column_name_null_count_;
 };
 
 class AggregatorDataBase {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -214,16 +214,16 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_inde
 
 void LocalVersionedEngine::create_column_stats_internal(
         const VersionedItem& versioned_item, const ReadOptions& read_options,
-        const std::optional<IndexRange>& date_range, const std::optional<SignedRowRange>& row_range
+        const std::shared_ptr<ReadQuery>& read_query
 ) {
     ARCTICDB_RUNTIME_SAMPLE(CreateColumnStatsInternal, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: create_column_stats");
-    create_column_stats_impl(store(), versioned_item, read_options, date_range, row_range);
+    create_column_stats_impl(store(), versioned_item, read_options, read_query);
 }
 
 void LocalVersionedEngine::create_column_stats_version_internal(
         const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options,
-        const std::optional<IndexRange>& date_range, const std::optional<SignedRowRange>& row_range
+        const std::shared_ptr<ReadQuery>& read_query
 ) {
     auto versioned_item = get_version_to_read(stream_id, version_query);
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
@@ -231,7 +231,7 @@ void LocalVersionedEngine::create_column_stats_version_internal(
             "create_column_stats_version_internal: version not found for stream '{}'",
             stream_id
     );
-    create_column_stats_internal(versioned_item.value(), read_options, date_range, row_range);
+    create_column_stats_internal(versioned_item.value(), read_options, read_query);
 }
 
 void LocalVersionedEngine::drop_column_stats_internal(const VersionedItem& versioned_item) {

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -213,15 +213,17 @@ folly::Future<folly::Unit> LocalVersionedEngine::delete_unreferenced_pruned_inde
 }
 
 void LocalVersionedEngine::create_column_stats_internal(
-        const VersionedItem& versioned_item, const ReadOptions& read_options
+        const VersionedItem& versioned_item, const ReadOptions& read_options,
+        const std::optional<IndexRange>& date_range, const std::optional<SignedRowRange>& row_range
 ) {
     ARCTICDB_RUNTIME_SAMPLE(CreateColumnStatsInternal, 0)
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: create_column_stats");
-    create_column_stats_impl(store(), versioned_item, read_options);
+    create_column_stats_impl(store(), versioned_item, read_options, date_range, row_range);
 }
 
 void LocalVersionedEngine::create_column_stats_version_internal(
-        const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options
+        const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options,
+        const std::optional<IndexRange>& date_range, const std::optional<SignedRowRange>& row_range
 ) {
     auto versioned_item = get_version_to_read(stream_id, version_query);
     missing_data::check<ErrorCode::E_NO_SUCH_VERSION>(
@@ -229,7 +231,7 @@ void LocalVersionedEngine::create_column_stats_version_internal(
             "create_column_stats_version_internal: version not found for stream '{}'",
             stream_id
     );
-    create_column_stats_internal(versioned_item.value(), read_options);
+    create_column_stats_internal(versioned_item.value(), read_options, date_range, row_range);
 }
 
 void LocalVersionedEngine::drop_column_stats_internal(const VersionedItem& versioned_item) {

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -240,14 +240,12 @@ class LocalVersionedEngine : public VersionedEngine {
 
     void create_column_stats_internal(
             const VersionedItem& versioned_item, const ReadOptions& read_options,
-            const std::optional<IndexRange>& date_range = std::nullopt,
-            const std::optional<SignedRowRange>& row_range = std::nullopt
+            const std::shared_ptr<ReadQuery>& read_query
     );
 
     void create_column_stats_version_internal(
             const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options,
-            const std::optional<IndexRange>& date_range = std::nullopt,
-            const std::optional<SignedRowRange>& row_range = std::nullopt
+            const std::shared_ptr<ReadQuery>& read_query
     );
 
     void drop_column_stats_internal(const VersionedItem& versioned_item);

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -238,10 +238,16 @@ class LocalVersionedEngine : public VersionedEngine {
             const VersionQuery& version_query
     );
 
-    void create_column_stats_internal(const VersionedItem& versioned_item, const ReadOptions& read_options);
+    void create_column_stats_internal(
+            const VersionedItem& versioned_item, const ReadOptions& read_options,
+            const std::optional<IndexRange>& date_range = std::nullopt,
+            const std::optional<SignedRowRange>& row_range = std::nullopt
+    );
 
     void create_column_stats_version_internal(
-            const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options
+            const StreamId& stream_id, const VersionQuery& version_query, const ReadOptions& read_options,
+            const std::optional<IndexRange>& date_range = std::nullopt,
+            const std::optional<SignedRowRange>& row_range = std::nullopt
     );
 
     void drop_column_stats_internal(const VersionedItem& versioned_item);

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -729,7 +729,11 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             .def("create_column_stats_version",
                  &PythonVersionStore::create_column_stats_version,
                  py::call_guard<SingleThreadMutexHolder>(),
-                 "Create column stats")
+                 "Create column stats",
+                 py::arg("stream_id"),
+                 py::arg("version_query"),
+                 py::arg("date_range") = std::nullopt,
+                 py::arg("row_range") = std::nullopt)
             .def("drop_column_stats_version",
                  &PythonVersionStore::drop_column_stats_version,
                  py::call_guard<SingleThreadMutexHolder>(),

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -732,8 +732,7 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                  "Create column stats",
                  py::arg("stream_id"),
                  py::arg("version_query"),
-                 py::arg("date_range") = std::nullopt,
-                 py::arg("row_range") = std::nullopt)
+                 py::arg("read_query"))
             .def("drop_column_stats_version",
                  &PythonVersionStore::drop_column_stats_version,
                  py::call_guard<SingleThreadMutexHolder>(),

--- a/cpp/arcticdb/version/test/test_admission_handler.cpp
+++ b/cpp/arcticdb/version/test/test_admission_handler.cpp
@@ -78,7 +78,7 @@ int64_t high_water_for_create_column_stats(
 ) {
     ScopedConfig config_guard{PROCESSING_UNITS_BOUND_KEY, k};
     ResidencyGuard residency_guard;
-    pvs.create_column_stats_version(stream_id, VersionQuery{});
+    pvs.create_column_stats_version(stream_id, VersionQuery{}, std::make_shared<ReadQuery>());
     return util::SegmentResidencyTracker::instance().high_water();
 }
 } // namespace

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2026,17 +2026,29 @@ AtomKey index_key_to_column_stats_key(const IndexTypeKey& index_key) {
 }
 
 void create_column_stats_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options
+        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options,
+        const std::optional<IndexRange>& date_range, const std::optional<SignedRowRange>& row_range
 ) {
     using namespace arcticdb::pipelines;
     auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
+    const bool range_given = date_range.has_value() || row_range.has_value();
+
     auto index_future = store->read(versioned_item.key_);
+    std::optional<folly::Future<std::pair<VariantKey, SegmentInMemory>>> column_stats_future;
+    if (range_given) {
+        storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
+        column_stats_future = store->read(column_stats_key, stats_read_opts);
+    }
 
-    storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-    auto column_stats_future = store->read_metadata(column_stats_key, stats_read_opts);
-
-    auto [index_try, column_stats_try] =
-            folly::collectAll(std::move(index_future), std::move(column_stats_future)).get();
+    folly::Try<std::pair<VariantKey, SegmentInMemory>> index_try;
+    std::optional<folly::Try<std::pair<VariantKey, SegmentInMemory>>> column_stats_try;
+    if (column_stats_future) {
+        auto [idx_try, stats_try] = folly::collectAll(std::move(index_future), std::move(*column_stats_future)).get();
+        index_try = std::move(idx_try);
+        column_stats_try = std::move(stats_try);
+    } else {
+        index_try = std::move(index_future).getTry();
+    }
 
     if (index_try.hasException()) {
         throw storage::NoDataFoundException(fmt::format(
@@ -2060,32 +2072,17 @@ void create_column_stats_impl(
                     arcticdb::proto::descriptors::NormalizationMetadata::InputTypeCase::kMsgPackFrame,
             "Cannot create column stats on pickled data"
     );
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            !(date_range.has_value() && row_range.has_value()), "Date range and row range both specified"
+    );
+    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
+            !date_range.has_value() || tsd.index().type() == IndexDescriptor::Type::TIMESTAMP,
+            "date_range is only supported for timestamp-indexed symbols when creating column stats"
+    );
 
     ColumnStats column_stats{tsd};
     if (column_stats.empty()) {
         return;
-    }
-
-    std::optional<google::protobuf::Any> old_metadata;
-    if (!column_stats_try.hasException()) {
-        old_metadata = std::move(column_stats_try.value().second);
-    }
-
-    if (old_metadata) {
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader old_header;
-        bool unpacked = old_metadata->UnpackTo(&old_header);
-        util::check(
-                unpacked,
-                "Could not unpack metadata of old_header in create_column_stats_impl? key={}",
-                column_stats_key
-        );
-        // The stats we would have to compute that do not already exist. The whole segment is
-        // rewritten below, so this only decides whether there is any work to do at all.
-        ColumnStats outstanding = column_stats;
-        outstanding.drop(ColumnStats{old_header, tsd}, false);
-        if (outstanding.empty()) {
-            return;
-        }
     }
 
     auto clause = column_stats.clause();
@@ -2094,23 +2091,53 @@ void create_column_stats_impl(
         return;
     }
 
+    std::vector<ColumnStatsRow> old_components;
+    if (column_stats_try) {
+        if (column_stats_try->hasException<storage::KeyNotFoundException>()) {
+            // no stats yet, nothing to preserve
+        } else {
+            column_stats_try->throwUnlessValue();
+            old_components = decode_column_stats_segment(column_stats_try->value().second);
+        }
+    }
+
     auto pipeline_context = std::make_shared<PipelineContext>();
     pipeline_context->stream_id_ = versioned_item.key_.id();
     auto read_query = std::make_shared<ReadQuery>(std::vector{std::make_shared<Clause>(std::move(*clause))});
+    read_query->row_range = row_range;
+    if (date_range) {
+        read_query->row_filter = *date_range;
+    }
     read_indexed_keys_to_pipeline(pipeline_context, *read_query, read_options, index_info);
+
+    // Now pipeline_context->slice_and_keys_ contains all the slices that have any intersection with the requested range and we're
+    // about to recalculate them. So drop them from old_components.
+    // Our end result will be the union of old_components and the recalculated stats so this exercise is to avoid duplicate rows.
+    std::unordered_set<RowRange, RowRange::Hasher> in_range;
+    for (const auto& sk : pipeline_context->slice_and_keys_) {
+        in_range.insert(sk.slice().rows());
+    }
+    std::erase_if(old_components, [&in_range](const ColumnStatsRow& c) {
+        return in_range.contains(RowRange{c.start_row, c.end_row});
+    });
 
     auto component_manager = std::make_shared<ComponentManager>();
     read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();
 
-    std::vector<ColumnStatsComponent> components;
-    component_manager->process_entities([&components](const ColumnStatsComponent& component) {
+    std::vector<ColumnStatsRow> components;
+    component_manager->process_entities([&components](const ColumnStatsRow& component) {
         components.emplace_back(component);
     });
     if (components.empty()) {
         return;
     }
 
-    SegmentInMemory new_segment = build_column_stats_segment(std::move(components));
+    components.insert(
+            components.end(),
+            std::make_move_iterator(old_components.begin()),
+            std::make_move_iterator(old_components.end())
+    );
+    SegmentInMemory new_segment = build_column_stats_segment(std::move(components), pipeline_context->descriptor());
     util::check(new_segment.metadata(), "new_segment should always have metadata");
     new_segment.descriptor().set_id(versioned_item.key_.id());
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2027,28 +2027,20 @@ AtomKey index_key_to_column_stats_key(const IndexTypeKey& index_key) {
 
 void create_column_stats_impl(
         const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options,
-        const std::optional<IndexRange>& date_range, const std::optional<SignedRowRange>& row_range
+        const std::shared_ptr<ReadQuery>& read_query
 ) {
     using namespace arcticdb::pipelines;
     auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
-    const bool range_given = date_range.has_value() || row_range.has_value();
+    const bool range_given =
+            read_query->row_range.has_value() || !std::holds_alternative<std::monostate>(read_query->row_filter);
 
     auto index_future = store->read(versioned_item.key_);
-    std::optional<folly::Future<std::pair<VariantKey, SegmentInMemory>>> column_stats_future;
+    std::optional<folly::Try<std::pair<VariantKey, SegmentInMemory>>> column_stats_try;
     if (range_given) {
         storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-        column_stats_future = store->read(column_stats_key, stats_read_opts);
+        column_stats_try = store->read(column_stats_key, stats_read_opts).getTry();
     }
-
-    folly::Try<std::pair<VariantKey, SegmentInMemory>> index_try;
-    std::optional<folly::Try<std::pair<VariantKey, SegmentInMemory>>> column_stats_try;
-    if (column_stats_future) {
-        auto [idx_try, stats_try] = folly::collectAll(std::move(index_future), std::move(*column_stats_future)).get();
-        index_try = std::move(idx_try);
-        column_stats_try = std::move(stats_try);
-    } else {
-        index_try = std::move(index_future).getTry();
-    }
+    auto index_try = std::move(index_future).getTry();
 
     if (index_try.hasException()) {
         throw storage::NoDataFoundException(fmt::format(
@@ -2073,10 +2065,8 @@ void create_column_stats_impl(
             "Cannot create column stats on pickled data"
     );
     user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-            !(date_range.has_value() && row_range.has_value()), "Date range and row range both specified"
-    );
-    user_input::check<ErrorCode::E_INVALID_USER_ARGUMENT>(
-            !date_range.has_value() || tsd.index().type() == IndexDescriptor::Type::TIMESTAMP,
+            !std::holds_alternative<IndexRange>(read_query->row_filter) ||
+                    tsd.index().type() == IndexDescriptor::Type::TIMESTAMP,
             "date_range is only supported for timestamp-indexed symbols when creating column stats"
     );
 
@@ -2091,51 +2081,48 @@ void create_column_stats_impl(
         return;
     }
 
-    std::vector<ColumnStatsRow> old_components;
+    std::vector<ColumnStatsRow> old_column_stats_rows;
     if (column_stats_try) {
         if (column_stats_try->hasException<storage::KeyNotFoundException>()) {
             // no stats yet, nothing to preserve
         } else {
             column_stats_try->throwUnlessValue();
-            old_components = decode_column_stats_segment(column_stats_try->value().second);
+            old_column_stats_rows = decode_column_stats_segment(column_stats_try->value().second);
         }
     }
 
     auto pipeline_context = std::make_shared<PipelineContext>();
     pipeline_context->stream_id_ = versioned_item.key_.id();
-    auto read_query = std::make_shared<ReadQuery>(std::vector{std::make_shared<Clause>(std::move(*clause))});
-    read_query->row_range = row_range;
-    if (date_range) {
-        read_query->row_filter = *date_range;
-    }
+    read_query->add_clauses(std::vector{std::make_shared<Clause>(std::move(*clause))});
     read_indexed_keys_to_pipeline(pipeline_context, *read_query, read_options, index_info);
 
     // Now pipeline_context->slice_and_keys_ contains all the slices that have any intersection with the requested range
-    // and we're about to recalculate them. So drop them from old_components. Our end result will be the union of
-    // old_components and the recalculated stats so this exercise is to avoid duplicate rows.
+    // and we're about to recalculate them. So drop them from old_column_stats_rows. Our end result will be the union of
+    // old_column_stats_rows and the recalculated stats so this exercise is to avoid duplicate rows.
     std::unordered_set<RowRange, RowRange::Hasher> in_range;
     for (const auto& sk : pipeline_context->slice_and_keys_) {
         in_range.insert(sk.slice().rows());
     }
-    std::erase_if(old_components, [&in_range](const ColumnStatsRow& c) {
-        return in_range.contains(RowRange{c.start_row, c.end_row});
+    std::erase_if(old_column_stats_rows, [&in_range](const ColumnStatsRow& c) {
+        return in_range.contains(c.row_range);
     });
 
     auto component_manager = std::make_shared<ComponentManager>();
     auto processed_entity_ids =
             read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();
 
-    auto [components] = component_manager->get_entities<ColumnStatsRow>(processed_entity_ids);
-    if (components.empty()) {
+    auto [new_column_stats_rows] = component_manager->get_entities<ColumnStatsRow>(processed_entity_ids);
+    if (new_column_stats_rows.empty()) {
         return;
     }
 
-    components.insert(
-            components.end(),
-            std::make_move_iterator(old_components.begin()),
-            std::make_move_iterator(old_components.end())
+    new_column_stats_rows.insert(
+            new_column_stats_rows.end(),
+            std::make_move_iterator(old_column_stats_rows.begin()),
+            std::make_move_iterator(old_column_stats_rows.end())
     );
-    SegmentInMemory new_segment = build_column_stats_segment(std::move(components), pipeline_context->descriptor());
+    SegmentInMemory new_segment =
+            build_column_stats_segment(std::move(new_column_stats_rows), pipeline_context->on_disk_descriptor());
     util::check(new_segment.metadata(), "new_segment should always have metadata");
     new_segment.descriptor().set_id(versioned_item.key_.id());
 

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2110,9 +2110,9 @@ void create_column_stats_impl(
     }
     read_indexed_keys_to_pipeline(pipeline_context, *read_query, read_options, index_info);
 
-    // Now pipeline_context->slice_and_keys_ contains all the slices that have any intersection with the requested range and we're
-    // about to recalculate them. So drop them from old_components.
-    // Our end result will be the union of old_components and the recalculated stats so this exercise is to avoid duplicate rows.
+    // Now pipeline_context->slice_and_keys_ contains all the slices that have any intersection with the requested range
+    // and we're about to recalculate them. So drop them from old_components. Our end result will be the union of
+    // old_components and the recalculated stats so this exercise is to avoid duplicate rows.
     std::unordered_set<RowRange, RowRange::Hasher> in_range;
     for (const auto& sk : pipeline_context->slice_and_keys_) {
         in_range.insert(sk.slice().rows());
@@ -2122,12 +2122,10 @@ void create_column_stats_impl(
     });
 
     auto component_manager = std::make_shared<ComponentManager>();
-    read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();
+    auto processed_entity_ids =
+            read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();
 
-    std::vector<ColumnStatsRow> components;
-    component_manager->process_entities([&components](const ColumnStatsRow& component) {
-        components.emplace_back(component);
-    });
+    auto [components] = component_manager->get_entities<ColumnStatsRow>(processed_entity_ids);
     if (components.empty()) {
         return;
     }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2032,12 +2032,8 @@ void create_column_stats_impl(
     auto column_stats_key = index_key_to_column_stats_key(versioned_item.key_);
     auto index_future = store->read(versioned_item.key_);
 
-    using OptionalSeg = std::optional<SegmentInMemory>;
     storage::ReadKeyOpts stats_read_opts{.dont_warn_about_missing_key = true};
-    auto column_stats_future = store->read(column_stats_key, stats_read_opts)
-                                       .thenValue([](std::pair<VariantKey, SegmentInMemory>&& key_seg) -> OptionalSeg {
-                                           return std::move(key_seg.second);
-                                       });
+    auto column_stats_future = store->read_metadata(column_stats_key, stats_read_opts);
 
     auto [index_try, column_stats_try] =
             folly::collectAll(std::move(index_future), std::move(column_stats_future)).get();
@@ -2070,26 +2066,24 @@ void create_column_stats_impl(
         return;
     }
 
-    std::optional<SegmentInMemory> old_segment;
-    if (column_stats_try.hasException()) {
-        // Old column stats key doesn't exist
-    } else {
-        old_segment = std::move(column_stats_try).value();
+    std::optional<google::protobuf::Any> old_metadata;
+    if (!column_stats_try.hasException()) {
+        old_metadata = std::move(column_stats_try.value().second);
     }
 
-    if (old_segment) {
+    if (old_metadata) {
         arcticc::pb2::column_stats_pb2::ColumnStatsHeader old_header;
-        bool unpacked = old_segment->metadata()->UnpackTo(&old_header);
+        bool unpacked = old_metadata->UnpackTo(&old_header);
         util::check(
                 unpacked,
                 "Could not unpack metadata of old_header in create_column_stats_impl? key={}",
                 column_stats_key
         );
-        ColumnStats old_column_stats(old_header, tsd);
-        // No need to redo work for any stats that already exist
-        column_stats.drop(old_column_stats, false);
-        // If all the column stats we are being asked to create already exist, there's no work to do
-        if (column_stats.empty()) {
+        // The stats we would have to compute that do not already exist. The whole segment is
+        // rewritten below, so this only decides whether there is any work to do at all.
+        ColumnStats outstanding = column_stats;
+        outstanding.drop(ColumnStats{old_header, tsd}, false);
+        if (outstanding.empty()) {
             return;
         }
     }
@@ -2105,62 +2099,24 @@ void create_column_stats_impl(
     auto read_query = std::make_shared<ReadQuery>(std::vector{std::make_shared<Clause>(std::move(*clause))});
     read_indexed_keys_to_pipeline(pipeline_context, *read_query, read_options, index_info);
 
-    auto segs = read_process_and_collect(store, pipeline_context, read_query, read_options).get();
-    schema::check<ErrorCode::E_COLUMN_DOESNT_EXIST>(
-            !segs.empty(), "Cannot create column stats for nonexistent columns"
-    );
+    auto component_manager = std::make_shared<ComponentManager>();
+    read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();
 
-    std::vector<SegmentInMemory> segments_in_memory;
-    for (auto& seg : segs) {
-        segments_in_memory.emplace_back(seg.release_segment(store));
+    std::vector<ColumnStatsComponent> components;
+    component_manager->process_entities([&components](const ColumnStatsComponent& component) {
+        components.emplace_back(component);
+    });
+    if (components.empty()) {
+        return;
     }
-    SegmentInMemory new_segment = merge_column_stats_segments(segments_in_memory);
+
+    SegmentInMemory new_segment = build_column_stats_segment(std::move(components));
     util::check(new_segment.metadata(), "new_segment should always have metadata");
     new_segment.descriptor().set_id(versioned_item.key_.id());
 
     storage::UpdateOpts update_opts;
     update_opts.upsert_ = true;
-    if (!old_segment.has_value()) {
-        store->update(column_stats_key, std::move(new_segment), update_opts).get();
-    } else {
-        // Check that the start and end index columns match
-        internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-                new_segment.column(0) == old_segment->column(0) && new_segment.column(1) == old_segment->column(1),
-                "Cannot create column stats, existing column stats row-groups do not match"
-        );
-        // Merge the ColumnStatsHeader metadata from old and new segments
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader old_header;
-        auto* old_metadata = old_segment->metadata();
-        if (!old_metadata) {
-            log::version().warn(
-                    "Found existing Column Stats key without metadata? Just creating new stats... {}", column_stats_key
-            );
-            store->update(column_stats_key, std::move(new_segment), update_opts).get();
-            return;
-        }
-        bool unpacked = old_metadata->UnpackTo(&old_header);
-        util::check(unpacked, "Could not unpack column stats metadata from the old header?");
-        validate_column_stats_header_version(old_header);
-        arcticc::pb2::column_stats_pb2::ColumnStatsHeader new_header;
-        unpacked = new_segment.metadata()->UnpackTo(&new_header);
-        util::check(unpacked, "Could not unpack column stats metadata from the new header?");
-        auto next_offset = old_segment->descriptor().field_count();
-        for (const auto& [data_col_offset, entry_list] : new_header.stats_by_column()) {
-            auto& merged_entry_list = (*old_header.mutable_stats_by_column())[data_col_offset];
-            for (const auto& entry : entry_list.entries()) {
-                auto* merged_entry = merged_entry_list.add_entries();
-                merged_entry->set_type(entry.type());
-                merged_entry->set_stats_seg_offset(next_offset++);
-            }
-        }
-        // Add new stat columns to the old segment
-        old_segment->concatenate(std::move(new_segment));
-        google::protobuf::Any any;
-        any.PackFrom(old_header);
-        old_segment->reset_metadata();
-        old_segment->set_metadata(std::move(any));
-        store->update(column_stats_key, std::move(*old_segment), update_opts).get();
-    }
+    store->update(column_stats_key, std::move(new_segment), update_opts).get();
 }
 
 void drop_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item) {

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -79,8 +79,7 @@ AtomKey index_key_to_column_stats_key(const IndexTypeKey& index_key);
 
 void create_column_stats_impl(
         const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options,
-        const std::optional<IndexRange>& date_range = std::nullopt,
-        const std::optional<SignedRowRange>& row_range = std::nullopt
+        const std::shared_ptr<ReadQuery>& read_query
 );
 
 void drop_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item);

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -78,7 +78,9 @@ folly::Future<IndexInformation> read_index_key_without_column_stats(
 AtomKey index_key_to_column_stats_key(const IndexTypeKey& index_key);
 
 void create_column_stats_impl(
-        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options
+        const std::shared_ptr<Store>& store, const VersionedItem& versioned_item, const ReadOptions& read_options,
+        const std::optional<IndexRange>& date_range = std::nullopt,
+        const std::optional<SignedRowRange>& row_range = std::nullopt
 );
 
 void drop_column_stats_impl(const std::shared_ptr<Store>& store, const VersionedItem& versioned_item);

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -889,10 +889,13 @@ VersionedItem PythonVersionStore::write_metadata(
     return write_versioned_metadata_internal(stream_id, prune_previous_versions, std::move(user_meta_proto));
 }
 
-void PythonVersionStore::create_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query) {
+void PythonVersionStore::create_column_stats_version(
+        const StreamId& stream_id, const VersionQuery& version_query, const std::optional<IndexRange>& date_range,
+        const std::optional<SignedRowRange>& row_range
+) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(cfg().write_options().dynamic_schema());
-    create_column_stats_version_internal(stream_id, version_query, read_options);
+    create_column_stats_version_internal(stream_id, version_query, read_options, date_range, row_range);
 }
 
 void PythonVersionStore::drop_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query) {

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -890,12 +890,11 @@ VersionedItem PythonVersionStore::write_metadata(
 }
 
 void PythonVersionStore::create_column_stats_version(
-        const StreamId& stream_id, const VersionQuery& version_query, const std::optional<IndexRange>& date_range,
-        const std::optional<SignedRowRange>& row_range
+        const StreamId& stream_id, const VersionQuery& version_query, const std::shared_ptr<ReadQuery>& read_query
 ) {
     ReadOptions read_options;
     read_options.set_dynamic_schema(cfg().write_options().dynamic_schema());
-    create_column_stats_version_internal(stream_id, version_query, read_options, date_range, row_range);
+    create_column_stats_version_internal(stream_id, version_query, read_options, read_query);
 }
 
 void PythonVersionStore::drop_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query) {

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -105,7 +105,11 @@ class PythonVersionStore : public LocalVersionedEngine {
 
     VersionedItem write_metadata(const StreamId& stream_id, const py::object& user_meta, bool prune_previous_versions);
 
-    void create_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query);
+    void create_column_stats_version(
+            const StreamId& stream_id, const VersionQuery& version_query,
+            const std::optional<IndexRange>& date_range = std::nullopt,
+            const std::optional<SignedRowRange>& row_range = std::nullopt
+    );
 
     void drop_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query);
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -106,9 +106,7 @@ class PythonVersionStore : public LocalVersionedEngine {
     VersionedItem write_metadata(const StreamId& stream_id, const py::object& user_meta, bool prune_previous_versions);
 
     void create_column_stats_version(
-            const StreamId& stream_id, const VersionQuery& version_query,
-            const std::optional<IndexRange>& date_range = std::nullopt,
-            const std::optional<SignedRowRange>& row_range = std::nullopt
+            const StreamId& stream_id, const VersionQuery& version_query, const std::shared_ptr<ReadQuery>& read_query
     );
 
     void drop_column_stats_version(const StreamId& stream_id, const VersionQuery& version_query);

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1343,9 +1343,8 @@ class NativeVersionStore:
         as_of : `Optional[VersionQueryInput]`, default=None
             See documentation of `read` method for more details.
         date_range: `Optional[DateRangeInput]`, default=None
-            Only recompute stats for row slices intersecting this range. Requires a sorted timestamp index; raises
-            for a non-timestamp index or an unsorted/descending one. Only one of `date_range` or `row_range` can be
-            provided.
+            Only recompute stats for row slices intersecting this range. Requires a sorted timestamp index.
+            Only one of `date_range` or `row_range` can be provided.
         row_range : `Optional[Tuple[Optional[int], Optional[int]]]`, default=None
             Only recompute stats for row slices intersecting this range. Accepts negative indices, with the same
             semantics as the `row_range` argument to `read`. Either end may be `None`, meaning the start or the end

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -25,7 +25,6 @@ import warnings
 import difflib
 from datetime import datetime
 
-from arcticdb_ext.exceptions import UserInputException
 from numpy import datetime64
 from pandas import Timestamp, to_datetime, Timedelta
 from typing import Any, Optional, Union, List, Sequence, Tuple, Dict, Set, NamedTuple
@@ -1354,12 +1353,9 @@ class NativeVersionStore:
         -------
         None
         """
-        if date_range is not None and row_range is not None:
-            raise UserInputException("Date range and row range both specified")
         version_query = self._get_version_query(as_of)
-        cxx_date_range = None if date_range is None else _normalize_dt_range(date_range)
-        cxx_row_range = None if row_range is None else _SignedRowRange(row_range[0], row_range[1])
-        self.version_store.create_column_stats_version(symbol, version_query, cxx_date_range, cxx_row_range)
+        read_query = self._get_read_query(date_range=date_range, row_range=row_range, columns=None, query_builder=None)
+        self.version_store.create_column_stats_version(symbol, version_query, read_query)
 
     def drop_column_stats_experimental(self, symbol: str, as_of: Optional[VersionQueryInput] = None) -> None:
         """

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -1321,6 +1321,8 @@ class NativeVersionStore:
         self,
         symbol: str,
         as_of: Optional[VersionQueryInput] = None,
+        date_range: Optional[DateRangeInput] = None,
+        row_range: Optional[Tuple[Optional[int], Optional[int]]] = None,
     ) -> None:
         """
         Calculates MINMAX column statistics for each row-slice for the given symbol. In the future, these
@@ -1329,8 +1331,10 @@ class NativeVersionStore:
 
         MINMAX stats are built for every data column and every inner multiindex index level whose dtype is numeric
         (uint/int/float/bool) or a UTC nanosecond timestamp. The outer/primary index is excluded, as it is already
-        pruned by the index mechanism. Any pre-existing stats are merged with the newly computed ones
-        (read-modify-write).
+        pruned by the index mechanism.
+
+        Stats for row slices that fall entirely outside `date_range`/`row_range` are preserved. Every row slice the
+        range intersects is recomputed. Omitting both `date_range` and `row_range` recomputes stats for the whole symbol.
 
         Parameters
         ----------
@@ -1338,13 +1342,25 @@ class NativeVersionStore:
             Symbol name.
         as_of : `Optional[VersionQueryInput]`, default=None
             See documentation of `read` method for more details.
+        date_range: `Optional[DateRangeInput]`, default=None
+            Only recompute stats for row slices intersecting this range. Requires a sorted timestamp index; raises
+            for a non-timestamp index or an unsorted/descending one. Only one of `date_range` or `row_range` can be
+            provided.
+        row_range : `Optional[Tuple[Optional[int], Optional[int]]]`, default=None
+            Only recompute stats for row slices intersecting this range. Accepts negative indices, with the same
+            semantics as the `row_range` argument to `read`. Either end may be `None`, meaning the start or the end
+            of the symbol. Only one of `date_range` or `row_range` can be provided.
 
         Returns
         -------
         None
         """
+        if date_range is not None and row_range is not None:
+            raise UserInputException("Date range and row range both specified")
         version_query = self._get_version_query(as_of)
-        self.version_store.create_column_stats_version(symbol, version_query)
+        cxx_date_range = None if date_range is None else _normalize_dt_range(date_range)
+        cxx_row_range = None if row_range is None else _SignedRowRange(row_range[0], row_range[1])
+        self.version_store.create_column_stats_version(symbol, version_query, cxx_date_range, cxx_row_range)
 
     def drop_column_stats_experimental(self, symbol: str, as_of: Optional[VersionQueryInput] = None) -> None:
         """

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -23,6 +23,7 @@ from arcticdb_ext.exceptions import SchemaException, SortingException, StorageEx
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
+from arcticdb.exceptions import ArcticNativeException
 from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked
 from arcticdb.util.test import config_context
 
@@ -82,12 +83,11 @@ def assert_stats_equal(received, expected, check_dtypes=False):
     pl_assert_frame_equal(received_pl, expected, check_column_order=False, check_dtypes=check_dtypes)
 
 
-def test_column_stats_basic_flow(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_basic_flow(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -110,12 +110,11 @@ def test_column_stats_basic_flow(version_store_factory, lib_name, encoding_versi
         lib.read_column_stats_experimental(sym)
 
 
-def test_column_stats_infinity(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_infinity(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -137,8 +136,8 @@ def test_column_stats_infinity(version_store_factory, lib_name, encoding_version
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_nan_values(lmdb_version_store, any_output_format):
-    lib = lmdb_version_store
+def test_column_stats_nan_values(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "test_column_stats_nan_values"
     df0 = pd.DataFrame({"col_1": [1.0, 3.0]}, index=pd.date_range("2000-01-01", periods=2))
@@ -166,8 +165,8 @@ def test_column_stats_nan_values(lmdb_version_store, any_output_format):
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_nat_values(lmdb_version_store, any_output_format):
-    lib = lmdb_version_store
+def test_column_stats_nat_values(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "test_column_stats_nat_values"
     df0 = pd.DataFrame(
@@ -244,8 +243,8 @@ def test_column_stats_nat_values(lmdb_version_store, any_output_format):
     assert raw_stats["v1_MAX(col_1)"].values.view("int64")[3] == nat_sentinel
 
 
-def test_column_stats_nan_and_null_counts(lmdb_version_store, any_output_format):
-    lib = lmdb_version_store
+def test_column_stats_nan_and_null_counts(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "test_column_stats_nan_and_null_counts"
 
@@ -307,10 +306,10 @@ def test_column_stats_nan_and_null_counts(lmdb_version_store, any_output_format)
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_nan_count_single_segment(lmdb_version_store, any_output_format):
+def test_column_stats_nan_count_single_segment(in_memory_store_factory, lib_name, encoding_version, any_output_format):
     """In-band sentinels (NaN in a float column, NaT in a timestamp column) count towards
     v1_NAN_COUNT. v1_NULL_COUNT is reserved for genuinely-missing rows (sparse-map gaps)."""
-    lib = lmdb_version_store
+    lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "test_column_stats_nan_count_single_segment"
     df = pd.DataFrame(
@@ -336,17 +335,16 @@ def test_column_stats_nan_count_single_segment(lmdb_version_store, any_output_fo
     assert cs["v1_NULL_COUNT(ts_col)"].to_list() == [0]
 
 
-def test_column_stats_null_count_sparse_floats(version_store_factory, lib_name, encoding_version, any_output_format):
+def test_column_stats_null_count_sparse_floats(in_memory_store_factory, lib_name, encoding_version, any_output_format):
     """sparsify_floats=True stores NaN floats as sparse-map gaps rather than dense NaN values.
     Those gaps are counted as nulls (v1_NULL_COUNT), not NaNs (v1_NAN_COUNT).
 
     The 6 rows span multiple segments (segment_row_size=3) with a different null count in each,
     so the per-segment null calculation is exercised rather than a single-segment case."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=3,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -364,8 +362,8 @@ def test_column_stats_null_count_sparse_floats(version_store_factory, lib_name, 
     assert cs["v1_MAX(col_1)"].to_list() == [2.0, 4.0]
 
 
-def test_column_stats_arrow_nan_and_null_same_column(lmdb_version_store_arrow):
-    lib = lmdb_version_store_arrow
+def test_column_stats_arrow_nan_and_null_same_column(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
     lib._cfg.write_options.segment_row_size = 100
     sym = "test_column_stats_arrow_nan_and_null_same_column"
 
@@ -403,8 +401,8 @@ def _segment_values():
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(segments=st.lists(_segment_values(), min_size=1, max_size=6))
-def test_column_stats_arrow_nan_null_counts_hypothesis(lmdb_version_store_arrow, segments):
-    lib = lmdb_version_store_arrow
+def test_column_stats_arrow_nan_null_counts_hypothesis(in_memory_version_store_arrow, segments):
+    lib = in_memory_version_store_arrow
     lib._cfg.write_options.segment_row_size = 100
     lib.version_store.clear()
     sym = "test_column_stats_arrow_nan_null_counts_hypothesis"
@@ -424,12 +422,11 @@ def test_column_stats_arrow_nan_null_counts_hypothesis(lmdb_version_store_arrow,
     assert cs["v1_NULL_COUNT(f)"].to_list() == expected_null
 
 
-def test_column_stats_as_of(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_as_of(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -453,12 +450,13 @@ def test_column_stats_as_of(version_store_factory, lib_name, encoding_version, a
         lib.read_column_stats_experimental(sym, as_of=0)
 
 
-def test_column_stats_as_of_version_doesnt_exist(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_as_of_version_doesnt_exist(
+    in_memory_store_factory, lib_name, encoding_version, any_output_format
+):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -476,13 +474,12 @@ def test_column_stats_as_of_version_doesnt_exist(version_store_factory, lib_name
 
 
 def test_column_stats_multiple_indexes_different_columns(
-    version_store_factory, lib_name, encoding_version, any_output_format
+    in_memory_store_factory, lib_name, encoding_version, any_output_format
 ):
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -496,12 +493,11 @@ def test_column_stats_multiple_indexes_different_columns(
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_pickled_symbol(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_pickled_symbol(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -513,12 +509,11 @@ def test_column_stats_pickled_symbol(version_store_factory, lib_name, encoding_v
         lib.create_column_stats_experimental(sym)
 
 
-def test_column_stats_duplicated_primary_index(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_duplicated_primary_index(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -540,8 +535,10 @@ def test_column_stats_duplicated_primary_index(version_store_factory, lib_name, 
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_dynamic_schema_missing_data(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_dynamic_schema_missing_data(
+    in_memory_store_factory, lib_name, encoding_version, any_output_format
+):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         dynamic_schema=True,
@@ -662,9 +659,9 @@ def assert_dynamic_schema_types_changing_schema(schema):
 
 
 def test_column_stats_dynamic_schema_types_changing(
-    version_store_factory, lib_name, encoding_version, any_output_format
+    in_memory_store_factory, lib_name, encoding_version, any_output_format
 ):
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         dynamic_schema=True,
@@ -717,7 +714,9 @@ def test_column_stats_dynamic_schema_types_changing(
     assert_dynamic_schema_types_changing_schema(pl.from_arrow(column_stats).schema)
 
 
-def test_column_stats_object_deleted_with_index_key(lmdb_version_store, any_output_format):
+def test_column_stats_object_deleted_with_index_key(
+    in_memory_store_factory, lib_name, encoding_version, any_output_format
+):
     def clear():
         nonlocal expected_count
         lib.version_store.clear()
@@ -850,7 +849,7 @@ def test_column_stats_object_deleted_with_index_key(lmdb_version_store, any_outp
         expected_count = 1
         assert_column_stats_key_count()
 
-    lib = lmdb_version_store
+    lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
     lib._set_output_format_for_pipeline_tests(any_output_format)
     lib_tool = lib.library_tool()
     sym = "test_column_stats_object_deleted_with_index_key"
@@ -927,12 +926,11 @@ def assert_header_offsets_match_field_names(lib, sym, header, col_name_by_offset
         assert fields[entry.stats_seg_offset].name == expected
 
 
-def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_header_metadata(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -962,8 +960,8 @@ def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_
     assert_header_offsets_match_field_names(lib, sym, header, {2: "col_1", 3: "col_2"})
 
 
-def test_column_stats_create_twice_is_idempotent(version_store_factory, lib_name):
-    lib = version_store_factory(
+def test_column_stats_create_twice_is_idempotent(in_memory_store_factory, lib_name):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         name=lib_name,
@@ -987,12 +985,11 @@ def test_column_stats_create_twice_is_idempotent(version_store_factory, lib_name
     assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)
 
 
-def test_column_stats_duplicated_column_names(version_store_factory, lib_name, encoding_version, any_output_format):
-    lib = version_store_factory(
+def test_column_stats_duplicated_column_names(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1017,15 +1014,14 @@ def test_column_stats_duplicated_column_names(version_store_factory, lib_name, e
 
 @pytest.mark.parametrize("index_name", ("index", "some-other-name"))
 def test_column_stats_col_called_index(
-    version_store_factory, lib_name, encoding_version, any_output_format, index_name
+    in_memory_store_factory, lib_name, encoding_version, any_output_format, index_name
 ):
     """Check some edge cases where the data column's name matches the index column. 'index' is used as an internal
     name for un-named indexes, so using it can expose some bugs."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1071,15 +1067,14 @@ def test_column_stats_col_called_index(
     ],
 )
 def test_column_stats_multiindex(
-    version_store_factory, lib_name, encoding_version, any_output_format, index_level_name, stored_col_name
+    in_memory_store_factory, lib_name, encoding_version, any_output_format, index_level_name, stored_col_name
 ):
     """Column stats on a multiindex DataFrame: auto-discovery picks up data columns and the inner
     index level; the outer/primary index is excluded (already pruned by the index)."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1160,16 +1155,15 @@ def test_column_stats_multiindex(
     ],
 )
 def test_column_stats_series(
-    version_store_factory, lib_name, encoding_version, any_output_format, series_name, stored_col_name
+    in_memory_store_factory, lib_name, encoding_version, any_output_format, series_name, stored_col_name
 ):
     """Column stats on a datetime-indexed pd.Series. A Series is normalized with input_type == "series"
     (not "df"); the outer/primary index must still be excluded (it is already pruned by the index
     mechanism) and only the single value column gets MINMAX stats."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1197,14 +1191,13 @@ def test_column_stats_series(
         lib.read_column_stats_experimental(sym)
 
 
-def test_column_stats_series_rangeindex(version_store_factory, lib_name, encoding_version, any_output_format):
+def test_column_stats_series_rangeindex(in_memory_store_factory, lib_name, encoding_version, any_output_format):
     """A RangeIndex pd.Series has no physically-stored index, so the single value column gets stats and
     nothing is treated as an index to exclude."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1216,8 +1209,8 @@ def test_column_stats_series_rangeindex(version_store_factory, lib_name, encodin
     assert lib.get_column_stats_info_experimental(sym) == {"myval": {"MINMAX"}}
 
 
-def test_column_stats_string_indexed_symbol(version_store_factory, lib_name):
-    lib = version_store_factory(
+def test_column_stats_string_indexed_symbol(in_memory_store_factory, lib_name):
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         name=lib_name,
@@ -1248,15 +1241,14 @@ def test_column_stats_string_indexed_symbol(version_store_factory, lib_name):
     ],
 )
 def test_column_stats_series_multiindex(
-    version_store_factory, lib_name, encoding_version, any_output_format, index_level_name, stored_col_name
+    in_memory_store_factory, lib_name, encoding_version, any_output_format, index_level_name, stored_col_name
 ):
     """Column stats on a MultiIndex pd.Series: the outer/primary index is excluded, while the inner
     index level and the value column both get MINMAX stats (mirrors the multiindex DataFrame case)."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1289,15 +1281,14 @@ def test_column_stats_series_multiindex(
 
 
 def test_column_stats_create_tiny_thread_pool(
-    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool
+    in_memory_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool
 ):
     """Simple test with tiny thread pool to check against deadlocks from the parallel load of the index key
     and the column stats key."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1312,15 +1303,14 @@ def test_column_stats_create_tiny_thread_pool(
 
 
 def test_column_stats_drop_tiny_thread_pool(
-    version_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool
+    in_memory_store_factory, lib_name, encoding_version, any_output_format, tiny_thread_pool
 ):
     """Simple test with tiny thread pool to check against deadlocks from the parallel load of the index key
     and the column stats key."""
-    lib = version_store_factory(
+    lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=2,
         encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -1409,9 +1399,9 @@ def test_column_stats_create_single_unit(
 
 
 def test_column_stats_duplicate_index_values_across_slice_boundary(
-    lmdb_version_store_tiny_segment, column_stats_filtering_enabled
+    in_memory_version_store_tiny_segment, column_stats_filtering_enabled
 ):
-    lib = lmdb_version_store_tiny_segment
+    lib = in_memory_version_store_tiny_segment
     sym = "test_column_stats_duplicate_index_values_across_slice_boundary"
     ts = pd.Timestamp("2000-01-01")
     lib.write(sym, pd.DataFrame({"col_1": [1, 2, 3, 4]}, index=[ts] * 4))
@@ -1525,8 +1515,8 @@ def expected_row_range_stats(df, expected_slices):
         ((None, -6), [(0, 3)]),
     ],
 )
-def test_column_stats_create_row_range(version_store_factory, lib_name, row_range, expected_slices):
-    lib = version_store_factory(segment_row_size=3, name=lib_name)
+def test_column_stats_create_row_range(in_memory_store_factory, lib_name, row_range, expected_slices):
+    lib = in_memory_store_factory(segment_row_size=3, name=lib_name)
     sym = "test_column_stats_create_row_range"
     df = write_nine_row_symbol(lib, sym)
 
@@ -1546,8 +1536,8 @@ def test_column_stats_create_row_range(version_store_factory, lib_name, row_rang
         ((pd.Timestamp("2000-01-07"), pd.Timestamp("2000-01-09")), [(6, 9)]),
     ],
 )
-def test_column_stats_create_date_range(version_store_factory, lib_name, date_range, expected_slices):
-    lib = version_store_factory(segment_row_size=3, name=lib_name)
+def test_column_stats_create_date_range(in_memory_store_factory, lib_name, date_range, expected_slices):
+    lib = in_memory_store_factory(segment_row_size=3, name=lib_name)
     sym = "test_column_stats_create_date_range"
     df = write_nine_row_symbol(lib, sym)
 
@@ -1580,10 +1570,14 @@ def test_column_stats_create_date_range(version_store_factory, lib_name, date_ra
         ([(0, 4), (2, 10)], [(0, 3), (3, 6), (6, 9), (9, 11)]),
         # [3, 6) is recalculated, [0, 3) is kept, [6, 9) is new
         ([(0, 4), (5, 9)], [(0, 3), (3, 6), (6, 9)]),
+        # read_index output, one row_range per row-slice
+        ([(0, 3), (3, 6), (6, 9), (9, 11)], [(0, 3), (3, 6), (6, 9), (9, 11)]),
+        # read_index output coalesced into fewer, larger row_ranges
+        ([(0, 6), (6, 11)], [(0, 3), (3, 6), (6, 9), (9, 11)]),
     ],
 )
-def test_column_stats_create_incrementally_by_row_range(version_store_factory, lib_name, row_ranges, expected_slices):
-    lib = version_store_factory(segment_row_size=3, name=lib_name)
+def test_column_stats_create_incrementally_by_row_range(in_memory_store_factory, lib_name, row_ranges, expected_slices):
+    lib = in_memory_store_factory(segment_row_size=3, name=lib_name)
     sym = "sym"
     df = write_eleven_row_symbol(lib, sym)
 
@@ -1616,8 +1610,10 @@ def test_column_stats_create_incrementally_by_row_range(version_store_factory, l
         ([(jan(1), jan(4)), (jan(6), jan(9))], [(0, 3), (3, 6), (6, 9)]),
     ],
 )
-def test_column_stats_create_incrementally_by_date_range(version_store_factory, lib_name, date_ranges, expected_slices):
-    lib = version_store_factory(segment_row_size=3, name=lib_name)
+def test_column_stats_create_incrementally_by_date_range(
+    in_memory_store_factory, lib_name, date_ranges, expected_slices
+):
+    lib = in_memory_store_factory(segment_row_size=3, name=lib_name)
     sym = "sym"
     df = write_eleven_row_symbol(lib, sym)
 
@@ -1629,10 +1625,10 @@ def test_column_stats_create_incrementally_by_date_range(version_store_factory, 
     )
 
 
-def test_column_stats_create_dynamic_schema_partial_create_uses_descriptor_type(version_store_factory, lib_name):
+def test_column_stats_create_dynamic_schema_partial_create_uses_descriptor_type(in_memory_store_factory, lib_name):
     """A range covering only the first row slice must still type MIN/MAX from the version's descriptor,
     not from that slice's own dtype"""
-    lib = version_store_factory(column_group_size=2, segment_row_size=2, dynamic_schema=True, name=lib_name)
+    lib = in_memory_store_factory(column_group_size=2, segment_row_size=2, dynamic_schema=True, name=lib_name)
     sym = "test_column_stats_create_dynamic_schema_partial_create_uses_descriptor_type"
 
     df0, df1 = dynamic_schema_types_changing_dfs()
@@ -1644,8 +1640,8 @@ def test_column_stats_create_dynamic_schema_partial_create_uses_descriptor_type(
     assert_dynamic_schema_types_changing_schema(pl.from_arrow(lib.read_column_stats_experimental(sym)).schema)
 
 
-def test_column_stats_create_partial_coverage_with_column_slicing(version_store_factory, lib_name):
-    lib = version_store_factory(column_group_size=2, segment_row_size=3, name=lib_name)
+def test_column_stats_create_partial_coverage_with_column_slicing(in_memory_store_factory, lib_name):
+    lib = in_memory_store_factory(column_group_size=2, segment_row_size=3, name=lib_name)
     sym = "test_column_stats_create_partial_coverage_with_column_slicing"
     df = pd.DataFrame(
         {f"col_{i}": np.arange(i * 100, i * 100 + 9) for i in range(1, 5)},
@@ -1673,8 +1669,8 @@ def test_column_stats_create_partial_coverage_with_column_slicing(version_store_
     assert_stats_equal(lib.read_column_stats_experimental(sym), expected)
 
 
-def test_column_stats_create_empty_range_is_noop(version_store_factory, lib_name):
-    lib = version_store_factory(segment_row_size=3, name=lib_name)
+def test_column_stats_create_empty_range_is_noop(in_memory_store_factory, lib_name):
+    lib = in_memory_store_factory(segment_row_size=3, name=lib_name)
     sym = "test_column_stats_create_empty_range_is_noop"
     df = write_nine_row_symbol(lib, sym)
 
@@ -1700,8 +1696,8 @@ def test_column_stats_create_empty_range_is_noop(version_store_factory, lib_name
     [{"row_range": (5, 2)}, {"date_range": (jan(7), jan(2))}],
     ids=["row_range", "date_range"],
 )
-def test_column_stats_create_reversed_range_is_noop(version_store_factory, lib_name, reversed_range):
-    lib = version_store_factory(segment_row_size=3, name=lib_name)
+def test_column_stats_create_reversed_range_is_noop(in_memory_store_factory, lib_name, reversed_range):
+    lib = in_memory_store_factory(segment_row_size=3, name=lib_name)
     sym = "test_column_stats_create_reversed_range_is_noop"
     df = write_nine_row_symbol(lib, sym)
 
@@ -1717,11 +1713,11 @@ def test_column_stats_create_reversed_range_is_noop(version_store_factory, lib_n
 
 
 def test_column_stats_create_dynamic_schema_preserves_stats_for_column_outside_the_range(
-    version_store_factory, lib_name
+    in_memory_store_factory, lib_name
 ):
     """col_2 exists only in the second row slice, so recomputing only the first must carry its stats
     over from the stored segment rather than from anything the create just calculated."""
-    lib = version_store_factory(segment_row_size=3, dynamic_schema=True, name=lib_name)
+    lib = in_memory_store_factory(segment_row_size=3, dynamic_schema=True, name=lib_name)
     sym = "test_column_stats_create_dynamic_schema_preserves_stats_for_column_outside_the_range"
     lib.write(sym, pd.DataFrame({"col_1": [1, 2, 3]}, index=pd.date_range("2000-01-01", periods=3)))
     lib.append(sym, pd.DataFrame({"col_2": [4, 5, 6]}, index=pd.date_range("2000-01-04", periods=3)))
@@ -1749,17 +1745,17 @@ def test_column_stats_create_dynamic_schema_preserves_stats_for_column_outside_t
     assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
 
 
-def test_column_stats_create_date_range_and_row_range_both_specified_raises(lmdb_version_store_tiny_segment):
-    lib = lmdb_version_store_tiny_segment
+def test_column_stats_create_date_range_and_row_range_both_specified_raises(in_memory_version_store_tiny_segment):
+    lib = in_memory_version_store_tiny_segment
     sym = "test_column_stats_create_date_range_and_row_range_both_specified_raises"
     lib.write(sym, df0)
 
-    with pytest.raises(UserInputException):
+    with pytest.raises(ArcticNativeException):
         lib.create_column_stats_experimental(sym, date_range=(df0.index[0], df0.index[-1]), row_range=(0, 2))
 
 
-def test_column_stats_create_date_range_non_timestamp_index_raises(version_store_factory, lib_name):
-    lib = version_store_factory(segment_row_size=2, name=lib_name)
+def test_column_stats_create_date_range_non_timestamp_index_raises(in_memory_store_factory, lib_name):
+    lib = in_memory_store_factory(segment_row_size=2, name=lib_name)
     sym = "test_column_stats_create_date_range_non_timestamp_index_raises"
     lib.write(sym, pd.Series([1, 2, 3, 4], name="myval"))
 
@@ -1767,8 +1763,8 @@ def test_column_stats_create_date_range_non_timestamp_index_raises(version_store
         lib.create_column_stats_experimental(sym, date_range=(pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")))
 
 
-def test_column_stats_create_date_range_unsorted_raises(version_store_factory, lib_name):
-    lib = version_store_factory(segment_row_size=2, name=lib_name)
+def test_column_stats_create_date_range_unsorted_raises(in_memory_store_factory, lib_name):
+    lib = in_memory_store_factory(segment_row_size=2, name=lib_name)
     sym = "test_column_stats_create_date_range_unsorted_raises"
     unsorted_index = [pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-01")]
     lib.write(sym, pd.DataFrame({"col_1": [1, 2]}, index=unsorted_index))

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -962,19 +962,12 @@ def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_
     assert_header_offsets_match_field_names(lib, sym, header, {2: "col_1", 3: "col_2"})
 
 
-def test_column_stats_create_twice_is_idempotent(version_store_factory, lib_name, encoding_version, any_output_format):
-    """Creating stats twice on one version with no range recomputes every row slice both times, but
-    the recomputed values are identical, so header and content come out the same. This does not
-    mean the second call is a no-op - a range-limited create can and does change the segment - only
-    that recomputing unchanged data is idempotent."""
+def test_column_stats_create_twice_is_idempotent(version_store_factory, lib_name):
     lib = version_store_factory(
         column_group_size=2,
         segment_row_size=2,
-        encoding_version=int(encoding_version),
-        lmdb_config={"map_size": 2**30},
-        name=lib_name + f"_{encoding_version.name}",
+        name=lib_name,
     )
-    lib._set_output_format_for_pipeline_tests(any_output_format)
     sym = "test_column_stats_create_twice_is_idempotent"
     expected_column_stats = generate_symbol(lib, sym)
 
@@ -1223,6 +1216,30 @@ def test_column_stats_series_rangeindex(version_store_factory, lib_name, encodin
     assert lib.get_column_stats_info_experimental(sym) == {"myval": {"MINMAX"}}
 
 
+def test_column_stats_string_indexed_symbol(version_store_factory, lib_name):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        name=lib_name,
+    )
+    sym = "test_column_stats_string_indexed_symbol"
+    df0 = pd.DataFrame({"col_1": [1, 2]}, index=["a", "b"])
+    df1 = pd.DataFrame({"col_1": [3, 4]}, index=["c", "d"])
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    # We don't support stats over strings yet, so no stats over the string index itself
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
+        pl.Series("v1_MIN(col_1)", [df0["col_1"].min(), df1["col_1"].min()]),
+        pl.Series("v1_MAX(col_1)", [df0["col_1"].max(), df1["col_1"].max()]),
+    )
+
+    lib.create_column_stats_experimental(sym)
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}}
+
+    column_stats = lib.read_column_stats_experimental(sym)
+    assert_stats_equal(column_stats, expected_column_stats)
+
+
 @pytest.mark.parametrize(
     "index_level_name, stored_col_name",
     [
@@ -1399,7 +1416,7 @@ def test_column_stats_duplicate_index_values_across_slice_boundary(
     ts = pd.Timestamp("2000-01-01")
     lib.write(sym, pd.DataFrame({"col_1": [1, 2, 3, 4]}, index=[ts] * 4))
 
-    # The premise: row slices are cut by row count, so both share one (start_index, end_index).
+    # both share one (start_index, end_index)
     index_df = lib.read_index(sym).reset_index()
     assert len(index_df) == 2
     assert index_df["start_index"].nunique() == 1
@@ -1407,8 +1424,6 @@ def test_column_stats_duplicate_index_values_across_slice_boundary(
 
     lib.create_column_stats_experimental(sym)
 
-    # One row per row slice, each keyed by its own row range and carrying its own stats. Keyed on the
-    # index values the two collided and both were discarded.
     column_stats = lib.read_column_stats_experimental(sym)
     assert column_stats.num_rows == 2
     expected_column_stats = pl.DataFrame(
@@ -1421,8 +1436,7 @@ def test_column_stats_duplicate_index_values_across_slice_boundary(
     )
     assert_stats_equal(column_stats, expected_column_stats)
 
-    # Both rows are usable for pruning, which is what the collision cost. The filter matches only the
-    # second row slice.
+    # Both rows can be used for pruning
     q = QueryBuilder()
     q = q[q["col_1"] > 2]
     result = lib.read(sym, query_builder=q).data
@@ -1679,6 +1693,60 @@ def test_column_stats_create_empty_range_is_noop(version_store_factory, lib_name
 
     lib.create_column_stats_experimental(sym, row_range=(100, 105))
     assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+
+@pytest.mark.parametrize(
+    "reversed_range",
+    [{"row_range": (5, 2)}, {"date_range": (jan(7), jan(2))}],
+    ids=["row_range", "date_range"],
+)
+def test_column_stats_create_reversed_range_is_noop(version_store_factory, lib_name, reversed_range):
+    lib = version_store_factory(segment_row_size=3, name=lib_name)
+    sym = "test_column_stats_create_reversed_range_is_noop"
+    df = write_nine_row_symbol(lib, sym)
+
+    lib.create_column_stats_experimental(sym, **reversed_range)
+    assert not lib.library_tool().find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
+
+    lib.create_column_stats_experimental(sym, row_range=(0, 3))
+    expected = expected_row_range_stats(df, [(0, 3)])
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+    lib.create_column_stats_experimental(sym, **reversed_range)
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+
+def test_column_stats_create_dynamic_schema_preserves_stats_for_column_outside_the_range(
+    version_store_factory, lib_name
+):
+    """col_2 exists only in the second row slice, so recomputing only the first must carry its stats
+    over from the stored segment rather than from anything the create just calculated."""
+    lib = version_store_factory(segment_row_size=3, dynamic_schema=True, name=lib_name)
+    sym = "test_column_stats_create_dynamic_schema_preserves_stats_for_column_outside_the_range"
+    lib.write(sym, pd.DataFrame({"col_1": [1, 2, 3]}, index=pd.date_range("2000-01-01", periods=3)))
+    lib.append(sym, pd.DataFrame({"col_2": [4, 5, 6]}, index=pd.date_range("2000-01-04", periods=3)))
+
+    expected = pl.DataFrame(
+        {
+            "start_row": pl.Series([0, 3], dtype=pl.UInt64),
+            "end_row": pl.Series([3, 6], dtype=pl.UInt64),
+            "v1_MIN(col_1)": pl.Series([1, None], dtype=pl.Int64),
+            "v1_MAX(col_1)": pl.Series([3, None], dtype=pl.Int64),
+            "v1_NAN_COUNT(col_1)": pl.Series([0, None], dtype=pl.UInt64),
+            "v1_NULL_COUNT(col_1)": pl.Series([0, None], dtype=pl.UInt64),
+            "v1_MIN(col_2)": pl.Series([None, 4], dtype=pl.Int64),
+            "v1_MAX(col_2)": pl.Series([None, 6], dtype=pl.Int64),
+            "v1_NAN_COUNT(col_2)": pl.Series([None, 0], dtype=pl.UInt64),
+            "v1_NULL_COUNT(col_2)": pl.Series([None, 0], dtype=pl.UInt64),
+        }
+    )
+
+    lib.create_column_stats_experimental(sym)
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+    lib.create_column_stats_experimental(sym, row_range=(0, 3))
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
 
 
 def test_column_stats_create_date_range_and_row_range_both_specified_raises(lmdb_version_store_tiny_segment):

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -53,15 +53,15 @@ df2 = pd.DataFrame(
 )
 
 
-def index_columns_to_pl(lib, sym):
+def row_range_columns_to_pl(lib, sym):
     pdf = lib.read_index(sym).reset_index()
-    return pl.from_pandas(pdf[["start_index", "end_index"]]).unique(maintain_order=True)
+    return pl.from_pandas(pdf[["start_row", "end_row"]]).unique(maintain_order=True)
 
 
 def generate_symbol(lib, sym):
     lib.write(sym, df0)
     lib.append(sym, df1)
-    return index_columns_to_pl(lib, sym).with_columns(
+    return row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [df0["col_1"].min(), df1["col_1"].min()]),
         pl.Series("v1_MAX(col_1)", [df0["col_1"].max(), df1["col_1"].max()]),
         pl.Series("v1_MIN(col_2)", [df0["col_2"].min(), df1["col_2"].min()]),
@@ -126,7 +126,7 @@ def test_column_stats_infinity(version_store_factory, lib_name, encoding_version
     lib.write(sym, df0)
     lib.append(sym, df1)
     lib.append(sym, df2)
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [df0["col_1"].min(), df1["col_1"].min(), df2["col_1"].min()]),
         pl.Series("v1_MAX(col_1)", [df0["col_1"].max(), df1["col_1"].max(), df2["col_1"].max()]),
     )
@@ -155,7 +155,7 @@ def test_column_stats_nan_values(lmdb_version_store, any_output_format):
     lib.append(sym, df5)
 
     # We store nan stats iff the whole block is nan
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [1.0, 5.0, 5.0, np.nan, 1.0, 1.0]),
         pl.Series("v1_MAX(col_1)", [3.0, 5.0, 5.0, np.nan, 2.0, 2.0]),
     )
@@ -173,7 +173,7 @@ def test_column_stats_only_nan_values(lmdb_version_store, any_output_format):
     df = pd.DataFrame({"col_1": [np.nan, np.nan]}, index=pd.date_range("2000-01-07", periods=2))
     lib.write(sym, df)
 
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [np.nan]),
         pl.Series("v1_MAX(col_1)", [np.nan]),
     )
@@ -221,7 +221,7 @@ def test_column_stats_nat_values(lmdb_version_store, any_output_format):
 
     # We store NaT stats iff the whole block is NaT. The Arrow output path converts NaT to null,
     # so the public read_column_stats API surfaces None for the all-NaT block.
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series(
             "v1_MIN(col_1)",
             [
@@ -269,7 +269,7 @@ def test_column_stats_only_nat_values(lmdb_version_store, any_output_format):
     df = pd.DataFrame({"col_1": [pd.NaT, pd.NaT]}, index=pd.date_range("2000-01-07", periods=2))
     lib.write(sym, df)
 
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [None], dtype=pl.Int64).cast(pl.Datetime("ns")),
         pl.Series("v1_MAX(col_1)", [None], dtype=pl.Int64).cast(pl.Datetime("ns")),
     )
@@ -318,7 +318,7 @@ def test_column_stats_nan_and_null_counts(lmdb_version_store, any_output_format)
 
     lib.create_column_stats_experimental(sym)
 
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(float_col)", [1.0, 5.0, np.nan, 1.0]),
         pl.Series("v1_MAX(float_col)", [2.0, 5.0, np.nan, 2.0]),
         pl.Series("v1_NAN_COUNT(float_col)", [0, 1, 2, 1], dtype=pl.UInt64),
@@ -401,7 +401,7 @@ def test_column_stats_null_count_sparse_floats(version_store_factory, lib_name, 
     lib.write(sym, df, sparsify_floats=True)
     lib.create_column_stats_experimental(sym)
 
-    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_index")
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_row")
     assert cs["v1_NULL_COUNT(col_1)"].to_list() == [1, 2]
     assert cs["v1_NAN_COUNT(col_1)"].to_list() == [0, 0]
     assert cs["v1_MIN(col_1)"].to_list() == [1.0, 4.0]
@@ -422,7 +422,7 @@ def test_column_stats_arrow_nan_and_null_same_column(lmdb_version_store_arrow):
     lib.append(sym, table([3.0, None, np.nan, 4.0, None]))  # nan=1, null=2, min=3, max=4
 
     lib.create_column_stats_experimental(sym)
-    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_index")
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_row")
 
     assert cs["v1_NAN_COUNT(f)"].to_list() == [1, 2, 0, 1]
     assert cs["v1_NULL_COUNT(f)"].to_list() == [1, 1, 2, 2]
@@ -458,7 +458,7 @@ def test_column_stats_arrow_nan_null_counts_hypothesis(lmdb_version_store_arrow,
         lib.append(sym, pa.table({"f": pa.array(seg, pa.float64())}))
 
     lib.create_column_stats_experimental(sym)
-    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_index")
+    cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_row")
 
     # Each write/append is its own row-slice, so column stats rows line up with segments in index order.
     expected_nan = [sum(1 for v in seg if v is not None and np.isnan(v)) for seg in segments]
@@ -570,7 +570,7 @@ def test_column_stats_duplicated_primary_index(version_store_factory, lib_name, 
 
     total_df = pd.concat((df0, df1))
     lib.write(sym, total_df)
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [df0["col_1"].min(), df1["col_1"].min()]),
         pl.Series("v1_MAX(col_1)", [df0["col_1"].max(), df1["col_1"].max()]),
         pl.Series("v1_MIN(col_2)", [df0["col_2"].min(), df1["col_2"].min()]),
@@ -616,7 +616,7 @@ def test_column_stats_dynamic_schema_missing_data(version_store_factory, lib_nam
     # The count columns follow the same rule: a fully-missing column has no aggregator run for that
     # slice, so its NAN_COUNT/NULL_COUNT are null (not 0). Present columns count their NaNs in
     # NAN_COUNT and leave NULL_COUNT at 0 (NaN floats are stored densely here, not as sparse gaps).
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series(
             "v1_MIN(col_1)",
             [df0["col_1"].min(), None, df2["col_1"].min(), None, df4["col_1"].min(), None],
@@ -707,7 +707,7 @@ def test_column_stats_dynamic_schema_types_changing(
             pl.Series(f"v1_MAX({name})", [float(df0[name].max()), float(df1[name].max())]),
         ]
 
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         *int_minmax("int_widening"),
         *int_minmax("int_narrowing"),
         *int_minmax("unsigned_to_wider_signed_int"),
@@ -1089,12 +1089,8 @@ def test_column_stats_col_called_index(
     res = lib.read_column_stats_experimental(sym)
     expected = pl.DataFrame(
         {
-            "start_index": pl.Series([pd.Timestamp("2000-01-01").value], dtype=pl.Int64).cast(pl.Datetime("ns")),
-            "end_index": (
-                pl.Series([(pd.Timestamp("2000-01-02") + pd.Timedelta(1)).value], dtype=pl.Int64).cast(
-                    pl.Datetime("ns")
-                )
-            ),
+            "start_row": pl.Series([0], dtype=pl.UInt64),
+            "end_row": pl.Series([2], dtype=pl.UInt64),
             f"v1_MIN({expected_title})": [0],
             f"v1_MAX({expected_title})": [1],
         }
@@ -1168,7 +1164,7 @@ def test_column_stats_multiindex(
 
     # Read and verify the stats
     stats = lib.read_column_stats_experimental(sym)
-    expected = index_columns_to_pl(lib, sym).with_columns(
+    expected = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(val)", [100, 300]),
         pl.Series("v1_MAX(val)", [200, 400]),
         pl.Series(f"v1_MIN({stored_col_name})", [10, 30]),
@@ -1232,7 +1228,7 @@ def test_column_stats_series(
     assert lib.get_column_stats_info_experimental(sym) == {stored_col_name: {"MINMAX"}}
 
     stats = lib.read_column_stats_experimental(sym)
-    expected = index_columns_to_pl(lib, sym).with_columns(
+    expected = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series(f"v1_MIN({stored_col_name})", [1, 3]),
         pl.Series(f"v1_MAX({stored_col_name})", [2, 4]),
     )
@@ -1303,7 +1299,7 @@ def test_column_stats_series_multiindex(
     assert lib.get_column_stats_info_experimental(sym) == {"val": {"MINMAX"}, stored_col_name: {"MINMAX"}}
 
     stats = lib.read_column_stats_experimental(sym)
-    expected = index_columns_to_pl(lib, sym).with_columns(
+    expected = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(val)", [100, 300]),
         pl.Series("v1_MAX(val)", [200, 400]),
         pl.Series(f"v1_MIN({stored_col_name})", [10, 30]),
@@ -1421,7 +1417,7 @@ def test_column_stats_create_single_unit(
     sym = "test_column_stats_single_unit"
     df = pd.DataFrame({"col_1": [1.0, 3.0]}, index=pd.date_range("2000-01-01", periods=2))
     lib.write(sym, df)
-    expected_column_stats = index_columns_to_pl(lib, sym).with_columns(
+    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(col_1)", [df["col_1"].min()]),
         pl.Series("v1_MAX(col_1)", [df["col_1"].max()]),
     )
@@ -1430,3 +1426,41 @@ def test_column_stats_create_single_unit(
         lib.create_column_stats_experimental(sym)
 
     assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)
+
+
+def test_column_stats_duplicate_index_values_across_slice_boundary(
+    lmdb_version_store_tiny_segment, column_stats_filtering_enabled
+):
+    lib = lmdb_version_store_tiny_segment
+    sym = "test_column_stats_duplicate_index_values_across_slice_boundary"
+    ts = pd.Timestamp("2000-01-01")
+    lib.write(sym, pd.DataFrame({"col_1": [1, 2, 3, 4]}, index=[ts] * 4))
+
+    # The premise: row slices are cut by row count, so both share one (start_index, end_index).
+    index_df = lib.read_index(sym).reset_index()
+    assert len(index_df) == 2
+    assert index_df["start_index"].nunique() == 1
+    assert index_df["end_index"].nunique() == 1
+
+    lib.create_column_stats_experimental(sym)
+
+    # One row per row slice, each keyed by its own row range and carrying its own stats. Keyed on the
+    # index values the two collided and both were discarded.
+    column_stats = lib.read_column_stats_experimental(sym)
+    assert column_stats.num_rows == 2
+    expected_column_stats = pl.DataFrame(
+        {
+            "start_row": [0, 2],
+            "end_row": [2, 4],
+            "v1_MIN(col_1)": [1, 3],
+            "v1_MAX(col_1)": [2, 4],
+        }
+    )
+    assert_stats_equal(column_stats, expected_column_stats)
+
+    # Both rows are usable for pruning, which is what the collision cost. The filter matches only the
+    # second row slice.
+    q = QueryBuilder()
+    q = q[q["col_1"] > 2]
+    result = lib.read(sym, query_builder=q).data
+    pd.testing.assert_frame_equal(result, pd.DataFrame({"col_1": [3, 4]}, index=[ts] * 2))

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -940,6 +940,31 @@ def header_all_entries(header):
             yield data_col_offset, entry
 
 
+def header_offset_by_stat(header):
+    """{(data_col_offset, stat type): stats_seg_offset}. Order-independent, unlike comparing the
+    serialized header, since protobuf map ordering is unspecified."""
+    return {
+        (data_col_offset, entry.type): entry.stats_seg_offset for data_col_offset, entry in header_all_entries(header)
+    }
+
+
+def assert_header_offsets_match_field_names(lib, sym, header, col_name_by_offset):
+    """Every entry's stats_seg_offset must point at the stats column named after the data column
+    at its data_col_offset."""
+    field_name_by_type = {
+        ColumnStatsType.MIN_V1: "v1_MIN",
+        ColumnStatsType.MAX_V1: "v1_MAX",
+        ColumnStatsType.NAN_COUNT_V1: "v1_NAN_COUNT",
+        ColumnStatsType.NULL_COUNT_V1: "v1_NULL_COUNT",
+    }
+    lib_tool = lib.library_tool()
+    keys = lib_tool.find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
+    fields = lib_tool.read_descriptor(keys[0]).fields()
+    for data_col_offset, entry in header_all_entries(header):
+        expected = f"{field_name_by_type[entry.type]}({col_name_by_offset[data_col_offset]})"
+        assert fields[entry.stats_seg_offset].name == expected
+
+
 def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_version, any_output_format):
     lib = version_store_factory(
         column_group_size=2,
@@ -972,19 +997,38 @@ def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_
     assert len(set(offsets)) == 8
 
     # Verify descriptor field names match the offsets
-    field_name_by_type = {
-        ColumnStatsType.MIN_V1: "v1_MIN",
-        ColumnStatsType.MAX_V1: "v1_MAX",
-        ColumnStatsType.NAN_COUNT_V1: "v1_NAN_COUNT",
-        ColumnStatsType.NULL_COUNT_V1: "v1_NULL_COUNT",
-    }
-    col_name_by_offset = {2: "col_1", 3: "col_2"}
-    lib_tool = lib.library_tool()
-    keys = lib_tool.find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
-    fields = lib_tool.read_descriptor(keys[0]).fields()
-    for data_col_offset, entry in header_all_entries(header):
-        expected = f"{field_name_by_type[entry.type]}({col_name_by_offset[data_col_offset]})"
-        assert fields[entry.stats_seg_offset].name == expected
+    assert_header_offsets_match_field_names(lib, sym, header, {2: "col_1", 3: "col_2"})
+
+
+def test_column_stats_create_twice_is_noop(version_store_factory, lib_name, encoding_version, any_output_format):
+    """Creating stats twice on one version must not duplicate or re-offset anything. The eligible
+    column set comes from the version's own descriptor, so the second call finds every requested
+    stat already present and does nothing."""
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        encoding_version=int(encoding_version),
+        lmdb_config={"map_size": 2**30},
+        name=lib_name + f"_{encoding_version.name}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_create_twice_is_noop"
+    expected_column_stats = generate_symbol(lib, sym)
+
+    lib.create_column_stats_experimental(sym)
+    first_header = read_column_stats_header(lib, sym)
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)
+
+    lib.create_column_stats_experimental(sym)
+    second_header = read_column_stats_header(lib, sym)
+
+    assert header_offset_by_stat(second_header) == header_offset_by_stat(first_header)
+    assert second_header.version == first_header.version
+    assert header_stat_count(second_header) == 8
+    assert len({entry.stats_seg_offset for _, entry in header_all_entries(second_header)}) == 8
+    assert_header_offsets_match_field_names(lib, sym, second_header, {2: "col_1", 3: "col_2"})
+    assert lib.get_column_stats_info_experimental(sym) == {"col_1": {"MINMAX"}, "col_2": {"MINMAX"}}
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected_column_stats)
 
 
 def test_column_stats_duplicated_column_names(version_store_factory, lib_name, encoding_version, any_output_format):

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -19,7 +19,7 @@ from polars.testing import assert_frame_equal as pl_assert_frame_equal
 from arcticc.pb2.column_stats_pb2 import ColumnStatsHeader, ColumnStatsType
 from google.protobuf.any_pb2 import Any as ProtobufAny
 
-from arcticdb_ext.exceptions import SchemaException, StorageException, UserInputException
+from arcticdb_ext.exceptions import SchemaException, SortingException, StorageException, UserInputException
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
@@ -69,7 +69,7 @@ def generate_symbol(lib, sym):
     )
 
 
-def assert_stats_equal(received, expected):
+def assert_stats_equal(received, expected, check_dtypes=False):
     assert isinstance(received, pa.Table)
     assert isinstance(expected, pl.DataFrame)
     received_pl = pl.from_arrow(received)
@@ -79,7 +79,7 @@ def assert_stats_equal(received, expected):
     missing = set(expected.columns) - set(received_pl.columns)
     assert not missing, f"Expected columns missing from received: {missing}"
     received_pl = received_pl.select(expected.columns)
-    pl_assert_frame_equal(received_pl, expected, check_column_order=False, check_dtypes=False)
+    pl_assert_frame_equal(received_pl, expected, check_column_order=False, check_dtypes=check_dtypes)
 
 
 def test_column_stats_basic_flow(version_store_factory, lib_name, encoding_version, any_output_format):
@@ -166,24 +166,6 @@ def test_column_stats_nan_values(lmdb_version_store, any_output_format):
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_only_nan_values(lmdb_version_store, any_output_format):
-    lib = lmdb_version_store
-    lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_nan_values"
-    df = pd.DataFrame({"col_1": [np.nan, np.nan]}, index=pd.date_range("2000-01-07", periods=2))
-    lib.write(sym, df)
-
-    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
-        pl.Series("v1_MIN(col_1)", [np.nan]),
-        pl.Series("v1_MAX(col_1)", [np.nan]),
-    )
-
-    lib.create_column_stats_experimental(sym)
-
-    column_stats = lib.read_column_stats_experimental(sym)
-    assert_stats_equal(column_stats, expected_column_stats)
-
-
 def test_column_stats_nat_values(lmdb_version_store, any_output_format):
     lib = lmdb_version_store
     lib._set_output_format_for_pipeline_tests(any_output_format)
@@ -260,32 +242,6 @@ def test_column_stats_nat_values(lmdb_version_store, any_output_format):
     raw_stats = lib_tool.read_to_dataframe(keys[0])
     assert raw_stats["v1_MIN(col_1)"].values.view("int64")[3] == nat_sentinel
     assert raw_stats["v1_MAX(col_1)"].values.view("int64")[3] == nat_sentinel
-
-
-def test_column_stats_only_nat_values(lmdb_version_store, any_output_format):
-    lib = lmdb_version_store
-    lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_only_nat_values"
-    df = pd.DataFrame({"col_1": [pd.NaT, pd.NaT]}, index=pd.date_range("2000-01-07", periods=2))
-    lib.write(sym, df)
-
-    expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
-        pl.Series("v1_MIN(col_1)", [None], dtype=pl.Int64).cast(pl.Datetime("ns")),
-        pl.Series("v1_MAX(col_1)", [None], dtype=pl.Int64).cast(pl.Datetime("ns")),
-    )
-
-    lib.create_column_stats_experimental(sym)
-
-    column_stats = lib.read_column_stats_experimental(sym)
-    assert_stats_equal(column_stats, expected_column_stats)
-
-    nat_sentinel = np.iinfo(np.int64).min
-    lib_tool = lib.library_tool()
-    keys = lib_tool.find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
-    assert len(keys) == 1
-    raw_stats = lib_tool.read_to_dataframe(keys[0])
-    assert raw_stats["v1_MIN(col_1)"].values.view("int64")[0] == nat_sentinel
-    assert raw_stats["v1_MAX(col_1)"].values.view("int64")[0] == nat_sentinel
 
 
 def test_column_stats_nan_and_null_counts(lmdb_version_store, any_output_format):
@@ -653,19 +609,7 @@ def test_column_stats_dynamic_schema_missing_data(version_store_factory, lib_nam
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_dynamic_schema_types_changing(
-    version_store_factory, lib_name, encoding_version, any_output_format
-):
-    lib = version_store_factory(
-        column_group_size=2,
-        segment_row_size=2,
-        dynamic_schema=True,
-        encoding_version=int(encoding_version),
-        name=lib_name + f"_{encoding_version.name}",
-    )
-    lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_dynamic_schema_types_changing"
-
+def dynamic_schema_types_changing_dfs():
     df0 = pd.DataFrame(
         {
             "int_widening": np.arange(0, 2, dtype=np.uint8),
@@ -691,7 +635,46 @@ def test_column_stats_dynamic_schema_types_changing(
         },
         index=pd.date_range("2000-01-03", periods=2),
     )
+    return df0, df1
 
+
+def assert_dynamic_schema_types_changing_schema(schema):
+    assert schema["v1_MIN(int_widening)"] == pl.UInt16
+    assert schema["v1_MAX(int_widening)"] == pl.UInt16
+
+    assert schema["v1_MIN(int_narrowing)"] == pl.Int16
+    assert schema["v1_MAX(int_narrowing)"] == pl.Int16
+
+    assert schema["v1_MIN(unsigned_to_wider_signed_int)"] == pl.Int32
+    assert schema["v1_MAX(unsigned_to_wider_signed_int)"] == pl.Int32
+
+    assert schema["v1_MIN(wider_signed_to_unsigned_int)"] == pl.Int32
+    assert schema["v1_MAX(wider_signed_to_unsigned_int)"] == pl.Int32
+
+    assert schema["v1_MIN(unsigned_to_signed_int_same_width)"] == pl.Int32
+    assert schema["v1_MAX(unsigned_to_signed_int_same_width)"] == pl.Int32
+
+    assert schema["v1_MIN(int_to_float)"] == pl.Float64
+    assert schema["v1_MAX(int_to_float)"] == pl.Float64
+
+    assert schema["v1_MIN(float_to_int)"] == pl.Float64
+    assert schema["v1_MAX(float_to_int)"] == pl.Float64
+
+
+def test_column_stats_dynamic_schema_types_changing(
+    version_store_factory, lib_name, encoding_version, any_output_format
+):
+    lib = version_store_factory(
+        column_group_size=2,
+        segment_row_size=2,
+        dynamic_schema=True,
+        encoding_version=int(encoding_version),
+        name=lib_name + f"_{encoding_version.name}",
+    )
+    lib._set_output_format_for_pipeline_tests(any_output_format)
+    sym = "test_column_stats_dynamic_schema_types_changing"
+
+    df0, df1 = dynamic_schema_types_changing_dfs()
     lib.write(sym, df0)
     lib.append(sym, df1)
 
@@ -731,28 +714,7 @@ def test_column_stats_dynamic_schema_types_changing(
     column_stats = lib.read_column_stats_experimental(sym)
     assert_stats_equal(column_stats, expected_column_stats)
 
-    schema = pl.from_arrow(column_stats).schema
-
-    assert schema["v1_MIN(int_widening)"] == pl.UInt16
-    assert schema["v1_MAX(int_widening)"] == pl.UInt16
-
-    assert schema["v1_MIN(int_narrowing)"] == pl.Int16
-    assert schema["v1_MAX(int_narrowing)"] == pl.Int16
-
-    assert schema["v1_MIN(unsigned_to_wider_signed_int)"] == pl.Int32
-    assert schema["v1_MAX(unsigned_to_wider_signed_int)"] == pl.Int32
-
-    assert schema["v1_MIN(wider_signed_to_unsigned_int)"] == pl.Int32
-    assert schema["v1_MAX(wider_signed_to_unsigned_int)"] == pl.Int32
-
-    assert schema["v1_MIN(unsigned_to_signed_int_same_width)"] == pl.Int32
-    assert schema["v1_MAX(unsigned_to_signed_int_same_width)"] == pl.Int32
-
-    assert schema["v1_MIN(int_to_float)"] == pl.Float64
-    assert schema["v1_MAX(int_to_float)"] == pl.Float64
-
-    assert schema["v1_MIN(float_to_int)"] == pl.Float64
-    assert schema["v1_MAX(float_to_int)"] == pl.Float64
+    assert_dynamic_schema_types_changing_schema(pl.from_arrow(column_stats).schema)
 
 
 def test_column_stats_object_deleted_with_index_key(lmdb_version_store, any_output_format):
@@ -1000,10 +962,11 @@ def test_column_stats_header_metadata(version_store_factory, lib_name, encoding_
     assert_header_offsets_match_field_names(lib, sym, header, {2: "col_1", 3: "col_2"})
 
 
-def test_column_stats_create_twice_is_noop(version_store_factory, lib_name, encoding_version, any_output_format):
-    """Creating stats twice on one version must not duplicate or re-offset anything. The eligible
-    column set comes from the version's own descriptor, so the second call finds every requested
-    stat already present and does nothing."""
+def test_column_stats_create_twice_is_idempotent(version_store_factory, lib_name, encoding_version, any_output_format):
+    """Creating stats twice on one version with no range recomputes every row slice both times, but
+    the recomputed values are identical, so header and content come out the same. This does not
+    mean the second call is a no-op - a range-limited create can and does change the segment - only
+    that recomputing unchanged data is idempotent."""
     lib = version_store_factory(
         column_group_size=2,
         segment_row_size=2,
@@ -1012,7 +975,7 @@ def test_column_stats_create_twice_is_noop(version_store_factory, lib_name, enco
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_create_twice_is_noop"
+    sym = "test_column_stats_create_twice_is_idempotent"
     expected_column_stats = generate_symbol(lib, sym)
 
     lib.create_column_stats_experimental(sym)
@@ -1464,3 +1427,283 @@ def test_column_stats_duplicate_index_values_across_slice_boundary(
     q = q[q["col_1"] > 2]
     result = lib.read(sym, query_builder=q).data
     pd.testing.assert_frame_equal(result, pd.DataFrame({"col_1": [3, 4]}, index=[ts] * 2))
+
+
+def nine_row_symbol_df():
+    # col_2's NaNs are distributed one/two/three per row slice (0,3)/(3,6)/(6,9)
+    return pd.DataFrame(
+        {
+            "col_1": list(range(9)),
+            "col_2": [10.0, 11.0, np.nan, np.nan, np.nan, 14.0, np.nan, np.nan, np.nan],
+        },
+        index=pd.date_range("2000-01-01", periods=9),
+    )
+
+
+def write_nine_row_symbol(lib, sym):
+    df = nine_row_symbol_df()
+    lib.write(sym, df)
+    return df
+
+
+def eleven_row_symbol_df():
+    # At segment_row_size=3 the slices are (0,3)/(3,6)/(6,9)/(9,11), the last one ragged. col_2's
+    # NaNs are one/two/three/none per slice, and (6,9) is entirely NaN so its min and max are NaN.
+    return pd.DataFrame(
+        {
+            "col_1": list(range(11)),
+            "col_2": [10.0, 11.0, np.nan, np.nan, np.nan, 14.0, np.nan, np.nan, np.nan, 19.0, 20.0],
+        },
+        index=pd.date_range("2000-01-01", periods=11),
+    )
+
+
+def write_eleven_row_symbol(lib, sym):
+    df = eleven_row_symbol_df()
+    lib.write(sym, df)
+    return df
+
+
+def jan(day):
+    return pd.Timestamp(f"2000-01-{day:02d}")
+
+
+def expected_row_range_stats(df, expected_slices):
+    def slice_stats(col):
+        values_by_slice = [df[col].iloc[s:e] for s, e in expected_slices]
+        return (
+            [values.min() for values in values_by_slice],
+            [values.max() for values in values_by_slice],
+            [int(values.isna().sum()) for values in values_by_slice],
+        )
+
+    col_1_min, col_1_max, col_1_nan = slice_stats("col_1")
+    col_2_min, col_2_max, col_2_nan = slice_stats("col_2")
+    null_counts = [0] * len(expected_slices)
+
+    return pl.DataFrame(
+        {
+            "start_row": pl.Series([s for s, _ in expected_slices], dtype=pl.UInt64),
+            "end_row": pl.Series([e for _, e in expected_slices], dtype=pl.UInt64),
+            "v1_MIN(col_1)": pl.Series([int(v) for v in col_1_min], dtype=pl.Int64),
+            "v1_MAX(col_1)": pl.Series([int(v) for v in col_1_max], dtype=pl.Int64),
+            "v1_NAN_COUNT(col_1)": pl.Series(col_1_nan, dtype=pl.UInt64),
+            "v1_NULL_COUNT(col_1)": pl.Series(null_counts, dtype=pl.UInt64),
+            "v1_MIN(col_2)": pl.Series(col_2_min, dtype=pl.Float64),
+            "v1_MAX(col_2)": pl.Series(col_2_max, dtype=pl.Float64),
+            "v1_NAN_COUNT(col_2)": pl.Series(col_2_nan, dtype=pl.UInt64),
+            "v1_NULL_COUNT(col_2)": pl.Series(null_counts, dtype=pl.UInt64),
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "row_range, expected_slices",
+    [
+        ((0, 3), [(0, 3)]),
+        ((0, 4), [(0, 3), (3, 6)]),
+        ((4, 5), [(3, 6)]),
+        ((6, 9), [(6, 9)]),
+        ((-9, -6), [(0, 3)]),
+        ((None, 3), [(0, 3)]),
+        ((6, None), [(6, 9)]),
+        ((None, None), [(0, 3), (3, 6), (6, 9)]),
+        ((None, -6), [(0, 3)]),
+    ],
+)
+def test_column_stats_create_row_range(version_store_factory, lib_name, row_range, expected_slices):
+    lib = version_store_factory(segment_row_size=3, name=lib_name)
+    sym = "test_column_stats_create_row_range"
+    df = write_nine_row_symbol(lib, sym)
+
+    lib.create_column_stats_experimental(sym, row_range=row_range)
+
+    assert_stats_equal(
+        lib.read_column_stats_experimental(sym), expected_row_range_stats(df, expected_slices), check_dtypes=True
+    )
+
+
+@pytest.mark.parametrize(
+    "date_range, expected_slices",
+    [
+        ((pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-03")), [(0, 3)]),
+        ((pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-04")), [(0, 3), (3, 6)]),
+        ((pd.Timestamp("2000-01-05"), pd.Timestamp("2000-01-05")), [(3, 6)]),
+        ((pd.Timestamp("2000-01-07"), pd.Timestamp("2000-01-09")), [(6, 9)]),
+    ],
+)
+def test_column_stats_create_date_range(version_store_factory, lib_name, date_range, expected_slices):
+    lib = version_store_factory(segment_row_size=3, name=lib_name)
+    sym = "test_column_stats_create_date_range"
+    df = write_nine_row_symbol(lib, sym)
+
+    lib.create_column_stats_experimental(sym, date_range=date_range)
+
+    assert_stats_equal(
+        lib.read_column_stats_experimental(sym), expected_row_range_stats(df, expected_slices), check_dtypes=True
+    )
+
+
+# We create an 11 row symbol with slices:
+# [0, 3) , [3, 6), [6, 9), [9, 11)
+# We check that after creating stats with a series of row ranges of the form [A, B)
+# we get stats over the set of segments covering the union of those row ranges
+# In particular you can end up calculating stats for up to N rows outside a row_range boundary,
+# where N is the row slice size minus one.
+@pytest.mark.parametrize(
+    "row_ranges, expected_slices",
+    [
+        ([(0, 4), (3, 5)], [(0, 3), (3, 6)]),
+        # Leave a hole over [6, 9)
+        ([(0, 4), (9, 10)], [(0, 3), (3, 6), (9, 11)]),
+        # Same, in the other order, checks sorting in the stats segment
+        ([(9, 10), (0, 4)], [(0, 3), (3, 6), (9, 11)]),
+        # Fill the hole
+        ([(0, 4), (9, 10), (6, 7)], [(0, 3), (3, 6), (6, 9), (9, 11)]),
+        # Repeating a range replaces its rows rather than duplicating them
+        ([(0, 4), (0, 4)], [(0, 3), (3, 6)]),
+        # You need all segments to cover (2,10)
+        ([(0, 4), (2, 10)], [(0, 3), (3, 6), (6, 9), (9, 11)]),
+        # [3, 6) is recalculated, [0, 3) is kept, [6, 9) is new
+        ([(0, 4), (5, 9)], [(0, 3), (3, 6), (6, 9)]),
+    ],
+)
+def test_column_stats_create_incrementally_by_row_range(version_store_factory, lib_name, row_ranges, expected_slices):
+    lib = version_store_factory(segment_row_size=3, name=lib_name)
+    sym = "sym"
+    df = write_eleven_row_symbol(lib, sym)
+
+    for row_range in row_ranges:
+        lib.create_column_stats_experimental(sym, row_range=row_range)
+
+    assert_stats_equal(
+        lib.read_column_stats_experimental(sym), expected_row_range_stats(df, expected_slices), check_dtypes=True
+    )
+
+
+# As above, but by date range. The 11 row symbol is indexed 2000-01-01 to 2000-01-11, so the slices
+# span [Jan 1, Jan 3], [Jan 4, Jan 6], [Jan 7, Jan 9], [Jan 10, Jan 11]. Unlike row ranges, date
+# ranges are inclusive at both ends.
+@pytest.mark.parametrize(
+    "date_ranges, expected_slices",
+    [
+        ([(jan(1), jan(4)), (jan(4), jan(5))], [(0, 3), (3, 6)]),
+        # Leave a hole over [6, 9)
+        ([(jan(1), jan(4)), (jan(10), jan(11))], [(0, 3), (3, 6), (9, 11)]),
+        # Same, in the other order, checks sorting in the stats segment
+        ([(jan(10), jan(11)), (jan(1), jan(4))], [(0, 3), (3, 6), (9, 11)]),
+        # Fill the hole
+        ([(jan(1), jan(4)), (jan(10), jan(11)), (jan(7), jan(8))], [(0, 3), (3, 6), (6, 9), (9, 11)]),
+        # Repeating a range replaces its rows rather than duplicating them
+        ([(jan(1), jan(4)), (jan(1), jan(4))], [(0, 3), (3, 6)]),
+        # You need all segments to cover [Jan 3, Jan 10]
+        ([(jan(1), jan(4)), (jan(3), jan(10))], [(0, 3), (3, 6), (6, 9), (9, 11)]),
+        # [3, 6) is recalculated, [0, 3) is kept, [6, 9) is new
+        ([(jan(1), jan(4)), (jan(6), jan(9))], [(0, 3), (3, 6), (6, 9)]),
+    ],
+)
+def test_column_stats_create_incrementally_by_date_range(version_store_factory, lib_name, date_ranges, expected_slices):
+    lib = version_store_factory(segment_row_size=3, name=lib_name)
+    sym = "sym"
+    df = write_eleven_row_symbol(lib, sym)
+
+    for date_range in date_ranges:
+        lib.create_column_stats_experimental(sym, date_range=date_range)
+
+    assert_stats_equal(
+        lib.read_column_stats_experimental(sym), expected_row_range_stats(df, expected_slices), check_dtypes=True
+    )
+
+
+def test_column_stats_create_dynamic_schema_partial_create_uses_descriptor_type(version_store_factory, lib_name):
+    """A range covering only the first row slice must still type MIN/MAX from the version's descriptor,
+    not from that slice's own dtype"""
+    lib = version_store_factory(column_group_size=2, segment_row_size=2, dynamic_schema=True, name=lib_name)
+    sym = "test_column_stats_create_dynamic_schema_partial_create_uses_descriptor_type"
+
+    df0, df1 = dynamic_schema_types_changing_dfs()
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+
+    lib.create_column_stats_experimental(sym, row_range=(0, 2))
+
+    assert_dynamic_schema_types_changing_schema(pl.from_arrow(lib.read_column_stats_experimental(sym)).schema)
+
+
+def test_column_stats_create_partial_coverage_with_column_slicing(version_store_factory, lib_name):
+    lib = version_store_factory(column_group_size=2, segment_row_size=3, name=lib_name)
+    sym = "test_column_stats_create_partial_coverage_with_column_slicing"
+    df = pd.DataFrame(
+        {f"col_{i}": np.arange(i * 100, i * 100 + 9) for i in range(1, 5)},
+        index=pd.date_range("2000-01-01", periods=9),
+    )
+    lib.write(sym, df)
+
+    lib.create_column_stats_experimental(sym, row_range=(0, 4))
+
+    expected_slices = [(0, 3), (3, 6)]
+    expected = pl.DataFrame(
+        {
+            "start_row": [s for s, _ in expected_slices],
+            "end_row": [e for _, e in expected_slices],
+            **{
+                f"v1_MIN(col_{i})": [int(df[f"col_{i}"].iloc[s:e].min()) for s, e in expected_slices]
+                for i in range(1, 5)
+            },
+            **{
+                f"v1_MAX(col_{i})": [int(df[f"col_{i}"].iloc[s:e].max()) for s, e in expected_slices]
+                for i in range(1, 5)
+            },
+        }
+    )
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected)
+
+
+def test_column_stats_create_empty_range_is_noop(version_store_factory, lib_name):
+    lib = version_store_factory(segment_row_size=3, name=lib_name)
+    sym = "test_column_stats_create_empty_range_is_noop"
+    df = write_nine_row_symbol(lib, sym)
+
+    lib.create_column_stats_experimental(sym, row_range=(2, 2))
+    assert not lib.library_tool().find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
+
+    lib.create_column_stats_experimental(sym, row_range=(100, 105))
+    assert not lib.library_tool().find_keys_for_symbol(KeyType.COLUMN_STATS, sym)
+
+    lib.create_column_stats_experimental(sym, row_range=(0, 3))
+    expected = expected_row_range_stats(df, [(0, 3)])
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+    lib.create_column_stats_experimental(sym, row_range=(2, 2))
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+    lib.create_column_stats_experimental(sym, row_range=(100, 105))
+    assert_stats_equal(lib.read_column_stats_experimental(sym), expected, check_dtypes=True)
+
+
+def test_column_stats_create_date_range_and_row_range_both_specified_raises(lmdb_version_store_tiny_segment):
+    lib = lmdb_version_store_tiny_segment
+    sym = "test_column_stats_create_date_range_and_row_range_both_specified_raises"
+    lib.write(sym, df0)
+
+    with pytest.raises(UserInputException):
+        lib.create_column_stats_experimental(sym, date_range=(df0.index[0], df0.index[-1]), row_range=(0, 2))
+
+
+def test_column_stats_create_date_range_non_timestamp_index_raises(version_store_factory, lib_name):
+    lib = version_store_factory(segment_row_size=2, name=lib_name)
+    sym = "test_column_stats_create_date_range_non_timestamp_index_raises"
+    lib.write(sym, pd.Series([1, 2, 3, 4], name="myval"))
+
+    with pytest.raises(UserInputException):
+        lib.create_column_stats_experimental(sym, date_range=(pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-02")))
+
+
+def test_column_stats_create_date_range_unsorted_raises(version_store_factory, lib_name):
+    lib = version_store_factory(segment_row_size=2, name=lib_name)
+    sym = "test_column_stats_create_date_range_unsorted_raises"
+    unsorted_index = [pd.Timestamp("2000-01-03"), pd.Timestamp("2000-01-01")]
+    lib.write(sym, pd.DataFrame({"col_1": [1, 2]}, index=unsorted_index))
+
+    with pytest.raises(SortingException):
+        lib.create_column_stats_experimental(sym, date_range=(pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-03")))

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -190,12 +190,12 @@ def test_column_stats_query_optimisation_no_stats(
 
 
 def test_column_stats_query_optimisation_column_not_in_stats(
-    lmdb_version_store_tiny_segment, column_stats_filtering_enabled
+    in_memory_version_store_tiny_segment, column_stats_filtering_enabled
 ):
     """
     Test that queries work when column stats exist but not for the filtered column.
     """
-    lib = lmdb_version_store_tiny_segment
+    lib = in_memory_version_store_tiny_segment
 
     df0 = pd.DataFrame({"col_1": [1, 2], "col_2": [10, 20]}, index=pd.date_range("2000-01-01", periods=2))
     df1 = pd.DataFrame({"col_1": [3, 4], "col_2": [30, 40]}, index=pd.date_range("2000-01-03", periods=2))
@@ -2371,21 +2371,12 @@ def test_column_stats_still_prunes_when_nan_does_not_save_row(
     assert table_data_reads == 0, "Both segments must still be pruned; NaN never satisfies a magnitude comparison"
 
 
-def write_six_segments(lib):
-    """Six single-slice segments, col_1 ascending in pairs, two rows each."""
-    for i in range(6):
-        df = pd.DataFrame(
-            {"col_1": [2 * i + 1, 2 * i + 2]},
-            index=pd.date_range(pd.Timestamp("2000-01-01") + pd.Timedelta(days=2 * i), periods=2),
-        )
-        lib.append(sym, df)
-
-
 def test_column_stats_date_range_clause_still_prunes(
-    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
+    in_memory_version_store_tiny_segment, clear_query_stats, column_stats_filtering_enabled
 ):
-    lib = in_memory_version_store
-    write_six_segments(lib)
+    lib = in_memory_version_store_tiny_segment
+    # segment_row_size=2 splits this into six two-row segments, col_1 ascending in pairs
+    lib.write(sym, pd.DataFrame({"col_1": list(range(1, 13))}, index=pd.date_range("2000-01-01", periods=12)))
     lib.create_column_stats_experimental(sym)
 
     qs.enable()

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -1468,12 +1468,12 @@ def test_column_stats_empty_dataframe(in_memory_version_store, column_stats_filt
     assert len(result) == 0
 
 
-def test_column_stats_duplicate_timestamp_index_drops_ambiguous_stats(
+def test_column_stats_duplicate_timestamp_index_prunes(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
 ):
     """
-    When two row-slices share the same (start_index, end_index) the stats for that key are
-    ambiguous and we should not use them.
+    Two row-slices sharing the same (start_index, end_index) are still distinct row ranges, so both
+    keep usable stats and the non-matching one is pruned.
     """
     lib = in_memory_version_store
 
@@ -1492,20 +1492,17 @@ def test_column_stats_duplicate_timestamp_index_drops_ambiguous_stats(
     qs.reset_stats()
     result = lib.read(sym, query_builder=q).data
 
-    # Both segments are read (stats are ambiguous for the duplicate key) and the filter in the
-    # processing pipeline keeps only rows where col_1 < 3.
     expected = pd.DataFrame({"col_1": [1, 2]}, index=[ts, ts])
     assert_frame_equal(expected, result)
-    # Both segments must be read because their stats were dropped.
-    assert get_table_data_read_count() == 2
+    # Only the first segment is read; the second is pruned on min=5 > 3
+    assert get_table_data_read_count() == 1
 
 
-def test_column_stats_duplicate_timestamp_index_still_prunes_unique_keys(
+def test_column_stats_duplicate_timestamp_index_prunes_all_slices(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
 ):
     """
-    When some row-slices share the same (start_index, end_index) but others are unique, only the
-    ambiguous entries are dropped. The unique entries should still be used for pruning.
+    A mixture of shared and unique (start_index, end_index) pairs.
     """
     lib = in_memory_version_store
 
@@ -1529,8 +1526,8 @@ def test_column_stats_duplicate_timestamp_index_still_prunes_unique_keys(
 
     expected = pd.DataFrame({"col_1": [1, 2]}, index=[ts1, ts1])
     assert_frame_equal(expected, result)
-    # seg0 and seg1 read (duplicate key, no pruning), seg2 pruned (unique key, min=100 > 3)
-    assert get_table_data_read_count() == 2
+    # seg1 (min=10) and seg2 (min=100) are both pruned. seg1 could not be pruned before.
+    assert get_table_data_read_count() == 1
 
 
 @pytest.mark.parametrize(
@@ -2323,3 +2320,33 @@ def test_column_stats_still_prunes_when_nan_does_not_save_row(
     expected = full_df[pandas_expr(full_df)]
     assert_frame_equal(expected, result)
     assert table_data_reads == 0, "Both segments must still be pruned; NaN never satisfies a magnitude comparison"
+
+
+def write_six_segments(lib):
+    """Six single-slice segments, col_1 ascending in pairs, two rows each."""
+    for i in range(6):
+        df = pd.DataFrame(
+            {"col_1": [2 * i + 1, 2 * i + 2]},
+            index=pd.date_range(pd.Timestamp("2000-01-01") + pd.Timedelta(days=2 * i), periods=2),
+        )
+        lib.append(sym, df)
+
+
+def test_column_stats_date_range_clause_still_prunes(
+    in_memory_version_store, clear_query_stats, column_stats_filtering_enabled
+):
+    lib = in_memory_version_store
+    write_six_segments(lib)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    # Segments 0-2 hold col_1 1..6; only segment 2 (col_1 in [5, 6]) matches col_1 > 4.
+    q = QueryBuilder()
+    q = q.date_range((pd.Timestamp("2000-01-01"), pd.Timestamp("2000-01-06")))
+    q = q[q["col_1"] > 4]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+
+    expected = pd.DataFrame({"col_1": [5, 6]}, index=pd.date_range("2000-01-05", periods=2))
+    assert_frame_equal(expected, result)
+    assert get_table_data_read_count() == 1

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -50,7 +50,56 @@ def test_create_column_stats_reads_index_key_once_and_writes_single_key(in_memor
     lib.create_column_stats_experimental(sym)
 
     assert get_table_index_read_count() == 1, qs.get_query_stats()
+    assert get_column_stats_read_count() == 0, qs.get_query_stats()
     assert get_column_stats_write_count() == 1, qs.get_query_stats()
+
+
+def test_create_column_stats_with_row_range_reads_and_writes_stats_key_once(in_memory_version_store, clear_query_stats):
+    lib = in_memory_version_store
+    df0 = pd.DataFrame({"col_1": [1, 2], "col_2": ["a", "b"]}, index=pd.date_range("2000-01-01", periods=2))
+    df1 = pd.DataFrame({"col_1": [3, 4], "col_2": ["c", "d"]}, index=pd.date_range("2000-01-03", periods=2))
+    lib.write(sym, df0)
+    lib.append(sym, df1)
+    lib.create_column_stats_experimental(sym)
+
+    qs.enable()
+    qs.reset_stats()
+    lib.create_column_stats_experimental(sym, row_range=(0, 2))
+
+    assert get_table_index_read_count() == 1, qs.get_query_stats()
+    assert get_column_stats_read_count() == 1, qs.get_query_stats()
+    assert get_column_stats_write_count() == 1, qs.get_query_stats()
+
+
+# Stats cover only the first of three row slices, so the other two must be read whatever the query:
+# a slice the stats say nothing about cannot be pruned.
+@pytest.mark.parametrize(
+    "threshold, expected_reads",
+    [
+        (-1, 3),  # the covered slice matches in full
+        (1, 3),  # the covered slice matches in part
+        (4, 2),  # the covered slice is pruned, max=2 < 4
+        (9, 2),  # nothing matches anywhere, but only the covered slice can be pruned
+    ],
+    ids=["gte_-1", "gte_1", "gte_4", "gte_9"],
+)
+def test_column_stats_partial_coverage_does_not_change_query_results(
+    in_memory_store_factory, clear_query_stats, column_stats_filtering_enabled, threshold, expected_reads
+):
+    lib = in_memory_store_factory(segment_row_size=3)
+    df = pd.DataFrame({"col_1": np.arange(9)}, index=pd.date_range("2000-01-01", periods=9))
+    lib.write(sym, df)
+    lib.create_column_stats_experimental(sym, row_range=(0, 3))
+
+    qs.enable()
+    q = QueryBuilder()
+    q = q[q["col_1"] >= threshold]
+    qs.reset_stats()
+    result = lib.read(sym, query_builder=q).data
+    table_data_reads = get_table_data_read_count()
+
+    assert_frame_equal(df[df["col_1"] >= threshold], result, check_freq=False)
+    assert table_data_reads == expected_reads, f"Expected {expected_reads} TABLE_DATA read(s), got {table_data_reads}"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This is split in to separate working commits, but they trample over each other so reviewing all together is likely best. This is why we have these all together in a single PR.

## Step 1: Do not create `SegmentInMemory` for each column stats row

This is a pure refactor. Rather than creating the `SegmentInMemory` repeatedly during column stats creation (we were creating one for each row of column stats, then merging them together in to one bigger `SegmentInMemory`). This had a lot of overhead because each of these needs a protobuf header `ColumnStatsHeader`, and was just needlessly confusing.

Now in the `ColumnStatsGenerationClause` the process returns entities that are `ColumnStatsRow` rather than `SegmentInMemory`. This is just:

```
struct ColumnStatValue {
    // to_segment_column_name(<name of the column at data_col_offset>, type), e.g. "v1_MIN(col)"
    std::string segment_column_name;
    ColumnStatTypeInternal type;
    size_t data_col_offset;
    Value value;
};

/// One per row slice. Added to the ComponentManager as a standalone entity by
/// ColumnStatsGenerationClause::process and read back by create_column_stats_impl via
/// process_entities, which scans the whole registry — no other code may add this component.
struct ColumnStatsRow {
    uint64_t start_row;
    uint64_t end_row;
    std::vector<ColumnStatValue> stats;
};
```

and models a single row in the column stats segment.

`create_column_stats_impl` now consumes them by,

```
    read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();

    std::vector<ColumnStatsRow> components;
    component_manager->process_entities([&components](const ColumnStatsRow& component) {
        components.emplace_back(component);
    });
```

and constructs the final `SegmentInMemory`: `    SegmentInMemory new_segment = build_column_stats_segment(std::move(components), pipeline_context->descriptor());`.

I've also made changes to calculate the types of the column stats rows based on the index TSD, rather than applying our type promotion logic to them at the point we merge them in to the `SegmentInMemory`.

## Step 2 - Store column stats by (start_row, end_row) rather than (start_index, end_index)

This new layout can handle duplicated index values.

When we come to do automatic stats maintenance at write time, I was worried about how this might work with `update`. The new layout gives us a reasonable way to do this - `flatten_and_fix_rows` takes `SliceAndKey`s with their old row range and stamps the new post-update row range on them. This gives us a natural place to map between old row range and new row range, which is what we need to take the pre-update column stats segment and map unchanged slices on to the new row ranges, without recalculating stats.

## Step 3 - Support creating stats with row_range or date_range args

Support creating stats with `row_range=` or `date_range=` while preserving any existing stats, so you can built up stats incrementally with successive calls with different ranges. The idea of this is to make it tractable to create stats over very large historical symbols, at least for more recent more relevant data.

## Review Fixes

Drop a check that column stats creation should not be attempted over string indexed columns. The commit message explains why we never needed this check with either the old or the new format. There was in fact already a test in test_column_stats_optimisation.py `test_column_stats_query_optimisation_index_types` showing that this worked.
