### PR TITLE
Correctly run tests with `NoCache`

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -82,7 +82,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3.3.0
         with:
-          fetch-depth: ${{ startsWith(github.ref, 'refs/tags/') && 0 || 1 }}
+          fetch-depth: ${{ startsWith(github.ref, 'refs/tags/') && '0' || '1' }}
           ref: ${{ inputs.ref }}
 
       - name: Init submodules
@@ -725,7 +725,7 @@ jobs:
           ARCTICDB_PYTEST_ARGS: ${{inputs.pytest_args}}
           STORAGE_TYPE: ${{ env.real_tests_storage_type }}
           # Testing with 0(no version cache) and -1(will use default timeout)
-          VERSION_MAP_RELOAD_INTERVAL: ${{matrix.version_cache_timeout == 'NoCache' && 0 || -1}}
+          VERSION_MAP_RELOAD_INTERVAL: ${{matrix.version_cache_timeout == 'NoCache' && '0' || -1}}
           # 1 admits one processing unit at a time, -1 leaves the residency limit at its default
           NUM_PROCESSING_UNITS_LIVE: ${{matrix.admission_limit == 'Serial' && 1 || -1}}
           ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: 0


### PR DESCRIPTION


#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->

#### What does this implement or fix?
GH Actions' `&&` / `||` operators are JS-style: `cond && 0 || fallback` always evaluates to `fallback` when cond is true, because 0 is falsy, so the || re-triggers. This silently broke two expressions:
- VERSION_MAP_RELOAD_INTERVAL always got -1 instead of 0 for the 'NoCache' test matrix leg, so that leg never actually ran with the version map cache disabled.
- fetch-depth always got 1 (shallow) instead of 0 (full history) for tag builds, regardless of intent.

Quote the numeric literal in the truthy branch so it's a non-empty string, which GH Actions treats as truthy.

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
