### PR TITLE
Add some APIs to read our default thread counts without instantiating the TaskScheduler

### DIFF
--- a/cpp/arcticdb/async/python_bindings.cpp
+++ b/cpp/arcticdb/async/python_bindings.cpp
@@ -26,8 +26,11 @@ void register_bindings(py::module& m) {
     async.def("print_scheduler_stats", &print_scheduler_stats);
 
     async.def("reinit_task_scheduler", &arcticdb::async::TaskScheduler::reattach_instance);
+    async.def("is_task_scheduler_initialized", &arcticdb::async::TaskScheduler::is_initialized);
     async.def("cpu_thread_count", []() { return arcticdb::async::TaskScheduler::instance()->cpu_thread_count(); });
     async.def("io_thread_count", []() { return arcticdb::async::TaskScheduler::instance()->io_thread_count(); });
+    async.def("get_default_cpu_count", &arcticdb::async::get_default_cpu_count);
+    async.def("get_default_io_count", []() { return arcticdb::async::get_default_io_count(); });
 }
 
 } // namespace arcticdb::async

--- a/cpp/arcticdb/async/task_scheduler.cpp
+++ b/cpp/arcticdb/async/task_scheduler.cpp
@@ -15,6 +15,8 @@ TaskScheduler* TaskScheduler::instance() {
     return instance_->ptr_;
 }
 
+bool TaskScheduler::is_initialized() { return static_cast<bool>(instance_); }
+
 std::shared_ptr<TaskSchedulerPtrWrapper> TaskScheduler::instance_;
 std::once_flag TaskScheduler::init_flag_;
 std::once_flag TaskScheduler::shutdown_flag_;

--- a/cpp/arcticdb/async/task_scheduler.hpp
+++ b/cpp/arcticdb/async/task_scheduler.hpp
@@ -219,6 +219,10 @@ inline long get_default_cpu_count() {
     );
 }
 
+inline long get_default_io_count(long cpu_count = get_default_cpu_count()) {
+    return ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", static_cast<int>(cpu_count * 1.5));
+}
+
 /*
  * Possible areas of inprovement in the future:
  * 1/ Task/op decoupling: push task and then use strategy to implement smart batching to
@@ -238,11 +242,7 @@ class TaskScheduler {
             const std::optional<size_t>& io_thread_count = std::nullopt
     ) :
         cpu_thread_count_(cpu_thread_count ? *cpu_thread_count : get_default_cpu_count()),
-        io_thread_count_(
-                io_thread_count
-                        ? *io_thread_count
-                        : ConfigsMap::instance()->get_int("VersionStore.NumIOThreads", (int)(cpu_thread_count_ * 1.5))
-        ),
+        io_thread_count_(io_thread_count ? *io_thread_count : get_default_io_count(cpu_thread_count_)),
         cpu_exec_(cpu_thread_count_, std::make_shared<InstrumentedNamedFactory>("CPUPool")),
         io_exec_(io_thread_count_, std::make_shared<InstrumentedNamedFactory>("IOPool", &io_pool_thread_started)) {
         util::check(
@@ -299,6 +299,7 @@ class TaskScheduler {
     static void init();
 
     static TaskScheduler* instance();
+    static bool is_initialized();
     static void reattach_instance();
     static void stop_active_threads();
     static bool forked_;

--- a/cpp/arcticdb/async/test/test_async.cpp
+++ b/cpp/arcticdb/async/test/test_async.cpp
@@ -310,6 +310,35 @@ TEST(Async, DynamicSizing) {
     (void)std::move(f2).get();
 }
 
+TEST(Async, DefaultThreadCounts) {
+    {
+        ScopedConfig cpu_config({{"VersionStore.NumCPUThreads", std::nullopt}});
+        ScopedConfig io_config({{"VersionStore.NumIOThreads", std::nullopt}});
+        ASSERT_EQ(
+                arcticdb::async::get_default_io_count(),
+                static_cast<int>(arcticdb::async::get_default_cpu_count() * 1.5)
+        );
+    }
+    {
+        ScopedConfig cpu_config("VersionStore.NumCPUThreads", 7);
+        ASSERT_EQ(arcticdb::async::get_default_cpu_count(), 7);
+    }
+    {
+        ScopedConfig io_config("VersionStore.NumIOThreads", 11);
+        ASSERT_EQ(arcticdb::async::get_default_io_count(), 11);
+        ASSERT_EQ(arcticdb::async::get_default_io_count(5), 11);
+    }
+    {
+        ScopedConfig io_config({{"VersionStore.NumIOThreads", std::nullopt}});
+        ASSERT_EQ(arcticdb::async::get_default_io_count(5), 7);
+    }
+}
+
+TEST(Async, IsInitialized) {
+    ASSERT_TRUE(arcticdb::async::TaskScheduler::instance() != nullptr);
+    ASSERT_TRUE(arcticdb::async::TaskScheduler::is_initialized());
+}
+
 TEST(Async, NumCoresCgroupV1) {
     std::string test_path{"./test_v1"};
     std::string cpu_quota_path{"./test_v1/cpu/cpu.cfs_quota_us"};

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -10,6 +10,8 @@ import numpy as np
 import pandas as pd
 import random
 import datetime
+import subprocess
+import sys
 import pytest
 
 
@@ -240,6 +242,37 @@ def test_parallel_write(basic_store_tiny_segment, num_segments_live_during_compa
             assert len(get_append_keys(store, sym)) == 0
     finally:
         adb_async.reinit_task_scheduler()
+
+
+@pytest.mark.parametrize("num_cpu_threads, num_io_threads", [(None, None), (3, 5), (3, None), (None, 5)])
+def test_default_thread_counts(num_cpu_threads, num_io_threads):
+    with config_context_multi(
+        {
+            "VersionStore.NumCPUThreads": num_cpu_threads,
+            "VersionStore.NumIOThreads": num_io_threads,
+        }
+    ):
+        if num_cpu_threads is not None:
+            assert adb_async.get_default_cpu_count() == num_cpu_threads
+
+        if num_io_threads is not None:
+            assert adb_async.get_default_io_count() == num_io_threads
+        else:
+            assert adb_async.get_default_io_count() == int(adb_async.get_default_cpu_count() * 1.5)
+
+
+def test_task_scheduler_is_initialized():
+    adb_async.cpu_thread_count()
+    assert adb_async.is_task_scheduler_initialized()
+
+
+def test_default_thread_counts_do_not_initialize_scheduler():
+    script = (
+        "import arcticdb_ext.cpp_async as adb_async; "
+        "adb_async.get_default_cpu_count(); adb_async.get_default_io_count(); "
+        "assert not adb_async.is_task_scheduler_initialized()"
+    )
+    subprocess.check_call([sys.executable, "-c", script])
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Our current functions in ```import arcticdb_ext.cpp_async``` to read thread counts read them off `TaskScheduler::instance()`. I want to add some new bindings that just check what values we would set, without possibly instantianting the `TaskScheduler`.

The motivation for this is that in Man we want to set small defaults for CPU and IO threads, so I need to write logic in internal code like:

- If user has set CPU threads or IO threads explicitly do nothing
- Else set CPU threads and IO threads to the min of their default values according to this repo, or to some small default defined in a Man repo

This will best be done at import time, and before initializing the task scheduler. With the current APIs, these checks initialize the task scheduler, and if we need to change the thread counts, the scheduler then needs a `reinit_task_scheduler`. That is clearly way too much work to be doing at import time so we need some lightweight APIs.

I have left the old APIs in place because they are often used as sanity checks in tests (eg the tiny_thread_pool fixture) which are more convincing if they are checking the actual `TaskScheduler` state.