### PR TITLE
Implement row slicing for merge update

### DIFF
--- a/cpp/arcticdb/column_store/column_reslicer.cpp
+++ b/cpp/arcticdb/column_store/column_reslicer.cpp
@@ -16,8 +16,18 @@
 
 namespace arcticdb {
 
+// Magic range for min/max rows per segment of +-33% chosen so that:
+// - 2 row slices with < min_rows_per_segment cannot be combined into one row slice with > max_rows_per_segment
+// - 1 row slice with a little more than max_rows_per_segment when split in half will still have
+//   >= min_rows_per_segment in each resulting row slice
+
+size_t min_rows_per_segment(size_t rows_per_segment) {
+    // If rows_per_segment == 1 the result would be 0 without the std::max
+    return std::max((2 * rows_per_segment) / 3, size_t(1));
+}
+
 size_t max_rows_per_segment(size_t rows_per_segment) {
-    // If rows_per_segment_ == 2 max_rows_per_segment_ would be 2 without the std::max
+    // If rows_per_segment == 2 the result would be 2 without the std::max
     return std::max((4 * rows_per_segment) / 3, rows_per_segment + 1);
 }
 

--- a/cpp/arcticdb/column_store/column_reslicer.cpp
+++ b/cpp/arcticdb/column_store/column_reslicer.cpp
@@ -12,8 +12,14 @@
 
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/column_store/column_reslicer.hpp>
+#include <arcticdb/entity/type_utils.hpp>
 
 namespace arcticdb {
+
+size_t max_rows_per_segment(size_t rows_per_segment) {
+    // If rows_per_segment_ == 2 max_rows_per_segment_ would be 2 without the std::max
+    return std::max((4 * rows_per_segment) / 3, rows_per_segment + 1);
+}
 
 ColumnReslicer::ColumnReslicer(const size_t num_input_slices, const ReslicingInfo& reslicing_info) :
     reslicing_info_(reslicing_info) {
@@ -259,12 +265,12 @@ std::vector<Column> ColumnReslicer::reslice_by_iteration(std::vector<StringPool>
 
 std::vector<Column> ColumnReslicer::initialise_output_columns() const {
     std::vector<Column> output_columns;
-    output_columns.reserve(reslicing_info_.num_segments);
+    output_columns.reserve(reslicing_info_.num_segments());
     const auto& type = *type_;
     if (sparse_) {
         uint64_t input_values{0};
         // Represents a global bitset for all of the input columns, with 0s where an entire row slice is missing
-        util::BitSet bitset(reslicing_info_.total_rows);
+        util::BitSet bitset(reslicing_info_.total_rows());
         util::BitSet::bulk_insert_iterator inserter(bitset);
         size_t idx{0};
         for (const auto& col_or_rows : cols_or_row_counts_) {
@@ -298,7 +304,7 @@ std::vector<Column> ColumnReslicer::initialise_output_columns() const {
         );
         uint64_t output_values{0};
         uint64_t output_rows{0};
-        for (idx = 0; idx < reslicing_info_.num_segments; ++idx) {
+        for (idx = 0; idx < reslicing_info_.num_segments(); ++idx) {
             auto num_rows = reslicing_info_.rows_in_slice(idx);
             auto set_bits = bitset.count_range(output_rows, output_rows + num_rows - 1, bit_index);
             output_values += set_bits;
@@ -319,7 +325,7 @@ std::vector<Column> ColumnReslicer::initialise_output_columns() const {
                 output_values
         );
     } else {
-        for (size_t idx = 0; idx < reslicing_info_.num_segments; ++idx) {
+        for (size_t idx = 0; idx < reslicing_info_.num_segments(); ++idx) {
             output_columns.emplace_back(
                     type, reslicing_info_.rows_in_slice(idx), AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
             );

--- a/cpp/arcticdb/column_store/column_reslicer.hpp
+++ b/cpp/arcticdb/column_store/column_reslicer.hpp
@@ -18,6 +18,8 @@
 
 namespace arcticdb {
 
+[[nodiscard]] size_t min_rows_per_segment(size_t rows_per_segment);
+
 [[nodiscard]] size_t max_rows_per_segment(size_t rows_per_segment);
 
 // Helper class used by both the column and segment reslicer classes

--- a/cpp/arcticdb/column_store/column_reslicer.hpp
+++ b/cpp/arcticdb/column_store/column_reslicer.hpp
@@ -14,39 +14,62 @@
 
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
-#include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 
 namespace arcticdb {
+
+[[nodiscard]] size_t max_rows_per_segment(size_t rows_per_segment);
 
 // Helper class used by both the column and segment reslicer classes
 class ReslicingInfo {
   public:
     ReslicingInfo(uint64_t _total_rows, uint64_t _rows_per_segment) :
-        total_rows(_total_rows),
-        num_segments((total_rows + _rows_per_segment - 1) / _rows_per_segment),
-        rows_per_segment(total_rows / num_segments),
-        num_remainder_segments(total_rows % num_segments),
-        num_exact_segments(num_segments - num_remainder_segments) {
+        total_rows_(_total_rows),
+        num_segments_((total_rows_ + _rows_per_segment - 1) / _rows_per_segment),
+        rows_per_segment(total_rows_ / num_segments_),
+        num_remainder_segments(total_rows_ % num_segments_),
+        num_exact_segments(num_segments_ - num_remainder_segments) {
         auto output_rows = num_exact_segments * rows_per_segment + num_remainder_segments * (rows_per_segment + 1);
         util::check(
-                output_rows == total_rows,
+                output_rows == total_rows_,
                 "SlicingInfo input rows does not match constructed output rows {} != {}",
-                total_rows,
+                total_rows_,
                 output_rows
         );
     }
 
     ARCTICDB_MOVE_COPY_DEFAULT(ReslicingInfo)
 
-    uint64_t rows_in_slice(uint64_t idx) const {
+    [[nodiscard]] uint64_t rows_in_slice(uint64_t idx) const {
         return idx < num_exact_segments ? rows_per_segment : rows_per_segment + 1;
     }
 
-    uint64_t total_rows;
-    uint64_t num_segments;
+    [[nodiscard]] uint64_t num_segments() const { return num_segments_; }
+
+    [[nodiscard]] uint64_t total_rows() const { return total_rows_; }
+
+    /// Inverse of ReslicingInfo::rows_in_slice: given a row index into the combined [0, total_rows) output, returns
+    /// the (slice index, offset within that slice) pair that rows_in_slice's slicing would place it in.
+    [[nodiscard]] std::pair<uint64_t, uint64_t> slice_and_offset_for_row(uint64_t global_row) const {
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                global_row < total_rows_,
+                "ReslicingInfo::slice_and_offset_for_row: row {} is out of bounds for {} total rows",
+                global_row,
+                total_rows_
+        );
+        const uint64_t exact_rows = num_exact_segments * rows_per_segment;
+        if (global_row < exact_rows) {
+            return {global_row / rows_per_segment, global_row % rows_per_segment};
+        }
+        const uint64_t remainder_row = global_row - exact_rows;
+        return {num_exact_segments + remainder_row / (rows_per_segment + 1), remainder_row % (rows_per_segment + 1)};
+    }
 
   private:
+    uint64_t total_rows_;
+    uint64_t num_segments_;
+
     // This is how many rows most segments will have
     uint64_t rows_per_segment;
     // This is how many segments will have rows_per_segment+1 rows

--- a/cpp/arcticdb/column_store/segment_reslicer.cpp
+++ b/cpp/arcticdb/column_store/segment_reslicer.cpp
@@ -41,7 +41,7 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
             }
         }
     }
-    std::vector<SegmentInMemory> res(reslicing_info.num_segments);
+    std::vector<SegmentInMemory> res(reslicing_info.num_segments());
     const auto& desc = segments.front().descriptor();
     for (auto& segment : res) {
         // add_column also adds to the FieldCollection, so start with an empty one
@@ -63,7 +63,7 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
     // This ensures that the refcount of the column shared pointers is 1 when they are reset after having their data
     // copied into the result column, and so the memory is freed as early as possible
     segments.clear();
-    std::vector<StringPool> string_pools(reslicing_info.num_segments);
+    std::vector<StringPool> string_pools(reslicing_info.num_segments());
     // We can use string_view keys here as they point to the keys in column_map, which are still live while this
     // variable is in use
     ankerl::unordered_dense::map<std::string_view, std::vector<Column>, util::TransparentStringHash, std::equal_to<>>
@@ -81,16 +81,16 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
     for (const auto& col_name : col_names_in_order) {
         auto& sliced_cols = resliced_column_map.at(col_name);
         util::check(
-                sliced_cols.size() == reslicing_info.num_segments,
+                sliced_cols.size() == reslicing_info.num_segments(),
                 "Mismatched sliced column size {} != {}",
                 sliced_cols.size(),
-                reslicing_info.num_segments
+                reslicing_info.num_segments()
         );
-        for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+        for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
             res.at(idx).add_column(col_name, std::make_shared<Column>(std::move(sliced_cols.at(idx))));
         }
     }
-    for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+    for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
         res.at(idx).set_row_id(reslicing_info.rows_in_slice(idx) - 1);
         res.at(idx).set_string_pool(std::make_shared<StringPool>(std::move(string_pools.at(idx))));
     }

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -1122,24 +1122,22 @@ std::vector<EntityId> WriteClause::process(std::vector<EntityId>&& entity_ids) c
     }
     const auto proc =
             gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
-                    *component_manager_, std::move(entity_ids)
+                    *component_manager_, entity_ids
             );
-
-    std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> data_segments_to_write;
-    data_segments_to_write.reserve(proc.segments_->size());
 
     for (size_t i = 0; i < proc.segments_->size(); ++i) {
         const SegmentInMemory& segment = *(*proc.segments_)[i];
         const RowRange& row_range = *(*proc.row_ranges_)[i];
         const ColRange& col_range = *(*proc.col_ranges_)[i];
         stream::PartialKey partial_key = create_partial_key(segment, row_range);
-        data_segments_to_write.push_back(
+        component_manager_->add_components(
+                entity_ids[i],
                 std::make_shared<folly::Future<SliceAndKey>>(store_->compress_and_schedule_async_write(
                         std::make_tuple(std::move(partial_key), segment, FrameSlice(col_range, row_range)), dedup_map_
                 ))
         );
     }
-    return component_manager_->add_entities(std::move(data_segments_to_write));
+    return entity_ids;
 }
 
 stream::PartialKey WriteClause::create_partial_key(const SegmentInMemory& segment, const RowRange& row_range) const {

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -318,7 +318,7 @@ std::vector<std::vector<EntityId>> AggregationClause::structure_for_processing(
     // Experimentation shows flattening the entities into a single vector and a single call to
     // component_manager_->get is faster than not flattening and making multiple calls
     auto entity_ids = util::flatten_vectors(std::move(entity_ids_vec));
-    auto [buckets] = component_manager_->get_entities<bucket_id>(entity_ids);
+    auto [buckets] = component_manager_->get_components<bucket_id>(entity_ids);
     for (auto [idx, entity_id] : folly::enumerate(entity_ids)) {
         res[buckets[idx]].emplace_back(entity_id);
     }
@@ -850,7 +850,7 @@ std::vector<std::vector<EntityId>> RowRangeClause::structure_for_processing(
     if (entity_ids.empty()) {
         return {};
     }
-    auto [segments, old_row_ranges, col_ranges] = component_manager_->get_entities<
+    auto [segments, old_row_ranges, col_ranges] = component_manager_->get_components<
             std::shared_ptr<SegmentInMemory>,
             std::shared_ptr<RowRange>,
             std::shared_ptr<ColRange>>(entity_ids);
@@ -1052,7 +1052,7 @@ std::vector<std::vector<EntityId>> ConcatClause::structure_for_processing(
     size_t prev_range_end{0};
     for (const auto& entity_ids : entity_ids_vec) {
         auto [old_row_ranges, col_ranges] =
-                component_manager_->get_entities<std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(entity_ids);
+                component_manager_->get_components<std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(entity_ids);
         // Map from old row ranges WITHIN THIS SYMBOL to new ones
         std::map<RowRange, RowRange> row_range_mapping;
         for (const auto& row_range : old_row_ranges) {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -861,7 +861,10 @@ struct MergeUpdateClause {
     MergeStrategy strategy_;
     std::shared_ptr<InputFrame> source_;
     bool fake_index_name_ = false;
-    MergeUpdateClause(std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source);
+    MergeUpdateClause(
+            std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source,
+            size_t rows_per_segment
+    );
     ARCTICDB_MOVE_COPY_DEFAULT(MergeUpdateClause)
 
     /// Row range indexes require full table scan
@@ -958,6 +961,8 @@ struct MergeUpdateClause {
     std::span<const timestamp> get_source_index(std::pair<size_t, size_t> source_start_end) const;
 
     std::span<const std::byte> get_source_data_bytes(size_t field_index, std::pair<size_t, size_t> range) const;
+
+    size_t rows_per_segment_;
 };
 
 struct CompactDataClause {

--- a/cpp/arcticdb/processing/clause_compact_data.cpp
+++ b/cpp/arcticdb/processing/clause_compact_data.cpp
@@ -26,13 +26,7 @@ CompactDataClause::CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<
     if (frame && frame->num_rows > 0) {
         frame_ = std::move(frame);
     }
-    // Magic range of +-33% chosen so that:
-    // - 2 row slices with < min_rows_per_segment_ cannot be combined into one row slice with > max_rows_per_segment_
-    // - 1 row slice with a little more than max_rows_per_segment_ when split in half will still have
-    //   >= min_rows_per_segment_ in each resulting row slice
-    // If rows_per_segment_ == 1 min_rows_per_segment_ would be 0 without the std::max
-    min_rows_per_segment_ = std::max((2 * rows_per_segment_) / 3, uint64_t(1));
-    // If rows_per_segment_ == 2 max_rows_per_segment_ would be 2 without the std::max
+    min_rows_per_segment_ = min_rows_per_segment(rows_per_segment_);
     max_rows_per_segment_ = max_rows_per_segment(rows_per_segment_);
     clause_info_.input_structure_ = ProcessingStructure::ONE_COL_SLICE_MULTIPLE_ROW_SLICES;
     clause_info_.output_structure_ = ProcessingStructure::ONE_COL_SLICE_MULTIPLE_ROW_SLICES;

--- a/cpp/arcticdb/processing/clause_compact_data.cpp
+++ b/cpp/arcticdb/processing/clause_compact_data.cpp
@@ -33,7 +33,7 @@ CompactDataClause::CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<
     // If rows_per_segment_ == 1 min_rows_per_segment_ would be 0 without the std::max
     min_rows_per_segment_ = std::max((2 * rows_per_segment_) / 3, uint64_t(1));
     // If rows_per_segment_ == 2 max_rows_per_segment_ would be 2 without the std::max
-    max_rows_per_segment_ = std::max((4 * rows_per_segment_) / 3, rows_per_segment_ + 1);
+    max_rows_per_segment_ = max_rows_per_segment(rows_per_segment_);
     clause_info_.input_structure_ = ProcessingStructure::ONE_COL_SLICE_MULTIPLE_ROW_SLICES;
     clause_info_.output_structure_ = ProcessingStructure::ONE_COL_SLICE_MULTIPLE_ROW_SLICES;
     clause_info_.can_combine_with_column_selection_ = false;
@@ -252,7 +252,7 @@ void CompactDataClause::add_segment_from_frame(
     ReslicingInfo reslicing_info{total_rows, max_rows_per_segment_};
     // Work out how many rows of the frame we need to combine with segments from disk
     uint64_t row_count{0};
-    for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+    for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
         row_count += reslicing_info.rows_in_slice(idx);
         if (row_count > total_rows_without_frame) {
             break;

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -6,6 +6,8 @@
  * will be governed by the Apache License, version 2.0.
  */
 
+#include "util/collection_utils.hpp"
+
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
@@ -15,6 +17,7 @@
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/stream/index.hpp>
+#include <arcticdb/column_store/column_reslicer.hpp>
 #include <ankerl/unordered_dense.h>
 #include <boost/regex.hpp>
 
@@ -256,7 +259,7 @@ struct InsertTargetData {
     std::span<ColumnWithStrings> columns;
     TypeDescriptor type;
     TargetRange range;
-    StringPool& new_string_pool;
+    std::span<StringPool> new_string_pools;
 };
 
 std::vector<size_t> compute_target_slice_offset(const InsertTargetData& target) {
@@ -279,30 +282,31 @@ std::vector<size_t> compute_target_slice_offset(const InsertTargetData& target) 
 /// with the same index value. The source and target must have the same index type.
 template<util::type_descriptor_tag TargetColumnTypeDescriptorTag, typename SourceRawType>
 requires(TargetColumnTypeDescriptorTag::dimension() == Dimension::Dim0)
-Column merge(
+std::vector<std::shared_ptr<Column>> merge(
         const InsertSourceData<SourceRawType>& source, const InsertTargetData& target,
-        const MergeUpdateClause::MatchRecord& match_record, const MergeStrategy& strategy
+        const MergeUpdateClause::MatchRecord& match_record, const MergeStrategy& strategy,
+        const ReslicingInfo& reslicing_info
 ) {
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    // One index value can appear in more than one row slice. In that case it can be shared by two processing units,
-    // each working on part of the target data.
-    const size_t num_rows_out_of_target_range =
-            target.range.start_row_in_first_row_slice +
-            (target.columns.back().column_->row_count() - target.range.end_row_in_last_row_slice);
-    const size_t combined_row_count =
-            std::accumulate(
-                    target.columns.begin(),
-                    target.columns.end(),
-                    match_record.total_unmatched_source_rows(),
-                    [](size_t acc, const ColumnWithStrings& col) { return acc + col.column_->row_count(); }
-            ) -
-            num_rows_out_of_target_range;
+    using ColumnRandomAccessorType = ColumnDataRandomAccessor<TargetColumnTypeDescriptorTag>;
     const std::vector<size_t> target_slice_offset = compute_target_slice_offset(target);
 
-    Column new_column(target.type, combined_row_count, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);
-    ColumnData new_column_data = new_column.data();
-    auto new_column_it = new_column_data.begin<TargetColumnTypeDescriptorTag>();
-    auto new_data = random_accessor<TargetColumnTypeDescriptorTag>(&new_column_data);
+    auto new_columns = util::reserve_vector<std::shared_ptr<Column>>(reslicing_info.num_segments());
+    auto new_column_datas = util::reserve_vector<ColumnData>(reslicing_info.num_segments());
+    auto new_column_accessors = util::reserve_vector<ColumnRandomAccessorType>(reslicing_info.num_segments());
+    for (size_t i = 0; i < reslicing_info.num_segments(); ++i) {
+        new_columns.push_back(std::make_shared<Column>(
+                target.type, reslicing_info.rows_in_slice(i), AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
+        ));
+        new_column_datas.emplace_back(new_columns.back()->data());
+        new_column_accessors.emplace_back(random_accessor<TargetColumnTypeDescriptorTag>(&new_column_datas.back()));
+    }
+    size_t new_column_row_slice_index{};
+    // Offset within the current output column
+    size_t new_column_row_idx{};
+    // Position in the combined [0, total_rows()) output
+    size_t output_row_idx{};
+    auto new_column_it = new_column_datas.front().begin<TargetColumnTypeDescriptorTag>();
 
     size_t target_row_slice = 0;
     ColumnData target_index_data = target.indexes[target_row_slice].column_->data();
@@ -313,7 +317,6 @@ Column merge(
     ColumnData target_column_data = target.columns[target_row_slice].column_->data();
     auto target_data = random_accessor<TargetColumnTypeDescriptorTag>(&target_column_data);
     size_t target_row_idx = target.range.start_row_in_first_row_slice;
-    size_t new_column_row_idx{};
 
     const auto target_index_is_exhausted = [&] {
         return target_row_slice == target.columns.size() - 1 && target_index_it == target_index_end;
@@ -345,7 +348,15 @@ Column merge(
 
     const auto advance_output = [&] {
         ++new_column_row_idx;
+        ++output_row_idx;
         ++new_column_it;
+
+        if (new_column_it == new_column_datas[new_column_row_slice_index].end<TargetColumnTypeDescriptorTag>() &&
+            new_column_row_slice_index + 1 < reslicing_info.num_segments()) [[unlikely]] {
+            ++new_column_row_slice_index;
+            new_column_row_idx = 0;
+            new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
+        }
     };
 
     // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
@@ -361,7 +372,7 @@ Column merge(
                     row,
                     RowRange{source.global_row_range.first, source.global_row_range.second},
                     scoped_gil_lock,
-                    target.new_string_pool,
+                    target.new_string_pools[new_column_row_slice_index],
                     target.columns.front().column_name_
             );
         }
@@ -369,14 +380,16 @@ Column merge(
 
     const auto set_string_from_source_at = [&](size_t source_row, size_t output_row) {
         if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
-            new_data[output_row] = write_py_string_to_pool_or_throw<TargetColumnTypeDescriptorTag>(
-                    source.data[source_row],
-                    source_row,
-                    RowRange{source.global_row_range.first, source.global_row_range.second},
-                    scoped_gil_lock,
-                    target.new_string_pool,
-                    target.columns.front().column_name_
-            );
+            const auto [slice_index, offset_in_slice] = reslicing_info.slice_and_offset_for_row(output_row);
+            new_column_accessors[slice_index][offset_in_slice] =
+                    write_py_string_to_pool_or_throw<TargetColumnTypeDescriptorTag>(
+                            source.data[source_row],
+                            source_row,
+                            RowRange{source.global_row_range.first, source.global_row_range.second},
+                            scoped_gil_lock,
+                            target.new_string_pools[slice_index],
+                            target.columns.front().column_name_
+                    );
         }
     };
 
@@ -386,14 +399,14 @@ Column merge(
             if (is_a_string(offset)) {
                 const StringPool& pool = *target.columns[target_row_slice].string_pool_;
                 const std::string_view string_data = pool.get_const_view(offset);
-                *new_column_it = target.new_string_pool.get(string_data).offset();
+                *new_column_it = target.new_string_pools[new_column_row_slice_index].get(string_data).offset();
             } else {
                 *new_column_it = offset;
             }
         }
     };
 
-    util::BitSet updated(new_column.row_count());
+    util::BitSet updated(reslicing_info.total_rows());
     std::vector<size_t> source_rows_to_insert;
 
     size_t source_row_idx = 0;
@@ -441,7 +454,8 @@ Column merge(
                         if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
                             set_string_from_source_at(source_row_idx, index_in_output);
                         } else {
-                            new_data[index_in_output] = source.data[source_row_idx];
+                            const auto [column, offset] = reslicing_info.slice_and_offset_for_row(index_in_output);
+                            new_column_accessors[column][offset] = source.data[source_row_idx];
                         }
                     }
                 }
@@ -453,7 +467,7 @@ Column merge(
         }
         // Place target values on non-updated output positions
         while (source_has_index_value && !target_index_is_exhausted() && *target_index_it == current_index_value) {
-            if (!updated.test(new_column_row_idx)) {
+            if (!updated.test(output_row_idx)) {
                 if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
                     set_string_from_target(target_row_idx);
                 } else {
@@ -508,10 +522,21 @@ Column merge(
             advance_output();
         }
     } else {
-        std::copy(source.data.begin() + source_row_idx, source.data.end(), new_column_it);
+        while (new_column_row_slice_index < new_columns.size()) {
+            const size_t free_elements_in_column =
+                    static_cast<size_t>(new_columns[new_column_row_slice_index]->row_count()) - new_column_row_idx;
+            std::copy_n(source.data.begin() + source_row_idx, free_elements_in_column, new_column_it);
+            source_row_idx += free_elements_in_column;
+            output_row_idx += free_elements_in_column;
+            ++new_column_row_slice_index;
+            new_column_row_idx = 0;
+            if (new_column_row_slice_index < new_columns.size()) {
+                new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
+            }
+        }
     }
 
-    return new_column;
+    return new_columns;
 }
 
 template<util::type_descriptor_tag ScalarType>
@@ -670,6 +695,68 @@ std::span<const timestamp>::iterator source_range_end_for_group(
     return std::ranges::upper_bound(source_range_start, source_index.end(), effective_segment_end - 1);
 }
 
+size_t compute_total_upsert_row_count(
+        std::span<const ColumnWithStrings> target_index_datas, const TargetRange& target_range,
+        const size_t unmatched_source_rows
+) {
+    // One index value can appear in more than one row slice. In that case it can be shared by two processing units,
+    // each working on part of the target data.
+    const size_t num_rows_out_of_target_range =
+            target_range.start_row_in_first_row_slice +
+            (target_index_datas.back().column_->row_count() - target_range.end_row_in_last_row_slice);
+    return std::accumulate(
+                   target_index_datas.begin(),
+                   target_index_datas.end(),
+                   unmatched_source_rows,
+                   [](size_t acc, const ColumnWithStrings& col) { return acc + col.column_->row_count(); }
+           ) -
+           num_rows_out_of_target_range;
+}
+
+void initialize_col_slices(
+        const StreamDescriptor& descriptor, const std::span<const std::shared_ptr<Column>> new_indexes,
+        std::span<ProcessingUnit> dest
+) {
+    for (auto&& [row_slice_idx, row_slice] : folly::enumerate(dest)) {
+        const std::shared_ptr<Column>& index_col = new_indexes[row_slice_idx];
+        row_slice.segments_->emplace_back(std::make_shared<SegmentInMemory>(descriptor, index_col->row_count()));
+        row_slice.segments_->back()->columns()[0] = index_col;
+    }
+}
+
+void finalize_col_slices(
+        const std::span<const std::shared_ptr<Column>> new_indexes, std::vector<StringPool>* new_string_pools,
+        std::span<ProcessingUnit> dest
+) {
+    for (auto&& [row_slice_idx, row_slice] : folly::enumerate(dest)) {
+        row_slice.segments_->back()->set_row_data(new_indexes[row_slice_idx]->row_count() - 1);
+        if (new_string_pools) {
+            row_slice.segments_->back()->string_pool() = std::move((*new_string_pools)[row_slice_idx]);
+            (*new_string_pools)[row_slice_idx].clear();
+        }
+    }
+}
+
+void set_upsert_ranges(
+        const TargetRange& target_range, const std::span<const ProcessingUnit> input_row_slices,
+        std::span<ProcessingUnit> dest
+) {
+    const size_t num_col_slices = input_row_slices.begin()->col_ranges_->size();
+    // Index key is merged in version_core.cpp::merge_update_impl. Since there are multiple parallel writes and the
+    // different processing units are not aware of how many rows were added before we cannot emit "final row ranges".
+    // The row ranges this clause emits are in the "coordinate system" of the unmodified target (meaning they don't
+    // account for insertion). Setting all resulting row ranges to the same values means: "The data that was originally
+    // in range row_range must be replaced by the concatenation of all new row ranges that have row_range set"
+    const auto row_range = std::make_shared<RowRange>(
+            input_row_slices.front().row_ranges_->front()->first + target_range.start_row_in_first_row_slice,
+            input_row_slices.back().row_ranges_->back()->first + target_range.end_row_in_last_row_slice
+    );
+    for (ProcessingUnit& row_slice : dest) {
+        row_slice.row_ranges_ = std::vector(num_col_slices, row_range);
+        row_slice.col_ranges_ = input_row_slices.front().col_ranges_;
+    }
+}
+
 } // namespace
 
 namespace arcticdb {
@@ -678,12 +765,14 @@ namespace ranges = std::ranges;
 using namespace pipelines;
 
 MergeUpdateClause::MergeUpdateClause(
-        std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source
+        std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source,
+        size_t rows_per_segment
 ) :
 
     on_(std::move(on)),
     strategy_(strategy),
-    source_(std::move(source)) {
+    source_(std::move(source)),
+    rows_per_segment_(rows_per_segment) {
     std::erase_if(on_, [&](const std::string& column) { return !on_set_.insert(column).second; });
 }
 
@@ -805,12 +894,13 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
         std::vector<EntityId> res;
         for (ProcessingUnit& row_slice : new_row_slices) {
             const size_t entity_count = row_slice.segments_->size();
+            const MergeUpdateRowSlicingInfoComponent row_slice_info(1, 0, row_slice.segments_->front()->row_count());
             std::vector<EntityId> entts = component_manager_->add_entities(
                     std::move(*row_slice.segments_),
                     std::move(*row_slice.row_ranges_),
                     std::move(*row_slice.col_ranges_),
                     std::vector<EntityFetchCount>(entity_count, 1),
-                    std::vector(entity_count, MergeUpdateInsertedRowsComponent{0})
+                    std::vector(entity_count, row_slice_info)
             );
             res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
         }
@@ -832,12 +922,15 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
             std::vector<EntityId> res;
             for (ProcessingUnit& row_slice : new_row_slices) {
                 const size_t entity_count = row_slice.segments_->size();
+                const MergeUpdateRowSlicingInfoComponent row_slice_info(
+                        1, 0, row_slice.segments_->front()->row_count()
+                );
                 std::vector<EntityId> entts = component_manager_->add_entities(
                         std::move(*row_slice.segments_),
                         std::move(*row_slice.row_ranges_),
                         std::move(*row_slice.col_ranges_),
                         std::vector<EntityFetchCount>(entity_count, 1),
-                        std::vector(entity_count, MergeUpdateInsertedRowsComponent{0}),
+                        std::vector(entity_count, row_slice_info),
                         std::vector(entity_count, unmatched_source_rows_component)
                 );
                 res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
@@ -855,14 +948,19 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
     auto new_row_slices = update_and_insert(matched, target_descriptor, std::move(row_slices), source_start_end);
 
     std::vector<EntityId> res;
-    for (auto& row_slice : new_row_slices) {
+    for (auto&& [row_slice_idx, row_slice] : folly::enumerate(new_row_slices)) {
+        const MergeUpdateRowSlicingInfoComponent row_slice_info(
+                static_cast<int>(new_row_slices.size()),
+                static_cast<int>(row_slice_idx),
+                row_slice.segments_->front()->row_count()
+        );
         const size_t entity_count = row_slice.segments_->size();
         std::vector<EntityId> entts = component_manager_->add_entities(
                 std::move(*row_slice.segments_),
                 std::move(*row_slice.row_ranges_),
                 std::move(*row_slice.col_ranges_),
                 std::vector<EntityFetchCount>(entity_count, 1),
-                std::vector(entity_count, MergeUpdateInsertedRowsComponent{matched.total_unmatched_source_rows()})
+                std::vector(entity_count, row_slice_info)
         );
         res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
     }
@@ -1023,32 +1121,36 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
             "All row slices should have the same number of column ranges"
     );
 
-    ProcessingUnit result{};
-    result.segments_.emplace();
-    result.segments_->reserve(num_col_slices);
-    result.col_ranges_ = row_slices.front().col_ranges_;
     std::vector<ColumnWithStrings> target_datas;
     std::vector<ColumnWithStrings> target_index_datas;
     target_index_datas.reserve(row_slices.size());
     std::ranges::transform(row_slices, std::back_inserter(target_index_datas), [&](const auto& proc) {
         return ColumnWithStrings(proc.segments_->front()->column_ptr(0), nullptr, target_descriptor.field(0).name());
     });
-    StringPool new_string_pool;
     bool has_string_column_in_column_slice = false;
     const TargetRange target_range = get_target_start_end(row_slices);
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    auto new_index = std::make_shared<Column>(merge<IndexType>(
+    const ReslicingInfo reslicing_info{
+            compute_total_upsert_row_count(
+                    target_index_datas, target_range, match_record.total_unmatched_source_rows()
+            ),
+            max_rows_per_segment(rows_per_segment_)
+    };
+    std::vector<ProcessingUnit> result(reslicing_info.num_segments());
+    std::vector<StringPool> new_string_pools(reslicing_info.num_segments());
+    std::vector<std::shared_ptr<Column>> new_indexes = merge<IndexType>(
             InsertSourceData{.index = source_index, .data = source_index, .global_row_range = source_start_end},
             InsertTargetData{
                     .indexes = target_index_datas,
                     .columns = target_index_datas,
-                    .type = TypeDescriptor{DataType::NANOSECONDS_UTC64, Dimension::Dim0},
+                    .type = IndexType::type_descriptor(),
                     .range = target_range,
-                    .new_string_pool = new_string_pool
+                    .new_string_pools = new_string_pools
             },
             match_record,
-            MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
-    ));
+            MergeStrategy{.not_matched_by_target = MergeAction::INSERT},
+            reslicing_info
+    );
     size_t col_slice_idx = 0;
     const auto [source_start, source_end] = source_start_end;
     for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
@@ -1059,53 +1161,52 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
         std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
             return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
         });
-        Column new_column = details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
-            using TargetDataTDT = ScalarTagType<TypeTag>;
-            has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
-            return merge<TargetDataTDT>(
-                    InsertSourceData{
-                            .index = source_index,
-                            .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
-                                    source_start, source_end - source_start
-                            ),
-                            .global_row_range = source_start_end
-                    },
-                    InsertTargetData{
-                            .indexes = target_index_datas,
-                            .columns = target_datas,
-                            .type = target_field.type(),
-                            .range = target_range,
-                            .new_string_pool = new_string_pool
-                    },
-                    match_record,
-                    // By construction, we cannot update the columns used to perform the match; only inserts are
-                    // allowed
-                    on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
-                                                  : strategy_
-            );
-        });
+        std::vector<std::shared_ptr<Column>> new_column_slices =
+                details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
+                    using TargetDataTDT = ScalarTagType<TypeTag>;
+                    has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
+                    return merge<TargetDataTDT>(
+                            InsertSourceData{
+                                    .index = source_index,
+                                    .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
+                                            source_start, source_end - source_start
+                                    ),
+                                    .global_row_range = source_start_end
+                            },
+                            InsertTargetData{
+                                    .indexes = target_index_datas,
+                                    .columns = target_datas,
+                                    .type = target_field.type(),
+                                    .range = target_range,
+                                    .new_string_pools = new_string_pools
+                            },
+                            match_record,
+                            // By construction, we cannot update the columns used to perform the match; only inserts are
+                            // allowed
+                            on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
+                                                          : strategy_,
+                            reslicing_info
+                    );
+                });
+        // Start working on new column slice.
         if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
-            const StreamDescriptor& desc = (*row_slices.front().segments_)[col_slice_idx]->descriptor();
-            result.segments_->emplace_back(std::make_shared<SegmentInMemory>(desc, new_index->row_count()));
-            result.segments_->back()->columns()[0] = new_index;
+            initialize_col_slices((*row_slices.front().segments_)[col_slice_idx]->descriptor(), new_indexes, result);
         }
+        // For each row slice set the corresponding column.
         const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
-        result.segments_->back()->columns()[col_in_slice] = std::make_shared<Column>(std::move(new_column));
+        for (auto&& [row_slice_idx, row_slice] : folly::enumerate(result)) {
+            row_slice.segments_->back()->columns()[col_in_slice] = std::move(new_column_slices[row_slice_idx]);
+        }
+
+        // The last column in the column slice is processed. Finish working on th segment by setting the string pool and
+        // the row data.
         if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
-            result.segments_->back()->set_row_data(new_index->row_count() - 1);
+            finalize_col_slices(new_indexes, has_string_column_in_column_slice ? &new_string_pools : nullptr, result);
             ++col_slice_idx;
-            if (has_string_column_in_column_slice) {
-                result.segments_->back()->string_pool() = std::move(new_string_pool);
-                new_string_pool.clear();
-                has_string_column_in_column_slice = false;
-            }
+            has_string_column_in_column_slice = false;
         }
     }
-    const auto new_row_range = std::make_shared<RowRange>(
-            row_slices.front().row_ranges_->front()->first + target_range.start_row_in_first_row_slice,
-            row_slices.back().row_ranges_->back()->first + target_range.end_row_in_last_row_slice
-    );
-    result.row_ranges_ = std::vector(num_col_slices, new_row_range);
+    set_upsert_ranges(target_range, row_slices, result);
     return std::vector{std::move(result)};
 }
 

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -6,8 +6,6 @@
  * will be governed by the Apache License, version 2.0.
  */
 
-#include "util/collection_utils.hpp"
-
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
@@ -18,6 +16,7 @@
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/column_store/column_reslicer.hpp>
+#include <arcticdb/util/collection_utils.hpp>
 #include <ankerl/unordered_dense.h>
 #include <boost/regex.hpp>
 
@@ -306,6 +305,7 @@ std::vector<std::shared_ptr<Column>> merge(
     size_t new_column_row_idx{};
     // Position in the combined [0, total_rows()) output
     size_t output_row_idx{};
+    size_t rows_in_current_slice = reslicing_info.rows_in_slice(0);
     auto new_column_it = new_column_datas.front().begin<TargetColumnTypeDescriptorTag>();
 
     size_t target_row_slice = 0;
@@ -351,9 +351,10 @@ std::vector<std::shared_ptr<Column>> merge(
         ++output_row_idx;
         ++new_column_it;
 
-        if (new_column_it == new_column_datas[new_column_row_slice_index].end<TargetColumnTypeDescriptorTag>() &&
+        if (new_column_row_idx == rows_in_current_slice &&
             new_column_row_slice_index + 1 < reslicing_info.num_segments()) [[unlikely]] {
             ++new_column_row_slice_index;
+            rows_in_current_slice = reslicing_info.rows_in_slice(new_column_row_slice_index);
             new_column_row_idx = 0;
             new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
         }
@@ -578,11 +579,13 @@ RowRange get_row_range(std::span<const ProcessingUnit> row_slice) {
     return {row_slice.front().row_ranges_->front()->first, row_slice.back().row_ranges_->back()->second};
 }
 
-ssize_t first_different_index_value_position(const ColumnData index) {
+std::optional<ssize_t> first_different_index_value_position(const ColumnData index) {
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
     auto it = index.cbegin<IndexType, IteratorType::ENUMERATED>();
     const timestamp first_source_row = it->value();
-    return exponential_upper_bound(++it, index.cend<IndexType, IteratorType::ENUMERATED>(), first_source_row)->idx();
+    const auto end = index.cend<IndexType, IteratorType::ENUMERATED>();
+    const auto first_different_position = exponential_upper_bound(++it, end, first_source_row);
+    return end == first_different_position ? std::nullopt : std::optional{first_different_position->idx()};
 };
 
 TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
@@ -593,11 +596,13 @@ TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
     if (row_slices.front().entity_fetch_count_) {
         if (row_slices.front().entity_fetch_count_->front() > 1) {
             const ColumnData index = row_slices.front().segments_->front()->column(0).data();
-            result.start_row_in_first_row_slice = first_different_index_value_position(index);
+            result.start_row_in_first_row_slice = first_different_index_value_position(index).value_or(0);
         }
         if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
             const ColumnData index = row_slices.back().segments_->back()->column(0).data();
-            result.end_row_in_last_row_slice = first_different_index_value_position(index);
+            result.end_row_in_last_row_slice = first_different_index_value_position(index).value_or(
+                    row_slices.back().segments_->back()->row_count()
+            );
         }
     }
     return result;
@@ -1137,6 +1142,9 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
             max_rows_per_segment(rows_per_segment_)
     };
     std::vector<ProcessingUnit> result(reslicing_info.num_segments());
+    for (ProcessingUnit& proc : result) {
+        proc.segments_.emplace(util::reserve_vector<std::shared_ptr<SegmentInMemory>>(num_col_slices));
+    }
     std::vector<StringPool> new_string_pools(reslicing_info.num_segments());
     std::vector<std::shared_ptr<Column>> new_indexes = merge<IndexType>(
             InsertSourceData{.index = source_index, .data = source_index, .global_row_range = source_start_end},
@@ -1151,61 +1159,73 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
             MergeStrategy{.not_matched_by_target = MergeAction::INSERT},
             reslicing_info
     );
-    size_t col_slice_idx = 0;
-    const auto [source_start, source_end] = source_start_end;
-    for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
-         ++field_idx) {
-        const Field& target_field = target_descriptor.field(field_idx);
-        const std::string_view column_name = target_field.name();
-        target_datas.clear();
-        std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
-            return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
-        });
-        std::vector<std::shared_ptr<Column>> new_column_slices =
-                details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
-                    using TargetDataTDT = ScalarTagType<TypeTag>;
-                    has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
-                    return merge<TargetDataTDT>(
-                            InsertSourceData{
-                                    .index = source_index,
-                                    .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
-                                            source_start, source_end - source_start
-                                    ),
-                                    .global_row_range = source_start_end
-                            },
-                            InsertTargetData{
-                                    .indexes = target_index_datas,
-                                    .columns = target_datas,
-                                    .type = target_field.type(),
-                                    .range = target_range,
-                                    .new_string_pools = new_string_pools
-                            },
-                            match_record,
-                            // By construction, we cannot update the columns used to perform the match; only inserts are
-                            // allowed
-                            on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
-                                                          : strategy_,
-                            reslicing_info
-                    );
-                });
-        // Start working on new column slice.
-        if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
-            initialize_col_slices((*row_slices.front().segments_)[col_slice_idx]->descriptor(), new_indexes, result);
-        }
-        // For each row slice set the corresponding column.
-        const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
-        for (auto&& [row_slice_idx, row_slice] : folly::enumerate(result)) {
-            row_slice.segments_->back()->columns()[col_in_slice] = std::move(new_column_slices[row_slice_idx]);
-        }
+    if (target_descriptor.field_count() == target_descriptor.index().field_count()) {
+        // Handle degenerate case of index-only dataframe
+        initialize_col_slices((*row_slices.front().segments_)[0]->descriptor(), new_indexes, result);
+        finalize_col_slices(new_indexes, nullptr, result);
+    } else {
+        size_t col_slice_idx = 0;
+        const auto [source_start, source_end] = source_start_end;
+        for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
+             ++field_idx) {
+            const Field& target_field = target_descriptor.field(field_idx);
+            const std::string_view column_name = target_field.name();
+            target_datas.clear();
+            std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
+                return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
+            });
+            std::vector<std::shared_ptr<Column>> new_column_slices =
+                    details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
+                        using TargetDataTDT = ScalarTagType<TypeTag>;
+                        has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
+                        return merge<TargetDataTDT>(
+                                InsertSourceData{
+                                        .index = source_index,
+                                        .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
+                                                source_start, source_end - source_start
+                                        ),
+                                        .global_row_range = source_start_end
+                                },
+                                InsertTargetData{
+                                        .indexes = target_index_datas,
+                                        .columns = target_datas,
+                                        .type = target_field.type(),
+                                        .range = target_range,
+                                        .new_string_pools = new_string_pools
+                                },
+                                match_record,
+                                // By construction, we cannot update the columns used to perform the match; only inserts
+                                // are allowed
+                                on_set_.contains(column_name)
+                                        ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
+                                        : strategy_,
+                                reslicing_info
+                        );
+                    });
+            // Start working on new column slice.
+            if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
+                initialize_col_slices(
+                        (*row_slices.front().segments_)[col_slice_idx]->descriptor(), new_indexes, result
+                );
+            }
+            // For each row slice set the corresponding column.
+            const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
+            for (auto&& [row_slice_idx, row_slice] : folly::enumerate(result)) {
+                row_slice.segments_->back()->columns()[col_in_slice] = std::move(new_column_slices[row_slice_idx]);
+            }
 
-        // The last column in the column slice is processed. Finish working on th segment by setting the string pool and
-        // the row data.
-        if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
-            finalize_col_slices(new_indexes, has_string_column_in_column_slice ? &new_string_pools : nullptr, result);
-            ++col_slice_idx;
-            has_string_column_in_column_slice = false;
+            // The last column in the column slice is processed. Finish working on th segment by setting the string pool
+            // and the row data.
+            if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
+                finalize_col_slices(
+                        new_indexes, has_string_column_in_column_slice ? &new_string_pools : nullptr, result
+                );
+                ++col_slice_idx;
+                has_string_column_in_column_slice = false;
+            }
         }
     }
