### PR TITLE
Make prune_previous a library option

### DIFF
--- a/cpp/arcticdb/storage/library_manager.cpp
+++ b/cpp/arcticdb/storage/library_manager.cpp
@@ -158,6 +158,9 @@ void LibraryManager::modify_library_option(
                 case ModifiableLibraryOption::RECURSIVE_NORMALIZERS:
                     mutable_write_options->set_recursive_normalizers(get_bool(new_value));
                     break;
+                case ModifiableLibraryOption::PRUNE_PREVIOUS_VERSIONS:
+                    mutable_write_options->set_prune_previous_version(get_bool(new_value));
+                    break;
                 default:
                     throw UnsupportedLibraryOptionValue(fmt::format("Invalid library option: {}", option));
                 }

--- a/cpp/arcticdb/storage/library_manager.hpp
+++ b/cpp/arcticdb/storage/library_manager.hpp
@@ -20,7 +20,8 @@ enum class ModifiableLibraryOption {
     DEDUP = 1,
     ROWS_PER_SEGMENT = 2,
     COLUMNS_PER_SEGMENT = 3,
-    RECURSIVE_NORMALIZERS = 4
+    RECURSIVE_NORMALIZERS = 4,
+    PRUNE_PREVIOUS_VERSIONS = 5
 };
 enum class ModifiableEnterpriseLibraryOption { REPLICATION = 1, BACKGROUND_DELETION = 2 };
 using LibraryOptionValue = std::variant<bool, int64_t>;
@@ -108,6 +109,8 @@ struct formatter<arcticdb::storage::ModifiableLibraryOption> {
             return fmt::format_to(ctx.out(), "COLUMNS_PER_SEGMENT");
         case arcticdb::storage::ModifiableLibraryOption::RECURSIVE_NORMALIZERS:
             return fmt::format_to(ctx.out(), "RECURSIVE_NORMALIZERS");
+        case arcticdb::storage::ModifiableLibraryOption::PRUNE_PREVIOUS_VERSIONS:
+            return fmt::format_to(ctx.out(), "PRUNE_PREVIOUS_VERSIONS");
         default:
             arcticdb::util::raise_rte("Unrecognized modifiable option {}", int(o));
         }

