### PR TITLE
Fix flaky version map tests

### DIFF
--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -1079,7 +1079,9 @@ def test_read_batch_missing_keys(arctic_library):
     lib_tool.remove(s2_data_key)
     lib_tool.remove(s3_key_to_delete)
     # When
-    batch = lib.read_batch(["s1", "s2", ReadRequest("s3", as_of=0)])
+    # Disable version map cache so the read hits storage and sees the missing keys
+    with config_context("VersionMap.ReloadInterval", 0):
+        batch = lib.read_batch(["s1", "s2", ReadRequest("s3", as_of=0)])
     # Then
     assert isinstance(batch[0], DataError)
     assert batch[0].symbol == "s1"

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -1220,7 +1220,9 @@ def test_get_description_batch_missing_keys(arctic_library):
     lib_tool.remove(s2_key_to_delete)
 
     # When
-    batch = lib.get_description_batch(["s1", ReadInfoRequest("s2", as_of=0), "s3"])
+    # Disable version map cache so the read hits storage and sees the missing keys
+    with config_context("VersionMap.ReloadInterval", 0):
+        batch = lib.get_description_batch(["s1", ReadInfoRequest("s2", as_of=0), "s3"])
 
     # Then
     assert isinstance(batch[0], DataError)

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1848,9 +1848,10 @@ def test_batch_read_missing_keys(basic_store):
     df3 = pd.DataFrame({"a": [5, 7, 9]})
     lib.write("s1", df1)
     lib.write("s2", df2)
-    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
-    # latest index key in the version ref key means it will still work if we just write one version key and then delete
-    # it
+    # Need three versions for this symbol as we're going to delete a version key, and the optimisation of storing
+    # the latest two index keys in the version ref key means it will still work if we just write two version keys
+    # and then delete the oldest
+    lib.write("s3", df3)
     lib.write("s3", df3)
     lib.write("s3", df3)
     lib_tool = lib.library_tool()

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1814,12 +1814,12 @@ def test_batch_read_metadata_missing_keys(basic_store):
     lib_tool.remove(s1_index_key)
     lib_tool.remove(s2_key_to_delete)
 
-    vits = lib.batch_read_metadata(["s2"], [1])
-    metadata = vits["s2"].metadata
-    assert metadata["s2"] == "more_metadata"
-
     # Disable version map cache so the read hits storage and sees the missing keys
     with config_context("VersionMap.ReloadInterval", 0):
+        vits = lib.batch_read_metadata(["s2"], [1])
+        metadata = vits["s2"].metadata
+        assert metadata["s2"] == "more_metadata"
+
         with pytest.raises(StorageException):
             _ = lib.batch_read_metadata(["s1"], [None])
         with pytest.raises(StorageException):
@@ -1864,8 +1864,10 @@ def test_batch_read_missing_keys(basic_store):
 
     # The exception thrown is different for missing version keys to everything else, and so depends on which symbol is
     # processed first
-    with pytest.raises((NoDataFoundException, StorageException)):
-        _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0])
+    # Disable version map cache so the read hits storage and sees the missing keys
+    with config_context("VersionMap.ReloadInterval", 0):
+        with pytest.raises((NoDataFoundException, StorageException)):
+            _ = lib.batch_read(["s1", "s2", "s3"], [None, None, 0])
 
 
 @pytest.mark.storage
@@ -1888,10 +1890,10 @@ def test_batch_get_info_missing_keys(basic_store):
     lib_tool.remove(s1_index_key)
     lib_tool.remove(s2_key_to_delete)
 
-    info = lib.batch_get_info(["s2"], [1])
-
     # Disable version map cache so the read hits storage and sees the missing keys
     with config_context("VersionMap.ReloadInterval", 0):
+        info = lib.batch_get_info(["s2"], [1])
+
         with pytest.raises(StorageException):
             _ = lib.batch_get_info(["s1"], [None])
         with pytest.raises(StorageException):

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -1818,10 +1818,12 @@ def test_batch_read_metadata_missing_keys(basic_store):
     metadata = vits["s2"].metadata
     assert metadata["s2"] == "more_metadata"
 