+
     set_upsert_ranges(target_range, row_slices, result);
     return std::vector{std::move(result)};
 }

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -346,18 +346,24 @@ std::vector<std::shared_ptr<Column>> merge(
         }
     };
 
-    const auto advance_output = [&] {
-        ++new_column_row_idx;
-        ++output_row_idx;
-        ++new_column_it;
-
-        if (new_column_row_idx == rows_in_current_slice &&
-            new_column_row_slice_index + 1 < reslicing_info.num_segments()) [[unlikely]] {
+    const auto advance_output = [&](size_t step_size = 1) {
+        util::check(
+                output_row_idx + step_size <= reslicing_info.total_rows(),
+                "Cannot advance the output by {} rows, only {} are left in the output",
+                step_size,
+                reslicing_info.total_rows() - output_row_idx
+        );
+        output_row_idx += step_size;
+        while (new_column_row_idx + step_size >= rows_in_current_slice &&
+               new_column_row_slice_index + 1 < reslicing_info.num_segments()) {
+            step_size -= rows_in_current_slice - new_column_row_idx;
             ++new_column_row_slice_index;
             rows_in_current_slice = reslicing_info.rows_in_slice(new_column_row_slice_index);
             new_column_row_idx = 0;
             new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
         }
+        new_column_row_idx += step_size;
+        std::advance(new_column_it, step_size);
     };
 
     // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
@@ -523,17 +529,16 @@ std::vector<std::shared_ptr<Column>> merge(
             advance_output();
         }
     } else {
-        while (new_column_row_slice_index < new_columns.size()) {
-            const size_t free_elements_in_column =
-                    static_cast<size_t>(new_columns[new_column_row_slice_index]->row_count()) - new_column_row_idx;
+        while (source_row_idx < source.index.size()) {
+            const size_t free_elements_in_column = rows_in_current_slice - new_column_row_idx;
+            util::check(
+                    free_elements_in_column > 0,
+                    "The output row slices are full but {} source rows are left to copy",
+                    source.index.size() - source_row_idx
+            );
             std::copy_n(source.data.begin() + source_row_idx, free_elements_in_column, new_column_it);
             source_row_idx += free_elements_in_column;
-            output_row_idx += free_elements_in_column;
-            ++new_column_row_slice_index;
-            new_column_row_idx = 0;
-            if (new_column_row_slice_index < new_columns.size()) {
-                new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
-            }
+            advance_output(free_elements_in_column);
         }
     }
 
@@ -596,7 +601,12 @@ TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
     if (row_slices.front().entity_fetch_count_) {
         if (row_slices.front().entity_fetch_count_->front() > 1) {
             const ColumnData index = row_slices.front().segments_->front()->column(0).data();
-            result.start_row_in_first_row_slice = first_different_index_value_position(index).value_or(0);
+            const std::optional<ssize_t> first_different = first_different_index_value_position(index);
+            util::check(
+                    first_different.has_value(),
+                    "A row slice shared between two processing units cannot consist of a single index value"
+            );
+            result.start_row_in_first_row_slice = *first_different;
         }
         if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
             const ColumnData index = row_slices.back().segments_->back()->column(0).data();
@@ -1135,12 +1145,11 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
     bool has_string_column_in_column_slice = false;
     const TargetRange target_range = get_target_start_end(row_slices);
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    const ReslicingInfo reslicing_info{
-            compute_total_upsert_row_count(
-                    target_index_datas, target_range, match_record.total_unmatched_source_rows()
-            ),
-            max_rows_per_segment(rows_per_segment_)
-    };
+    const size_t total_upsert_row_count = compute_total_upsert_row_count(
+            target_index_datas, target_range, match_record.total_unmatched_source_rows()
+    );
+    util::check(total_upsert_row_count > 0, "Merge update produced a row slice group containing no rows");
+    const ReslicingInfo reslicing_info{total_upsert_row_count, max_rows_per_segment(rows_per_segment_)};
     std::vector<ProcessingUnit> result(reslicing_info.num_segments());
     for (ProcessingUnit& proc : result) {
         proc.segments_.emplace(util::reserve_vector<std::shared_ptr<SegmentInMemory>>(num_col_slices));

--- a/cpp/arcticdb/processing/clause_resample.cpp
+++ b/cpp/arcticdb/processing/clause_resample.cpp
@@ -224,7 +224,7 @@ std::vector<std::vector<EntityId>> ResampleClause<closed_boundary>::structure_fo
         return {};
     }
     ARCTICDB_RUNTIME_DEBUG(log::memory(), "ResampleClause: structure for processing 2");
-    auto [segments, row_ranges, col_ranges] = component_manager_->get_entities<
+    auto [segments, row_ranges, col_ranges] = component_manager_->get_components<
             std::shared_ptr<SegmentInMemory>,
             std::shared_ptr<RowRange>,
             std::shared_ptr<ColRange>>(entity_ids);

--- a/cpp/arcticdb/processing/clause_utils.cpp
+++ b/cpp/arcticdb/processing/clause_utils.cpp
@@ -29,7 +29,7 @@ std::vector<std::vector<EntityId>> structure_by_row_slice(
         ComponentManager& component_manager, std::vector<EntityId>&& entity_ids
 ) {
     auto [row_ranges, col_ranges] =
-            component_manager.get_entities<std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(entity_ids);
+            component_manager.get_components<std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(entity_ids);
     std::vector<RangesAndEntity> ranges_and_entities;
     ranges_and_entities.reserve(entity_ids.size());
     for (size_t idx = 0; idx < entity_ids.size(); ++idx) {

--- a/cpp/arcticdb/processing/clause_utils.hpp
+++ b/cpp/arcticdb/processing/clause_utils.hpp
@@ -169,7 +169,7 @@ std::vector<std::vector<EntityId>> offsets_to_entity_ids(
 template<class... Args>
 ProcessingUnit gather_entities(ComponentManager& component_manager, const std::vector<EntityId>& entity_ids) {
     ProcessingUnit res;
-    auto components = component_manager.get_entities_and_decrement_refcount<Args...>(entity_ids);
+    auto components = component_manager.get_components_and_decrement_refcount<Args...>(entity_ids);
     (
             [&] {
                 auto component = std::move(std::get<std::vector<Args>>(components));

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -15,7 +15,6 @@
 
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/constructors.hpp>
-#include <boost/locale/boundary/index.hpp>
 #include <folly/container/Enumerate.h>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -61,7 +61,7 @@ class ComponentManager {
 
     std::vector<EntityId> get_new_entity_ids(size_t count);
 
-    // Add a single entity with the components defined by args
+    // Add components defined by args to entity id
     template<class... Args>
     void add_components(EntityId id, Args... args) {
         std::unique_lock lock(mtx_);
@@ -144,16 +144,26 @@ class ComponentManager {
 
     static_assert(sizeof(entt::entity) == sizeof(uint64_t));
 
-    // Get a collection of entities. Returns a tuple of vectors, one for each component requested via Args
+    // Get the requested components for a collection of entities. Returns a tuple of vectors, one for each component
+    // requested via Args
     template<class... Args>
-    std::tuple<std::vector<Args>...> get_entities_and_decrement_refcount(const std::vector<EntityId>& ids) {
-        return get_entities_impl<Args...>(ids, true);
+    std::tuple<std::vector<Args>...> get_components_and_decrement_refcount(const std::vector<EntityId>& ids) {
+        return get_components_impl<Args...>(ids, true, false);
     }
 
-    // Get a collection of entities. Returns a tuple of vectors, one for each component requested via Args
+    // Get the requested components for a collection of entities. Returns a tuple of vectors, one for each component
+    // requested via Args
     template<class... Args>
-    std::tuple<std::vector<Args>...> get_entities(const std::vector<EntityId>& ids) {
-        return get_entities_impl<Args...>(ids, false);
+    std::tuple<std::vector<Args>...> get_components(const std::vector<EntityId>& ids) {
+        return get_components_impl<Args...>(ids, false, false);
+    }
+
+    // Get the requested components for a collection of entities and remove them from the entities. Returns a tuple of
+    // vectors, one for each component requested via Args
+    template<class... Args>
+    requires(!std::same_as<Args, EntityFetchCount> && ...)
+    std::tuple<std::vector<Args>...> get_components_and_remove_components(const std::vector<EntityId>& ids) {
+        return get_components_impl<Args...>(ids, false, true);
     }
 
     template<typename ProcessComponents>
@@ -182,7 +192,9 @@ class ComponentManager {
     void update_entity_fetch_count(EntityId id, EntityFetchCount count);
 
     template<class... Args>
-    std::tuple<std::vector<Args>...> get_entities_impl(const std::vector<EntityId>& ids, bool decrement_ref_count) {
+    std::tuple<std::vector<Args>...> get_components_impl(
+            const std::vector<EntityId>& ids, bool decrement_ref_count, bool remove_components
+    ) {
         std::vector<std::tuple<Args...>> tuple_res;
         ARCTICDB_SAMPLE_DEFAULT(GetEntities)
         tuple_res.reserve(ids.size());
@@ -197,6 +209,17 @@ class ComponentManager {
                 for (const auto id : ids) {
                     decrement_entity_fetch_count(id);
                 }
+            }
+        }
+        if (remove_components) {
+            internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+                    (!std::same_as<Args, EntityFetchCount> && ...),
+                    "Removing the EntityFetchCount component is not allowed yet and must be implemented"
+            );
+            // Safe to erase only after tuple_res has copied the component values out
+            std::unique_lock lock(mtx_);
+            for (const auto id : ids) {
+                registry_.remove<Args...>(id);
             }
         }
         // Convert vector of tuples into tuple of vectors

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -162,7 +162,7 @@ class ComponentManager {
     // vectors, one for each component requested via Args
     template<class... Args>
     requires(!std::same_as<Args, EntityFetchCount> && ...)
-    std::tuple<std::vector<Args>...> get_components_and_remove_components(const std::vector<EntityId>& ids) {
+    std::tuple<std::vector<Args>...> get_and_remove_components(const std::vector<EntityId>& ids) {
         return get_components_impl<Args...>(ids, false, true);
     }
 

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -15,6 +15,7 @@
 
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/constructors.hpp>
+#include <boost/locale/boundary/index.hpp>
 #include <folly/container/Enumerate.h>
 
 namespace arcticdb {
@@ -30,11 +31,15 @@ using namespace entt::literals;
 /// clause adding this entity and then after read_modify_write it reads it in order to compute the correct row ranges
 /// accounting for insertion. If any other piece of code adds this entity to the component manager the merge updates
 /// will iterate over them as well, producing wrong results. See merge_update_impl and Monday 12618296803
-struct MergeUpdateInsertedRowsComponent {
-    MergeUpdateInsertedRowsComponent() = default;
-    MergeUpdateInsertedRowsComponent(const size_t inserted_rows) : inserted_rows(inserted_rows) {}
-    operator size_t() const { return inserted_rows; }
-    size_t inserted_rows = 0;
+struct MergeUpdateRowSlicingInfoComponent {
+    MergeUpdateRowSlicingInfoComponent() = default;
+    MergeUpdateRowSlicingInfoComponent(int num_segments, int segment_index, size_t num_rows) :
+        num_segments_(num_segments),
+        segment_index_(segment_index),
+        num_rows_(num_rows) {}
+    int num_segments_ = 1;
+    int segment_index_ = 0;
+    size_t num_rows_ = 0;
 };
 
 /// Used only by the MergeUpdateClause, and only for row-count indexed targets. After the pipeline finishes,
@@ -59,7 +64,7 @@ class ComponentManager {
 
     // Add a single entity with the components defined by args
     template<class... Args>
-    void add_entity(EntityId id, Args... args) {
+    void add_components(EntityId id, Args... args) {
         std::unique_lock lock(mtx_);
         (
                 [&] {
@@ -166,6 +171,13 @@ class ComponentManager {
         }(static_cast<NoRefArgs*>(nullptr));
     }
 
+    template<typename T>
+    requires(!std::same_as<T, EntityFetchCount>)
+    void remove_component(const EntityId entt) {
+        std::unique_lock lock(mtx_);
+        registry_.remove<T>(entt);
+    }
+
   private:
     void decrement_entity_fetch_count(EntityId id);
     void update_entity_fetch_count(EntityId id, EntityFetchCount count);
@@ -180,12 +192,10 @@ class ComponentManager {
             // Using view.get theoretically and empirically faster than registry_.get
             auto view = registry_.view<const Args...>();
 
-            for (auto id : ids) {
-                tuple_res.emplace_back(std::move(view.get(id)));
-            }
+            std::ranges::transform(ids, std::back_inserter(tuple_res), [&](auto id) { return view.get(id); });
 
             if (decrement_ref_count) {
-                for (auto id : ids) {
+                for (const auto id : ids) {
                     decrement_entity_fetch_count(id);
                 }
             }

--- a/cpp/arcticdb/processing/test/benchmark_resample.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_resample.cpp
@@ -146,7 +146,7 @@ std::vector<EntityId> register_segments(
         const auto rows = seg->row_count();
         auto rr = std::make_shared<RowRange>(row_offset, row_offset + rows);
         auto cr = std::make_shared<ColRange>(1, num_value_cols + 1);
-        component_manager.add_entity(ids[i], seg, rr, cr, EntityFetchCount{1});
+        component_manager.add_components(ids[i], seg, rr, cr, EntityFetchCount{1});
         row_offset += rows;
     }
     return ids;

--- a/cpp/arcticdb/processing/test/test_component_manager.cpp
+++ b/cpp/arcticdb/processing/test/test_component_manager.cpp
@@ -28,9 +28,9 @@ TEST(ComponentManager, Simple) {
     uint64_t entity_fetch_count_1{2};
 
     auto ids = component_manager.get_new_entity_ids(2);
-    component_manager.add_entity(ids[0], segment_0, row_range_0, col_range_0, key_0, entity_fetch_count_0);
+    component_manager.add_components(ids[0], segment_0, row_range_0, col_range_0, key_0, entity_fetch_count_0);
 
-    component_manager.add_entity(ids[1], segment_1, row_range_1, col_range_1, key_1, entity_fetch_count_1);
+    component_manager.add_components(ids[1], segment_1, row_range_1, col_range_1, key_1, entity_fetch_count_1);
 
     auto [segments, row_ranges, col_ranges, keys, entity_fetch_counts] =
             component_manager.get_entities_and_decrement_refcount<

--- a/cpp/arcticdb/processing/test/test_component_manager.cpp
+++ b/cpp/arcticdb/processing/test/test_component_manager.cpp
@@ -33,7 +33,7 @@ TEST(ComponentManager, Simple) {
     component_manager.add_components(ids[1], segment_1, row_range_1, col_range_1, key_1, entity_fetch_count_1);
 
     auto [segments, row_ranges, col_ranges, keys, entity_fetch_counts] =
-            component_manager.get_entities_and_decrement_refcount<
+            component_manager.get_components_and_decrement_refcount<
                     std::shared_ptr<SegmentInMemory>,
                     std::shared_ptr<RowRange>,
                     std::shared_ptr<ColRange>,
@@ -53,7 +53,7 @@ TEST(ComponentManager, Simple) {
     ASSERT_EQ(entity_fetch_counts[1], entity_fetch_count_1);
 
     // EntityFetchCount for entity with id_1 is 2, so can be fetched again without exceptions
-    component_manager.get_entities_and_decrement_refcount<
+    component_manager.get_components_and_decrement_refcount<
             std::shared_ptr<SegmentInMemory>,
             std::shared_ptr<RowRange>,
             std::shared_ptr<ColRange>,

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -16,6 +16,8 @@ using namespace arcticdb;
 using namespace std::ranges;
 
 namespace {
+constexpr size_t rows_per_segment = 100'000;
+
 constexpr MergeStrategy update_only_strategy{.matched = MergeAction::UPDATE};
 constexpr MergeStrategy update_and_insert_strategy{
         .matched = MergeAction::UPDATE,
@@ -106,7 +108,9 @@ MergeUpdateClause create_clause(
         const MergeStrategy strategy, std::shared_ptr<ComponentManager> component_manager, InputFrame&& input_frame,
         std::vector<std::string> on = {}
 ) {
-    MergeUpdateClause clause(std::move(on), strategy, std::make_shared<InputFrame>(std::move(input_frame)));
+    MergeUpdateClause clause(
+            std::move(on), strategy, std::make_shared<InputFrame>(std::move(input_frame)), rows_per_segment
+    );
     clause.set_component_manager(std::move(component_manager));
     return clause;
 }

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -2527,7 +2527,7 @@ TEST(MergeUpdateInsertIndexSpansMultipleSegments, TwoGroupsOfSegmentsWithMatchin
         ASSERT_TRUE(std::ranges::equal(structure_indices[0], std::array{0, 1, 2, 3, 4, 5}));
         ASSERT_EQ(structured_entities[0].size(), 6);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])),
                 std::array{1, 1, 1, 1, 2, 2}
         ));
         ASSERT_TRUE(std::ranges::equal(
@@ -2585,7 +2585,7 @@ TEST(MergeUpdateInsertIndexSpansMultipleSegments, TwoGroupsOfSegmentsWithMatchin
         ASSERT_TRUE(std::ranges::equal(structure_indices[1], std::array{4, 5, 6, 7}));
         ASSERT_EQ(structured_entities[1].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[1])),
                 std::array{2, 2, 2, 2}
         ));
         ASSERT_TRUE(std::ranges::equal(
@@ -2626,7 +2626,8 @@ TEST(MergeUpdateInsertIndexSpansMultipleSegments, TwoGroupsOfSegmentsWithMatchin
         ASSERT_TRUE(std::ranges::equal(structure_indices[2], std::array{6, 7}));
         ASSERT_EQ(structured_entities[2].size(), 2);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[2])), std::array{2, 2}
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[2])),
+                std::array{2, 2}
         ));
         ASSERT_TRUE(std::ranges::equal(
                 structure_indices[2] |
@@ -2666,7 +2667,8 @@ TEST(MergeUpdateInsertIndexSpansMultipleSegments, TwoGroupsOfSegmentsWithMatchin
         ASSERT_TRUE(std::ranges::equal(structure_indices[3], std::array{8, 9}));
         ASSERT_EQ(structured_entities[3].size(), 2);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[3])), std::array{1, 1}
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[3])),
+                std::array{1, 1}
         ));
         ASSERT_TRUE(std::ranges::equal(
                 structure_indices[3] |
@@ -2781,7 +2783,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice0) {
     ASSERT_EQ(structured_entities.size(), 1);
     ASSERT_EQ(structured_entities[0].size(), 2);
     ASSERT_TRUE(std::ranges::equal(
-            std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])), std::array{1, 1}
+            std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])), std::array{1, 1}
     ));
     auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
             desc,
@@ -2829,7 +2831,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice1ValueI
     ASSERT_EQ(structured_entities.size(), 1);
     ASSERT_EQ(structured_entities[0].size(), 6);
     ASSERT_TRUE(std::ranges::equal(
-            std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+            std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])),
             std::array{1, 1, 1, 1, 1, 1}
     ));
     auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -2897,7 +2899,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice1ValueI
     {
         ASSERT_EQ(structured_entities[0].size(), 6);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])),
                 std::array{1, 1, 1, 1, 2, 2}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -2914,7 +2916,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice1ValueI
     {
         ASSERT_EQ(structured_entities[1].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[1])),
                 std::array{2, 2, 1, 1}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -2990,7 +2992,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice3) {
     {
         ASSERT_EQ(structured_entities[0].size(), 6);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])),
                 std::array{1, 1, 1, 1, 2, 2}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -3007,7 +3009,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice3) {
     {
         ASSERT_EQ(structured_entities[1].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[1])),
                 std::array{2, 2, 2, 2}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -3024,7 +3026,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice3) {
     {
         ASSERT_EQ(structured_entities[2].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[2])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[2])),
                 std::array{2, 2, 1, 1}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -3090,7 +3092,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice5) {
     {
         ASSERT_EQ(structured_entities[0].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])),
                 std::array{1, 1, 2, 2}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -3107,7 +3109,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice5) {
     {
         ASSERT_EQ(structured_entities[1].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[1])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[1])),
                 std::array{2, 2, 2, 2}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -3124,7 +3126,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain, SourceInRowSlice5) {
     {
         ASSERT_EQ(structured_entities[2].size(), 4);
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[2])),
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[2])),
                 std::array{2, 2, 1, 1}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
@@ -3169,7 +3171,7 @@ TEST_F(MergeUpdateInsertIndexSpansMultipleSegmentsChain,
     ASSERT_EQ(structured_entities.size(), 1);
     ASSERT_EQ(structured_entities[0].size(), 2);
     ASSERT_TRUE(std::ranges::equal(
-            std::get<0>(component_manager->get_entities<EntityFetchCount>(structured_entities[0])), std::array{1, 1}
+            std::get<0>(component_manager->get_components<EntityFetchCount>(structured_entities[0])), std::array{1, 1}
     ));
     auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
             desc,
@@ -3293,7 +3295,7 @@ TEST(MergeUpdateInsertOnlySharedSlice, InsertsIntoChainWithSharedBoundaries) {
     ASSERT_EQ(structured.size(), 2);
     {
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured[0])), std::array{1, 2}
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured[0])), std::array{1, 2}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
                 desc, 100'000, 1, std::array<timestamp, 3>{10, 20, 20}, std::array<int64_t, 3>{0, 1, 2}
@@ -3312,7 +3314,7 @@ TEST(MergeUpdateInsertOnlySharedSlice, InsertsIntoChainWithSharedBoundaries) {
     }
     {
         ASSERT_TRUE(std::ranges::equal(
-                std::get<0>(component_manager->get_entities<EntityFetchCount>(structured[1])), std::array{2, 1}
+                std::get<0>(component_manager->get_components<EntityFetchCount>(structured[1])), std::array{2, 1}
         ));
         auto [expected_segments, _r, _c] = slice_data_into_segments<TimeseriesIndex>(
                 desc, 100'000, 1, std::array<timestamp, 4>{25, 30, 30, 40}, std::array<int64_t, 4>{1000, 3, 4, 5}

--- a/cpp/arcticdb/processing/test/test_parallel_processing.cpp
+++ b/cpp/arcticdb/processing/test/test_parallel_processing.cpp
@@ -272,7 +272,7 @@ TEST(Clause, ScheduleRowSliceProcessingAndWrite) {
     std::vector<folly::Future<SliceAndKey>> write_segments_futures;
     std::ranges::transform(
             std::get<0>(
-                    component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(processed_entity_ids)
+                    component_manager->get_components<std::shared_ptr<folly::Future<SliceAndKey>>>(processed_entity_ids)
             ),
             std::back_inserter(write_segments_futures),
             [](const std::shared_ptr<folly::Future<SliceAndKey>>& fut) { return std::move(*fut); }

--- a/cpp/arcticdb/processing/test/test_resample.cpp
+++ b/cpp/arcticdb/processing/test/test_resample.cpp
@@ -406,9 +406,9 @@ TEST(Resample, ProcessMultipleSegments) {
     auto col_range_2 = std::make_shared<ColRange>(1, 2);
 
     auto ids = component_manager->get_new_entity_ids(3);
-    component_manager->add_entity(ids[0], seg_0, row_range_0, col_range_0, EntityFetchCount(1));
-    component_manager->add_entity(ids[1], seg_1, row_range_1, col_range_1, EntityFetchCount(2));
-    component_manager->add_entity(ids[2], seg_2, row_range_2, col_range_2, EntityFetchCount(1));
+    component_manager->add_components(ids[0], seg_0, row_range_0, col_range_0, EntityFetchCount(1));
+    component_manager->add_components(ids[1], seg_1, row_range_1, col_range_1, EntityFetchCount(2));
+    component_manager->add_components(ids[2], seg_2, row_range_2, col_range_2, EntityFetchCount(1));
 
     std::vector<EntityId> ids_0{ids[0], ids[1]};
     std::vector<EntityId> ids_1{ids[1]};

--- a/cpp/arcticdb/util/collection_utils.hpp
+++ b/cpp/arcticdb/util/collection_utils.hpp
@@ -9,15 +9,17 @@
 #pragma once
 
 #include <memory>
+#include <numeric>
 #include <ranges>
 #include <vector>
+#include <arcticdb/util/preconditions.hpp>
 
 namespace arcticdb {
 
 namespace util {
 
 template<typename T>
-inline std::vector<T> flatten_vectors(std::vector<std::vector<T>>&& vec_of_vecs) {
+std::vector<T> flatten_vectors(std::vector<std::vector<T>>&& vec_of_vecs) {
     size_t res_size = std::accumulate(
             vec_of_vecs.cbegin(),
             vec_of_vecs.cend(),

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -461,26 +461,25 @@ std::vector<StreamDescriptor> split_rowrange_descriptor(
     return descriptors;
 }
 
-/// One instance is the single output data segment covering one column slice's columns for one output row slice's
-/// rows.
-struct MergeUpdateRowRangeInsertInfo {
-    /// Check which source rows within this range must be inserted. Note, not all source rows within this range will be
-    /// inserted.
-    RowRange source_range_to_check_for_appends{};
+/// Used only by merge update for row-range (integer) indexed targets, where the unmatched source rows are
+/// appended after the last target row.
+struct MergeUpdateSliceInfo {
+    /// The window of source rows this output segment scans. Note, not all source rows within this range will be
+    /// inserted, only those set in the bitset of unmatched source rows.
+    RowRange candidate_source_rows{};
     /// The row range in the final result inserted rows from source will be placed
     RowRange output_row_range{};
     /// Column slice inside the row slice
     size_t col_slice_index{};
 };
 
-std::vector<MergeUpdateRowRangeInsertInfo> plan_inserted_segments_for_row_range_merge_update(
+std::vector<MergeUpdateSliceInfo> plan_inserted_segments_for_row_range_merge_update(
         const util::BitSet& source_rows_to_insert, const ReslicingInfo& reslicing_info, size_t last_row_in_target,
         size_t num_column_slices
 ) {
-    auto insert_plans =
-            util::reserve_vector<MergeUpdateRowRangeInsertInfo>(num_column_slices * reslicing_info.num_segments());
+    auto insert_plans = util::reserve_vector<MergeUpdateSliceInfo>(num_column_slices * reslicing_info.num_segments());
     auto set_insert_info_for_col_slices = [&] {
-        MergeUpdateRowRangeInsertInfo current_row_slice = insert_plans.back();
+        MergeUpdateSliceInfo current_row_slice = insert_plans.back();
         for (size_t col_slice_index = 1; col_slice_index < num_column_slices; ++col_slice_index) {
             current_row_slice.col_slice_index = col_slice_index;
             insert_plans.push_back(current_row_slice);
@@ -491,24 +490,24 @@ std::vector<MergeUpdateRowRangeInsertInfo> plan_inserted_segments_for_row_range_
     insert_plans.back().output_row_range = RowRange{last_row_in_target, last_row_in_target};
     iterate_over_set_positions(source_rows_to_insert, [&](const size_t source_row) {
         if (insert_plans.back().output_row_range.diff() >= reslicing_info.rows_in_slice(row_slice_index)) {
-            insert_plans.back().source_range_to_check_for_appends.second = source_row;
+            insert_plans.back().candidate_source_rows.second = source_row;
             set_insert_info_for_col_slices();
             const size_t next_output_row_begin = insert_plans.back().output_row_range.second;
             insert_plans.emplace_back();
-            insert_plans.back().source_range_to_check_for_appends.first = source_row;
+            insert_plans.back().candidate_source_rows.first = source_row;
             insert_plans.back().output_row_range = RowRange{next_output_row_begin, next_output_row_begin};
             ++row_slice_index;
         }
         ++insert_plans.back().output_row_range.second;
     });
-    insert_plans.back().source_range_to_check_for_appends.second = source_rows_to_insert.size();
+    insert_plans.back().candidate_source_rows.second = source_rows_to_insert.size();
     set_insert_info_for_col_slices();
     return insert_plans;
 }
 
 SegmentInMemory create_segment_for_merge_update_row_range_insert(
-        const StreamDescriptor& col_slice_descriptor, const MergeUpdateRowRangeInsertInfo& insert_info,
-        size_t columns_per_slice, const InputFrame& source, const util::BitSet& source_rows_to_insert
+        const StreamDescriptor& col_slice_descriptor, const MergeUpdateSliceInfo& insert_info, size_t columns_per_slice,
+        const InputFrame& source, const util::BitSet& source_rows_to_insert
 ) {
     const size_t rows_to_insert = insert_info.output_row_range.diff();
     SegmentInMemory new_segment(
@@ -530,8 +529,8 @@ SegmentInMemory create_segment_for_merge_update_row_range_insert(
             std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
             iterate_over_set_positions(
                     source_rows_to_insert,
-                    insert_info.source_range_to_check_for_appends.first,
-                    insert_info.source_range_to_check_for_appends.second,
+                    insert_info.candidate_source_rows.first,
+                    insert_info.candidate_source_rows.second,
                     [&](size_t source_row) {
                         if constexpr (is_sequence_type(TDT::data_type())) {
                             *data_it = write_py_string_to_pool_or_throw<TDT>(
@@ -582,7 +581,7 @@ folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
              de_dup_map,
              target_index_partial_key,
              columns_per_slice = write_opts.column_group_size,
-             store = &store](MergeUpdateRowRangeInsertInfo insert_info) {
+             store = &store](MergeUpdateSliceInfo insert_info) {
                 return store->async_write(
                         folly::via(
                                 &async::cpu_executor(),
@@ -803,21 +802,19 @@ folly::Future<std::vector<EntityId>> read_modify_write_data_keys(
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
             .thenValue([component_manager = std::move(component_manager),
                         read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
-                std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> slice_components =
-                        std::get<0>(component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(
-                                processed_entity_ids
-                        ));
-                auto write_segments_futures = util::reserve_vector<folly::Future<EntityId>>(slice_components.size());
-                for (auto&& [index, slice_future] : folly::enumerate(slice_components)) {
+                std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> slice_futures =
+                        std::get<0>(component_manager->get_components_and_remove_components<
+                                    std::shared_ptr<folly::Future<SliceAndKey>>>(processed_entity_ids));
+                auto write_segments_futures = util::reserve_vector<folly::Future<EntityId>>(slice_futures.size());
+                for (auto&& [index, slice_future] : folly::enumerate(slice_futures)) {
                     write_segments_futures.push_back(
                             std::move(*slice_future)
-                                    .thenValueInline([component_manager,
-                                                      entt = processed_entity_ids[index]](SliceAndKey&& slice_and_key) {
-                                        component_manager
-                                                ->remove_component<std::shared_ptr<folly::Future<SliceAndKey>>>(entt);
+                                    .thenValueInline([component_manager, entity_id = processed_entity_ids[index]](
+                                                             SliceAndKey&& slice_and_key
+                                                     ) {
                                         slice_and_key.unset_segment();
-                                        component_manager->add_components(entt, std::move(slice_and_key));
-                                        return entt;
+                                        component_manager->add_components(entity_id, std::move(slice_and_key));
+                                        return entity_id;
                                     })
                     );
                 }
@@ -833,7 +830,7 @@ std::vector<SliceAndMergeInfo> gather_slices_and_infos_for_merge_update_index_co
             processed_entities.size() + row_slices_appended_for_rowcount_index.size()
     );
     auto [new_slices, new_infos] =
-            component_manager.get_entities<SliceAndKey, MergeUpdateRowSlicingInfoComponent>(processed_entities);
+            component_manager.get_components<SliceAndKey, MergeUpdateRowSlicingInfoComponent>(processed_entities);
     for (size_t i = 0; i < new_slices.size(); ++i) {
         total_slices_and_infos.emplace_back(std::move(new_slices[i]), new_infos[i]);
     }
@@ -3198,7 +3195,7 @@ folly::Future<VersionedItem> read_modify_write_impl(
                         store,
                         target_partial_index_key](std::vector<EntityId>&& entities) mutable {
                 std::vector<SliceAndKey> data_keys_and_slices =
-                        std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
+                        std::get<0>(component_manager->get_components<SliceAndKey>(entities));
                 ARCTICDB_DEBUG_CHECK(
                         ErrorCode::E_ASSERTION_FAILURE,
                         std::ranges::all_of(
@@ -3614,7 +3611,7 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                                  component_manager](std::vector<EntityId>&& entities
                                 ) -> folly::Future<std::optional<AtomKey>> {
                                     std::vector<SliceAndKey> slices_and_keys =
-                                            std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
+                                            std::get<0>(component_manager->get_components<SliceAndKey>(entities));
                                     if (slices_and_keys.empty() && !frame) {
                                         return folly::makeFuture(std::optional<AtomKey>());
                                     }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -441,7 +441,7 @@ util::BitSet source_rows_to_insert_for_row_range_merge_update(const ComponentMan
             rows_to_insert = *unmatched_source_rows.unmatched_source_rows;
         }
     });
-    return *std::move(rows_to_insert);
+    return std::move(rows_to_insert).value_or(util::BitSet{});
 }
 
 std::vector<StreamDescriptor> split_rowrange_descriptor(
@@ -3191,7 +3191,12 @@ folly::Future<VersionedItem> read_modify_write_impl(
     return read_modify_write_data_keys(
                    store, read_query, read_options, target_partial_index_key, pipeline_context, component_manager
     )
-            .thenValue([&](std::vector<EntityId>&& entities) {
+            .thenValue([component_manager,
+                        pipeline_context,
+                        user_meta_proto = std::move(user_meta_proto),
+                        write_options,
+                        store,
+                        target_partial_index_key](std::vector<EntityId>&& entities) mutable {
                 std::vector<SliceAndKey> data_keys_and_slices =
                         std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
                 ARCTICDB_DEBUG_CHECK(

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -358,46 +358,69 @@ bool is_fake_index_name(const arcticc::pb2::descriptors_pb2::NormalizationMetada
     return is_fake_datetime_index_name || is_fake_mutliindex_name;
 }
 
+/// A slice emitted by the merge update clause, paired with its position in the group of output row slices that
+/// replaced one consumed target row range. Both items are needed in order to sort the slices and keys.
+struct SliceAndMergeInfo {
+    SliceAndKey slice_and_key;
+    MergeUpdateRowSlicingInfoComponent info;
+};
+
 std::vector<SliceAndKey> merge_slices_and_keys(
-        std::vector<SliceAndKey>&& old_slices, std::vector<SliceAndKey>&& new_slices,
-        ankerl::unordered_dense::map<RowRange, size_t>&& inserted_rows_per_row_range
+        std::vector<SliceAndKey>&& old_slices, std::vector<SliceAndMergeInfo>&& new_slices
 ) {
-    ranges::sort(new_slices);
+    // Every slice carries its own position within its group. (col_range, row_range, segment_index_) is a total
+    // order over new_slices. Sorting on the FrameSlice alone would not be enough because a group's slices deliberately
+    // share one row_range while holding different AtomKeys, so ties would be broken arbitrarily and the row ranges
+    // assigned below would land on the wrong keys.
+    ranges::sort(new_slices, [](const SliceAndMergeInfo& left, const SliceAndMergeInfo& right) {
+        const FrameSlice& l = left.slice_and_key.slice();
+        const FrameSlice& r = right.slice_and_key.slice();
+        return std::tie(l.col_range.first, l.row_range.first, left.info.segment_index_) <
+               std::tie(r.col_range.first, r.row_range.first, right.info.segment_index_);
+    });
     std::vector<SliceAndKey> merged_ranges_and_keys;
     auto new_slice_and_key_it = new_slices.begin();
     auto old_slice_and_key_it = old_slices.begin();
     while (old_slice_and_key_it != old_slices.end()) {
         size_t total_inserted_rows{};
-        ColRange current_col_range = old_slice_and_key_it->slice().col_range;
-        while (old_slice_and_key_it != old_slices.end() && current_col_range == old_slice_and_key_it->slice().col_range
-        ) {
-            if (new_slice_and_key_it == new_slices.end() ||
-                old_slice_and_key_it->slice() < new_slice_and_key_it->slice()) {
+        const ColRange current_col_range = old_slice_and_key_it->slice().col_range;
+        const auto old_column_slice_exhausted = [&] {
+            return old_slice_and_key_it == old_slices.end() ||
+                   old_slice_and_key_it->slice().col_range != current_col_range;
+        };
+        const auto new_column_slice_exhausted = [&] {
+            return new_slice_and_key_it == new_slices.end() ||
+                   new_slice_and_key_it->slice_and_key.slice().col_range != current_col_range;
+        };
+        while (!old_column_slice_exhausted() || !new_column_slice_exhausted()) {
+            if (new_column_slice_exhausted() ||
+                (!old_column_slice_exhausted() &&
+                 old_slice_and_key_it->slice() < new_slice_and_key_it->slice_and_key.slice())) {
                 old_slice_and_key_it->slice().row_range.first += total_inserted_rows;
                 old_slice_and_key_it->slice().row_range.second += total_inserted_rows;
                 merged_ranges_and_keys.emplace_back(std::move(*old_slice_and_key_it));
                 ++old_slice_and_key_it;
-            } else {
-                const RowRange new_row_range = new_slice_and_key_it->slice().row_range;
-                const size_t inserted_rows = inserted_rows_per_row_range.at(new_row_range);
-                new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
-                new_slice_and_key_it->slice().row_range.second += total_inserted_rows + inserted_rows;
-                total_inserted_rows += inserted_rows;
-                merged_ranges_and_keys.emplace_back(std::move(*new_slice_and_key_it));
-                ++new_slice_and_key_it;
-                while (old_slice_and_key_it != old_slices.end() &&
-                       old_slice_and_key_it->slice().col_range == current_col_range &&
-                       old_slice_and_key_it->slice().row_range.first < new_row_range.second) {
-                    ++old_slice_and_key_it;
-                }
+                continue;
             }
-        }
-        while (new_slice_and_key_it != new_slices.end() && new_slice_and_key_it->slice().col_range == current_col_range
-        ) {
-            new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
-            new_slice_and_key_it->slice().row_range.second += total_inserted_rows;
-            merged_ranges_and_keys.emplace_back(std::move(*new_slice_and_key_it));
-            ++new_slice_and_key_it;
+            const RowRange consumed = new_slice_and_key_it->slice_and_key.slice().row_range;
+            // Read the group size before the loop: the body advances new_slice_and_key_it, so re-reading it from
+            // the iterator would take the bound from the next group, or dereference end() on the last group.
+            const size_t group_size = static_cast<size_t>(new_slice_and_key_it->info.num_segments_);
+            const size_t group_start = consumed.first + total_inserted_rows;
+            size_t offset_in_group{};
+            for (size_t position = 0; position < group_size; ++position) {
+                const size_t num_rows = new_slice_and_key_it->info.num_rows_;
+                new_slice_and_key_it->slice_and_key.slice().row_range =
+                        RowRange{group_start + offset_in_group, group_start + offset_in_group + num_rows};
+                offset_in_group += num_rows;
+                merged_ranges_and_keys.emplace_back(std::move(new_slice_and_key_it->slice_and_key));
+                ++new_slice_and_key_it;
+            }
+            const size_t num_new_rows = offset_in_group - consumed.diff();
+            total_inserted_rows += num_new_rows;
+            while (!old_column_slice_exhausted() && old_slice_and_key_it->slice().row_range.first < consumed.second) {
+                ++old_slice_and_key_it;
+            }
         }
     }
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -409,8 +432,7 @@ std::vector<SliceAndKey> merge_slices_and_keys(
     return merged_ranges_and_keys;
 }
 
-std::optional<util::BitSet> source_rows_to_insert_for_row_range_merge_update(const ComponentManager& component_manager
-) {
+util::BitSet source_rows_to_insert_for_row_range_merge_update(const ComponentManager& component_manager) {
     std::optional<util::BitSet> rows_to_insert;
     component_manager.process_entities([&](const MergeUpdateNotMatchedSourceRowsComponent& unmatched_source_rows) {
         if (rows_to_insert) {
@@ -419,7 +441,7 @@ std::optional<util::BitSet> source_rows_to_insert_for_row_range_merge_update(con
             rows_to_insert = *unmatched_source_rows.unmatched_source_rows;
         }
     });
-    return rows_to_insert;
+    return *std::move(rows_to_insert);
 }
 
 std::vector<StreamDescriptor> split_rowrange_descriptor(
@@ -439,76 +461,395 @@ std::vector<StreamDescriptor> split_rowrange_descriptor(
     return descriptors;
 }
 
-folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
-        const InputFrame& source, const ComponentManager& component_manager, const StreamDescriptor& target_descriptor,
-        const size_t columns_per_slice, const IndexPartialKey& target_index_partial_key,
-        const size_t last_row_in_target, Store& store
+/// One instance is the single output data segment covering one column slice's columns for one output row slice's
+/// rows.
+struct MergeUpdateRowRangeInsertInfo {
+    /// Check which source rows within this range must be inserted. Note, not all source rows within this range will be
+    /// inserted.
+    RowRange source_range_to_check_for_appends{};
+    /// The row range in the final result inserted rows from source will be placed
+    RowRange output_row_range{};
+    /// Column slice inside the row slice
+    size_t col_slice_index{};
+};
+
+std::vector<MergeUpdateRowRangeInsertInfo> plan_inserted_segments_for_row_range_merge_update(
+        const util::BitSet& source_rows_to_insert, const ReslicingInfo& reslicing_info, size_t last_row_in_target,
+        size_t num_column_slices
 ) {
-    const std::optional<util::BitSet> source_rows_to_insert =
-            source_rows_to_insert_for_row_range_merge_update(component_manager);
-    const size_t num_rows_to_insert = source_rows_to_insert ? source_rows_to_insert->count() : 0;
+    auto insert_plans =
+            util::reserve_vector<MergeUpdateRowRangeInsertInfo>(num_column_slices * reslicing_info.num_segments());
+    auto set_insert_info_for_col_slices = [&] {
+        MergeUpdateRowRangeInsertInfo current_row_slice = insert_plans.back();
+        for (size_t col_slice_index = 1; col_slice_index < num_column_slices; ++col_slice_index) {
+            current_row_slice.col_slice_index = col_slice_index;
+            insert_plans.push_back(current_row_slice);
+        }
+    };
+    size_t row_slice_index = 0;
+    insert_plans.emplace_back();
+    insert_plans.back().output_row_range = RowRange{last_row_in_target, last_row_in_target};
+    iterate_over_set_positions(source_rows_to_insert, [&](const size_t source_row) {
+        if (insert_plans.back().output_row_range.diff() >= reslicing_info.rows_in_slice(row_slice_index)) {
+            insert_plans.back().source_range_to_check_for_appends.second = source_row;
+            set_insert_info_for_col_slices();
+            const size_t next_output_row_begin = insert_plans.back().output_row_range.second;
+            insert_plans.emplace_back();
+            insert_plans.back().source_range_to_check_for_appends.first = source_row;
+            insert_plans.back().output_row_range = RowRange{next_output_row_begin, next_output_row_begin};
+            ++row_slice_index;
+        }
+        ++insert_plans.back().output_row_range.second;
+    });
+    insert_plans.back().source_range_to_check_for_appends.second = source_rows_to_insert.size();
+    set_insert_info_for_col_slices();
+    return insert_plans;
+}
+
+SegmentInMemory create_segment_for_merge_update_row_range_insert(
+        const StreamDescriptor& col_slice_descriptor, const MergeUpdateRowRangeInsertInfo& insert_info,
+        size_t columns_per_slice, const InputFrame& source, const util::BitSet& source_rows_to_insert
+) {
+    const size_t rows_to_insert = insert_info.output_row_range.diff();
+    SegmentInMemory new_segment(
+            col_slice_descriptor, rows_to_insert, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
+    );
+    const StreamDescriptor& slice_descriptor = new_segment.descriptor();
+    const size_t first_col_idx = insert_info.col_slice_index * columns_per_slice;
+    for (size_t column_in_segment = 0; column_in_segment < slice_descriptor.field_count(); ++column_in_segment) {
+        std::optional<ScopedGILLock> gil_lock;
+        ColumnData col_data = new_segment.column_data(column_in_segment);
+        const Field& field = slice_descriptor.field(column_in_segment);
+        const size_t source_field_pos = first_col_idx + column_in_segment;
+        details::visit_scalar(field.type(), [&]<util::type_descriptor_tag TDT>(TDT) {
+            using SourceRawType = std::conditional_t<
+                    is_sequence_type(TDT::data_type()),
+                    PyObject* const,
+                    typename TDT::DataTypeTag::raw_type>;
+            auto data_it = col_data.begin<TDT>();
+            std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
+            iterate_over_set_positions(
+                    source_rows_to_insert,
+                    insert_info.source_range_to_check_for_appends.first,
+                    insert_info.source_range_to_check_for_appends.second,
+                    [&](size_t source_row) {
+                        if constexpr (is_sequence_type(TDT::data_type())) {
+                            *data_it = write_py_string_to_pool_or_throw<TDT>(
+                                    source_data[source_row],
+                                    source_row,
+                                    RowRange{0, source.num_rows},
+                                    gil_lock,
+                                    new_segment.string_pool(),
+                                    field.name()
+                            );
+                        } else {
+                            *data_it = source_data[source_row];
+                        }
+                        ++data_it;
+                    }
+            );
+        });
+    }
+    new_segment.set_row_data(static_cast<ssize_t>(rows_to_insert) - 1);
+    return new_segment;
+}
+
+folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
+        std::shared_ptr<InputFrame> source, const ComponentManager& component_manager,
+        const StreamDescriptor& target_descriptor, const WriteOptions& write_opts,
+        const IndexPartialKey& target_index_partial_key, size_t last_row_in_target, Store& store,
+        std::shared_ptr<DeDupMap> de_dup_map
+) {
+    util::BitSet source_rows_to_insert = source_rows_to_insert_for_row_range_merge_update(component_manager);
+    const size_t num_rows_to_insert = source_rows_to_insert.count();
     if (num_rows_to_insert == 0) {
         return folly::makeFuture<std::vector<SliceAndKey>>(std::vector<SliceAndKey>{});
     }
-    std::vector<StreamDescriptor> descriptors = split_rowrange_descriptor(target_descriptor, columns_per_slice);
-    const RowRange new_row_range{last_row_in_target, last_row_in_target + num_rows_to_insert};
-    auto write_data_keys_future = util::reserve_vector<folly::Future<SliceAndKey>>(descriptors.size());
-    for (size_t col_slice = 0; col_slice < descriptors.size(); ++col_slice) {
-        SegmentInMemory new_segment(
-                std::move(descriptors[col_slice]), num_rows_to_insert, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
-        );
-        const StreamDescriptor& slice_descriptor = new_segment.descriptor();
-        const ColRange col_range{
-                col_slice * columns_per_slice,
-                std::min((col_slice + 1) * columns_per_slice, target_descriptor.field_count())
-        };
-        for (size_t column_in_segment = 0; column_in_segment < slice_descriptor.field_count(); ++column_in_segment) {
-            std::optional<ScopedGILLock> gil_lock;
-            ColumnData col_data = new_segment.column_data(column_in_segment);
-            const Field& field = slice_descriptor.field(column_in_segment);
-            const size_t source_field_pos = col_range.start() + column_in_segment;
-            details::visit_scalar(field.type(), [&]<util::type_descriptor_tag TDT>(TDT) {
-                using SourceRawType = std::conditional_t<
-                        is_sequence_type(TDT::data_type()),
-                        PyObject* const,
-                        typename TDT::DataTypeTag::raw_type>;
-                auto data_it = col_data.begin<TDT>();
-                std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
-                iterate_over_set_positions(*source_rows_to_insert, [&](size_t source_row) {
-                    if constexpr (is_sequence_type(TDT::data_type())) {
-                        *data_it = write_py_string_to_pool_or_throw<TDT>(
-                                source_data[source_row],
-                                source_row,
-                                RowRange{0, source.num_rows},
-                                gil_lock,
-                                new_segment.string_pool(),
-                                field.name()
-                        );
-                    } else {
-                        *data_it = source_data[source_row];
-                    }
-                    ++data_it;
-                });
-            });
-        }
-        new_segment.set_row_data(num_rows_to_insert - 1);
-        write_data_keys_future.push_back(store.compress_and_schedule_async_write(
-                std::make_tuple(
-                        PartialKey{
-                                .key_type = KeyType::TABLE_DATA,
-                                .version_id = target_index_partial_key.version_id,
-                                .stream_id = target_index_partial_key.id,
-                                .start_index = static_cast<timestamp>(new_row_range.first),
-                                .end_index = static_cast<timestamp>(new_row_range.second)
-                        },
-                        std::move(new_segment),
-                        FrameSlice(col_range, new_row_range)
-                ),
-                std::make_shared<DeDupMap>()
-        ));
-    }
-    return folly::collect(std::move(write_data_keys_future));
+    const auto source_rows_to_insert_ptr = std::make_shared<const util::BitSet>(std::move(source_rows_to_insert));
+    const ReslicingInfo reslicing_info{num_rows_to_insert, max_rows_per_segment(write_opts.segment_row_size)};
+    auto column_slice_descriptors = std::make_shared<const std::vector<StreamDescriptor>>(
+            split_rowrange_descriptor(target_descriptor, write_opts.column_group_size)
+    );
+    auto insert_infos = plan_inserted_segments_for_row_range_merge_update(
+            *source_rows_to_insert_ptr, reslicing_info, last_row_in_target, column_slice_descriptors->size()
+    );
+
+    auto write_futures = folly::window(
+            std::move(insert_infos),
+            [source,
+             source_rows_to_insert = source_rows_to_insert_ptr,
+             column_slice_descriptors,
+             de_dup_map,
+             target_index_partial_key,
+             columns_per_slice = write_opts.column_group_size,
+             store = &store](MergeUpdateRowRangeInsertInfo insert_info) {
+                return store->async_write(
+                        folly::via(
+                                &async::cpu_executor(),
+                                [source,
+                                 source_rows_to_insert,
+                                 column_slice_descriptors,
+                                 target_index_partial_key,
+                                 columns_per_slice,
+                                 insert_info]() mutable -> std::tuple<PartialKey, SegmentInMemory, FrameSlice> {
+                                    const StreamDescriptor& slice_descriptor =
+                                            (*column_slice_descriptors)[insert_info.col_slice_index];
+                                    const size_t first_col_idx = insert_info.col_slice_index * columns_per_slice;
+                                    return {PartialKey{
+                                                    .key_type = KeyType::TABLE_DATA,
+                                                    .version_id = target_index_partial_key.version_id,
+                                                    .stream_id = target_index_partial_key.id,
+                                                    .start_index =
+                                                            static_cast<timestamp>(insert_info.output_row_range.first),
+                                                    .end_index =
+                                                            static_cast<timestamp>(insert_info.output_row_range.second)
+                                            },
+                                            create_segment_for_merge_update_row_range_insert(
+                                                    slice_descriptor,
+                                                    insert_info,
+                                                    columns_per_slice,
+                                                    *source,
+                                                    *source_rows_to_insert
+                                            ),
+                                            FrameSlice(
+                                                    ColRange{
+                                                            first_col_idx,
+                                                            first_col_idx + slice_descriptor.field_count()
+                                                    },
+                                                    insert_info.output_row_range
+                                            )};
+                                }
+                        ),
+                        de_dup_map
+                );
+            },
+            write_window_size()
+    );
+    return folly::collect(std::move(write_futures));
 }
+
+std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_context) {
+    std::vector<RangesAndKey> res;
+    res.reserve(pipeline_context.slice_and_keys_.size());
+    bool is_incomplete{false};
+    for (auto it = pipeline_context.begin(); it != pipeline_context.end(); it++) {
+        if (it == pipeline_context.incompletes_begin()) {
+            is_incomplete = true;
+        }
+        auto& sk = it->slice_and_key();
+        // Take a copy here as things like defrag need the keys in pipeline_context->slice_and_keys_ that aren't being
+        // modified at the end
+        auto key = sk.key();
+        res.emplace_back(sk.slice(), std::move(key), is_incomplete);
+    }
+    return res;
+}
+
+StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
+    const StreamDescriptor& desc = pipeline_context.output_descriptor();
+    // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
+    // it to constrain the initial set of columns. If dynamic schema is used and only certain columns must be read we
+    // use the whole descriptor and at the end of the read return only the ones that were selected. This is because
+    // currently dynamic schema cannot handle column dependencies e.g.
+    // columns on disk: col1, col2
+    // q = QueryBuilder()
+    // q = q["col1" < 1]
+    // lib.read(columns=["col2", query_builder=q)
+    // We want to read only col2 but the filtering requires col1, thus the OutputSchema must contain both col1 and col2
+    // in order to satisfy the filter clause.
+    if (pipeline_context.overall_column_bitset_) {
+        FieldCollection fields_to_use;
+        auto overall_fields_it = pipeline_context.overall_column_bitset_->first();
+        const auto overall_fields_end = pipeline_context.overall_column_bitset_->end();
+        while (overall_fields_it != overall_fields_end) {
+            fields_to_use.add(desc.field(*overall_fields_it).ref());
+            ++overall_fields_it;
+        }
+        return StreamDescriptor{desc.data_ptr(), std::make_shared<FieldCollection>(std::move(fields_to_use))};
+    }
+    return desc;
+}
+
+OutputSchema create_initial_output_schema(PipelineContext& pipeline_context) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            pipeline_context.has_normalization(), "Normalization metadata should not be missing during read_and_process"
+    );
+    return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), pipeline_context.normalization()};
+}
+
+OutputSchema generate_output_schema(PipelineContext& pipeline_context, const ReadQuery& read_query) {
+    auto output_schema = modify_schema(create_initial_output_schema(pipeline_context), read_query.clauses_);
+    if (read_query.columns) {
+        std::unordered_set<std::string_view> selected_columns(read_query.columns->begin(), read_query.columns->end());
+        FieldCollection fields_to_use;
+        if (!pipeline_context.filter_columns_) {
+            pipeline_context.filter_columns_ = std::make_shared<FieldCollection>();
+        }
+        for (const Field& field : output_schema.stream_descriptor().fields()) {
+            if (selected_columns.contains(field.name())) {
+                fields_to_use.add(field.ref());
+                if (!pipeline_context.is_in_filter_columns_set(field.name())) {
+                    pipeline_context.filter_columns_->add(field.ref());
+                }
+            }
+        }
+        pipeline_context.filter_columns_set_ = std::move(selected_columns);
+        output_schema.set_stream_descriptor(StreamDescriptor{
+                output_schema.stream_descriptor().data_ptr(),
+                std::make_shared<FieldCollection>(std::move(fields_to_use))
+        });
+    }
+    return output_schema;
+}
+
+std::shared_ptr<std::unordered_set<std::string>> columns_to_decode(
+        const std::shared_ptr<PipelineContext>& pipeline_context
+) {
+    std::shared_ptr<std::unordered_set<std::string>> res;
+    ARCTICDB_DEBUG(
+            log::version(),
+            "Creating columns list with {} bits set",
+            pipeline_context->overall_column_bitset_ ? pipeline_context->overall_column_bitset_->count() : -1
+    );
+    if (pipeline_context->overall_column_bitset_) {
+        res = std::make_shared<std::unordered_set<std::string>>();
+        auto en = pipeline_context->overall_column_bitset_->first();
+        auto en_end = pipeline_context->overall_column_bitset_->end();
+        while (en < en_end) {
+            ARCTICDB_DEBUG(log::version(), "Adding field {}", pipeline_context->on_disk_descriptor().field(*en).name());
+            res->insert(std::string(pipeline_context->on_disk_descriptor().field(*en++).name()));
+        }
+    }
+    return res;
+}
+
+folly::Future<std::vector<EntityId>> read_and_schedule_processing(
+        const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
+        const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
+        std::shared_ptr<ComponentManager> component_manager
+) {
+    const ProcessingConfig processing_config{
+            opt_false(read_options.dynamic_schema()),
+            pipeline_context->rows_,
+            pipeline_context->on_disk_descriptor().index().type()
+    };
+    for (auto& clause : read_query->clauses_) {
+        clause->set_processing_config(processing_config);
+        clause->set_component_manager(component_manager);
+    }
+
+    auto ranges_and_keys = generate_ranges_and_keys(*pipeline_context);
+
+    // Each element of the vector corresponds to one processing unit containing the list of indexes in ranges_and_keys
+    // required for that processing unit i.e. if the first processing unit needs ranges_and_keys[0] and
+    // ranges_and_keys[1], and the second needs ranges_and_keys[2] and ranges_and_keys[3] then the structure will be
+    // {{0, 1}, {2, 3}}
+    std::vector<std::vector<size_t>> processing_unit_indexes;
+    if (read_query->clauses_.empty()) {
+        processing_unit_indexes = structure_by_row_slice(ranges_and_keys);
+    } else {
+        processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
+    }
+
+    const size_t max_processing_units_in_flight = max_resident_processing_units(processing_unit_indexes);
+    const size_t read_window = segment_read_window();
+
+    auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
+    SegmentReader reader = [base_reader = std::move(base_reader),
+                            pipeline_desc = pipeline_context->on_disk_descriptor(),
+                            processing_config](pipelines::RangesAndKey&& rk) {
+        const bool is_incomplete = rk.is_incomplete();
+        return base_reader(std::move(rk))
+                .thenValueInline([pipeline_desc, processing_config, is_incomplete](pipelines::SegmentAndSlice&& r) {
+                    if (is_incomplete && !processing_config.dynamic_schema_) {
+                        auto check = check_schema_matches_incomplete(r.segment_in_memory_.descriptor(), pipeline_desc);
+                        if (std::holds_alternative<Error>(check)) {
+                            std::get<Error>(check).throw_error();
+                        }
+                    }
+                    return std::move(r);
+                });
+    };
+
+    auto admission = std::make_shared<ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges_and_keys),
+            std::move(processing_unit_indexes),
+            max_processing_units_in_flight,
+            read_window
+    );
+
+    auto processed = schedule_clause_processing(
+            component_manager, admission, std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
+    );
+
+    return std::move(processed).via(&async::cpu_executor());
+}
+
+folly::Future<std::vector<EntityId>> read_modify_write_data_keys(
+        const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
+        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
+        std::shared_ptr<ComponentManager> component_manager,
+        std::shared_ptr<DeDupMap> de_dup_map = std::make_shared<DeDupMap>()
+) {
+    const auto write_clause_processing_structure =
+            read_query->clauses_.empty() ? ProcessingStructure::ROW_SLICE
+                                         : read_query->clauses_.back()->clause_info().output_structure_;
+    read_query->clauses_.push_back(std::make_shared<Clause>(
+            WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
+    ));
+    pipeline_context->set_output_schema(generate_output_schema(*pipeline_context, *read_query));
+
+    return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
+            .thenValue([component_manager = std::move(component_manager),
+                        read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
+                std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> slice_components =
+                        std::get<0>(component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(
+                                processed_entity_ids
+                        ));
+                auto write_segments_futures = util::reserve_vector<folly::Future<EntityId>>(slice_components.size());
+                for (auto&& [index, slice_future] : folly::enumerate(slice_components)) {
+                    write_segments_futures.push_back(
+                            std::move(*slice_future)
+                                    .thenValueInline([component_manager,
+                                                      entt = processed_entity_ids[index]](SliceAndKey&& slice_and_key) {
+                                        component_manager
+                                                ->remove_component<std::shared_ptr<folly::Future<SliceAndKey>>>(entt);
+                                        slice_and_key.unset_segment();
+                                        component_manager->add_components(entt, std::move(slice_and_key));
+                                        return entt;
+                                    })
+                    );
+                }
+                return folly::collect(std::move(write_segments_futures));
+            });
+}
+
+std::vector<SliceAndMergeInfo> gather_slices_and_infos_for_merge_update_index_construction(
+        const std::vector<EntityId>& processed_entities,
+        std::vector<SliceAndKey>&& row_slices_appended_for_rowcount_index, ComponentManager& component_manager
+) {
+    auto total_slices_and_infos = util::reserve_vector<SliceAndMergeInfo>(
+            processed_entities.size() + row_slices_appended_for_rowcount_index.size()
+    );
+    auto [new_slices, new_infos] =
+            component_manager.get_entities<SliceAndKey, MergeUpdateRowSlicingInfoComponent>(processed_entities);
+    for (size_t i = 0; i < new_slices.size(); ++i) {
+        total_slices_and_infos.emplace_back(std::move(new_slices[i]), new_infos[i]);
+    }
+    new_slices.clear();
+    new_infos.clear();
+    // The appended row-count insert slices are not entities and each occupies its own row
+    // range beyond the target, so each one is a group of a single slice.
+    for (SliceAndKey& slice_and_key : row_slices_appended_for_rowcount_index) {
+        const size_t num_rows = slice_and_key.slice().row_range.diff();
+        total_slices_and_infos.push_back(
+                {.slice_and_key = std::move(slice_and_key), .info = MergeUpdateRowSlicingInfoComponent(1, 0, num_rows)}
+        );
+    }
+    return total_slices_and_infos;
+}
+
 } // namespace
 
 VersionedItem delete_range_impl(
@@ -843,7 +1184,7 @@ void add_slice_to_component_manager(
         std::shared_ptr<ComponentManager> component_manager, EntityFetchCount fetch_count
 ) {
     ARCTICDB_DEBUG(log::memory(), "Adding entity id {}", entity_id);
-    component_manager->add_entity(
+    component_manager->add_components(
             entity_id,
             std::make_shared<SegmentInMemory>(std::move(segment_and_slice.segment_in_memory_)),
             std::make_shared<RowRange>(std::move(segment_and_slice.ranges_and_key_.row_range_)),
@@ -1092,164 +1433,6 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
         remove_processed_clauses(*clauses);
         return schedule_remaining_iterations(std::move(entity_ids_vec), clauses);
     });
-}
-
-std::shared_ptr<std::unordered_set<std::string>> columns_to_decode(
-        const std::shared_ptr<PipelineContext>& pipeline_context
-) {
-    std::shared_ptr<std::unordered_set<std::string>> res;
-    ARCTICDB_DEBUG(
-            log::version(),
-            "Creating columns list with {} bits set",
-            pipeline_context->overall_column_bitset_ ? pipeline_context->overall_column_bitset_->count() : -1
-    );
-    if (pipeline_context->overall_column_bitset_) {
-        res = std::make_shared<std::unordered_set<std::string>>();
-        auto en = pipeline_context->overall_column_bitset_->first();
-        auto en_end = pipeline_context->overall_column_bitset_->end();
-        while (en < en_end) {
-            ARCTICDB_DEBUG(log::version(), "Adding field {}", pipeline_context->on_disk_descriptor().field(*en).name());
-            res->insert(std::string(pipeline_context->on_disk_descriptor().field(*en++).name()));
-        }
-    }
-    return res;
-}
-
-std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_context) {
-    std::vector<RangesAndKey> res;
-    res.reserve(pipeline_context.slice_and_keys_.size());
-    bool is_incomplete{false};
-    for (auto it = pipeline_context.begin(); it != pipeline_context.end(); it++) {
-        if (it == pipeline_context.incompletes_begin()) {
-            is_incomplete = true;
-        }
-        auto& sk = it->slice_and_key();
-        // Take a copy here as things like defrag need the keys in pipeline_context->slice_and_keys_ that aren't being
-        // modified at the end
-        auto key = sk.key();
-        res.emplace_back(sk.slice(), std::move(key), is_incomplete);
-    }
-    return res;
-}
-
-static StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
-    const StreamDescriptor& desc = pipeline_context.output_descriptor();
-    // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
-    // it to constrain the initial set of columns. If dynamic schema is used and only certain columns must be read we
-    // use the whole descriptor and at the end of the read return only the ones that were selected. This is because
-    // currently dynamic schema cannot handle column dependencies e.g.
-    // columns on disk: col1, col2
-    // q = QueryBuilder()
-    // q = q["col1" < 1]
-    // lib.read(columns=["col2", query_builder=q)
-    // We want to read only col2 but the filtering requires col1, thus the OutputSchema must contain both col1 and col2
-    // in order to satisfy the filter clause.
-    if (pipeline_context.overall_column_bitset_) {
-        FieldCollection fields_to_use;
-        auto overall_fields_it = pipeline_context.overall_column_bitset_->first();
-        const auto overall_fields_end = pipeline_context.overall_column_bitset_->end();
-        while (overall_fields_it != overall_fields_end) {
-            fields_to_use.add(desc.field(*overall_fields_it).ref());
-            ++overall_fields_it;
-        }
-        return StreamDescriptor{desc.data_ptr(), std::make_shared<FieldCollection>(std::move(fields_to_use))};
-    }
-    return desc;
-}
-
-static OutputSchema create_initial_output_schema(PipelineContext& pipeline_context) {
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            pipeline_context.has_normalization(), "Normalization metadata should not be missing during read_and_process"
-    );
-    return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), pipeline_context.normalization()};
-}
-
-static OutputSchema generate_output_schema(PipelineContext& pipeline_context, const ReadQuery& read_query) {
-    auto output_schema = modify_schema(create_initial_output_schema(pipeline_context), read_query.clauses_);
-    if (read_query.columns) {
-        std::unordered_set<std::string_view> selected_columns(read_query.columns->begin(), read_query.columns->end());
-        FieldCollection fields_to_use;
-        if (!pipeline_context.filter_columns_) {
-            pipeline_context.filter_columns_ = std::make_shared<FieldCollection>();
-        }
-        for (const Field& field : output_schema.stream_descriptor().fields()) {
-            if (selected_columns.contains(field.name())) {
-                fields_to_use.add(field.ref());
-                if (!pipeline_context.is_in_filter_columns_set(field.name())) {
-                    pipeline_context.filter_columns_->add(field.ref());
-                }
-            }
-        }
-        pipeline_context.filter_columns_set_ = std::move(selected_columns);
-        output_schema.set_stream_descriptor(StreamDescriptor{
-                output_schema.stream_descriptor().data_ptr(),
-                std::make_shared<FieldCollection>(std::move(fields_to_use))
-        });
-    }
-    return output_schema;
-}
-
-folly::Future<std::vector<EntityId>> read_and_schedule_processing(
-        const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
-        const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
-        std::shared_ptr<ComponentManager> component_manager
-) {
-    const ProcessingConfig processing_config{
-            opt_false(read_options.dynamic_schema()),
-            pipeline_context->rows_,
-            pipeline_context->on_disk_descriptor().index().type()
-    };
-    for (auto& clause : read_query->clauses_) {
-        clause->set_processing_config(processing_config);
-        clause->set_component_manager(component_manager);
-    }
-
-    auto ranges_and_keys = generate_ranges_and_keys(*pipeline_context);
-
-    // Each element of the vector corresponds to one processing unit containing the list of indexes in ranges_and_keys
-    // required for that processing unit i.e. if the first processing unit needs ranges_and_keys[0] and
-    // ranges_and_keys[1], and the second needs ranges_and_keys[2] and ranges_and_keys[3] then the structure will be
-    // {{0, 1}, {2, 3}}
-    std::vector<std::vector<size_t>> processing_unit_indexes;
-    if (read_query->clauses_.empty()) {
-        processing_unit_indexes = structure_by_row_slice(ranges_and_keys);
-    } else {
-        processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
-    }
-
-    const size_t max_processing_units_in_flight = max_resident_processing_units(processing_unit_indexes);
-    const size_t read_window = segment_read_window();
-
-    auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
-    SegmentReader reader = [base_reader = std::move(base_reader),
-                            pipeline_desc = pipeline_context->on_disk_descriptor(),
-                            processing_config](pipelines::RangesAndKey&& rk) {
-        const bool is_incomplete = rk.is_incomplete();
-        return base_reader(std::move(rk))
-                .thenValueInline([pipeline_desc, processing_config, is_incomplete](pipelines::SegmentAndSlice&& r) {
-                    if (is_incomplete && !processing_config.dynamic_schema_) {
-                        auto check = check_schema_matches_incomplete(r.segment_in_memory_.descriptor(), pipeline_desc);
-                        if (std::holds_alternative<Error>(check)) {
-                            std::get<Error>(check).throw_error();
-                        }
-                    }
-                    return std::move(r);
-                });
-    };
-
-    auto admission = std::make_shared<ProcessingUnitAdmissionHandler>(
-            std::move(reader),
-            std::move(ranges_and_keys),
-            std::move(processing_unit_indexes),
-            max_processing_units_in_flight,
-            read_window
-    );
-
-    auto processed = schedule_clause_processing(
-            component_manager, admission, std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
-    );
-
-    return std::move(processed).via(&async::cpu_executor());
 }
 
 /*
@@ -2998,49 +3181,19 @@ folly::Future<ReadVersionOutput> read_frame_for_version(
     return start_pipeline(VersionIdentifier{version_info});
 }
 
-folly::Future<std::vector<SliceAndKey>> read_modify_write_data_keys(
-        const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
-        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
-        std::shared_ptr<ComponentManager> component_manager = std::make_shared<ComponentManager>(),
-        std::shared_ptr<DeDupMap> de_dup_map = std::make_shared<DeDupMap>()
-) {
-    auto write_clause_processing_structure = read_query->clauses_.empty()
-                                                     ? ProcessingStructure::ROW_SLICE
-                                                     : read_query->clauses_.back()->clause_info().output_structure_;
-    read_query->clauses_.push_back(std::make_shared<Clause>(
-            WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
-    ));
-    pipeline_context->set_output_schema(generate_output_schema(*pipeline_context, *read_query));
-
-    return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
-            .thenValue([component_manager = std::move(component_manager),
-                        pipeline_context,
-                        read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
-                std::vector<folly::Future<SliceAndKey>> write_segments_futures;
-                ranges::transform(
-                        std::get<0>(component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(
-                                processed_entity_ids
-                        )),
-                        std::back_inserter(write_segments_futures),
-                        [](const std::shared_ptr<folly::Future<SliceAndKey>>& fut) {
-                            return std::move(*fut).thenValueInline([](SliceAndKey&& slice_and_key) {
-                                slice_and_key.unset_segment();
-                                return slice_and_key;
-                            });
-                        }
-                );
-                return folly::collect(std::move(write_segments_futures));
-            });
-}
-
 folly::Future<VersionedItem> read_modify_write_impl(
         const std::shared_ptr<Store>& store, const std::shared_ptr<ReadQuery>& read_query,
         const ReadOptions& read_options, const WriteOptions& write_options,
         const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
         std::optional<proto::descriptors::UserDefinedMetadata>&& user_meta_proto
 ) {
-    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
-            .thenValue([&](std::vector<SliceAndKey>&& data_keys_and_slices) {
+    auto component_manager = std::make_shared<ComponentManager>();
+    return read_modify_write_data_keys(
+                   store, read_query, read_options, target_partial_index_key, pipeline_context, component_manager
+    )
+            .thenValue([&](std::vector<EntityId>&& entities) {
+                std::vector<SliceAndKey> data_keys_and_slices =
+                        std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
                 ARCTICDB_DEBUG_CHECK(
                         ErrorCode::E_ASSERTION_FAILURE,
                         std::ranges::all_of(
@@ -3082,7 +3235,10 @@ folly::Future<AtomKey> merge_update_impl(
         std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto read_query = std::make_shared<ReadQuery>();
-    auto merge_update_clause = std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source));
+    auto merge_update_clause =
+            std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source, write_options.segment_row_size)
+            );
+
     read_query->clauses_.push_back(merge_update_clause);
     VersionIdentifier resolved = VersionedItem{*update_info.previous_index_key_};
     if (auto* vi = std::get_if<VersionedItem>(&resolved)) {
@@ -3136,7 +3292,7 @@ folly::Future<AtomKey> merge_update_impl(
                    target_partial_index_key,
                    pipeline_context,
                    component_manager,
-                   std::move(de_dup_map)
+                   de_dup_map
     )
             .thenValue([pipeline_context = std::move(pipeline_context),
                         component_manager = std::move(component_manager),
@@ -3144,18 +3300,20 @@ folly::Future<AtomKey> merge_update_impl(
                         write_options,
                         source = std::move(source),
                         target_partial_index_key,
-                        strategy](std::vector<SliceAndKey>&& data_keys_and_slices) {
+                        strategy,
+                        de_dup_map](std::vector<EntityId>&& processed_entities) {
                 const StreamDescriptor& target_descriptor = pipeline_context->output_descriptor();
                 folly::SemiFuture<std::vector<SliceAndKey>> inserted_row_slices_fut =
                         (target_descriptor.index().type() == IndexDescriptor::Type::ROWCOUNT && strategy.insert())
                                 ? write_inserted_row_range_data(
-                                          *source,
+                                          source,
                                           *component_manager,
                                           target_descriptor,
-                                          write_options.column_group_size,
+                                          write_options,
                                           target_partial_index_key,
                                           pipeline_context->last_row(),
-                                          *store
+                                          *store,
+                                          de_dup_map
                                   )
                                 : folly::makeSemiFuture(std::vector<SliceAndKey>{});
                 return std::move(inserted_row_slices_fut)
@@ -3166,24 +3324,14 @@ folly::Future<AtomKey> merge_update_impl(
                                     write_options,
                                     source,
                                     target_partial_index_key,
-                                    data_keys_and_slices = std::move(data_keys_and_slices
+                                    processed_entities = std::move(processed_entities
                                     )](std::vector<SliceAndKey>&& inserted_row_slices) mutable {
-                            ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
-                            component_manager->process_entities(
-                                    [&](const MergeUpdateInsertedRowsComponent& inserted_rows,
-                                        const std::shared_ptr<RowRange>& row_range) {
-                                        inserted_rows_per_row_range.emplace(*row_range, inserted_rows);
-                                    }
-                            );
-                            data_keys_and_slices.insert(
-                                    data_keys_and_slices.end(),
-                                    std::make_move_iterator(inserted_row_slices.begin()),
-                                    std::make_move_iterator(inserted_row_slices.end())
-                            );
+                            std::vector<SliceAndMergeInfo> new_slices =
+                                    gather_slices_and_infos_for_merge_update_index_construction(
+                                            processed_entities, std::move(inserted_row_slices), *component_manager
+                                    );
                             std::vector<SliceAndKey> merged_ranges_and_keys = merge_slices_and_keys(
-                                    std::move(pipeline_context->slice_and_keys_),
-                                    std::move(data_keys_and_slices),
-                                    std::move(inserted_rows_per_row_range)
+                                    std::move(pipeline_context->slice_and_keys_), std::move(new_slices)
                             );
                             pipeline_context->slice_and_keys_.clear();
                             const size_t row_count =
@@ -3264,7 +3412,7 @@ folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
                     row_slices_after.emplace_back(0);
                     for (const auto& row_range : processing_row_ranges) {
                         ReslicingInfo reslicing_info(row_range.diff(), clause.max_rows_per_segment_);
-                        for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+                        for (uint64_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
                             row_slices_after.emplace_back(row_slices_after.back() + reslicing_info.rows_in_slice(idx));
                         }
                     }
@@ -3288,8 +3436,8 @@ static folly::Future<std::vector<SliceAndKey>> slice_and_write_frame_remainder(
 ) {
     auto remaining_rows_to_write = (frame->offset + frame->num_rows) - start_row;
     ReslicingInfo reslicing_info{remaining_rows_to_write, max_rows_per_segment};
-    auto row_ranges = util::reserve_vector<RowRange>(reslicing_info.num_segments);
-    for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+    auto row_ranges = util::reserve_vector<RowRange>(reslicing_info.num_segments());
+    for (uint64_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
         row_ranges.emplace_back(start_row, start_row + reslicing_info.rows_in_slice(idx));
         start_row += reslicing_info.rows_in_slice(idx);
     }
@@ -3441,8 +3589,14 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                 IndexPartialKey target_partial_index_key{stream_id, update_info.next_version_id_};
                 ReadOptions read_options;
                 read_options.set_dynamic_schema(dynamic_schema);
+                auto component_manager = std::make_shared<ComponentManager>();
                 return read_modify_write_data_keys(
-                               store, read_query, read_options, target_partial_index_key, pipeline_context
+                               store,
+                               read_query,
+                               read_options,
+                               target_partial_index_key,
+                               pipeline_context,
+                               component_manager
                 )
                         .thenValue(
                                 [pipeline_context = std::move(pipeline_context),
@@ -3451,8 +3605,11 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                                  target_partial_index_key,
                                  read_query,
                                  tsd,
-                                 frame](std::vector<SliceAndKey>&& slices_and_keys
+                                 frame,
+                                 component_manager](std::vector<EntityId>&& entities
                                 ) -> folly::Future<std::optional<AtomKey>> {
+                                    std::vector<SliceAndKey> slices_and_keys =
+                                            std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
                                     if (slices_and_keys.empty() && !frame) {
                                         return folly::makeFuture(std::optional<AtomKey>());
                                     }
@@ -3469,7 +3626,8 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                                             std::make_move_iterator(unchanged_slices.begin()),
                                             std::make_move_iterator(unchanged_slices.end())
                                     );
-                                    // This implies there are more rows in frame that have not yet been written to disk
+                                    // This implies there are more rows in frame that have not yet been written
+                                    // to disk
                                     auto remaining_slice_and_keys_fut =
                                             frame && last_row_on_disk < frame->offset + frame->num_rows
                                                     ? slice_and_write_frame_remainder(

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2293,7 +2293,7 @@ void create_column_stats_impl(
     auto processed_entity_ids =
             read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager).get();
 
-    auto [new_column_stats_rows] = component_manager->get_entities<ColumnStatsRow>(processed_entity_ids);
+    auto [new_column_stats_rows] = component_manager->get_components<ColumnStatsRow>(processed_entity_ids);
     if (new_column_stats_rows.empty()) {
         return;
     }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -802,9 +802,11 @@ folly::Future<std::vector<EntityId>> read_modify_write_data_keys(
     return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
             .thenValue([component_manager = std::move(component_manager),
                         read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
-                std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> slice_futures =
-                        std::get<0>(component_manager->get_components_and_remove_components<
-                                    std::shared_ptr<folly::Future<SliceAndKey>>>(processed_entity_ids));
+                std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> slice_futures = std::get<0>(
+                        component_manager->get_and_remove_components<std::shared_ptr<folly::Future<SliceAndKey>>>(
+                                processed_entity_ids
+                        )
+                );
                 auto write_segments_futures = util::reserve_vector<folly::Future<EntityId>>(slice_futures.size());
                 for (auto&& [index, slice_future] : folly::enumerate(slice_futures)) {
                     write_segments_futures.push_back(

--- a/docs/claude/cpp/PROCESSING.md
+++ b/docs/claude/cpp/PROCESSING.md
@@ -216,7 +216,7 @@ Key methods: `set_segments()`, `set_row_ranges()`, `set_col_ranges()`, `set_atom
 Key methods:
 - `get_new_entity_ids(count)` - Allocate new entity IDs
 - `add_entity(id, args...)` / `add_entities(ids, tuples)` - Add entities with components
-- `get_entities_and_decrement_refcount(ids)` - Get entities (removed when fetch count reaches 0)
+- `get_components_and_decrement_refcount(ids)` - Get entities (removed when fetch count reaches 0)
 - `get<T>(id)` - Get a single component for an entity
 
 ## Read Admission Control

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -282,7 +282,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1786453888142165015)"
+       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1787833486388750013)"
       ]
      },
      "execution_count": 4,
@@ -2287,7 +2287,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260811 16:11:28.381648 18717 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260827 15:24:46.798258 31417 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -3106,6 +3106,298 @@
         "version": "2238d0faf29b5206ab9dd61d1acea68ae7883b8ac95bc8c0fafaefb85ff1527b",
         "warmup_time": 0.1
     },
+    "merge_functions.MergeSplitSegmentsThinDatetime.peakmem_merge": {
+        "code": "class MergeSplitSegmentsThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "name": "merge_functions.MergeSplitSegmentsThinDatetime.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "600000"
+            ],
+            [
+                "1"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:552",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "3b466cca3b7d4fd34d37ff99ac0c859d1530ace69880a2ef996b351733a8d49d"
+    },
+    "merge_functions.MergeSplitSegmentsThinDatetime.time_merge": {
+        "code": "class MergeSplitSegmentsThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeSplitSegmentsThinDatetime.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "600000"
+            ],
+            [
+                "1"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:552",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "6363e35d1c32a8547dc427cafe3d2a0460875d97dd22a0aeb43691d798bc270e",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeSplitSegmentsThinRowRange.peakmem_merge": {
+        "code": "class MergeSplitSegmentsThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "name": "merge_functions.MergeSplitSegmentsThinRowRange.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "600000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:651",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "f41f80d7cba090c9c523bee9733f5d84bdf7433306836c74cc57b4b9de3788aa"
+    },
+    "merge_functions.MergeSplitSegmentsThinRowRange.time_merge": {
+        "code": "class MergeSplitSegmentsThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeSplitSegmentsThinRowRange.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "600000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:651",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "61ee5420d47eb3ed8b2a239e0670d0aa614c7b18098145b8d915185ed2eecf5e",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeSplitSegmentsThinStringDatetime.peakmem_merge": {
+        "code": "class MergeSplitSegmentsThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "name": "merge_functions.MergeSplitSegmentsThinStringDatetime.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "600000"
+            ],
+            [
+                "1"
+            ],
+            [
+                "5000",
+                "10000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:593",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "34172a11db4d62086d1a24bf620e17a6458ffeaf1f5263cb871465d85093be65"
+    },
+    "merge_functions.MergeSplitSegmentsThinStringDatetime.time_merge": {
+        "code": "class MergeSplitSegmentsThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeSplitSegmentsThinStringDatetime.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "matched_slices",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "1"
+            ],
+            [
+                "600000"
+            ],
+            [
+                "1"
+            ],
+            [
+                "5000",
+                "10000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:593",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "9c84aaba0c3772dc7937d9dacf8df599c6413ec3da87ea5258c112da6732046c",
+        "warmup_time": 0
+    },
+    "merge_functions.MergeSplitSegmentsThinStringRowRange.peakmem_merge": {
+        "code": "class MergeSplitSegmentsThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "name": "merge_functions.MergeSplitSegmentsThinStringRowRange.peakmem_merge",
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "2"
+            ],
+            [
+                "600000"
+            ],
+            [
+                "5000",
+                "100000"
+            ]
+        ],
+        "setup_cache_key": "merge_functions:696",
+        "timeout": 600,
+        "type": "peakmemory",
+        "unit": "bytes",
+        "version": "ca7e92377fef48a952253f2a33cb3d0f2dbe42ffc13f63e271f81c28c904ec79"
+    },
+    "merge_functions.MergeSplitSegmentsThinStringRowRange.time_merge": {
+        "code": "class MergeSplitSegmentsThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "min_run_count": 2,
+        "name": "merge_functions.MergeSplitSegmentsThinStringRowRange.time_merge",
+        "number": 1,
+        "param_names": [
+            "scenario",
+            "strategy",
+            "on_count",
+            "source_size",
+            "num_unique_strings"
+        ],
+        "params": [
+            [
+                "(100000, 3)"
+            ],
+            [
+                "'update_and_insert'"
+            ],
+            [
+                "2"
+            ],
+            [
+                "600000"
+            ],
+            [
+                "5000",
+                "100000"
+            ]
+        ],
+        "repeat": 10,
+        "rounds": 1,
+        "sample_time": 0.01,
+        "setup_cache_key": "merge_functions:696",
+        "timeout": 600,
+        "type": "time",
+        "unit": "seconds",
+        "version": "80a966e0db9339ce94fd23b93a941fc4a972eaad012441a68f8fbe3e8c9128e4",
+        "warmup_time": 0
+    },
     "merge_functions.MergeThinDatetime.peakmem_merge": {
         "code": "class MergeThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
         "name": "merge_functions.MergeThinDatetime.peakmem_merge",
@@ -3137,7 +3429,7 @@
                 "40"
             ]
         ],
-        "setup_cache_key": "merge_functions:264",
+        "setup_cache_key": "merge_functions:276",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -3179,7 +3471,7 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:264",
+        "setup_cache_key": "merge_functions:276",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -3212,7 +3504,7 @@
                 "500000"
             ]
         ],
-        "setup_cache_key": "merge_functions:304",
+        "setup_cache_key": "merge_functions:316",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -3249,7 +3541,7 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:304",
+        "setup_cache_key": "merge_functions:316",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -3292,7 +3584,7 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "merge_functions:345",
+        "setup_cache_key": "merge_functions:357",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -3339,7 +3631,7 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:345",
+        "setup_cache_key": "merge_functions:357",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -3377,7 +3669,7 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "merge_functions:401",
+        "setup_cache_key": "merge_functions:413",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -3419,7 +3711,7 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:401",
+        "setup_cache_key": "merge_functions:413",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -3452,7 +3744,7 @@
                 "100"
             ]
         ],
-        "setup_cache_key": "merge_functions:456",
+        "setup_cache_key": "merge_functions:468",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -3489,7 +3781,7 @@
         "repeat": 5,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:456",
+        "setup_cache_key": "merge_functions:468",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -3522,7 +3814,7 @@
                 "100"
             ]
         ],
-        "setup_cache_key": "merge_functions:496",
+        "setup_cache_key": "merge_functions:508",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -3559,7 +3851,7 @@
         "repeat": 5,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:496",
+        "setup_cache_key": "merge_functions:508",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -3107,7 +3107,7 @@
         "warmup_time": 0.1
     },
     "merge_functions.MergeSplitSegmentsThinDatetime.peakmem_merge": {
-        "code": "class MergeSplitSegmentsThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeSplitSegmentsThinDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3118,7 +3118,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3127,20 +3127,20 @@
                 "1"
             ],
             [
-                "600000"
+                "1000000"
             ],
             [
                 "1"
             ]
         ],
-        "setup_cache_key": "merge_functions:552",
+        "setup_cache_key": "merge_functions:551",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "3b466cca3b7d4fd34d37ff99ac0c859d1530ace69880a2ef996b351733a8d49d"
+        "version": "f4bc50c0cd6bb5b3f8e20630cd56d48efbebf544a071e73e32044a5e3437d374"
     },
     "merge_functions.MergeSplitSegmentsThinDatetime.time_merge": {
-        "code": "class MergeSplitSegmentsThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeSplitSegmentsThinDatetime.time_merge",
         "number": 1,
@@ -3153,7 +3153,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3162,7 +3162,7 @@
                 "1"
             ],
             [
-                "600000"
+                "1000000"
             ],
             [
                 "1"
@@ -3171,15 +3171,15 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:552",
+        "setup_cache_key": "merge_functions:551",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "6363e35d1c32a8547dc427cafe3d2a0460875d97dd22a0aeb43691d798bc270e",
+        "version": "bf817081b08ee0845f3b7f61b866e76099fca43db6a20d537a3839475e8c5004",
         "warmup_time": 0
     },
     "merge_functions.MergeSplitSegmentsThinRowRange.peakmem_merge": {
-        "code": "class MergeSplitSegmentsThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeSplitSegmentsThinRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3189,7 +3189,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3198,17 +3198,17 @@
                 "1"
             ],
             [
-                "600000"
+                "1000000"
             ]
         ],
-        "setup_cache_key": "merge_functions:651",
+        "setup_cache_key": "merge_functions:650",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "f41f80d7cba090c9c523bee9733f5d84bdf7433306836c74cc57b4b9de3788aa"
+        "version": "3b692b1bd30ad8b831a31488108c8b4f47280042beae097aeece67b48e6a640e"
     },
     "merge_functions.MergeSplitSegmentsThinRowRange.time_merge": {
-        "code": "class MergeSplitSegmentsThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeSplitSegmentsThinRowRange.time_merge",
         "number": 1,
@@ -3220,7 +3220,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3229,21 +3229,21 @@
                 "1"
             ],
             [
-                "600000"
+                "1000000"
             ]
         ],
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:651",
+        "setup_cache_key": "merge_functions:650",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "61ee5420d47eb3ed8b2a239e0670d0aa614c7b18098145b8d915185ed2eecf5e",
+        "version": "884123c47afcb1edcf257f2555780ec223292c9fa5c6ac807f388f5cae0f31d2",
         "warmup_time": 0
     },
     "merge_functions.MergeSplitSegmentsThinStringDatetime.peakmem_merge": {
-        "code": "class MergeSplitSegmentsThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeSplitSegmentsThinStringDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3255,7 +3255,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3264,24 +3264,24 @@
                 "1"
             ],
             [
-                "600000"
+                "1000000"
             ],
             [
                 "1"
             ],
             [
                 "5000",
-                "10000"
+                "100000"
             ]
         ],
-        "setup_cache_key": "merge_functions:593",
+        "setup_cache_key": "merge_functions:592",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "34172a11db4d62086d1a24bf620e17a6458ffeaf1f5263cb871465d85093be65"
+        "version": "e6853be507b924cc8e379b9524707ae44165a0f96454bfbd434b7aaf6910efcf"
     },
     "merge_functions.MergeSplitSegmentsThinStringDatetime.time_merge": {
-        "code": "class MergeSplitSegmentsThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeSplitSegmentsThinStringDatetime.time_merge",
         "number": 1,
@@ -3295,7 +3295,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3304,28 +3304,28 @@
                 "1"
             ],
             [
-                "600000"
+                "1000000"
             ],
             [
                 "1"
             ],
             [
                 "5000",
-                "10000"
+                "100000"
             ]
         ],
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:593",
+        "setup_cache_key": "merge_functions:592",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "9c84aaba0c3772dc7937d9dacf8df599c6413ec3da87ea5258c112da6732046c",
+        "version": "5750e2ec3120576ea3eb4ce61a775b419e96367f0034c592ce6e903acbd92929",
         "warmup_time": 0
     },
     "merge_functions.MergeSplitSegmentsThinStringRowRange.peakmem_merge": {
-        "code": "class MergeSplitSegmentsThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeSplitSegmentsThinStringRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3336,7 +3336,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3345,21 +3345,21 @@
                 "2"
             ],
             [
-                "600000"
+                "1000000"
             ],
             [
                 "5000",
                 "100000"
             ]
         ],
-        "setup_cache_key": "merge_functions:696",
+        "setup_cache_key": "merge_functions:695",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "ca7e92377fef48a952253f2a33cb3d0f2dbe42ffc13f63e271f81c28c904ec79"
+        "version": "8bf549372be7cd07d67882421e2774705a721e5026e8a0d79bce30a103b39bd9"
     },
     "merge_functions.MergeSplitSegmentsThinStringRowRange.time_merge": {
-        "code": "class MergeSplitSegmentsThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeSplitSegmentsThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeSplitSegmentsThinStringRowRange.time_merge",
         "number": 1,
@@ -3372,7 +3372,7 @@
         ],
         "params": [
             [
-                "(100000, 3)"
+                "(10000, 3)"
             ],
             [
                 "'update_and_insert'"
@@ -3381,7 +3381,7 @@
                 "2"
             ],
             [
-                "600000"
+                "1000000"
             ],
             [
                 "5000",
@@ -3391,15 +3391,15 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:696",
+        "setup_cache_key": "merge_functions:695",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "80a966e0db9339ce94fd23b93a941fc4a972eaad012441a68f8fbe3e8c9128e4",
+        "version": "63959c1857b835567cdf0b9a754e5037879ba4dbb0e723b6b6cc663582109c5a",
         "warmup_time": 0
     },
     "merge_functions.MergeThinDatetime.peakmem_merge": {
-        "code": "class MergeThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeThinDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeThinDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3429,14 +3429,14 @@
                 "40"
             ]
         ],
-        "setup_cache_key": "merge_functions:276",
+        "setup_cache_key": "merge_functions:275",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "bda038e7ac799f351dadb49a529e87aa2762d0993fa7b3f2fb5534f80d20c5d6"
+        "version": "7d2b5c11ed805715ee6da786796cd6d15ae6ac8cadae444e79e1376c61ef19f8"
     },
     "merge_functions.MergeThinDatetime.time_merge": {
-        "code": "class MergeThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeThinDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinDatetime.time_merge",
         "number": 1,
@@ -3471,15 +3471,15 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:276",
+        "setup_cache_key": "merge_functions:275",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "5fa0f07cbaf18da0b38b5fa5a212bd62af352193686538be081fad7bfd09497f",
+        "version": "7f4ebaacfbe6935664653180b420ba3913e83117d584c018d84f7da71f5c8e9e",
         "warmup_time": 0
     },
     "merge_functions.MergeThinRowRange.peakmem_merge": {
-        "code": "class MergeThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeThinRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeThinRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3504,14 +3504,14 @@
                 "500000"
             ]
         ],
-        "setup_cache_key": "merge_functions:316",
+        "setup_cache_key": "merge_functions:315",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "aa4096cc5f46058c309c21eb33ebaabc2e84d6e07560aac829027da71086ea6b"
+        "version": "da794da85500988fd41d5314e5c0bcd1cc50d510bd73b7cd922d5fd9841f436a"
     },
     "merge_functions.MergeThinRowRange.time_merge": {
-        "code": "class MergeThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeThinRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinRowRange.time_merge",
         "number": 1,
@@ -3541,15 +3541,15 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:316",
+        "setup_cache_key": "merge_functions:315",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "256a83ebc7be8dd867cee611d7e3e1fafe2e35dc4ccc40358530caf35984706f",
+        "version": "2336555771ffaf4602ee086d12a0fbf12c600fc5ec020db14410919625c1950d",
         "warmup_time": 0
     },
     "merge_functions.MergeThinStringDatetime.peakmem_merge": {
-        "code": "class MergeThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeThinStringDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeThinStringDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3584,14 +3584,14 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "merge_functions:357",
+        "setup_cache_key": "merge_functions:356",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "4deaada28c22d2cd8a4edfb8d8d9c558ab7b4c68bd9c3bc81cf099cdd90d2585"
+        "version": "5595ae2cd8381b51bd09df24e7803f3a177f3589b9b188837cb5cbe61bc3bc45"
     },
     "merge_functions.MergeThinStringDatetime.time_merge": {
-        "code": "class MergeThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeThinStringDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        parameter_map = dict(zip(self.param_names, self.params))\n        for scenario in parameter_map[\"scenario\"]:\n            for num_unique_strings in parameter_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinStringDatetime.time_merge",
         "number": 1,
@@ -3631,15 +3631,15 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:357",
+        "setup_cache_key": "merge_functions:356",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "cfc2523da2cb2b2cc7892532ef9027eeeaf039dd512c09875e6cc054fd3e977b",
+        "version": "cd104aa177b27d67de5ae437dfac52c8067e5547ef5038784554807e7d02162a",
         "warmup_time": 0
     },
     "merge_functions.MergeThinStringRowRange.peakmem_merge": {
-        "code": "class MergeThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeThinStringRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeThinStringRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3669,14 +3669,14 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "merge_functions:413",
+        "setup_cache_key": "merge_functions:412",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "16b046fab8ab2ff6a54e7b6c1b6bca4b1f3518b5a093be95fc3b02422b00a2ec"
+        "version": "02d6cc5012f6975fb1b46576b2656c59cf2ce6c6e4600d28961a5d6a19cd42aa"
     },
     "merge_functions.MergeThinStringRowRange.time_merge": {
-        "code": "class MergeThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target)\n                self._precompute_sources(library_name, target)",
+        "code": "class MergeThinStringRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):\n        self.target_prefix = f\"target_{num_unique_strings}\"\n        self.source_prefix = f\"source_{num_unique_strings}\"\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        param_map = dict(zip(self.param_names, self.params))\n        for scenario in param_map[\"scenario\"]:\n            for num_unique_strings in param_map[\"num_unique_strings\"]:\n                num_rows, num_value_cols = scenario\n                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])\n                target = generate_merge_target(\n                    num_rows,\n                    num_value_cols,\n                    self.value_dtype,\n                    self.INDEX_KIND,\n                    rng,\n                    num_unique_strings=num_unique_strings,\n                )\n                # One target per pool size; per-size prefixes let setup copy only the variant being merged.\n                self.target_prefix = f\"target_{num_unique_strings}\"\n                self.source_prefix = f\"source_{num_unique_strings}\"\n                library_name = lib_name(*scenario, self.INDEX_KIND)\n                self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n                self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeThinStringRowRange.time_merge",
         "number": 1,
@@ -3711,15 +3711,15 @@
         "repeat": 10,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:413",
+        "setup_cache_key": "merge_functions:412",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "5b1ad5a07078537f4b40748fd746b8053078bd52e4f3ff7d2c141470c7ccb6a7",
+        "version": "c4c635450d3d20640c64c8d6a43b1d64c6858cd4ab02c5decebff0494dabc8f3",
         "warmup_time": 0
     },
     "merge_functions.MergeWideDatetime.peakmem_merge": {
-        "code": "class MergeWideDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeWideDatetime:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeWideDatetime.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3744,14 +3744,14 @@
                 "100"
             ]
         ],
-        "setup_cache_key": "merge_functions:468",
+        "setup_cache_key": "merge_functions:467",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "5f3a5dffc5a5810c9c7edad0c697800df32682f9c4ec49442c6e85cca031184b"
+        "version": "717481c366c5d07455245b3d24d558d6046f5606defb5db68a6aa1388d1c32fc"
     },
     "merge_functions.MergeWideDatetime.time_merge": {
-        "code": "class MergeWideDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeWideDatetime:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeWideDatetime.time_merge",
         "number": 1,
@@ -3781,15 +3781,15 @@
         "repeat": 5,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:468",
+        "setup_cache_key": "merge_functions:467",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "4d658e12e079c00f5d468ed7a82c1b2facd8de1b98e5388b569c1737a3d82607",
+        "version": "55774717fd65ab122bca30f931c474f1408f763412f579f2bc33642acdf30e50",
         "warmup_time": 0
     },
     "merge_functions.MergeWideRowRange.peakmem_merge": {
-        "code": "class MergeWideRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeWideRowRange:\n    def peakmem_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "name": "merge_functions.MergeWideRowRange.peakmem_merge",
         "param_names": [
             "scenario",
@@ -3814,14 +3814,14 @@
                 "100"
             ]
         ],
-        "setup_cache_key": "merge_functions:508",
+        "setup_cache_key": "merge_functions:507",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
-        "version": "f33e277e4413aa7b086be54628ec33080037cbdf369f347c5dd190ffca5a6fff"
+        "version": "8c890be84ffc4d698701cc495839ce082396d662febe8b4cc42e7bca62af6906"
     },
     "merge_functions.MergeWideRowRange.time_merge": {
-        "code": "class MergeWideRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target)\n            self._precompute_sources(library_name, target)",
+        "code": "class MergeWideRowRange:\n    def time_merge(self, scenario, strategy, on_count, source_size):\n        self.merge(strategy)\n\n    def setup(self, scenario, strategy, on_count, source_size):\n        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)\n\n    def setup_cache(self):\n        reset_bucket(self.seaweed, CACHE_BUCKET)\n        for scenario in self.params[0]:\n            num_rows, num_value_cols = scenario\n            rng = np.random.default_rng([num_rows, num_value_cols])\n            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)\n            library_name = lib_name(*scenario, self.INDEX_KIND)\n            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)\n            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)",
         "min_run_count": 2,
         "name": "merge_functions.MergeWideRowRange.time_merge",
         "number": 1,
@@ -3851,11 +3851,11 @@
         "repeat": 5,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "merge_functions:508",
+        "setup_cache_key": "merge_functions:507",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
-        "version": "8be4bc6bfde5a0e7db280ac5e667e58f53c945de9de79a16e0965936c6b6f547",
+        "version": "3f73079962007f3dc83486fc180caa05ef53dc62f5c9c301edbdb453c0f72ed0",
         "warmup_time": 0
     },
     "modification_functions.DeleteBatchSymbols.time_delete_batch_symbols": {

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -1658,6 +1658,12 @@ def query_stats_operation_count(stats, operation, key_type):
     return stats.get("storage_operations", {}).get(operation, {}).get(key_type, {}).get("count", 0)
 
 
+def min_rows_per_segment(rows_per_segment: int) -> int:
+    """Lower bound on the number of rows the C++ ColumnReslicer can put in a single row slice when resegmenting,
+    given a target of `rows_per_segment`. Mirrors cpp/arcticdb/column_store/column_reslicer.cpp."""
+    return max((2 * rows_per_segment) // 3, 1)
+
+
 def max_rows_per_segment(rows_per_segment: int) -> int:
     """Upper bound on the number of rows the C++ ColumnReslicer can put in a single row slice when resegmenting,
     given a target of `rows_per_segment`. Mirrors cpp/arcticdb/column_store/column_reslicer.cpp."""

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -1656,3 +1656,38 @@ def merge(
 
 def query_stats_operation_count(stats, operation, key_type):
     return stats.get("storage_operations", {}).get(operation, {}).get(key_type, {}).get("count", 0)
+
+
+def max_rows_per_segment(rows_per_segment: int) -> int:
+    """Upper bound on the number of rows the C++ ColumnReslicer can put in a single row slice when resegmenting,
+    given a target of `rows_per_segment`. Mirrors cpp/arcticdb/column_store/column_reslicer.cpp."""
+    return max((4 * rows_per_segment) // 3, rows_per_segment + 1)
+
+
+def assert_index_key_structure_static_schema(index_df: pd.DataFrame, rows_per_segment: int) -> None:
+    max_slice = max_rows_per_segment(rows_per_segment)
+    row_ranges = {}
+    prev_col_range = None
+
+    is_continuous_range = lambda lst: all(lst[i][0] == lst[i - 1][1] for i in range(1, len(lst)))
+    is_row_range_size_within_bounds = lambda rr: 1 <= rr[1] - rr[0] <= max_slice
+
+    for start_col, end_col, start_row, end_row in zip(
+        index_df["start_col"], index_df["end_col"], index_df["start_row"], index_df["end_row"]
+    ):
+        col_range, row_range = (start_col, end_col), (start_row, end_row)
+        row_ranges.setdefault(row_range, []).append(col_range)
+        if col_range != prev_col_range:
+            if prev_col_range is not None:
+                # Non decreasing column major order
+                assert col_range[0] == prev_col_range[1]
+            prev_col_range = col_range
+
+    if not row_ranges:
+        return
+
+    reference_col_slices = next(iter(row_ranges.values()))
+    assert is_continuous_range(reference_col_slices)
+    assert is_continuous_range(list(row_ranges.keys()))
+    assert all(is_row_range_size_within_bounds(row_range) for row_range in row_ranges.keys())
+    assert all(col_slices == reference_col_slices for col_slices in row_ranges.values())

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -13,7 +13,7 @@ import pandas as pd
 
 from arcticdb import Arctic
 from arcticdb.version_store.library import MergeStrategy
-from arcticdb.util.test import random_strings_of_length
+from arcticdb.util.test import max_rows_per_segment, random_strings_of_length
 
 from benchmarks.common import lib_name
 from benchmarks.seaweed_utils import SeaweedClient
@@ -22,6 +22,10 @@ CACHE_BUCKET = "arcticdb-merge-update-cache"
 WORK_BUCKET = "arcticdb-merge-work"
 ROWS_PER_SEGMENT = 100_000
 START_DATE = pd.Timestamp("1960-01-01")
+# Target of exactly one row slice, merged with a source large enough that reslicing splits it into MIN_SPLIT_SEGMENTS
+SPLIT_TARGET_ROWS = ROWS_PER_SEGMENT
+SPLIT_SOURCE_ROWS = 600_000
+MIN_SPLIT_SEGMENTS = 5
 random.seed(0)  # random_strings_of_length draws string pools from stdlib random
 
 
@@ -77,6 +81,10 @@ def generate_source_for_row_range(target, source_size, matched_count, rng, on=No
                 else np.linspace(0, 100_000, len(matched), dtype=value_dtype)
             )
     rest_count = source_size - len(matched)
+    if is_string and matched_count == 0:
+        # No row may match, so the pool must hold strings absent from the target. The target's strings are all 10
+        # characters long, so a longer one cannot be among them.
+        string_pool = [f"zz{value}" for value in string_pool]
     rest = pd.DataFrame(
         {
             col: (
@@ -88,7 +96,8 @@ def generate_source_for_row_range(target, source_size, matched_count, rng, on=No
             for col in target.columns
         }
     )
-    source = pd.concat([matched, rest])
+    # Concatenating an empty frame would upcast the dtypes
+    source = rest if matched.empty else pd.concat([matched, rest])
     source = source[~source.duplicated(subset=on, keep="first").values]
     source.index = pd.RangeIndex(len(source))
     return source.sample(frac=1, random_state=42).reset_index(drop=True)
@@ -210,8 +219,11 @@ class MergeBase:
                 value_dtype=self.value_dtype,
             )
         return generate_source_for_row_range(
-            target, source_size, source_size // 2, rng, on=on, value_dtype=self.value_dtype
+            target, source_size, self._row_range_matched_count(source_size), rng, on=on, value_dtype=self.value_dtype
         )
+
+    def _row_range_matched_count(self, source_size):
+        return source_size // 2
 
     def _source_sym(self, source_size, matched_slices=None):
         return f"src_{source_size}" if matched_slices is None else f"src_{source_size}_{matched_slices}"
@@ -513,4 +525,205 @@ class MergeWideRowRange(MergeBase):
         self.merge(strategy)
 
     def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+
+class MergeSplitSegmentsThinDatetime(MergeBase):
+    """
+    Insertion into a single full 100k row segment, long-thin numeric dataframe, datetime index. The source is
+    much larger than the target, so the merged row slice group is resliced into several output segments. All source
+    rows fall inside the target's index range and matching is done on an additional column.
+    """
+
+    INDEX_KIND = "datetime"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float32"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_slices"]
+        self.params = [
+            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            ["update_and_insert"],  # strategy
+            [1],  # on_count
+            [SPLIT_SOURCE_ROWS],  # source_size (source row count)
+            [1],  # matched_slices: the whole source lands in the target's single row slice
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            rng = np.random.default_rng([num_rows, num_value_cols])
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
+            library_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(library_name, target)
+            self._precompute_sources(library_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size, matched_slices):
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
+
+    def teardown(self, scenario, strategy, on_count, source_size, matched_slices):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices):
+        self.merge(strategy)
+
+
+class MergeSplitSegmentsThinStringDatetime(MergeBase):
+    """As MergeSplitSegmentsThinDatetime, with string columns so a string pool is rebuilt for every output segment."""
+
+    INDEX_KIND = "datetime"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "string"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_slices", "num_unique_strings"]
+        self.params = [
+            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            ["update_and_insert"],  # strategy
+            [1],  # on_count
+            [SPLIT_SOURCE_ROWS],  # source_size (source row count)
+            [1],  # matched_slices: the whole source lands in the target's single row slice
+            [5_000, 100_00],  # num_unique_strings (size of the pool each column is drawn from)
+        ]
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        parameter_map = dict(zip(self.param_names, self.params))
+        for scenario in parameter_map["scenario"]:
+            for num_unique_strings in parameter_map["num_unique_strings"]:
+                num_rows, num_value_cols = scenario
+                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])
+                target = generate_merge_target(
+                    num_rows,
+                    num_value_cols,
+                    self.value_dtype,
+                    self.INDEX_KIND,
+                    rng,
+                    num_unique_strings=num_unique_strings,
+                )
+                self.target_prefix = f"target_{num_unique_strings}"
+                self.source_prefix = f"source_{num_unique_strings}"
+                library_name = lib_name(*scenario, self.INDEX_KIND)
+                self._write_cache_target(library_name, target)
+                self._precompute_sources(library_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.target_prefix = f"target_{num_unique_strings}"
+        self.source_prefix = f"source_{num_unique_strings}"
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
+
+    def teardown(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
+        self.merge(strategy)
+
+
+class MergeSplitSegmentsThinRowRange(MergeBase):
+    """
+    Insertion after a single full 100k row segment, long-thin numeric dataframe, row-range index. No source row
+    matches, so all of them are appended and resliced into several output segments.
+    """
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "float32"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size"]
+        self.params = [
+            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            ["update_and_insert"],  # strategy
+            [1],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
+            [SPLIT_SOURCE_ROWS],  # source_size (source row count)
+        ]
+
+    def _row_range_matched_count(self, source_size):
+        return 0
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        for scenario in self.params[0]:
+            num_rows, num_value_cols = scenario
+            rng = np.random.default_rng([num_rows, num_value_cols])
+            target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
+            library_name = lib_name(*scenario, self.INDEX_KIND)
+            self._write_cache_target(library_name, target)
+            self._precompute_sources(library_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size):
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
+
+    def teardown(self, scenario, strategy, on_count, source_size):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size):
+        self.merge(strategy)
+
+
+class MergeSplitSegmentsThinStringRowRange(MergeBase):
+    """As MergeSplitSegmentsThinRowRange, with string columns so a string pool is rebuilt for every output segment."""
+
+    INDEX_KIND = "rowrange"
+
+    def __init__(self):
+        super().__init__()
+        self.value_dtype = "string"
+        self.param_names = ["scenario", "strategy", "on_count", "source_size", "num_unique_strings"]
+        self.params = [
+            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            ["update_and_insert"],  # strategy
+            # on_count: the source needs source_size unique join keys and the key space is
+            # num_unique_strings ** on_count, so one column would cap the source at the pool size.
+            [2],
+            [SPLIT_SOURCE_ROWS],  # source_size (source row count)
+            [5_000, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
+        ]
+
+    def _row_range_matched_count(self, source_size):
+        return 0
+
+    def setup_cache(self):
+        reset_bucket(self.seaweed, CACHE_BUCKET)
+        param_map = dict(zip(self.param_names, self.params))
+        for scenario in param_map["scenario"]:
+            for num_unique_strings in param_map["num_unique_strings"]:
+                num_rows, num_value_cols = scenario
+                rng = np.random.default_rng([num_rows, num_value_cols, num_unique_strings])
+                target = generate_merge_target(
+                    num_rows,
+                    num_value_cols,
+                    self.value_dtype,
+                    self.INDEX_KIND,
+                    rng,
+                    num_unique_strings=num_unique_strings,
+                )
+                self.target_prefix = f"target_{num_unique_strings}"
+                self.source_prefix = f"source_{num_unique_strings}"
+                library_name = lib_name(*scenario, self.INDEX_KIND)
+                self._write_cache_target(library_name, target)
+                self._precompute_sources(library_name, target)
+
+    def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.target_prefix = f"target_{num_unique_strings}"
+        self.source_prefix = f"source_{num_unique_strings}"
+        self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
+
+    def teardown(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.seaweed.delete_bucket(WORK_BUCKET)
+
+    def time_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):
+        self.merge(strategy)
+
+    def peakmem_merge(self, scenario, strategy, on_count, source_size, num_unique_strings):
         self.merge(strategy)

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -11,9 +11,9 @@ import random
 import numpy as np
 import pandas as pd
 
-from arcticdb import Arctic
+from arcticdb import Arctic, LibraryOptions
 from arcticdb.version_store.library import MergeStrategy
-from arcticdb.util.test import max_rows_per_segment, random_strings_of_length
+from arcticdb.util.test import random_strings_of_length
 
 from benchmarks.common import lib_name
 from benchmarks.seaweed_utils import SeaweedClient
@@ -22,10 +22,8 @@ CACHE_BUCKET = "arcticdb-merge-update-cache"
 WORK_BUCKET = "arcticdb-merge-work"
 ROWS_PER_SEGMENT = 100_000
 START_DATE = pd.Timestamp("1960-01-01")
-# Target of exactly one row slice, merged with a source large enough that reslicing splits it into MIN_SPLIT_SEGMENTS
-SPLIT_TARGET_ROWS = ROWS_PER_SEGMENT
-SPLIT_SOURCE_ROWS = 600_000
-MIN_SPLIT_SEGMENTS = 5
+SPLIT_ROWS_PER_SEGMENT = 10_000
+SPLIT_SOURCE_ROWS = 1_000_000
 random.seed(0)  # random_strings_of_length draws string pools from stdlib random
 
 
@@ -199,22 +197,23 @@ class MergeBase:
 
     SYM = "sym"
 
-    def _write_cache_target(self, lib_name, target):
+    def _write_cache_target(self, lib_name, target, rows_per_segment):
         uri = self.seaweed.arctic_uri(CACHE_BUCKET, self.target_prefix)
-        Arctic(uri).create_library(lib_name).write(self.SYM, target)
+        options = LibraryOptions(rows_per_segment=rows_per_segment)
+        Arctic(uri).create_library(lib_name, library_options=options).write(self.SYM, target)
 
-    def _generate_source(self, target, source_size, matched_slices=None):
+    def _generate_source(self, target, source_size, rows_per_segment, matched_slices=None):
         # Params-seeded rng: the same (class, params) always generate the identical source.
         rng = np.random.default_rng([source_size, matched_slices or 0])
         on = [f"val_{j}" for j in range(max(dict(zip(self.param_names, self.params))["on_count"]))]
         if self.INDEX_KIND == "datetime":
-            slices = matched_slices or max(1, len(target) // ROWS_PER_SEGMENT)
+            slices = matched_slices or max(1, len(target) // rows_per_segment)
             return generate_source_for_datetime(
                 target,
                 source_size,
                 rng,
                 affected_row_slice_idx=affected_slices(len(target), slices),
-                rows_per_segment=ROWS_PER_SEGMENT,
+                rows_per_segment=rows_per_segment,
                 on=on,
                 value_dtype=self.value_dtype,
             )
@@ -228,12 +227,12 @@ class MergeBase:
     def _source_sym(self, source_size, matched_slices=None):
         return f"src_{source_size}" if matched_slices is None else f"src_{source_size}_{matched_slices}"
 
-    def _precompute_sources(self, lib_name, target):
+    def _precompute_sources(self, lib_name, target, rows_per_segment):
         src_lib = Arctic(self.seaweed.arctic_uri(CACHE_BUCKET, self.source_prefix)).create_library(lib_name)
         parameter_map = dict(zip(self.param_names, self.params))
         for source_size in parameter_map["source_size"]:
             for matched_slices in parameter_map.get("matched_slices", [None]):
-                source = self._generate_source(target, source_size, matched_slices)
+                source = self._generate_source(target, source_size, rows_per_segment, matched_slices)
                 src_lib.write(self._source_sym(source_size, matched_slices), source)
 
     def _prepare_merge(self, lib_name, on_count, source_size, matched_slices=None):
@@ -280,8 +279,8 @@ class MergeThinDatetime(MergeBase):
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
             library_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(library_name, target)
-            self._precompute_sources(library_name, target)
+            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)
+            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size, matched_slices):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
@@ -320,8 +319,8 @@ class MergeThinRowRange(MergeBase):
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
             library_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(library_name, target)
-            self._precompute_sources(library_name, target)
+            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)
+            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
@@ -373,8 +372,8 @@ class MergeThinStringDatetime(MergeBase):
                 self.target_prefix = f"target_{num_unique_strings}"
                 self.source_prefix = f"source_{num_unique_strings}"
                 library_name = lib_name(*scenario, self.INDEX_KIND)
-                self._write_cache_target(library_name, target)
-                self._precompute_sources(library_name, target)
+                self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)
+                self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
         self.target_prefix = f"target_{num_unique_strings}"
@@ -429,8 +428,8 @@ class MergeThinStringRowRange(MergeBase):
                 self.target_prefix = f"target_{num_unique_strings}"
                 self.source_prefix = f"source_{num_unique_strings}"
                 library_name = lib_name(*scenario, self.INDEX_KIND)
-                self._write_cache_target(library_name, target)
-                self._precompute_sources(library_name, target)
+                self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)
+                self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):
         self.target_prefix = f"target_{num_unique_strings}"
@@ -472,8 +471,8 @@ class MergeWideDatetime(MergeBase):
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
             library_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(library_name, target)
-            self._precompute_sources(library_name, target)
+            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)
+            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
@@ -512,8 +511,8 @@ class MergeWideRowRange(MergeBase):
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
             library_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(library_name, target)
-            self._precompute_sources(library_name, target)
+            self._write_cache_target(library_name, target, ROWS_PER_SEGMENT)
+            self._precompute_sources(library_name, target, ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
@@ -542,7 +541,7 @@ class MergeSplitSegmentsThinDatetime(MergeBase):
         self.value_dtype = "float32"
         self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_slices"]
         self.params = [
-            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            [(SPLIT_ROWS_PER_SEGMENT, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
             ["update_and_insert"],  # strategy
             [1],  # on_count
             [SPLIT_SOURCE_ROWS],  # source_size (source row count)
@@ -556,8 +555,8 @@ class MergeSplitSegmentsThinDatetime(MergeBase):
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
             library_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(library_name, target)
-            self._precompute_sources(library_name, target)
+            self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)
+            self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size, matched_slices):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size, matched_slices)
@@ -582,12 +581,12 @@ class MergeSplitSegmentsThinStringDatetime(MergeBase):
         self.value_dtype = "string"
         self.param_names = ["scenario", "strategy", "on_count", "source_size", "matched_slices", "num_unique_strings"]
         self.params = [
-            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            [(SPLIT_ROWS_PER_SEGMENT, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
             ["update_and_insert"],  # strategy
             [1],  # on_count
             [SPLIT_SOURCE_ROWS],  # source_size (source row count)
             [1],  # matched_slices: the whole source lands in the target's single row slice
-            [5_000, 100_00],  # num_unique_strings (size of the pool each column is drawn from)
+            [5_000, 100_000],  # num_unique_strings (size of the pool each column is drawn from)
         ]
 
     def setup_cache(self):
@@ -608,8 +607,8 @@ class MergeSplitSegmentsThinStringDatetime(MergeBase):
                 self.target_prefix = f"target_{num_unique_strings}"
                 self.source_prefix = f"source_{num_unique_strings}"
                 library_name = lib_name(*scenario, self.INDEX_KIND)
-                self._write_cache_target(library_name, target)
-                self._precompute_sources(library_name, target)
+                self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)
+                self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size, matched_slices, num_unique_strings):
         self.target_prefix = f"target_{num_unique_strings}"
@@ -639,7 +638,7 @@ class MergeSplitSegmentsThinRowRange(MergeBase):
         self.value_dtype = "float32"
         self.param_names = ["scenario", "strategy", "on_count", "source_size"]
         self.params = [
-            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            [(SPLIT_ROWS_PER_SEGMENT, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
             ["update_and_insert"],  # strategy
             [1],  # on_count: row-range indexes cannot be a join key on their own, so on_count >= 1
             [SPLIT_SOURCE_ROWS],  # source_size (source row count)
@@ -655,8 +654,8 @@ class MergeSplitSegmentsThinRowRange(MergeBase):
             rng = np.random.default_rng([num_rows, num_value_cols])
             target = generate_merge_target(num_rows, num_value_cols, self.value_dtype, self.INDEX_KIND, rng)
             library_name = lib_name(*scenario, self.INDEX_KIND)
-            self._write_cache_target(library_name, target)
-            self._precompute_sources(library_name, target)
+            self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)
+            self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size):
         self._prepare_merge(lib_name(*scenario, self.INDEX_KIND), on_count, source_size)
@@ -681,7 +680,7 @@ class MergeSplitSegmentsThinStringRowRange(MergeBase):
         self.value_dtype = "string"
         self.param_names = ["scenario", "strategy", "on_count", "source_size", "num_unique_strings"]
         self.params = [
-            [(SPLIT_TARGET_ROWS, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
+            [(SPLIT_ROWS_PER_SEGMENT, 3)],  # scenario: (num_rows, num_value_cols) — exactly one row slice
             ["update_and_insert"],  # strategy
             # on_count: the source needs source_size unique join keys and the key space is
             # num_unique_strings ** on_count, so one column would cap the source at the pool size.
@@ -711,8 +710,8 @@ class MergeSplitSegmentsThinStringRowRange(MergeBase):
                 self.target_prefix = f"target_{num_unique_strings}"
                 self.source_prefix = f"source_{num_unique_strings}"
                 library_name = lib_name(*scenario, self.INDEX_KIND)
-                self._write_cache_target(library_name, target)
-                self._precompute_sources(library_name, target)
+                self._write_cache_target(library_name, target, SPLIT_ROWS_PER_SEGMENT)
+                self._precompute_sources(library_name, target, SPLIT_ROWS_PER_SEGMENT)
 
     def setup(self, scenario, strategy, on_count, source_size, num_unique_strings):
         self.target_prefix = f"target_{num_unique_strings}"

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -14,7 +14,12 @@ from arcticdb.version_store._store import MergeStrategy, MergeAction, normalize_
 from hypothesis import assume, strategies as st, given, settings, HealthCheck
 from typing import List, Tuple, Optional
 
-from arcticdb.util.test import assert_frame_equal, merge, random_strings_of_length_with_nan
+from arcticdb.util.test import (
+    assert_frame_equal,
+    assert_index_key_structure_static_schema,
+    merge,
+    random_strings_of_length_with_nan,
+)
 from tests.util.mark import MACOS, WINDOWS
 
 from arcticdb.options import LibraryOptions
@@ -280,37 +285,6 @@ def random_values_for_dtype(dtype, count):
     return np.random.randint(low, high, size=count, dtype=np.int64).astype(dtype)
 
 
-def assert_valid_index(index_df):
-    # Every column slice must be split into the exact same set of contiguous row ranges.
-    first_slice_row_ranges = None
-    current_col_range = None
-    current_row_ranges = []
-    prev_row_range = None
-
-    for start_col, end_col, start_row, end_row in zip(
-        index_df["start_col"], index_df["end_col"], index_df["start_row"], index_df["end_row"]
-    ):
-        col_range, row_range = (start_col, end_col), (start_row, end_row)
-        if current_col_range is None:
-            current_col_range = col_range
-        elif col_range != current_col_range:
-            assert col_range[0] == current_col_range[1]
-            if first_slice_row_ranges is None:
-                first_slice_row_ranges = current_row_ranges[:]
-            else:
-                assert current_row_ranges == first_slice_row_ranges
-            current_row_ranges, prev_row_range, current_col_range = [], None, col_range
-        if prev_row_range is not None:
-            assert row_range[0] == prev_row_range[1]
-        current_row_ranges.append(row_range)
-        prev_row_range = row_range
-
-    if first_slice_row_ranges is None:
-        first_slice_row_ranges = current_row_ranges
-    else:
-        assert current_row_ranges == first_slice_row_ranges
-
-
 def randomize_values(frame, positions, columns):
     if not len(positions) or not columns:
         return
@@ -401,6 +375,7 @@ def test_insert(s3_storage, strategy, index_type, data):
     )
     lib.write("symbol", target)
     lib.merge_experimental("symbol", source, strategy=strategy, on=on)
-    assert_valid_index(lib._dev_tools.library_tool().read_index("symbol"))
+    index_df = lib._dev_tools.library_tool().read_index("symbol")
+    assert_index_key_structure_static_schema(index_df, rows_per_segment=rows_per_segment)
     result = lib.read("symbol").data
     assert_frame_equal(result, expected)

--- a/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
@@ -23,6 +23,8 @@ from arcticdb.util.hypothesis import (
 from arcticdb.util.test import (
     assert_frame_equal,
     assert_series_equal,
+    max_rows_per_segment,
+    min_rows_per_segment,
     query_stats_operation_count,
     random_strings_of_length,
 )
@@ -59,13 +61,10 @@ def generic_append_compact_data_test(lib, sym, df, batch=False, **append_kwargs)
     assert_frame_equal_pl(expected, received)
     post_compaction_index = lib.read_index(sym)
     row_counts = post_compaction_index["end_row"] - post_compaction_index["start_row"]
-    # Definitions taken from CompactDataClause constructor
-    min_rows_per_segment = max((2 * rows_per_segment) // 3, 1)
-    max_rows_per_segment = max((4 * rows_per_segment) // 3, rows_per_segment + 1)
-    # There might be fewer rows in total than min_rows_per_segment
-    min_rows_per_segment = min(min_rows_per_segment, len(expected))
-    assert row_counts.min() >= min_rows_per_segment
-    assert row_counts.max() <= max_rows_per_segment
+    # There might be fewer rows in total than min_rows
+    min_rows = min(min_rows_per_segment(rows_per_segment), len(expected))
+    assert row_counts.min() >= min_rows
+    assert row_counts.max() <= max_rows_per_segment(rows_per_segment)
 
     post_compaction_data_keys = len(post_compaction_index)
     new_data_keys = len(post_compaction_index[post_compaction_index["version_id"] > vit_before_compaction.version])

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -27,6 +27,8 @@ from arcticdb.util.test import (
     assert_frame_equal,
     assert_series_equal,
     config_context,
+    max_rows_per_segment,
+    min_rows_per_segment,
     query_stats_operation_count,
     random_strings_of_length,
 )
@@ -96,14 +98,13 @@ def generic_compact_data_test(lib, sym, method_arg=None, batch=False):
         assert_frame_equal_pl(expected, received)
     post_compaction_index = lib.read_index(sym)
     row_counts = post_compaction_index["end_row"] - post_compaction_index["start_row"]
-    # Definitions taken from CompactDataClause constructor
-    min_rows_per_segment = max((2 * rows_per_segment) // 3, 1)
-    max_rows_per_segment = max((4 * rows_per_segment) // 3, rows_per_segment + 1)
+    min_rows = min_rows_per_segment(rows_per_segment)
+    max_rows = max_rows_per_segment(rows_per_segment)
     if not pickled:
-        # There might be fewer rows in total than min_rows_per_segment
-        min_rows_per_segment = min(min_rows_per_segment, len(expected))
-    assert row_counts.min() >= min_rows_per_segment
-    assert row_counts.max() <= max_rows_per_segment
+        # There might be fewer rows in total than min_rows
+        min_rows = min(min_rows, len(expected))
+    assert row_counts.min() >= min_rows
+    assert row_counts.max() <= max_rows
 
     post_compaction_data_keys = len(post_compaction_index)
     new_data_keys = len(post_compaction_index[post_compaction_index["version_id"] > vit_before_compaction.version])

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -7,6 +7,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import arcticdb
+import os
 from typing import List, Optional, Union
 import arcticdb.toolbox.query_stats as qs
 import numpy as np

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -6,26 +6,25 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
-import os
-import pytest
-import pandas as pd
-from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data, merge, query_stats_operation_count
 import arcticdb
+from typing import List, Optional, Union
+import arcticdb.toolbox.query_stats as qs
+import numpy as np
+import pandas as pd
+import pytest
+from arcticdb.exceptions import ArcticException, StorageException, UnsortedDataException, UserInputException
+from arcticdb.util.test import (
+    assert_frame_equal,
+    assert_index_key_structure_static_schema,
+    assert_vit_equals_except_data,
+    merge,
+    query_stats_operation_count,
+)
 from arcticdb.version_store import VersionedItem
+from arcticdb.version_store._store import normalize_merge_action
+from arcticdb.version_store.library import MergeAction, MergeStrategy
 from arcticdb_ext.exceptions import SchemaException
 from arcticdb_ext.storage import KeyType
-import numpy as np
-from arcticdb.exceptions import (
-    UserInputException,
-    UnsortedDataException,
-    StorageException,
-    ArcticException,
-)
-from arcticdb.version_store.library import MergeAction, MergeStrategy
-from arcticdb.version_store._store import normalize_merge_action
-from typing import Union, List, Optional
-import arcticdb.toolbox.query_stats as qs
-
 from arcticdb_ext.version_store import MergeAction
 
 pytestmark = [
@@ -3172,6 +3171,780 @@ class TestMergeRowrangeUpdateAndInsert:
         lib.write("sym", target)
         with pytest.raises(UserInputException):
             lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)],
+    ids=["do_nothing_insert", "update_insert"],
+)
+class TestMergeInsertRowSlicingRowRange:
+
+    def test_insert_splits_into_multiple_row_slices(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": ["a", "b", "c", "d", "e", "f"]})
+        source = pd.DataFrame(
+            {
+                "a": [1, 101, 102, 103, 104, 105, 106, 107, 108, 109],
+                "b": ["Z", "A", "B", "C", "D", "E", "F", "G", "H", "I"],
+            }
+        )
+        lib.write("sym", target)
+        # With update the first segment is rewritten
+        # Inserts slices unmatched rows and appends them at the back
+        expected_data_key_writes = 4 if strategy.matched == MergeAction.UPDATE else 3
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105, 106, 107, 108, 109],
+                    "b": [
+                        "Z",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                        "F",
+                        "G",
+                        "H",
+                        "I",
+                    ],
+                }
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105, 106, 107, 108, 109],
+                    "b": [
+                        "a",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                        "F",
+                        "G",
+                        "H",
+                        "I",
+                    ],
+                }
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    @pytest.mark.parametrize(
+        "num_unmatched, source_a, source_b, expected_a, expected_b, expected_num_segments, expected_data_key_writes",
+        [
+            (
+                3,
+                [100, 101, 102],
+                ["A", "B", "C"],
+                [1, 2, 100, 101, 102],
+                ["a", "b", "A", "B", "C"],
+                2,
+                1,
+            ),
+            (
+                4,
+                [100, 101, 102, 103],
+                ["A", "B", "C", "D"],
+                [1, 2, 100, 101, 102, 103],
+                ["a", "b", "A", "B", "C", "D"],
+                2,
+                1,
+            ),
+            (
+                5,
+                [100, 101, 102, 103, 104],
+                ["A", "B", "C", "D", "E"],
+                [1, 2, 100, 101, 102, 103, 104],
+                ["a", "b", "A", "B", "C", "D", "E"],
+                3,
+                2,
+            ),
+        ],
+        ids=["max_minus_one", "max", "max_plus_one"],
+    )
+    def test_insert_at_max_boundary(
+        self,
+        mem_library_factory,
+        strategy,
+        num_unmatched,
+        source_a,
+        source_b,
+        expected_a,
+        expected_b,
+        expected_num_segments,
+        expected_data_key_writes,
+    ):
+        """
+        Rows per segment is 3. Using the formula for max allowed rows for reslicing
+        max((4 * rows_per_segment) / 3, rows_per_segment + 1) the maximum allowed rows are 4. Test with row slice size
+        around that value (one less, exactly the same and one more) to catch off-by-one errors
+        """
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1, 2], "b": ["a", "b"]})
+        source = pd.DataFrame({"a": source_a, "b": source_b})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        expected = pd.DataFrame({"a": expected_a, "b": expected_b})
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_alternating_matched_unmatched(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]}
+        )
+        source = pd.DataFrame(
+            {
+                "a": [1, 101, 3, 103, 5, 105, 7, 107, 9, 109],
+                "b": ["Z", "A", "Y", "B", "X", "C", "W", "D", "V", "E"],
+            }
+        )
+        lib.write("sym", target)
+        # All four segments on disk are matched
+        # Inserted data is sliced into two segments and apended
+        expected_data_key_writes = 6 if strategy.matched == MergeAction.UPDATE else 2
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 101, 103, 105, 107, 109],
+                    "b": [
+                        "a",
+                        "Z",
+                        "c",
+                        "Y",
+                        "e",
+                        "X",
+                        "g",
+                        "W",
+                        "i",
+                        "V",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                    ],
+                }
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 101, 103, 105, 107, 109],
+                    "b": [
+                        "a",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "g",
+                        "h",
+                        "i",
+                        "j",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                    ],
+                }
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_all_source_rows_unmatched(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": ["a", "b", "c", "d", "e", "f"]})
+        source = pd.DataFrame({"a": [101, 102, 103, 104, 105, 106, 107], "b": ["A", "B", "C", "D", "E", "F", "G"]})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105, 106, 107],
+                "b": ["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F", "G"],
+            }
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_target_empty(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": np.array([], dtype=np.int64), "b": np.array([], dtype=np.float64)})
+        source = pd.DataFrame({"a": [10, 20, 30, 40, 50], "b": [10.0, 20.0, 30.0, 40.0, 50.0]})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame({"a": [10, 20, 30, 40, 50], "b": [10.0, 20.0, 30.0, 40.0, 50.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_with_column_slicing(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, columns_per_segment=2))
+        target = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+                "b": ["a", "b", "c", "d", "e", "f"],
+                "c": [10, 20, 30, 40, 50, 60],
+                "d": ["aa", "bb", "cc", "dd", "ee", "ff"],
+                "e": [100, 200, 300, 400, 500, 600],
+                "f": ["aaa", "bbb", "ccc", "ddd", "eee", "fff"],
+            }
+        )
+        source = pd.DataFrame(
+            {
+                "a": [3, 101, 102, 103, 104, 105],
+                "b": ["Z", "A", "B", "C", "D", "E"],
+                "c": [3000, 110, 120, 130, 140, 150],
+                "d": ["ZZ", "AA", "BB", "CC", "DD", "EE"],
+                "e": [30000, 1100, 1200, 1300, 1400, 1500],
+                "f": ["ZZZ", "AAA", "BBB", "CCC", "DDD", "EEE"],
+            }
+        )
+        lib.write("sym", target)
+        expected_data_key_writes = 9 if strategy.matched == MergeAction.UPDATE else 6
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105],
+                    "b": ["a", "b", "Z", "d", "e", "f", "A", "B", "C", "D", "E"],
+                    "c": [10, 20, 3000, 40, 50, 60, 110, 120, 130, 140, 150],
+                    "d": ["aa", "bb", "ZZ", "dd", "ee", "ff", "AA", "BB", "CC", "DD", "EE"],
+                    "e": [100, 200, 30000, 400, 500, 600, 1100, 1200, 1300, 1400, 1500],
+                    "f": [
+                        "aaa",
+                        "bbb",
+                        "ZZZ",
+                        "ddd",
+                        "eee",
+                        "fff",
+                        "AAA",
+                        "BBB",
+                        "CCC",
+                        "DDD",
+                        "EEE",
+                    ],
+                }
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105],
+                    "b": ["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E"],
+                    "c": [10, 20, 30, 40, 50, 60, 110, 120, 130, 140, 150],
+                    "d": ["aa", "bb", "cc", "dd", "ee", "ff", "AA", "BB", "CC", "DD", "EE"],
+                    "e": [100, 200, 300, 400, 500, 600, 1100, 1200, 1300, 1400, 1500],
+                    "f": ["aaa", "bbb", "ccc", "ddd", "eee", "fff", "AAA", "BBB", "CCC", "DDD", "EEE"],
+                }
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_duplicate_unmatched_on_values_across_slice_boundary(self, mem_library_factory, strategy):
+        """Unmatched rows are inserted in order even when there are duplicates"""
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1], "b": ["a"]})
+        source = pd.DataFrame({"a": [7, 7, 7, 7, 7, 8], "b": ["A", "B", "C", "D", "E", "F"]})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame({"a": [1, 7, 7, 7, 7, 7, 8], "b": ["a", "A", "B", "C", "D", "E", "F"]})
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)],
+    ids=["do_nothing_insert", "update_insert"],
+)
+class TestMergeDatetimeInsertRowSlicing:
+
+    def test_interleaved_insert_slices_touched_groups(self, mem_library_factory, strategy):
+        """
+        When inserting values in a middle of the segment, the segment must be split.
+        """
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"b": [1.0, 3.0, 5.0, 7.0, 9.0, 11.0], "s": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-03", "2024-01-05", "2024-01-07", "2024-01-09", "2024-01-11"]
+            ),
+        )
+        source = pd.DataFrame(
+            {"b": [2.0, 6.0, 8.0, 10.0], "s": ["A", "B", "C", "D"]},
+            index=pd.DatetimeIndex(["2024-01-02", "2024-01-06", "2024-01-08", "2024-01-10"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
+        expected = pd.DataFrame(
+            {
+                "b": [1.0, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+                "s": ["a", "A", "b", "c", "B", "d", "C", "e", "D", "f"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-05",
+                    "2024-01-06",
+                    "2024-01-07",
+                    "2024-01-08",
+                    "2024-01-09",
+                    "2024-01-10",
+                    "2024-01-11",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    @pytest.mark.parametrize(
+        "target_index, target_b, target_s, expected_index, expected_b, expected_s, expected_num_segments",
+        [
+            (
+                pd.date_range("2024-01-01", periods=6),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                ["a", "b", "c", "d", "e", "f"],
+                pd.DatetimeIndex(
+                    [
+                        "2024-01-01",
+                        "2024-01-02",
+                        "2024-01-03",
+                        "2024-01-04",
+                        "2024-01-05",
+                        "2024-01-06",
+                        "2024-01-10",
+                        "2024-01-11",
+                        "2024-01-12",
+                        "2024-01-13",
+                        "2024-01-14",
+                        "2024-01-15",
+                        "2024-01-16",
+                    ]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                ["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F", "G"],
+                4,
+            ),
+            (
+                pd.date_range("2024-01-01", periods=5),
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                ["a", "b", "c", "d", "e"],
+                pd.DatetimeIndex(
+                    [
+                        "2024-01-01",
+                        "2024-01-02",
+                        "2024-01-03",
+                        "2024-01-04",
+                        "2024-01-05",
+                        "2024-01-10",
+                        "2024-01-11",
+                        "2024-01-12",
+                        "2024-01-13",
+                        "2024-01-14",
+                        "2024-01-15",
+                        "2024-01-16",
+                    ]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                ["a", "b", "c", "d", "e", "A", "B", "C", "D", "E", "F", "G"],
+                4,
+            ),
+        ],
+        ids=["full_last_segment", "partial_last_segment"],
+    )
+    def test_insert_after_last_timestamp_slices_tail(
+        self,
+        mem_library_factory,
+        strategy,
+        target_index,
+        target_b,
+        target_s,
+        expected_index,
+        expected_b,
+        expected_s,
+        expected_num_segments,
+    ):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"b": target_b, "s": target_s}, index=target_index)
+        source = pd.DataFrame(
+            {"b": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0], "s": ["A", "B", "C", "D", "E", "F", "G"]},
+            index=pd.date_range("2024-01-10", periods=7),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 3
+        expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    @pytest.mark.parametrize(
+        "target_index, target_b, target_s, expected_index, expected_b, expected_s, expected_num_segments",
+        [
+            (
+                pd.date_range("2024-01-10", periods=6),
+                [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                ["a", "b", "c", "d", "e", "f"],
+                pd.DatetimeIndex(
+                    [
+                        "2024-01-01",
+                        "2024-01-02",
+                        "2024-01-03",
+                        "2024-01-04",
+                        "2024-01-05",
+                        "2024-01-10",
+                        "2024-01-11",
+                        "2024-01-12",
+                        "2024-01-13",
+                        "2024-01-14",
+                        "2024-01-15",
+                    ]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                ["A", "B", "C", "D", "E", "a", "b", "c", "d", "e", "f"],
+                3,
+            ),
+            (
+                pd.DatetimeIndex(["2024-01-10", "2024-01-11"]),
+                [10.0, 11.0],
+                ["a", "b"],
+                pd.DatetimeIndex(
+                    ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-10", "2024-01-11"]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0],
+                ["A", "B", "C", "D", "E", "a", "b"],
+                2,
+            ),
+        ],
+        ids=["full_first_segment", "partial_first_segment"],
+    )
+    def test_insert_before_first_timestamp(
+        self,
+        mem_library_factory,
+        strategy,
+        target_index,
+        target_b,
+        target_s,
+        expected_index,
+        expected_b,
+        expected_s,
+        expected_num_segments,
+    ):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"b": target_b, "s": target_s}, index=target_index)
+        source = pd.DataFrame(
+            {"b": [1.0, 2.0, 3.0, 4.0, 5.0], "s": ["A", "B", "C", "D", "E"]},
+            index=pd.date_range("2024-01-01", periods=5),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_index_value_spanning_two_slices(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-02", "2024-01-02", "2024-01-02", "2024-01-03", "2024-01-04"]
+            ),
+        )
+        # on=["a"] means the Jan2 source rows are unmatched despite the equal timestamps.
+        source = pd.DataFrame(
+            {"a": [20, 21, 22, 50], "b": ["A", "B", "C", "D"]},
+            index=pd.DatetimeIndex(["2024-01-02", "2024-01-02", "2024-01-02", "2024-01-05"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 3
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 20, 21, 22, 5, 6, 50],
+                "b": ["a", "b", "c", "d", "A", "B", "C", "e", "f", "D"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-04",
+                    "2024-01-05",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_index_value_spanning_three_slices(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i"]},
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-04",
+                ]
+            ),
+        )
+        source = pd.DataFrame({"a": [999], "b": ["A"]}, index=pd.DatetimeIndex(["2024-01-03"]))
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 7, 8, 999, 9],
+                "b": ["a", "b", "c", "d", "e", "f", "g", "h", "A", "i"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-04",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_matched_update_inside_resliced_group(self, mem_library_factory, strategy):
+        """Update happens in a row slice that is being resliced"""
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"b": [1.0, 2.0, 5.0, 6.0, 7.0, 8.0], "s": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-02", "2024-01-05", "2024-01-06", "2024-01-07", "2024-01-08"]
+            ),
+        )
+        source = pd.DataFrame(
+            {"b": [10.0, 1.25, 1.5], "s": ["Z", "A", "B"]},
+            index=pd.DatetimeIndex(["2024-01-01", "2024-01-01 06:00:00", "2024-01-01 12:00:00"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected_index = pd.DatetimeIndex(
+            [
+                "2024-01-01",
+                "2024-01-01 06:00:00",
+                "2024-01-01 12:00:00",
+                "2024-01-02",
+                "2024-01-05",
+                "2024-01-06",
+                "2024-01-07",
+                "2024-01-08",
+            ]
+        )
+        if strategy.matched == MergeAction.UPDATE:
+            expected_b = [10.0, 1.25, 1.5, 2.0, 5.0, 6.0, 7.0, 8.0]
+            expected_s = ["Z", "A", "B", "b", "c", "d", "e", "f"]
+        else:
+            expected_b = [1.0, 1.25, 1.5, 2.0, 5.0, 6.0, 7.0, 8.0]
+            expected_s = ["a", "A", "B", "b", "c", "d", "e", "f"]
+        expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_with_column_slicing(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, columns_per_segment=2))
+        target = pd.DataFrame(
+            {
+                "a": [1, 4, 8],
+                "b": ["a", "b", "c"],
+                "c": [10, 40, 80],
+                "d": ["aa", "bb", "cc"],
+                "e": [100, 400, 800],
+                "f": ["aaa", "bbb", "ccc"],
+            },
+            index=pd.DatetimeIndex(["2024-01-01", "2024-01-04", "2024-01-08"]),
+        )
+        source = pd.DataFrame(
+            {
+                "a": [2, 3, 400, 5, 6, 7],
+                "b": ["A", "B", "Z", "C", "D", "E"],
+                "c": [20, 30, 440, 50, 60, 70],
+                "d": ["AA", "BB", "ZZ", "CC", "DD", "EE"],
+                "e": [200, 300, 4400, 500, 600, 700],
+                "f": ["AAA", "BBB", "ZZZ", "CCC", "DDD", "EEE"],
+            },
+            index=pd.DatetimeIndex(
+                ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06", "2024-01-07"]
+            ),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 6
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 400, 5, 6, 7, 8],
+                    "b": ["a", "A", "B", "Z", "C", "D", "E", "c"],
+                    "c": [10, 20, 30, 440, 50, 60, 70, 80],
+                    "d": ["aa", "AA", "BB", "ZZ", "CC", "DD", "EE", "cc"],
+                    "e": [100, 200, 300, 4400, 500, 600, 700, 800],
+                    "f": ["aaa", "AAA", "BBB", "ZZZ", "CCC", "DDD", "EEE", "ccc"],
+                },
+                index=pd.date_range("2024-01-01", periods=8),
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 7, 8],
+                    "b": ["a", "A", "B", "b", "C", "D", "E", "c"],
+                    "c": [10, 20, 30, 40, 50, 60, 70, 80],
+                    "d": ["aa", "AA", "BB", "bb", "CC", "DD", "EE", "cc"],
+                    "e": [100, 200, 300, 400, 500, 600, 700, 800],
+                    "f": ["aaa", "AAA", "BBB", "bbb", "CCC", "DDD", "EEE", "ccc"],
+                },
+                index=pd.date_range("2024-01-01", periods=8),
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_merging_touches_only_first_row_slice(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        # Row slices [0,3) = [Jan1, Jan8, Jan9], [3,6) = [Jan20, Jan21, Jan22].
+        target = pd.DataFrame(
+            {"b": [1.0, 8.0, 9.0, 20.0, 21.0, 22.0], "s": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-08", "2024-01-09", "2024-01-20", "2024-01-21", "2024-01-22"]
+            ),
+        )
+        # 5 unmatched rows, all inside the first group's index range. Second slice is untouched. The result from
+        # inserting in the first slice is resliced
+        source = pd.DataFrame(
+            {"b": [2.0, 3.0, 4.0, 5.0, 6.0], "s": ["A", "B", "C", "D", "E"]},
+            index=pd.DatetimeIndex(["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame(
+            {
+                "b": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 20.0, 21.0, 22.0],
+                "s": ["a", "A", "B", "C", "D", "E", "b", "c", "d", "e", "f"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-04",
+                    "2024-01-05",
+                    "2024-01-06",
+                    "2024-01-08",
+                    "2024-01-09",
+                    "2024-01-20",
+                    "2024-01-21",
+                    "2024-01-22",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
 
 class TestMergeMultiindexUpdate:

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -3756,8 +3756,9 @@ class TestMergeDatetimeInsertRowSlicing:
         index_df = lib._dev_tools.library_tool().read_index("sym")
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
-    def test_index_value_spanning_three_slices(self, mem_library_factory, strategy):
-        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+    @pytest.mark.parametrize("dedup", [True, False])
+    def test_index_value_spanning_three_slices(self, mem_library_factory, strategy, dedup):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, dedup=dedup))
         target = pd.DataFrame(
             {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i"]},
             index=pd.DatetimeIndex(
@@ -3780,7 +3781,7 @@ class TestMergeDatetimeInsertRowSlicing:
         with qs.query_stats():
             lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
-        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == (2 if dedup else 4)
         expected = pd.DataFrame(
             {
                 "a": [1, 2, 3, 4, 5, 6, 7, 8, 999, 9],
@@ -3804,64 +3805,6 @@ class TestMergeDatetimeInsertRowSlicing:
         assert_frame_equal(lib.read("sym").data, expected)
         index_df = lib._dev_tools.library_tool().read_index("sym")
         assert (index_df["end_row"] - index_df["start_row"]).tolist() == [3, 3, 3, 1]
-        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
-
-    def test_index_value_spanning_three_slices_dedup(self, mem_library_factory, strategy):
-        """
-        Same as test_index_value_spanning_three_slices. 2024-01-03 spans all three row slices, so the first two
-        row slice groups are merged and resliced as one unit of 9 rows and the last row slice is re-emitted on its
-        own. The first two output segments happen to hold exactly the rows of the first two input segments, so with
-        de-duplication enabled their data keys are reused and only 2 of the 4 segments are written.
-        """
-        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, dedup=True))
-        target = pd.DataFrame(
-            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i"]},
-            index=pd.DatetimeIndex(
-                [
-                    "2024-01-01",
-                    "2024-01-02",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-04",
-                ]
-            ),
-        )
-        source = pd.DataFrame({"a": [999], "b": ["A"]}, index=pd.DatetimeIndex(["2024-01-03"]))
-        lib.write("sym", target)
-        qs.reset_stats()
-        with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
-        stats = qs.get_query_stats()
-        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
-        expected = pd.DataFrame(
-            {
-                "a": [1, 2, 3, 4, 5, 6, 7, 8, 999, 9],
-                "b": ["a", "b", "c", "d", "e", "f", "g", "h", "A", "i"],
-            },
-            index=pd.DatetimeIndex(
-                [
-                    "2024-01-01",
-                    "2024-01-02",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-03",
-                    "2024-01-04",
-                ]
-            ),
-        )
-        assert_frame_equal(lib.read("sym").data, expected)
-        index_df = lib._dev_tools.library_tool().read_index("sym")
-        assert (index_df["end_row"] - index_df["start_row"]).tolist() == [3, 3, 3, 1]
-        # The first two data keys are the ones written by lib.write
-        assert index_df["version_id"].tolist() == [0, 0, 1, 1]
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
     def test_matched_update_inside_resliced_group(self, mem_library_factory, strategy):

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -3311,6 +3311,7 @@ class TestMergeInsertRowSlicingRowRange:
         expected = pd.DataFrame({"a": expected_a, "b": expected_b})
         assert_frame_equal(lib.read("sym").data, expected)
         index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert len(index_df) == expected_num_segments
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
     def test_alternating_matched_unmatched(self, mem_library_factory, strategy):
@@ -3552,6 +3553,9 @@ class TestMergeDatetimeInsertRowSlicing:
         )
         assert_frame_equal(lib.read("sym").data, expected)
         index_df = lib._dev_tools.library_tool().read_index("sym")
+        # Each of the two touched row slices is resliced on its own. Reslicing the whole 10 row table at once would
+        # give [3, 3, 4] instead.
+        assert (index_df["end_row"] - index_df["start_row"]).tolist() == [2, 3, 2, 3]
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
     @pytest.mark.parametrize(
@@ -3636,6 +3640,7 @@ class TestMergeDatetimeInsertRowSlicing:
         expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
         assert_frame_equal(lib.read("sym").data, expected)
         index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert len(index_df) == expected_num_segments
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
     @pytest.mark.parametrize(
@@ -3705,6 +3710,7 @@ class TestMergeDatetimeInsertRowSlicing:
         expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
         assert_frame_equal(lib.read("sym").data, expected)
         index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert len(index_df) == expected_num_segments
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
     def test_index_value_spanning_two_slices(self, mem_library_factory, strategy):
@@ -3797,6 +3803,65 @@ class TestMergeDatetimeInsertRowSlicing:
         )
         assert_frame_equal(lib.read("sym").data, expected)
         index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert (index_df["end_row"] - index_df["start_row"]).tolist() == [3, 3, 3, 1]
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_index_value_spanning_three_slices_dedup(self, mem_library_factory, strategy):
+        """
+        Same as test_index_value_spanning_three_slices. 2024-01-03 spans all three row slices, so the first two
+        row slice groups are merged and resliced as one unit of 9 rows and the last row slice is re-emitted on its
+        own. The first two output segments happen to hold exactly the rows of the first two input segments, so with
+        de-duplication enabled their data keys are reused and only 2 of the 4 segments are written.
+        """
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, dedup=True))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i"]},
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-04",
+                ]
+            ),
+        )
+        source = pd.DataFrame({"a": [999], "b": ["A"]}, index=pd.DatetimeIndex(["2024-01-03"]))
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 7, 8, 999, 9],
+                "b": ["a", "b", "c", "d", "e", "f", "g", "h", "A", "i"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-04",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert (index_df["end_row"] - index_df["start_row"]).tolist() == [3, 3, 3, 1]
+        # The first two data keys are the ones written by lib.write
+        assert index_df["version_id"].tolist() == [0, 0, 1, 1]
         assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
     def test_matched_update_inside_resliced_group(self, mem_library_factory, strategy):


### PR DESCRIPTION
This branch implements row slicing for merge update.
Monday Ticket: 12846079278

Row slicing can happen only if the strategy allows insertion. It's impossible to trigger for update-only strategy.

There are two cases based on the index of the dataframe. Both cases use the `ReslicingInfo` class and the strategy of max size = `4/3 * rows_per_segment` from the compaction algorithm. Neither of the two options allocates one big chunk and then slices it. Both options use the `ReslicingInfo` to see how much row slices are there and and create that many slices with the row count prescribed by `ReslicingInfo`

# Merge update
## `Datetime`

For `Datetime` the logic is in 2 places.

* `update_and_insert` finds the number of unmatched rows and computes the total row count for the insertion. It creates the `ReslicingInfo` and then calls `merge` column by column.
* `merge` is the function that performs the merging of source and target and the updates (if required). It's mostly unchanged. It still calls `advance_output` to move the tip of the output where new data is placed but now it tracks which row slice is used and if rows per slice is exceeded it moves to the next slice.

Keeping track of new row sliced becomes a bit harder. The non-sliced version had 1:1 mapping between input row range and output row range. Now one input row range can be split into several output row ranges. A new component is introduced which keeps track of this. Each entity produced by the MergeUpdate clause has `MergeUpdateRowSlicingInfoComponent` it tracks the number of segments the input row range was split into, the index of the row range this entity represents and the number of rows in the current row range. Version core then groups all entities by their input row range.

## `Rowrange`

Row range must be performed after the pipeline ends in order to gather all unmatched rows and combine them. All unmatched rows are still appended at the end, but the `ReslicingInfo` is used to compute the number of row slices. This has an optimization of the previous iteration that column slices are processed (data is copied from source to the result) in parallel

# Other changes
* WriteClause is changed to forward all entities it got from the previous clause instead of discarding them and creating new entities.