--- a/cpp/arcticdb/storage/python_bindings.cpp
+++ b/cpp/arcticdb/storage/python_bindings.cpp
@@ -47,7 +47,8 @@ void register_bindings(py::module& storage, py::exception<arcticdb::ArcticExcept
             .value("DEDUP", ModifiableLibraryOption::DEDUP)
             .value("ROWS_PER_SEGMENT", ModifiableLibraryOption::ROWS_PER_SEGMENT)
             .value("COLUMNS_PER_SEGMENT", ModifiableLibraryOption::COLUMNS_PER_SEGMENT)
-            .value("RECURSIVE_NORMALIZERS", ModifiableLibraryOption::RECURSIVE_NORMALIZERS);
+            .value("RECURSIVE_NORMALIZERS", ModifiableLibraryOption::RECURSIVE_NORMALIZERS)
+            .value("PRUNE_PREVIOUS_VERSIONS", ModifiableLibraryOption::PRUNE_PREVIOUS_VERSIONS);
 
     py::enum_<ModifiableEnterpriseLibraryOption>(storage, "ModifiableEnterpriseLibraryOption", R"pbdoc(
          Enterprise library options that can be modified after library creation.

--- a/python/arcticdb/adapters/arctic_library_adapter.py
+++ b/python/arcticdb/adapters/arctic_library_adapter.py
@@ -28,7 +28,6 @@ def set_library_options(
     write_options.fast_tombstone_all = True
     lib_desc.version.symbol_list = True
 
-    write_options.prune_previous_version = False
     write_options.pickle_on_failure = False
     write_options.snapshot_dedup = False
     write_options.delayed_deletes = False
@@ -38,6 +37,7 @@ def set_library_options(
     write_options.segment_row_size = options.rows_per_segment
     write_options.column_group_size = options.columns_per_segment
     write_options.recursive_normalizers = options.recursive_normalizers
+    write_options.prune_previous_version = options.prune_previous_versions
 
     lib_desc.version.encoding_version = (
         options.encoding_version if options.encoding_version is not None else DEFAULT_ENCODING_VERSION

--- a/python/arcticdb/options.py
+++ b/python/arcticdb/options.py
@@ -35,6 +35,8 @@ class LibraryOptions:
         See `__init__` for details.
     recursive_normalizers: bool
         See `__init__` for details.
+    prune_previous_versions: bool
+        See `__init__` for details.
     """
 
     def __init__(
@@ -46,6 +48,7 @@ class LibraryOptions:
         columns_per_segment: int = 127,
         encoding_version: Optional[EncodingVersion] = None,
         recursive_normalizers: bool = False,
+        prune_previous_versions: bool = False,
     ):
         """
         Parameters
@@ -139,6 +142,18 @@ class LibraryOptions:
                 lib.write(symbol, data) # ArcticUnsupportedDataTypeException will be thrown by default
                 lib2 = ac.create_library(lib_name, LibraryOptions(recursive_normalizers=True))
                 lib2.write(symbol, data) # data will be successfully written
+
+        prune_previous_versions: bool, default False
+            The default value of the ``prune_previous_versions`` argument for the library's modification methods
+            (``write``, ``append``, ``update``, and so on). When those methods are called without an explicit
+            ``prune_previous_versions`` argument, this library-level setting is used.
+
+            If False (the default), modification methods keep previous versions unless the caller passes
+            ``prune_previous_versions=True``. If True, modification methods prune previous (non-snapshotted) versions
+            by default; a caller can still override per call by passing ``prune_previous_versions=False``.
+
+            This option can be changed after creation via ``Arctic.modify_library_option`` with
+            ``ModifiableLibraryOption.PRUNE_PREVIOUS_VERSIONS``.
         """
         self.dynamic_schema = dynamic_schema
         self.dedup = dedup
@@ -146,6 +161,7 @@ class LibraryOptions:
         self.columns_per_segment = columns_per_segment
         self.encoding_version = encoding_version
         self.recursive_normalizers = recursive_normalizers
+        self.prune_previous_versions = prune_previous_versions
 
     def __eq__(self, right):
         return (
@@ -155,6 +171,7 @@ class LibraryOptions:
             and self.columns_per_segment == right.columns_per_segment
             and self.encoding_version == right.encoding_version
             and self.recursive_normalizers == right.recursive_normalizers
+            and self.prune_previous_versions == right.prune_previous_versions
         )
 
     def __repr__(self):
@@ -162,7 +179,8 @@ class LibraryOptions:
             f"LibraryOptions(dynamic_schema={self.dynamic_schema}, dedup={self.dedup},"
             f" rows_per_segment={self.rows_per_segment}, columns_per_segment={self.columns_per_segment},"
             f" encoding_version={self.encoding_version if self.encoding_version is not None else 'Default'},"
-            f" recursive_normalizers={self.recursive_normalizers})"
+            f" recursive_normalizers={self.recursive_normalizers},"
+            f" prune_previous_versions={self.prune_previous_versions})"
         )
 
 

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4386,7 +4386,7 @@ class NativeVersionStore:
         strategy: MergeStrategy = MergeStrategy(),
         on: Optional[List[str]] = None,
         metadata: Any = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         upsert: bool = False,
     ):
         """
@@ -4433,8 +4433,8 @@ class NativeVersionStore:
             index.
         metadata : Any, optional
             Metadata to save alongside the new version.
-        prune_previous_versions : bool, default False
-            If True, removes previous versions from the version list.
+        prune_previous_versions : bool, default=None
+            If True, removes previous versions from the version list. Uses library default if left as None.
         upsert : bool, default False
             If True and the symbol does not exist, create it by writing `source` to the store. Requires a strategy
             with `not_matched_by_target="insert"`; combining it with an update-only strategy raises
@@ -4481,6 +4481,12 @@ class NativeVersionStore:
             norm_failure_options_msg="Source data must be normalizable in order to merge it into existing dataframe",
         )
         on = [] if on is None else on
+        prune_previous_versions = resolve_defaults(
+            "prune_previous_version",
+            self._write_options(),
+            global_default=False,
+            existing_value=prune_previous_versions,
+        )
         vit = self.version_store.merge(symbol, item, norm_meta, udm, prune_previous_versions, upsert, strategy, on)
         return self._convert_thin_cxx_item_to_python(vit, metadata)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1010,7 +1010,7 @@ class Library:
         symbol: str,
         data: NormalizableType,
         metadata: Any = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         staged=False,
         validate_index=True,
         index_column: bool = False,
@@ -1050,8 +1050,9 @@ class Library:
             Data to be written. To write non-normalizable data, use `write_pickle`.
         metadata : Any, default=None
             Optional metadata to persist along with the symbol.
-        prune_previous_versions : bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions : Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
         staged: bool, default=False
             Deprecated. Use stage() instead.
             Whether to write to a staging area rather than immediately to the library.
@@ -1145,7 +1146,7 @@ class Library:
         symbol: str,
         data: Any,
         metadata: Any = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         staged=False,
         recursive_normalizers: bool = None,
     ) -> VersionedItem:
@@ -1228,7 +1229,7 @@ class Library:
         raise ArcticUnsupportedDataTypeException(error_message)
 
     def write_batch(
-        self, payloads: List[WritePayload], prune_previous_versions: bool = False, validate_index=True
+        self, payloads: List[WritePayload], prune_previous_versions: Optional[bool] = None, validate_index=True
     ) -> List[Union[VersionedItem, DataError]]:
         """
         Write a batch of multiple symbols.
@@ -1237,8 +1238,9 @@ class Library:
         ----------
         payloads : `List[WritePayload]`
             Symbols and their corresponding data. There must not be any duplicate symbols in `payload`.
-        prune_previous_versions: `bool`, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions: `Optional[bool]`, default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
         validate_index: bool, default=True
             Verify that each entry in the batch has an index that supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
@@ -1306,7 +1308,7 @@ class Library:
         )
 
     def write_pickle_batch(
-        self, payloads: List[WritePayload], prune_previous_versions: bool = False
+        self, payloads: List[WritePayload], prune_previous_versions: Optional[bool] = None
     ) -> List[Union[VersionedItem, DataError]]:
         """
         Write a batch of multiple symbols, pickling their data if necessary.
@@ -1315,8 +1317,9 @@ class Library:
         ----------
         payloads : `List[WritePayload]`
             Symbols and their corresponding data. There must not be any duplicate symbols in `payload`.
-        prune_previous_versions: `bool`, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions: `Optional[bool]`, default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
 
         Returns
         -------
@@ -1352,7 +1355,7 @@ class Library:
         symbol: str,
         data: NormalizableType,
         metadata: Any = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         validate_index: bool = True,
         index_column: bool = False,
         compact_data: bool = False,
@@ -1380,8 +1383,9 @@ class Library:
         metadata
             Optional metadata to persist along with the new symbol version. Note that the metadata is
             not combined in any way with the metadata stored in the previous version.
-        prune_previous_versions
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions: Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
         validate_index
             If True, verify that the index of `data` supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
@@ -1458,7 +1462,7 @@ class Library:
     def append_batch(
         self,
         append_payloads: List[WritePayload],
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         validate_index: bool = True,
         compact_data: bool = False,
     ) -> List[Union[VersionedItem, DataError]]:
@@ -1473,8 +1477,9 @@ class Library:
         ----------
         append_payloads : `List[WritePayload]`
             Symbols and their corresponding data. There must not be any duplicate symbols in `append_payloads`.
-        prune_previous_versions : bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions : Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
         validate_index: bool, default=True
             Verify that each entry in the batch has an index that supports date range searches and update operations.
             This tests that the data is sorted in ascending order, using Pandas DataFrame.index.is_monotonic_increasing.
@@ -1525,7 +1530,7 @@ class Library:
         metadata: Any = None,
         upsert: bool = False,
         date_range: Optional[Tuple[Optional[Timestamp], Optional[Timestamp]]] = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         index_column: bool = False,
     ) -> VersionedItem:
         """
@@ -1565,8 +1570,9 @@ class Library:
             ``data``. This allows the user to update with data that might only be a subset of the stored value. Leaving
             any part of the tuple as None leaves that part of the range open ended. Only data with date_range will be
             modified, even if ``data`` covers a wider date range.
-        prune_previous_versions: bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions: Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
         index_column: bool, default=False
             Only applicable when data is a PyArrow Table or Polars DataFrame. If True, the first column
             is treated as the timeseries index.
@@ -1645,7 +1651,7 @@ class Library:
         self,
         update_payloads: List[UpdatePayload],
         upsert: bool = False,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> List[Union[VersionedItem, DataError]]:
         """
         Perform an update operation on a list of symbols in parallel. All constrains on
@@ -1657,8 +1663,9 @@ class Library:
             List of `UpdatePayload`. Each element of the list describes an update operation for a
             particular symbol. Providing the symbol name, data, etc. The same symbol should not appear twice in this
             list.
-        prune_previous_versions: bool, default=False
-            Removes previous (non-snapshotted) versions from the library.
+        prune_previous_versions: Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the library. If None, the value is taken from the
+            library configuration (defaults to False).
         upsert: bool, default=False
             If True any symbol in `update_payloads` which is not already in the library will be created.
 
@@ -1741,7 +1748,7 @@ class Library:
         self,
         symbol: str,
         mode: Optional[Union[StagedDataFinalizeMethod, str]] = StagedDataFinalizeMethod.WRITE,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         metadata: Any = None,
         validate_index=True,
         delete_staged_data_on_failure: bool = False,
@@ -1776,8 +1783,9 @@ class Library:
 
             Also accepts strings "write" or "append" (case-insensitive).
 
-        prune_previous_versions: bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions: Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
         metadata : Any, default=None
             Optional metadata to persist along with the symbol.
         validate_index: bool, default=True
@@ -1875,7 +1883,7 @@ class Library:
         self,
         symbol: str,
         mode: Optional[Union[StagedDataFinalizeMethod, str]] = StagedDataFinalizeMethod.WRITE,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         metadata: Any = None,
         delete_staged_data_on_failure: bool = False,
         stage_results: Optional[List[StageResult]] = None,
@@ -1910,8 +1918,9 @@ class Library:
 
             Also accepts strings "write" or "append" (case-insensitive).
 
-        prune_previous_versions : bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions : Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
 
         metadata : Any, default=None
             Optional metadata to persist along with the symbol.
@@ -1979,6 +1988,12 @@ class Library:
         2024-01-04    4
         """
         mode = Library._normalize_staged_data_mode(mode)
+        prune_previous_versions = self._nvs.resolve_defaults(
+            "prune_previous_version",
+            self._nvs._write_options(),
+            global_default=False,
+            existing_value=prune_previous_versions,
+        )
         compaction_result = self._nvs.version_store.sort_merge(
             symbol,
             normalize_metadata(metadata),
@@ -2536,7 +2551,7 @@ class Library:
         self,
         symbol: str,
         metadata: Any,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> VersionedItem:
         """
         Write metadata under the specified symbol name to this library. The data will remain unchanged.
@@ -2555,9 +2570,10 @@ class Library:
             Symbol name for the item
         metadata
             Metadata to persist along with the symbol
-        prune_previous_versions : bool, default=False
+        prune_previous_versions : Optional[bool], default=None
             Removes previous (non-snapshotted) versions from the database. Note that metadata is versioned alongside the
-            data it is referring to, and so this operation removes old versions of data as well as metadata.
+            data it is referring to, and so this operation removes old versions of data as well as metadata. If None,
+            the value is taken from the library configuration (defaults to False).
 
         Returns
         -------
@@ -2569,7 +2585,7 @@ class Library:
     def write_metadata_batch(
         self,
         write_metadata_payloads: List[WriteMetadataPayload],
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> List[Union[VersionedItem, DataError]]:
         """
         Write metadata to multiple symbols in a batch fashion. This is more efficient than making multiple `write_metadata` calls
@@ -2584,9 +2600,10 @@ class Library:
         ----------
         write_metadata_payloads : `List[WriteMetadataPayload]`
             Symbols and their corresponding metadata. There must not be any duplicate symbols in `payload`.
-        prune_previous_versions : bool, default=False
+        prune_previous_versions : Optional[bool], default=None
             Removes previous (non-snapshotted) versions from the database. Note that metadata is versioned alongside the
-            data it is referring to, and so this operation removes old versions of data as well as metadata.
+            data it is referring to, and so this operation removes old versions of data as well as metadata. If None,
+            the value is taken from the library configuration (defaults to False).
 
         Returns
         -------
@@ -2752,7 +2769,7 @@ class Library:
         self,
         symbol: str,
         date_range: Tuple[Optional[Timestamp], Optional[Timestamp]],
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> None:
         """Delete data within the given date range, creating a new version of ``symbol``.
 
@@ -2765,8 +2782,9 @@ class Library:
         date_range
             The date range in which to delete data. Leaving any part of the tuple as None leaves that part of the range
             open ended.
-        prune_previous_versions : bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions : Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
 
         Examples
         --------
@@ -3260,7 +3278,7 @@ class Library:
         self,
         symbol: str,
         rows_per_segment: Optional[int] = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> VersionedItem:
         """
         Compact the data keys associated with the latest version of a symbol such that the number of rows in each
@@ -3279,8 +3297,9 @@ class Library:
             The target number of rows for each segment after the compaction. If None, uses the library configuration
             setting. Note that subsequent calls to write, append, and update will continue to use the library
             configuration setting.
-        prune_previous_versions : bool, default=False
-            If True, removes previous versions from the version list.
+        prune_previous_versions : Optional[bool], default=None
+            If True, removes previous versions from the version list. If None, the value is taken from the
+            library configuration (defaults to False).
 
         Returns
         -------
@@ -3317,7 +3336,7 @@ class Library:
         self,
         symbols: List[str],
         rows_per_segment: Optional[int] = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> List[Union[VersionedItem, DataError]]:
         """
         Compact the data keys associated with the latest versions of a collection of symbols such that the number of
@@ -3336,8 +3355,9 @@ class Library:
             The target number of rows for each segment after the compaction. If None, uses the library configuration
             setting. Note that subsequent calls to write, append, and update will continue to use the library
             configuration setting.
-        prune_previous_versions : bool, default=False
-            If True, removes previous versions from the version list.
+        prune_previous_versions : Optional[bool], default=None
+            If True, removes previous versions from the version list. If None, the value is taken from the
+            library configuration (defaults to False).
 
         Returns
         -------
@@ -3414,7 +3434,7 @@ class Library:
         self,
         symbol: str,
         segment_size: Optional[int] = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
     ) -> VersionedItem:
         """
         This method has been deprecated and will be removed in a future release. Please use compact_data instead.
@@ -3440,8 +3460,9 @@ class Library:
             If parameter is not provided, library option - "segment_row_size" will be used
             Note that no. of rows per segment, after compaction, may exceed the target.
             It is for achieving smallest no. of segment after compaction. Please refer to below example for further explanation.
-        prune_previous_versions : bool, default=False
-            Removes previous (non-snapshotted) versions from the database.
+        prune_previous_versions : Optional[bool], default=None
+            Removes previous (non-snapshotted) versions from the database. If None, the value is taken from the
+            library configuration (defaults to False).
 
         Returns
         -------
@@ -3486,7 +3507,7 @@ class Library:
         strategy: MergeStrategy = MergeStrategy(),
         on: Optional[List[str]] = None,
         metadata: Any = None,
-        prune_previous_versions: bool = False,
+        prune_previous_versions: Optional[bool] = None,
         upsert: bool = False,
     ):
         """
@@ -3533,8 +3554,9 @@ class Library:
             index.
         metadata : Any, optional
             Metadata to save alongside the new version.
-        prune_previous_versions : bool, default False
-            If True, removes previous versions from the version list.
+        prune_previous_versions : Optional[bool], default None
+            If True, removes previous versions from the version list. If None, the value is taken from the
+            library configuration (defaults to False).
         upsert : bool, default False
             If True and the symbol does not exist, create it by writing `source` to the store. Requires a strategy
             with `not_matched_by_target="insert"`; combining it with an update-only strategy raises

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -935,6 +935,8 @@ class Library:
             rows_per_segment=write_options.segment_row_size,
             columns_per_segment=write_options.column_group_size,
             encoding_version=self._nvs.lib_cfg().lib_desc.version.encoding_version,
+            recursive_normalizers=write_options.recursive_normalizers,
+            prune_previous_versions=write_options.prune_previous_version,
         )
 
     def enterprise_options(self) -> EnterpriseLibraryOptions:

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -386,6 +386,8 @@ def test_library_options(arctic_client, lib_name):
         rows_per_segment=20,
         columns_per_segment=3,
         encoding_version=EncodingVersion.V2,
+        recursive_normalizers=True,
+        prune_previous_versions=True,
     )
     lib_name_eo = f"{lib_name}_eo"  # explicit options
     ac.create_library(
@@ -400,7 +402,61 @@ def test_library_options(arctic_client, lib_name):
     assert write_options.segment_row_size == 20
     assert write_options.column_group_size == 3
     assert write_options.dynamic_strings
+    assert write_options.recursive_normalizers
+    assert write_options.prune_previous_version
     assert lib._nvs._lib_cfg.lib_desc.version.encoding_version == EncodingVersion.V2
+
+
+def test_library_options_recursive_normalizers_round_trip(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    ac.create_library(lib_name, LibraryOptions(recursive_normalizers=True))
+    options = ac[lib_name].options()
+    assert options.recursive_normalizers is True
+    assert options == LibraryOptions(recursive_normalizers=True, encoding_version=ac._encoding_version)
+
+
+def test_library_options_prune_previous_versions_round_trip(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    ac.create_library(lib_name, LibraryOptions(prune_previous_versions=True))
+    options = ac[lib_name].options()
+    assert options.prune_previous_versions is True
+    assert options == LibraryOptions(prune_previous_versions=True, encoding_version=ac._encoding_version)
+
+
+def test_get_library_create_if_missing_with_recursive_normalizers(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    ac.create_library(lib_name, LibraryOptions(recursive_normalizers=True))
+    lib = ac.get_library(lib_name, create_if_missing=True, library_options=LibraryOptions(recursive_normalizers=True))
+    assert lib.options() == LibraryOptions(recursive_normalizers=True, encoding_version=ac._encoding_version)
+    with pytest.raises(MismatchingLibraryOptions):
+        ac.get_library(lib_name, create_if_missing=True, library_options=LibraryOptions(recursive_normalizers=False))
+
+
+def test_get_library_create_if_missing_with_prune_previous_versions(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    ac.create_library(lib_name, LibraryOptions(prune_previous_versions=True))
+    lib = ac.get_library(lib_name, create_if_missing=True, library_options=LibraryOptions(prune_previous_versions=True))
+    assert lib.options() == LibraryOptions(prune_previous_versions=True, encoding_version=ac._encoding_version)
+    with pytest.raises(MismatchingLibraryOptions):
+        ac.get_library(lib_name, create_if_missing=True, library_options=LibraryOptions(prune_previous_versions=False))
+
+
+def test_modify_recursive_normalizers_reflected_in_library_options(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    lib = ac.create_library(lib_name)
+    ac.modify_library_option(lib, ModifiableLibraryOption.RECURSIVE_NORMALIZERS, True)
+    options = Arctic(ac.get_uri())[lib_name].options()
+    assert options.recursive_normalizers is True
+    assert options == LibraryOptions(recursive_normalizers=True, encoding_version=ac._encoding_version)
+
+
+def test_modify_prune_previous_versions_reflected_in_library_options(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    lib = ac.create_library(lib_name)
+    ac.modify_library_option(lib, ModifiableLibraryOption.PRUNE_PREVIOUS_VERSIONS, True)
+    options = Arctic(ac.get_uri())[lib_name].options()
+    assert options.prune_previous_versions is True
+    assert options == LibraryOptions(prune_previous_versions=True, encoding_version=ac._encoding_version)
 
 
 @pytest.mark.storage

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -16,6 +16,7 @@ from arcticdb import QueryBuilder
 from arcticdb.exceptions import UserInputException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import assert_frame_equal, assert_series_equal, config_context
+from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
 from arcticdb.version_store.library import Library
 from arcticdb_ext import set_config_int
 import arcticdb_ext.cpp_async as adb_async
@@ -97,6 +98,9 @@ def test_update_int_nan(object_and_mem_and_lmdb_version_store_dynamic_schema):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Only dynamic strings are supported on Windows")
+@pytest.mark.skipif(
+    _use_pyarrow_strings_in_pandas(), reason="Fixed-width strings unsupported with string dtype columns"
+)
 @pytest.mark.storage
 def test_append_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
@@ -148,6 +152,9 @@ def test_append_fixed_width_to_dynamic_strings(object_and_mem_and_lmdb_version_s
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Only dynamic strings are supported on Windows")
+@pytest.mark.skipif(
+    _use_pyarrow_strings_in_pandas(), reason="Fixed-width strings unsupported with string dtype columns"
+)
 @pytest.mark.storage
 def test_update_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
@@ -310,9 +317,11 @@ def test_date_range_multi_index(lmdb_version_store):
     )
     lib.write(sym, existing_df)
 
+    # Empty slice of a string index rather than a bare [], so the level's dtype matches whatever pandas infers
+    # for strings: object without future.infer_string, str with it.
     expected_df = pd.DataFrame(
         {"col": pd.Series([], dtype=np.int64)},
-        index=pd.MultiIndex.from_arrays([pd.DatetimeIndex([]), []], names=["dt_level", "str_level"]),
+        index=pd.MultiIndex.from_arrays([pd.DatetimeIndex([]), pd.Index(["a"])[:0]], names=["dt_level", "str_level"]),
     )
     result_df = lib.read(sym, date_range=DateRange(pd.Timestamp("2099-01-01"), pd.Timestamp("2099-01-02"))).data
     assert_frame_equal(result_df, expected_df)
@@ -504,7 +513,7 @@ def test_resampling_non_timeseries(lmdb_version_store_v1):
     df = pd.DataFrame({"col": np.arange(10)})
     lib.write(sym, df)
     q = QueryBuilder().resample("1min").agg({"col": "sum"})
-    with pytest.raises(UserInputException):
+    with pytest.raises(SchemaException):
         lib.read(sym, query_builder=q)
     q = (
         QueryBuilder()
@@ -512,7 +521,7 @@ def test_resampling_non_timeseries(lmdb_version_store_v1):
         .resample("1min")
         .agg({"col": "sum"})
     )
-    with pytest.raises(UserInputException) as e:
+    with pytest.raises(SchemaException) as e:
         lib.read(sym, query_builder=q)
     assert "std::length_error(vector::reserve)" not in str(e.value)
 

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -16,7 +16,6 @@ from arcticdb import QueryBuilder
 from arcticdb.exceptions import UserInputException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import assert_frame_equal, assert_series_equal, config_context
-from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
 from arcticdb.version_store.library import Library
 from arcticdb_ext import set_config_int
 import arcticdb_ext.cpp_async as adb_async
@@ -98,9 +97,6 @@ def test_update_int_nan(object_and_mem_and_lmdb_version_store_dynamic_schema):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Only dynamic strings are supported on Windows")
-@pytest.mark.skipif(
-    _use_pyarrow_strings_in_pandas(), reason="Fixed-width strings unsupported with string dtype columns"
-)
 @pytest.mark.storage
 def test_append_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
@@ -152,9 +148,6 @@ def test_append_fixed_width_to_dynamic_strings(object_and_mem_and_lmdb_version_s
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="SKIP_WIN Only dynamic strings are supported on Windows")
-@pytest.mark.skipif(
-    _use_pyarrow_strings_in_pandas(), reason="Fixed-width strings unsupported with string dtype columns"
-)
 @pytest.mark.storage
 def test_update_dynamic_to_fixed_width_strings(object_and_mem_and_lmdb_version_store_dynamic_schema):
     lib = object_and_mem_and_lmdb_version_store_dynamic_schema
@@ -317,11 +310,9 @@ def test_date_range_multi_index(lmdb_version_store):
     )
     lib.write(sym, existing_df)
 
-    # Empty slice of a string index rather than a bare [], so the level's dtype matches whatever pandas infers
-    # for strings: object without future.infer_string, str with it.
     expected_df = pd.DataFrame(
         {"col": pd.Series([], dtype=np.int64)},
-        index=pd.MultiIndex.from_arrays([pd.DatetimeIndex([]), pd.Index(["a"])[:0]], names=["dt_level", "str_level"]),
+        index=pd.MultiIndex.from_arrays([pd.DatetimeIndex([]), []], names=["dt_level", "str_level"]),
     )
     result_df = lib.read(sym, date_range=DateRange(pd.Timestamp("2099-01-01"), pd.Timestamp("2099-01-02"))).data
     assert_frame_equal(result_df, expected_df)
@@ -513,7 +504,7 @@ def test_resampling_non_timeseries(lmdb_version_store_v1):
     df = pd.DataFrame({"col": np.arange(10)})
     lib.write(sym, df)
     q = QueryBuilder().resample("1min").agg({"col": "sum"})
-    with pytest.raises(SchemaException):
+    with pytest.raises(UserInputException):
         lib.read(sym, query_builder=q)
     q = (
         QueryBuilder()
@@ -521,7 +512,7 @@ def test_resampling_non_timeseries(lmdb_version_store_v1):
         .resample("1min")
         .agg({"col": "sum"})
     )
-    with pytest.raises(SchemaException) as e:
+    with pytest.raises(UserInputException) as e:
         lib.read(sym, query_builder=q)
     assert "std::length_error(vector::reserve)" not in str(e.value)
 

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -113,7 +113,7 @@ def test_finalize_staged_data(arctic_library_lmdb, input_mode, expected_append):
     default_args = {
         "convert_int_to_float": False,
         "metadata": None,
-        "prune_previous_version": False,
+        "prune_previous_version": None,
         "validate_index": True,
         "delete_staged_data_on_failure": False,
         "stage_results": None,

--- a/python/tests/unit/arcticdb/version_store/test_library_options.py
+++ b/python/tests/unit/arcticdb/version_store/test_library_options.py
@@ -27,8 +27,9 @@ def setup_write_then_stage(lib):
     lib.write(SYM, DF_1, prune_previous_versions=False)
     lib.stage(SYM, DF_2)
 
+
 def list_versions(lib):
-    return sorted(v.version for v in lib.list_versions(SYM)) 
+    return sorted(v.version for v in lib.list_versions(SYM))
 
 
 Operation = namedtuple("Operation", ["setup", "run", "created_versions"])

--- a/python/tests/unit/arcticdb/version_store/test_library_options.py
+++ b/python/tests/unit/arcticdb/version_store/test_library_options.py
@@ -1,0 +1,211 @@
+from collections import namedtuple
+
+import pandas as pd
+import pytest
+
+from arcticdb import LibraryOptions
+from arcticdb.version_store.library import StagedDataFinalizeMethod, UpdatePayload, WriteMetadataPayload, WritePayload
+from arcticdb_ext.storage import ModifiableLibraryOption
+
+SYM = "sym"
+DF_1 = pd.DataFrame({"col": [1, 2]}, index=pd.date_range("2024-01-01", periods=2))
+DF_2 = pd.DataFrame({"col": [3, 4]}, index=pd.date_range("2024-01-03", periods=2))
+DF_UPDATE = pd.DataFrame({"col": [10]}, index=pd.date_range("2024-01-01", periods=1))
+MERGE_SOURCE = pd.DataFrame({"col": [99]}, index=pd.date_range("2024-01-02", periods=1))
+
+
+def setup_one_write(lib):
+    lib.write(SYM, DF_1, prune_previous_versions=False)
+
+
+def setup_write_then_append(lib):
+    lib.write(SYM, DF_1, prune_previous_versions=False)
+    lib.append(SYM, DF_2, prune_previous_versions=False)
+
+
+def setup_write_then_stage(lib):
+    lib.write(SYM, DF_1, prune_previous_versions=False)
+    lib.stage(SYM, DF_2)
+
+def list_versions(lib):
+    return sorted(v.version for v in lib.list_versions(SYM)) 
+
+
+Operation = namedtuple("Operation", ["setup", "run", "created_versions"])
+
+OPERATIONS = [
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.write(SYM, DF_2, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="write",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.write_pickle(SYM, {"a": 1}, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="write_pickle",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.write_batch([WritePayload(SYM, DF_2)], **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="write_batch",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.write_pickle_batch([WritePayload(SYM, {"a": 1})], **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="write_pickle_batch",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.append(SYM, DF_2, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="append",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.append_batch([WritePayload(SYM, DF_2)], **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="append_batch",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.update(SYM, DF_UPDATE, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="update",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.update_batch([UpdatePayload(SYM, DF_UPDATE)], **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="update_batch",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_write_then_stage,
+            run=lambda lib, kwargs: lib.finalize_staged_data(SYM, StagedDataFinalizeMethod.WRITE, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="finalize_staged_data",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_write_then_stage,
+            run=lambda lib, kwargs: lib.sort_and_finalize_staged_data(SYM, StagedDataFinalizeMethod.WRITE, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="sort_and_finalize_staged_data",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.write_metadata(SYM, {"m": 1}, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="write_metadata",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.write_metadata_batch([WriteMetadataPayload(SYM, {"m": 1})], **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="write_metadata_batch",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.delete_data_in_range(
+                SYM, (pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")), **kwargs
+            ),
+            created_versions=(0, 1),
+        ),
+        id="delete_data_in_range",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_one_write,
+            run=lambda lib, kwargs: lib.merge_experimental(SYM, MERGE_SOURCE, **kwargs),
+            created_versions=(0, 1),
+        ),
+        id="merge_experimental",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_write_then_append,
+            run=lambda lib, kwargs: lib.compact_data(SYM, **kwargs),
+            created_versions=(0, 1, 2),
+        ),
+        id="compact_data",
+    ),
+    pytest.param(
+        Operation(
+            setup=setup_write_then_append,
+            run=lambda lib, kwargs: lib.compact_data_batch([SYM], **kwargs),
+            created_versions=(0, 1, 2),
+        ),
+        id="compact_data_batch",
+    ),
+]
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_library_option_true_prunes_when_argument_omitted(lmdb_library_factory, operation):
+    lib = lmdb_library_factory(LibraryOptions(prune_previous_versions=True))
+    operation.setup(lib)
+    operation.run(lib, {})
+    assert list_versions(lib) == [max(operation.created_versions)]
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_library_option_defaults_to_false(lmdb_library_factory, operation):
+    lib = lmdb_library_factory()
+    operation.setup(lib)
+    operation.run(lib, {})
+    assert list_versions(lib) == sorted(operation.created_versions)
+
+
+@pytest.mark.parametrize("operation", OPERATIONS)
+def test_explicit_false_argument_overrides_library_option(lmdb_library_factory, operation):
+    lib = lmdb_library_factory(LibraryOptions(prune_previous_versions=True))
+    operation.setup(lib)
+    operation.run(lib, {"prune_previous_versions": False})
+    assert list_versions(lib) == sorted(operation.created_versions)
+
+
+def test_modify_library_option_to_true_prunes_when_argument_omitted(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    lib = ac.create_library(lib_name)
+    lib.write(SYM, DF_1, prune_previous_versions=False)
+    ac.modify_library_option(lib, ModifiableLibraryOption.PRUNE_PREVIOUS_VERSIONS, True)
+    assert lib._nvs.lib_cfg().lib_desc.version.write_options.prune_previous_version
+    lib.write(SYM, DF_2)
+    assert list_versions(lib) == [1]
+
+
+def test_modify_library_option_to_false_stops_pruning(lmdb_storage, lib_name):
+    ac = lmdb_storage.create_arctic()
+    lib = ac.create_library(lib_name, library_options=LibraryOptions(prune_previous_versions=True))
+    ac.modify_library_option(lib, ModifiableLibraryOption.PRUNE_PREVIOUS_VERSIONS, False)
+    assert not lib._nvs.lib_cfg().lib_desc.version.write_options.prune_previous_version
+    lib.write(SYM, DF_1)
+    lib.write(SYM, DF_2)
+    assert list_versions(lib) == [0, 1]


### PR DESCRIPTION
This PR makes prune previous a proper library option.
Monday Ticket: 12783692495

The defaults for each method in the V2 API are changed. The default is now None which defaults to using the library option. Library option itself defaults to False, thus there are no functional changes.

This also fixes some bugs the recursive_normalizers library option.