-    with pytest.raises(StorageException):
-        _ = lib.batch_read_metadata(["s1"], [None])
-    with pytest.raises(StorageException):
-        _ = lib.batch_read_metadata(["s2"], [0])
+    # Disable version map cache so the read hits storage and sees the missing keys
+    with config_context("VersionMap.ReloadInterval", 0):
+        with pytest.raises(StorageException):
+            _ = lib.batch_read_metadata(["s1"], [None])
+        with pytest.raises(StorageException):
+            _ = lib.batch_read_metadata(["s2"], [0])
 
 
 @pytest.mark.storage
@@ -1888,10 +1890,12 @@ def test_batch_get_info_missing_keys(basic_store):
 
     info = lib.batch_get_info(["s2"], [1])
 
-    with pytest.raises(StorageException):
-        _ = lib.batch_get_info(["s1"], [None])
-    with pytest.raises(StorageException):
-        _ = lib.batch_get_info(["s2"], [0])
+    # Disable version map cache so the read hits storage and sees the missing keys
+    with config_context("VersionMap.ReloadInterval", 0):
+        with pytest.raises(StorageException):
+            _ = lib.batch_get_info(["s1"], [None])
+        with pytest.raises(StorageException):
+            _ = lib.batch_get_info(["s2"], [0])
 
 
 @pytest.mark.storage

--- a/python/tests/integration/arcticdb/version_store/test_num_storage_operations.py
+++ b/python/tests/integration/arcticdb/version_store/test_num_storage_operations.py
@@ -11,11 +11,15 @@ from arcticdb.util.test import (
     assert_frame_equal,
     config_context,
     config_context_string,
+    query_stats_operation_count,
 )
 from arcticdb.version_store.processing import QueryBuilder
 import arcticdb.toolbox.query_stats as qs
 
-from tests.util.mark import MACOS_WHEEL_BUILD
+from tests.util.mark import MACOS_WHEEL_BUILD, MEM_TESTS_MARK
+
+# Large enough that the version map cache never expires during a test
+MAX_RELOAD_INTERVAL = 2_000_000_000_000
 
 
 def sum_operations(stats):
