### PR TITLE
Enhancement 18053144964: fix get description output with arrow written data

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -3677,6 +3677,8 @@ class NativeVersionStore:
             return "pickled"
         elif input_type == "ts":
             return "normalized_timeseries"
+        elif input_type == "experimental_arrow":
+            return "arrow"
         else:
             return "missing_type_info"
 
@@ -3738,6 +3740,11 @@ class NativeVersionStore:
         if input_type == "df":
             index_metadata = desc.normalization.df.common
             tz = get_timezone_from_metadata(index_metadata)
+        elif input_type == "experimental_arrow":
+            index_column_name = desc.fields[0].name
+            index_column_meta = desc.normalization.experimental_arrow.columns.get(index_column_name, None)
+            if index_column_meta is not None:
+                tz = index_column_meta.timezone
         if date_range_ns_precision:
             # V2 API expects pandas timestamps with nanosecond precision
             min_ts_pd = pd.Timestamp(min_ts)
@@ -3882,6 +3889,11 @@ class NativeVersionStore:
                     index_dtype.append(dtypes.pop(0))
             if timeseries_descriptor.normalization.df.has_synthetic_columns:
                 columns = pd.RangeIndex(0, len(columns))
+        elif input_type == "experimental_arrow":
+            arrow_meta = timeseries_descriptor.normalization.experimental_arrow
+            if arrow_meta.has_index:
+                index = [columns.pop(0)]
+                index_dtype = [dtypes.pop(0)]
 
         date_range = self._get_time_range_from_ts(
             timeseries_descriptor, dit.start_index, dit.end_index, date_range_ns_precision

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -137,7 +137,9 @@ class SymbolDescription(NamedTuple):
     index : Tuple[NameWithDType]
         Index of the symbol.
     index_type : str {"NA", "index", "multi_index"}
-        Whether the index is a simple index or a multi_index. ``NA`` indicates that the stored data does not have an index.
+        If the written data was a Pandas object, whether the index is a simple index or a multi_index. ``NA`` for all
+        other written object types. This includes Arrow data with ``index_column=True``. With Arrow data, the ``index``
+        field of this object can be used to determine whether the on-disk data is a timeseries or not.
     row_count : Optional[int]
         Number of rows, or None if the symbol is pickled.
     last_update_time : datetime.datetime

--- a/python/tests/unit/arcticdb/test_arrow_api.py
+++ b/python/tests/unit/arcticdb/test_arrow_api.py
@@ -400,3 +400,88 @@ def test_read_batch_and_join_strings(mem_storage, lib_name, default, per_column)
     assert result.schema.field(2).type == per_column or default or pa.large_string()
     expected_df = pd.concat([df_1, df_2]).reset_index(drop=True)
     assert_frame_equal_with_arrow(expected_df, result)
+
+
+# See test with the same name in test_arrow_read.py for V1 API equivalent
+def test_arrow_written_data_get_info_non_timeseries(mem_library):
+    lib = mem_library
+    sym = "test_arrow_written_data_get_info_non_timeseries"
+    lib._nvs._set_allow_arrow_input()
+    table = pa.table({"col": pa.array(np.arange(10), type=pa.int64())})
+    lib.write(sym, table)
+    desc = lib.get_description(sym)
+    assert len(desc.columns) == 1
+    assert desc.columns[0].name == "col"
+    assert len(desc.index) == 0
+    assert "INT64" in str(desc.columns[0].dtype)
+    assert np.isnat(desc.date_range[0]) and np.isnat(desc.date_range[1])
+    assert desc.index_type == "NA"
+    assert desc.row_count == 10
+    assert desc.sorted == "UNKNOWN"
+
+
+# See test with the same name in test_arrow_read.py for V1 API equivalent
+@pytest.mark.parametrize(
+    "table",
+    [
+        pytest.param(
+            pa.table(
+                {
+                    "ts": pa.Array.from_pandas(
+                        pd.date_range("2025-01-01", periods=20),
+                        type=pa.timestamp("ns"),
+                    ),
+                    "col": pa.array(np.arange(20), type=pa.uint8()),
+                }
+            ),
+            id="sorted",
+        ),
+        pytest.param(
+            pa.table(
+                {
+                    "ts": pa.Array.from_pandas(
+                        reversed(pd.date_range("2025-01-01", periods=20)),
+                        type=pa.timestamp("ns"),
+                    ),
+                    "col": pa.array(np.arange(20), type=pa.uint8()),
+                }
+            ),
+            id="unsorted",
+        ),
+    ],
+)
+@pytest.mark.parametrize("tz", [None, "UTC", "Europe/Brussels"])
+@pytest.mark.parametrize("has_index", [False, True])
+@pytest.mark.parametrize("validate_index", [False, True])
+def test_arrow_written_data_get_info_timeseries(mem_library, table, tz, has_index, validate_index):
+    lib = mem_library
+    sym = "test_arrow_written_data_get_info_timeseries"
+    lib._nvs._set_allow_arrow_input()
+    if tz is not None:
+        table = table.set_column(0, "ts", table.column(0).cast(pa.timestamp("ns", tz=tz)))
+    sorted = (pa.compute.sort_indices(table.column(0)).to_numpy() == np.arange(20, dtype=np.uint64)).all()
+    if has_index and validate_index and not sorted:
+        pytest.skip("Write will fail")
+    lib.write(sym, table, validate_index=validate_index, index_column=has_index)
+    desc = lib.get_description(sym)
+    assert len(desc.columns) == (1 if has_index else 2)
+    assert desc.columns[-1].name == "col"
+    assert "UINT8" in str(desc.columns[-1].dtype)
+    if not has_index:
+        assert desc.columns[0].name == "ts"
+        assert "NANOSECONDS_UTC64" in str(desc.columns[0].dtype)
+    assert len(desc.index) == (1 if has_index else 0)
+    if has_index:
+        assert desc.index[0].name == "ts"
+        assert "NANOSECONDS_UTC64" in str(desc.index[0].dtype)
+    if has_index:
+        assert desc.date_range == (table.to_pandas()["ts"][0], table.to_pandas()["ts"][19])
+    else:
+        assert np.isnat(desc.date_range[0]) and np.isnat(desc.date_range[1])
+    assert desc.index_type == "NA"
+    assert desc.row_count == 20
+    # # With Arrow and validate_index enabled, it is impossible to write sorted-descending data
+    if has_index and validate_index and sorted:
+        assert desc.sorted == "ASCENDING"
+    else:
+        assert desc.sorted == "UNKNOWN"

--- a/python/tests/unit/arcticdb/test_arrow_api.py
+++ b/python/tests/unit/arcticdb/test_arrow_api.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pc
 import polars as pl
 import pytest
 
@@ -459,7 +460,7 @@ def test_arrow_written_data_get_info_timeseries(mem_library, table, tz, has_inde
     lib._nvs._set_allow_arrow_input()
     if tz is not None:
         table = table.set_column(0, "ts", table.column(0).cast(pa.timestamp("ns", tz=tz)))
-    sorted = (pa.compute.sort_indices(table.column(0)).to_numpy() == np.arange(20, dtype=np.uint64)).all()
+    sorted = (pc.sort_indices(table.column(0)).to_numpy() == np.arange(20, dtype=np.uint64)).all()
     if has_index and validate_index and not sorted:
         pytest.skip("Write will fail")
     lib.write(sym, table, validate_index=validate_index, index_column=has_index)

--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -1390,7 +1390,7 @@ def test_arrow_written_data_get_info_timeseries(in_memory_version_store_arrow, t
     sym = "test_arrow_written_data_get_info_timeseries"
     if tz is not None:
         table = table.set_column(0, "ts", table.column(0).cast(pa.timestamp("ns", tz=tz)))
-    sorted = (pa.compute.sort_indices(table.column(0)).to_numpy() == np.arange(20, dtype=np.uint64)).all()
+    sorted = (pc.sort_indices(table.column(0)).to_numpy() == np.arange(20, dtype=np.uint64)).all()
     if has_index and validate_index and not sorted:
         pytest.skip("Write will fail")
     lib.write(sym, table, validate_index=validate_index, index_column=has_index)

--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pandas as pd
 import numpy as np
 import pytest
@@ -1328,3 +1330,90 @@ def test_arrow_read_all_empty_strings(in_memory_version_store_arrow, any_arrow_s
     result = lib.read(sym, arrow_string_format_default=any_arrow_string_format).data
     expected = lib.read(sym, output_format=OutputFormat.PANDAS).data
     assert_frame_equal_with_arrow(result, expected)
+
+
+# See test with the same name in test_arrow_api.py for V2 API equivalent
+def test_arrow_written_data_get_info_non_timeseries(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
+    sym = "test_arrow_written_data_get_info_non_timeseries"
+    table = pa.table({"col": pa.array(np.arange(10), type=pa.int64())})
+    lib.write(sym, table)
+    info = lib.get_info(sym)
+    assert info["col_names"]["columns"] == ["col"]
+    assert len(info["dtype"]) == 1
+    assert "INT64" in str(info["dtype"][0])
+    assert len(info["col_names"]["index"]) == 0
+    assert len(info["col_names"]["index_dtype"]) == 0
+    assert info["rows"] == 10
+    assert info["input_type"] == "experimental_arrow"
+    assert info["index_type"] == "NA"
+    assert info["type"] == "arrow"
+    assert np.isnat(info["date_range"][0]) and np.isnat(info["date_range"][1])
+    assert info["sorted"] == "UNKNOWN"
+
+
+# See test with the same name in test_arrow_api.py for V2 API equivalent
+@pytest.mark.parametrize(
+    "table",
+    [
+        pytest.param(
+            pa.table(
+                {
+                    "ts": pa.Array.from_pandas(
+                        pd.date_range("2025-01-01", periods=20),
+                        type=pa.timestamp("ns"),
+                    ),
+                    "col": pa.array(np.arange(20), type=pa.uint8()),
+                }
+            ),
+            id="sorted",
+        ),
+        pytest.param(
+            pa.table(
+                {
+                    "ts": pa.Array.from_pandas(
+                        reversed(pd.date_range("2025-01-01", periods=20)),
+                        type=pa.timestamp("ns"),
+                    ),
+                    "col": pa.array(np.arange(20), type=pa.uint8()),
+                }
+            ),
+            id="unsorted",
+        ),
+    ],
+)
+@pytest.mark.parametrize("tz", [None, "UTC", "Europe/Brussels"])
+@pytest.mark.parametrize("has_index", [False, True])
+@pytest.mark.parametrize("validate_index", [False, True])
+def test_arrow_written_data_get_info_timeseries(in_memory_version_store_arrow, table, tz, has_index, validate_index):
+    lib = in_memory_version_store_arrow
+    sym = "test_arrow_written_data_get_info_timeseries"
+    if tz is not None:
+        table = table.set_column(0, "ts", table.column(0).cast(pa.timestamp("ns", tz=tz)))
+    sorted = (pa.compute.sort_indices(table.column(0)).to_numpy() == np.arange(20, dtype=np.uint64)).all()
+    if has_index and validate_index and not sorted:
+        pytest.skip("Write will fail")
+    lib.write(sym, table, validate_index=validate_index, index_column=has_index)
+    info = lib.get_info(sym)
+    assert info["col_names"]["columns"] == (["col"] if has_index else ["ts", "col"])
+    assert len(info["dtype"]) == (1 if has_index else 2)
+    if not has_index:
+        assert "NANOSECONDS_UTC64" in str(info["dtype"][0])
+    assert "UINT8" in str(info["dtype"][-1])
+    assert info["col_names"]["index"] == (["ts"] if has_index else [])
+    assert len(info["col_names"]["index_dtype"]) == (1 if has_index else 0)
+    if has_index:
+        assert "NANOSECONDS_UTC64" in str(info["col_names"]["index_dtype"][0])
+    assert info["rows"] == 20
+    assert info["input_type"] == "experimental_arrow"
+    assert info["index_type"] == "NA"
+    assert info["type"] == "arrow"
+    if has_index:
+        assert info["date_range"] == (table.to_pandas()["ts"][0], table.to_pandas()["ts"][19])
+    else:
+        assert np.isnat(info["date_range"][0]) and np.isnat(info["date_range"][1])
+    # With Arrow and validate_index enabled, it is impossible to write sorted-descending data
+    if has_index and validate_index and sorted:
+        assert info["sorted"] == "ASCENDING"
+    else:
+        assert info["sorted"] == "UNKNOWN"


### PR DESCRIPTION
#### Reference Issues/PRs
[18053144964](https://man312219.monday.com/boards/7852509418/pulses/18053144964)

#### What does this implement or fix?
Correctly populates all fields returned by `get_info` (V1 API) and `get_description` (V2 API) when data is written with Arrow.