@@ -246,6 +250,49 @@ def test_read_as_of_version(lib_name, s3_and_nfs_storage_bucket, clear_query_sta
         assert get_obj_ops["TABLE_DATA"]["count"] == 1, pformat(stats)
         if expected_version_ops:
             assert get_obj_ops["VERSION"]["count"] == expected_version_ops, pformat(stats)
+
+
+@MEM_TESTS_MARK
+def test_read_as_of_after_write_with_cache(in_memory_version_store, clear_query_stats):
+    lib = in_memory_version_store
+
+    with config_context("VersionMap.ReloadInterval", MAX_RELOAD_INTERVAL):
+        lib.write("s", data=create_df())
+        lib.write("s", data=create_df(), prune_previous_version=False)
+        lib.write("s", data=create_df(), prune_previous_version=False)
+
+        qs.enable()
+        lib.read("s", as_of=0)
+        stats = qs.get_query_stats()
+        qs.reset_stats()
+
+        # TODO (monday ref 12842636013) reading immediately after write with cache enabled should not
+        # reload from storage.
+        # The writes appended every version's keys to the cached entry, but they never advanced its
+        # load_progress_, so loaded_as_far_as_version_id rejects the cache for as_of=0 and the whole
+        # chain is re-read.
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 1, pformat(stats)
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION") == 3, pformat(stats)
+
+
+@MEM_TESTS_MARK
+def test_write_reads_version_ref_only_once(in_memory_version_store, clear_query_stats):
+    lib = in_memory_version_store
+
+    with config_context("VersionMap.ReloadInterval", 0):
+        qs.enable()
+        lib.write("s", data=create_df())
+        stats = qs.get_query_stats()
+        qs.reset_stats()
+
+        # TODO (monday ref 12842618577) VERSION_REF should be read just once. Currently it is read 2 times
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 2, pformat(stats)
+
+        lib.write("s", data=create_df(), prune_previous_version=False)
+        stats = qs.get_query_stats()
+        qs.reset_stats()
+
+        assert query_stats_operation_count(stats, "Memory_GetObject", "VERSION_REF") == 2, pformat(stats)
 
 
 def get_dataframe_for_range_edge_cases():

--- a/python/tests/unit/arcticdb/version_store/test_list_versions.py
+++ b/python/tests/unit/arcticdb/version_store/test_list_versions.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import pytest
 
 import arcticdb.toolbox.query_stats as qs
-from arcticdb.util.test import query_stats_operation_count
+from arcticdb.util.test import config_context, query_stats_operation_count
 from arcticdb_ext.exceptions import InternalException, KeyNotFoundException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 
@@ -391,8 +391,10 @@ def test_broken_version_chain(lmdb_version_store_v1, latest_only):
     # The version chain traversal raises KeyNotFoundException directly, but if the
     # symbol list load path hits the missing key first, ExponentialBackoff retries and
     # eventually throws InternalException ("Exhausted retry attempts").
-    with pytest.raises((KeyNotFoundException, InternalException)) as e:
-        lib.list_versions(latest_only=latest_only)
+    # Disable version map cache so the read hits storage and sees the missing key
+    with config_context("VersionMap.ReloadInterval", 0):
+        with pytest.raises((KeyNotFoundException, InternalException)) as e:
+            lib.list_versions(latest_only=latest_only)
     assert broken_sym in str(e.value)
 
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
@@ -138,9 +138,10 @@ def test_filter_batch_missing_keys(lmdb_version_store_v1, any_output_format):
     df3 = pd.DataFrame({"a": [5, 7, 9]})
     lib.write("s1", df1)
     lib.write("s2", df2)
-    # Need two versions for this symbol as we're going to delete a version key, and the optimisation of storing the
-    # latest index key in the version ref key means it will still work if we just write one version key and then delete
-    # it
+    # Need three versions for this symbol as we're going to delete a version key, and the optimisation of storing
+    # the latest two index keys in the version ref key means it will still work if we just write two version keys
+    # and then delete the oldest
+    lib.write("s3", df3)
     lib.write("s3", df3)
     lib.write("s3", df3)
     lib_tool = lib.library_tool()

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
@@ -11,6 +11,7 @@ import pandas as pd
 import pytest
 
 from arcticdb.exceptions import ArcticNativeException
+from arcticdb.util.test import config_context
 from arcticdb_ext.storage import KeyType, NoDataFoundException
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb_ext.exceptions import InternalException, StorageException, UserInputException
@@ -156,5 +157,7 @@ def test_filter_batch_missing_keys(lmdb_version_store_v1, any_output_format):
 
     # The exception thrown is different for missing version keys to everything else, and so depends on which symbol is
     # processed first
-    with pytest.raises((NoDataFoundException, StorageException)):
-        lib.batch_read(["s1", "s2", "s3"], [None, None, 0], query_builder=q)
+    # Disable version map cache so the read hits storage and sees the missing keys
+    with config_context("VersionMap.ReloadInterval", 0):
+        with pytest.raises((NoDataFoundException, StorageException)):
+            lib.batch_read(["s1", "s2", "s3"], [None, None, 0], query_builder=q)


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #3268 
Fixes #3276 
Fixes #3277 

Opens monday ref 12842636013
Opens monday ref 12842618577

#### What does this implement or fix?
For all test which do `lib_tool.remove(version_key)` we should use a disabled version map cache to succesfully reproduce the missing key failure.

Also adds two tests highlighting surprising version map behavior, which should be fixed in corresponding tickets.

#### Any other comments?
The version map cache kicks in depending on timing:
```
  lib = Arctic("mem://").create_library("demo")
  df = pd.DataFrame({"a": [5, 7, 9]})
  lib.write("s3", df)
  lib.write("s3", df)
  time.sleep(3)  # exceed VersionMap.ReloadInterval, so the next write reloads the chain
  lib.write("s3", df)

  with qs.query_stats():
      lib.read("s3", as_of=0)

  print(qs.get_query_stats()["storage_operations"]["Memory_GetObject"].keys())

  dict_keys(['TABLE_DATA', 'TABLE_INDEX'])
```
but if we remove the `sleep` we end up reading the version chain.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
