### PR TITLE
Performance Improvement on VAST storage: Set CURLOPT_DNS_SHUFFLE_ADDRESSES in our S3 client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,13 @@ protoc: ## Generate protobuf stubs
 	$(_ENV) $(PROXY_CMD) $(_VENV_PYTHON) setup.py protoc --build-lib python
 
 # ── venv ─────────────────────────────────────────────────────────────────────
-venv: ## Create a dev venv (NAME=<name> required, CLEAN=1 to replace existing)
+venv: ## Create a dev venv (VENV_NAME=<name> required, CLEAN=1 to replace existing)
 ifdef CLEAN
 	rm -rf $(VENV_DIR)/$(VENV_NAME)
 endif
 	./build_tooling/create_venv.sh $(if $(PROXY_CMD),--proxy-cmd $(PROXY_CMD)) $(VENV_DIR)/$(VENV_NAME)
 
-activate: ## Print venv activate path (NAME=<name> required). Use: source $$(make activate NAME=x)
+activate: ## Print venv activate path (VENV_NAME=<name> required). Use: source $$(make activate VENV_NAME=x)
 	@echo $(VENV_DIR)/$(VENV_NAME)/bin/activate
 
 # ── setup ────────────────────────────────────────────────────────────────────

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -14,6 +14,11 @@
 #include <arcticdb/storage/s3/ec2_utils.hpp>
 #include <cstdarg>
 #include <vector>
+#ifndef WIN32
+#include <aws/core/http/standard/StandardHttpRequest.h>
+#include <aws/core/http/URI.h>
+#include <signal.h>
+#endif
 
 namespace arcticdb::storage::s3 {
 
@@ -68,6 +73,67 @@ void SpdlogLogSystem::LogStream(
 
 void SpdlogLogSystem::Flush() { log::s3().flush(); }
 
+#ifndef WIN32
+namespace {
+constexpr const char* ARCTIC_CURL_ALLOCATION_TAG = "ArcticCurlHttpClient";
+} // namespace
+
+bool dns_shuffle_addresses_enabled() {
+    return ConfigsMap::instance()->get_int("S3Storage.DnsShuffleAddresses", 1) != 0;
+}
+
+ArcticCurlHttpClient::ArcticCurlHttpClient(const Aws::Client::ClientConfiguration& client_configuration) :
+    Aws::Http::CurlHttpClient(client_configuration),
+    dns_shuffle_addresses_enabled_(dns_shuffle_addresses_enabled()) {}
+
+bool ArcticCurlHttpClient::should_shuffle_dns_addresses() const { return dns_shuffle_addresses_enabled_; }
+
+void ArcticCurlHttpClient::OverrideOptionsOnConnectionHandle(CURL* connection_handle) const {
+    if (should_shuffle_dns_addresses()) {
+        curl_easy_setopt(connection_handle, CURLOPT_DNS_SHUFFLE_ADDRESSES, 1L);
+    }
+}
+
+ArcticCurlHttpClientFactory::ArcticCurlHttpClientFactory(bool init_and_cleanup_curl, bool install_sigpipe_handler) :
+    init_and_cleanup_curl_(init_and_cleanup_curl),
+    install_sigpipe_handler_(install_sigpipe_handler) {}
+
+std::shared_ptr<Aws::Http::HttpClient> ArcticCurlHttpClientFactory::CreateHttpClient(
+        const Aws::Client::ClientConfiguration& client_configuration
+) const {
+    return Aws::MakeShared<ArcticCurlHttpClient>(ARCTIC_CURL_ALLOCATION_TAG, client_configuration);
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> ArcticCurlHttpClientFactory::CreateHttpRequest(
+        const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& stream_factory
+) const {
+    return CreateHttpRequest(Aws::Http::URI(uri), method, stream_factory);
+}
+
+std::shared_ptr<Aws::Http::HttpRequest> ArcticCurlHttpClientFactory::CreateHttpRequest(
+        const Aws::Http::URI& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& stream_factory
+) const {
+    auto request = Aws::MakeShared<Aws::Http::Standard::StandardHttpRequest>(ARCTIC_CURL_ALLOCATION_TAG, uri, method);
+    request->SetResponseStreamFactory(stream_factory);
+    return request;
+}
+
+void ArcticCurlHttpClientFactory::InitStaticState() {
+    if (init_and_cleanup_curl_) {
+        Aws::Http::CurlHttpClient::InitGlobalState();
+    }
+    if (install_sigpipe_handler_) {
+        ::signal(SIGPIPE, [](int) {});
+    }
+}
+
+void ArcticCurlHttpClientFactory::CleanupStaticState() {
+    if (init_and_cleanup_curl_) {
+        Aws::Http::CurlHttpClient::CleanupGlobalState();
+    }
+}
+#endif // WIN32
+
 S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level, bool log_to_file) :
     log_level_(log_level),
     options_() {
@@ -84,6 +150,17 @@ S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level, bool log_t
             Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<SpdlogLogSystem>("v", log_level));
         }
     }
+#ifndef WIN32
+    {
+        const bool init_and_cleanup_curl = options_.httpOptions.initAndCleanupCurl;
+        const bool install_sigpipe_handler = options_.httpOptions.installSigPipeHandler;
+        options_.httpOptions.httpClientFactory_create_fn = [init_and_cleanup_curl, install_sigpipe_handler] {
+            return Aws::MakeShared<ArcticCurlHttpClientFactory>(
+                    ARCTIC_CURL_ALLOCATION_TAG, init_and_cleanup_curl, install_sigpipe_handler
+            );
+        };
+    }
+#endif
     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Begin initializing AWS API");
     Aws::InitAPI(options_);
     // A workaround for https://github.com/aws/aws-sdk-cpp/issues/1410.

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -10,6 +10,10 @@
 
 #include <aws/core/Aws.h>
 #include <aws/core/utils/logging/LogSystemInterface.h>
+#ifndef WIN32
+#include <aws/core/http/HttpClientFactory.h>
+#include <aws/core/http/curl/CurlHttpClient.h>
+#endif
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -34,6 +38,46 @@ class SpdlogLogSystem : public Aws::Utils::Logging::LogSystemInterface {
   private:
     std::atomic<Aws::Utils::Logging::LogLevel> log_level_;
 };
+
+#ifndef WIN32
+// Whether to set CURLOPT_DNS_SHUFFLE_ADDRESSES.
+bool dns_shuffle_addresses_enabled();
+
+// Custom client that allows setting specific cUrl options.
+class ArcticCurlHttpClient : public Aws::Http::CurlHttpClient {
+  public:
+    explicit ArcticCurlHttpClient(const Aws::Client::ClientConfiguration& client_configuration);
+
+    bool should_shuffle_dns_addresses() const;
+
+  protected:
+    void OverrideOptionsOnConnectionHandle(CURL* connection_handle) const override;
+
+  private:
+    const bool dns_shuffle_addresses_enabled_;
+};
+
+class ArcticCurlHttpClientFactory : public Aws::Http::HttpClientFactory {
+  public:
+    // Defaults mirror Aws::HttpOptions
+    explicit ArcticCurlHttpClientFactory(bool init_and_cleanup_curl = true, bool install_sigpipe_handler = false);
+
+    std::shared_ptr<Aws::Http::HttpClient> CreateHttpClient(const Aws::Client::ClientConfiguration& client_configuration
+    ) const override;
+    std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+            const Aws::String& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& stream_factory
+    ) const override;
+    std::shared_ptr<Aws::Http::HttpRequest> CreateHttpRequest(
+            const Aws::Http::URI& uri, Aws::Http::HttpMethod method, const Aws::IOStreamFactory& stream_factory
+    ) const override;
+    void InitStaticState() override;
+    void CleanupStaticState() override;
+
+  private:
+    bool init_and_cleanup_curl_;
+    bool install_sigpipe_handler_;
+};
+#endif // WIN32
 
 class S3ApiInstance {
   public:

--- a/cpp/arcticdb/storage/s3/s3_client_impl.hpp
+++ b/cpp/arcticdb/storage/s3/s3_client_impl.hpp
@@ -16,7 +16,7 @@ namespace arcticdb::storage::s3 {
 class S3ClientImpl : public S3ClientInterface {
   public:
     template<typename... Args>
-    S3ClientImpl(Args&&... args) : s3_client(std::forward<Args>(args)...){};
+    explicit S3ClientImpl(Args&&... args) : s3_client(std::forward<Args>(args)...) {}
 
     S3Result<std::monostate> head_object(const std::string& s3_object_name, const std::string& bucket_name)
             const override;

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -515,7 +515,7 @@ TEST(TestS3Storage, curl_http_client_factory_is_registered) {
 
 TEST(TestS3Storage, dns_shuffle_addresses_enabled_by_default) {
     using namespace arcticdb::storage::s3;
-    ConfigsMap::instance()->unset_int("S3Storage.DnsShuffleAddresses");
+    ScopedConfig::unset_int("S3Storage.DnsShuffleAddresses");
     ASSERT_TRUE(dns_shuffle_addresses_enabled());
 }
 

--- a/cpp/arcticdb/storage/test/test_s3_storage.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_storage.cpp
@@ -16,14 +16,19 @@
 #include <arcticdb/entity/variant_key.hpp>
 #include <arcticdb/storage/test/common.hpp>
 #include <arcticdb/util/test/gtest_utils.hpp>
+#include <arcticdb/util/configs_map.hpp>
 
 #include <arcticdb/log/log.hpp>
 
 #include <aws/core/Aws.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
+#ifndef WIN32
+#include <aws/core/http/HttpClientFactory.h>
+#endif
 
 #include <spdlog/sinks/ostream_sink.h>
 
+#include <set>
 #include <sstream>
 
 struct EnvFunctionShim : ::testing::Test {
@@ -499,3 +504,54 @@ TEST(S3LogSystem, RoutesToSpdlogWithLevelAndTag) {
     ASSERT_NE(out.find("trace|[TraceTag] msg-TraceTag"), std::string::npos);
     ASSERT_NE(out.find("error|[FmtTag] value=42"), std::string::npos);
 }
+
+#ifndef WIN32
+TEST(TestS3Storage, curl_http_client_factory_is_registered) {
+    arcticdb::storage::s3::S3ApiInstance::instance();
+    Aws::Client::ClientConfiguration client_configuration;
+    auto http_client = Aws::Http::CreateHttpClient(client_configuration);
+    ASSERT_NE(dynamic_cast<arcticdb::storage::s3::ArcticCurlHttpClient*>(http_client.get()), nullptr);
+}
+
+TEST(TestS3Storage, dns_shuffle_addresses_enabled_by_default) {
+    using namespace arcticdb::storage::s3;
+    ConfigsMap::instance()->unset_int("S3Storage.DnsShuffleAddresses");
+    ASSERT_TRUE(dns_shuffle_addresses_enabled());
+}
+
+TEST(TestS3Storage, dns_shuffle_addresses_can_be_disabled_via_config) {
+    using namespace arcticdb::storage::s3;
+    ScopedConfig scoped_config("S3Storage.DnsShuffleAddresses", 0);
+    ASSERT_FALSE(dns_shuffle_addresses_enabled());
+}
+
+TEST(TestS3Storage, curl_http_client_captures_dns_shuffle_config_at_construction) {
+    using namespace arcticdb::storage::s3;
+    S3ApiInstance::instance();
+
+    Aws::Client::ClientConfiguration client_configuration;
+    client_configuration.endpointOverride = "s3.us-east-1.amazonaws.com";
+
+    {
+        ScopedConfig scoped_config("S3Storage.DnsShuffleAddresses", 1);
+        auto http_client = Aws::Http::CreateHttpClient(client_configuration);
+        auto* arctic_curl_http_client = dynamic_cast<ArcticCurlHttpClient*>(http_client.get());
+        ASSERT_NE(arctic_curl_http_client, nullptr);
+
+        // Flipping the config after construction must not affect a client that already exists, since the value
+        // is captured once in the constructor rather than read live on every request.
+        ConfigsMap::instance()->set_int("S3Storage.DnsShuffleAddresses", 0);
+        ASSERT_TRUE(arctic_curl_http_client->should_shuffle_dns_addresses());
+    }
+
+    {
+        ScopedConfig scoped_config("S3Storage.DnsShuffleAddresses", 0);
+        auto http_client = Aws::Http::CreateHttpClient(client_configuration);
+        auto* arctic_curl_http_client = dynamic_cast<ArcticCurlHttpClient*>(http_client.get());
+        ASSERT_NE(arctic_curl_http_client, nullptr);
+
+        ConfigsMap::instance()->set_int("S3Storage.DnsShuffleAddresses", 1);
+        ASSERT_FALSE(arctic_curl_http_client->should_shuffle_dns_addresses());
+    }
+}
+#endif // WIN32

--- a/cpp/arcticdb/util/configs_map.hpp
+++ b/cpp/arcticdb/util/configs_map.hpp
@@ -69,6 +69,8 @@ struct ScopedConfig {
     ConfigOptions originals;
     ScopedConfig(std::string name, int64_t val) : ScopedConfig({{std::move(name), std::make_optional(val)}}) {}
 
+    static ScopedConfig unset_int(std::string name) { return ScopedConfig({{std::move(name), std::nullopt}}); }
+
     explicit ScopedConfig(ConfigOptions overrides) {
         for (auto& config : overrides) {
             auto& [name, new_value] = config;

--- a/cpp/arcticdb/version/test/benchmark_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/benchmark_symbol_list.cpp
@@ -114,21 +114,21 @@ static void BM_symbol_list_load(benchmark::State& state) {
         SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 0);
     }
 
-    // Force compaction on first load to create the compacted segment
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
     {
-        SymbolList sl{version_map};
-        sl.load<std::set<StreamId>>(version_map, store, false);
-    }
+        // Force compaction on first load to create the compacted segment
+        ScopedConfig max_delta("SymbolList.MaxDelta", 0);
+        {
+            SymbolList sl{version_map};
+            sl.load<std::set<StreamId>>(version_map, store, false);
+        }
 
-    // Add a few journal entries to exercise the merge path
-    for (int64_t i = 0; i < 100; ++i) {
-        SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 1);
-    }
+        // Add a few journal entries to exercise the merge path
+        for (int64_t i = 0; i < 100; ++i) {
+            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 1);
+        }
+    } // Compaction disabled again for the benchmark iterations below
 
-    // Disable compaction during the benchmark iterations
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
-
+    ScopedConfig::unset_int("SymbolList.MaxDelta");
     for (auto _ : state) {
         PeakHeapTracker tracker;
         tracker.start();
@@ -168,22 +168,23 @@ static void BM_symbol_list_load_many_entries(benchmark::State& state) {
         }
     }
 
-    // Force compaction to create the compacted segment
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
     {
-        SymbolList sl{version_map};
-        sl.load<std::set<StreamId>>(version_map, store, false);
-    }
+        // Force compaction to create the compacted segment
+        ScopedConfig max_delta("SymbolList.MaxDelta", 0);
+        {
+            SymbolList sl{version_map};
+            sl.load<std::set<StreamId>>(version_map, store, false);
+        }
 
-    // Write more journal entries (uncompacted)
-    for (int64_t i = 0; i < num_symbols; ++i) {
-        for (int64_t v = 0; v < entries_per_symbol; ++v) {
-            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, entries_per_symbol + v);
+        // Write more journal entries (uncompacted)
+        for (int64_t i = 0; i < num_symbols; ++i) {
+            for (int64_t v = 0; v < entries_per_symbol; ++v) {
+                SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, entries_per_symbol + v);
+            }
         }
     }
 
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
-
+    ScopedConfig::unset_int("SymbolList.MaxDelta");
     for (auto _ : state) {
         PeakHeapTracker tracker;
         tracker.start();
@@ -227,7 +228,7 @@ static void BM_symbol_list_compaction(benchmark::State& state) {
         }
     }
 
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    ScopedConfig max_delta("SymbolList.MaxDelta", 0);
 
     for (auto _ : state) {
         PeakHeapTracker tracker;
@@ -244,8 +245,6 @@ static void BM_symbol_list_compaction(benchmark::State& state) {
 
         benchmark::DoNotOptimize(result);
     }
-
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
 }
 
 BENCHMARK(BM_symbol_list_compaction)
@@ -275,18 +274,19 @@ static void BM_symbol_list_load_s3(benchmark::State& state) {
         SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 0);
     }
 
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
     {
-        SymbolList sl{version_map};
-        sl.load<std::set<StreamId>>(version_map, store, false);
+        ScopedConfig max_delta("SymbolList.MaxDelta", 0);
+        {
+            SymbolList sl{version_map};
+            sl.load<std::set<StreamId>>(version_map, store, false);
+        }
+
+        for (int64_t i = 0; i < 100; ++i) {
+            SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 1);
+        }
     }
 
-    for (int64_t i = 0; i < 100; ++i) {
-        SymbolList::add_symbol(store, StreamId{fmt::format("symbol_{:06d}", i)}, 1);
-    }
-
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
-
+    ScopedConfig::unset_int("SymbolList.MaxDelta");
     for (auto _ : state) {
         PeakHeapTracker tracker;
         tracker.start();
@@ -317,7 +317,7 @@ BENCHMARK(BM_symbol_list_load_s3)->Arg(10'000)->Unit(benchmark::kMillisecond)->I
         }
     }
 
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
+    ScopedConfig max_delta("SymbolList.MaxDelta", 0);
 
     for (auto _ : state) {
         PeakHeapTracker tracker;
@@ -334,8 +334,6 @@ BENCHMARK(BM_symbol_list_load_s3)->Arg(10'000)->Unit(benchmark::kMillisecond)->I
 
         benchmark::DoNotOptimize(result);
     }
-
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
 }
 
 BENCHMARK(BM_symbol_list_compaction_s3)->Args({1'000, 100})->Unit(benchmark::kMillisecond)->Iterations(1);

--- a/cpp/arcticdb/version/test/test_admission_handler.cpp
+++ b/cpp/arcticdb/version/test/test_admission_handler.cpp
@@ -302,15 +302,16 @@ TEST(ProcessingUnitAdmissionHandlerTest, ReadWindowLimitsInFlightReads) {
 }
 
 namespace {
-struct TinyThreadPool {
-    TinyThreadPool() {
-        ConfigsMap::instance()->set_int("VersionStore.NumIOThreads", 1);
-        ConfigsMap::instance()->set_int("VersionStore.NumCPUThreads", 1);
-        async::TaskScheduler::reattach_instance();
-    }
-    ~TinyThreadPool() {
-        ConfigsMap::instance()->unset_int("VersionStore.NumIOThreads");
-        ConfigsMap::instance()->unset_int("VersionStore.NumCPUThreads");
+struct ReattachTaskSchedulerOnScopeExit {
+    ~ReattachTaskSchedulerOnScopeExit() { async::TaskScheduler::reattach_instance(); }
+};
+
+struct ScopedThreadCounts {
+    ReattachTaskSchedulerOnScopeExit reattach_guard;
+    ScopedConfig config;
+
+    explicit ScopedThreadCounts(int64_t cpu = 1, int64_t io = 1) :
+        config({{"VersionStore.NumCPUThreads", cpu}, {"VersionStore.NumIOThreads", io}}) {
         async::TaskScheduler::reattach_instance();
     }
 };
@@ -321,7 +322,7 @@ struct TinyThreadPool {
 // Reaching .get() shows that the admit -> process -> advance loop does not deadlock.
 TEST(ProcessingUnitAdmissionHandlerTest, OverlappingUnitsAdvanceWithCeilingOne) {
     using namespace arcticdb::pipelines;
-    TinyThreadPool tiny_pool;
+    ScopedThreadCounts tiny_pool;
 
     const std::vector<std::vector<size_t>> units{{0, 1}, {1, 2}}; // segment 1 shared between the two units
     const size_t num_segments = 3;
@@ -387,7 +388,7 @@ TEST(ProcessingUnitAdmissionHandlerTest, OverlappingUnitsAdvanceWithCeilingOne) 
 
 TEST(ProcessingUnitAdmissionHandlerTest, AdvancesWithReadWindowOfOne) {
     using namespace arcticdb::pipelines;
-    TinyThreadPool tiny_pool;
+    ScopedThreadCounts tiny_pool;
 
     const size_t num_units = 3;
     const size_t unit_size = 2;
@@ -503,14 +504,14 @@ std::vector<folly::Try<folly::Unit>> run_synchronous_read_throw_case(size_t thro
 // window of 1 the whole pipeline stops. Unit 1 completing shows that the window recovered, because with a
 // ceiling of 1 it is only admitted once unit 0 has finished.
 TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowDoesNotHang) {
-    TinyThreadPool tiny_pool;
+    ScopedThreadCounts tiny_pool;
     const auto results = run_synchronous_read_throw_case(/*throwing_segment=*/1); // second segment of unit 0
     EXPECT_TRUE(results.at(0).hasException());
     EXPECT_TRUE(results.at(1).hasValue());
 }
 
 TEST(ProcessingUnitAdmissionHandlerTest, SynchronousReadThrowOnFirstSegmentOfUnitDoesNotHang) {
-    TinyThreadPool tiny_pool;
+    ScopedThreadCounts tiny_pool;
     const auto results = run_synchronous_read_throw_case(/*throwing_segment=*/0); // first segment of unit 0
     EXPECT_TRUE(results.at(0).hasException());
     EXPECT_TRUE(results.at(1).hasValue());
@@ -680,21 +681,6 @@ TEST(ColumnStatsMixedColSlicing, ResidencyBoundedWithUnevenUnitsWiderFirst) {
     };
     EXPECT_EQ(info.to_map(), expected);
 }
-
-namespace {
-struct ScopedThreadCounts {
-    ScopedThreadCounts(int64_t cpu, int64_t io) {
-        ConfigsMap::instance()->set_int("VersionStore.NumCPUThreads", cpu);
-        ConfigsMap::instance()->set_int("VersionStore.NumIOThreads", io);
-        async::TaskScheduler::reattach_instance();
-    }
-    ~ScopedThreadCounts() {
-        ConfigsMap::instance()->unset_int("VersionStore.NumCPUThreads");
-        ConfigsMap::instance()->unset_int("VersionStore.NumIOThreads");
-        async::TaskScheduler::reattach_instance();
-    }
-};
-} // namespace
 
 // Dividing the window by a wide unit size rounds down to almost nothing, so the per-CPU-thread term is what keeps
 // enough units admitted to occupy the CPU pool.

--- a/cpp/arcticdb/version/test/test_symbol_list.cpp
+++ b/cpp/arcticdb/version/test/test_symbol_list.cpp
@@ -1083,37 +1083,38 @@ TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPath) {
         version_map_->write_version(store_, key, std::nullopt);
     }
 
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
-    SymbolList sl{version_map_};
-    sl.load<std::set<StreamId>>(version_map_, store_, false);
+    {
+        ScopedConfig max_delta("SymbolList.MaxDelta", 0);
+        SymbolList sl{version_map_};
+        sl.load<std::set<StreamId>>(version_map_, store_, false);
 
-    // Journal entries on top of the compaction key, split by scenario:
+        // Journal entries on top of the compaction key, split by scenario:
 
-    // sym_40..49 already exist at version 0 (from the setup above); write a genuine second
-    // version for them, so the reference_id on the new ADD entry is 1 (the version just written).
-    for (int i = 40; i < 50; ++i) {
-        auto symbol = fmt::format("sym_{}", i);
-        auto key = atom_key_builder().version_id(1).build(symbol, KeyType::TABLE_INDEX);
-        version_map_->write_version(store_, key, std::nullopt);
-        SymbolList::add_symbol(store_, StreamId{symbol}, 1);
+        // sym_40..49 already exist at version 0 (from the setup above); write a genuine second
+        // version for them, so the reference_id on the new ADD entry is 1 (the version just written).
+        for (int i = 40; i < 50; ++i) {
+            auto symbol = fmt::format("sym_{}", i);
+            auto key = atom_key_builder().version_id(1).build(symbol, KeyType::TABLE_INDEX);
+            version_map_->write_version(store_, key, std::nullopt);
+            SymbolList::add_symbol(store_, StreamId{symbol}, 1);
+        }
+        // sym_50..59 are brand new symbols; their first version is 0, so the reference_id matches that.
+        for (int i = 50; i < 60; ++i) {
+            auto symbol = fmt::format("sym_{}", i);
+            auto key = atom_key_builder().version_id(0).build(symbol, KeyType::TABLE_INDEX);
+            version_map_->write_version(store_, key, std::nullopt);
+            SymbolList::add_symbol(store_, StreamId{symbol}, 0);
+        }
+        // sym_0..9 are removed, but their only version (0) is left live in the version map below -
+        // the reference_id on the DELETE entry must match that still-live version, not a version that
+        // was never written.
+        for (int i = 0; i < 10; ++i) {
+            auto symbol = fmt::format("sym_{}", i);
+            SymbolList::remove_symbol(store_, StreamId{symbol}, 0);
+        }
     }
-    // sym_50..59 are brand new symbols; their first version is 0, so the reference_id matches that.
-    for (int i = 50; i < 60; ++i) {
-        auto symbol = fmt::format("sym_{}", i);
-        auto key = atom_key_builder().version_id(0).build(symbol, KeyType::TABLE_INDEX);
-        version_map_->write_version(store_, key, std::nullopt);
-        SymbolList::add_symbol(store_, StreamId{symbol}, 0);
-    }
-    // sym_0..9 are removed, but their only version (0) is left live in the version map below -
-    // the reference_id on the DELETE entry must match that still-live version, not a version that
-    // was never written.
-    for (int i = 0; i < 10; ++i) {
-        auto symbol = fmt::format("sym_{}", i);
-        SymbolList::remove_symbol(store_, StreamId{symbol}, 0);
-    }
 
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
-
+    ScopedConfig::unset_int("SymbolList.MaxDelta");
     // Load via compaction-eligible path (will not actually compact since threshold is default)
     SymbolList sl1{version_map_};
     auto compaction_result = sl1.load<std::set<StreamId>>(version_map_, store_, false);
@@ -1143,28 +1144,29 @@ TEST_F(SymbolListSuite, NoCompactionLoadMatchesCompactionPathWithTrueDeletes) {
         version_map_->write_version(store_, key, std::nullopt);
     }
 
-    ConfigsMap::instance()->set_int("SymbolList.MaxDelta", 0);
-    SymbolList sl{version_map_};
-    sl.load<std::set<StreamId>>(version_map_, store_, false);
+    {
+        ScopedConfig max_delta("SymbolList.MaxDelta", 0);
+        SymbolList sl{version_map_};
+        sl.load<std::set<StreamId>>(version_map_, store_, false);
 
-    // Add new symbols; their first version is 0, so the reference_id matches that.
-    for (int i = 50; i < 60; ++i) {
-        auto symbol = fmt::format("sym_{}", i);
-        auto key = atom_key_builder().version_id(0).build(symbol, KeyType::TABLE_INDEX);
-        version_map_->write_version(store_, key, std::nullopt);
-        SymbolList::add_symbol(store_, StreamId{symbol}, 0);
+        // Add new symbols; their first version is 0, so the reference_id matches that.
+        for (int i = 50; i < 60; ++i) {
+            auto symbol = fmt::format("sym_{}", i);
+            auto key = atom_key_builder().version_id(0).build(symbol, KeyType::TABLE_INDEX);
+            version_map_->write_version(store_, key, std::nullopt);
+            SymbolList::add_symbol(store_, StreamId{symbol}, 0);
+        }
+
+        // Delete symbols 0-9 via both the symbol list journal AND the version map. Their only version
+        // is 0, so that's the version being tombstoned and the reference_id the DELETE entry must carry.
+        for (int i = 0; i < 10; ++i) {
+            auto symbol = fmt::format("sym_{}", i);
+            SymbolList::remove_symbol(store_, StreamId{symbol}, 0);
+            version_map_->tombstone_from_key_or_all(store_, StreamId{symbol});
+        }
     }
 
-    // Delete symbols 0-9 via both the symbol list journal AND the version map. Their only version
-    // is 0, so that's the version being tombstoned and the reference_id the DELETE entry must carry.
-    for (int i = 0; i < 10; ++i) {
-        auto symbol = fmt::format("sym_{}", i);
-        SymbolList::remove_symbol(store_, StreamId{symbol}, 0);
-        version_map_->tombstone_from_key_or_all(store_, StreamId{symbol});
-    }
-
-    ConfigsMap::instance()->unset_int("SymbolList.MaxDelta");
-
+    ScopedConfig::unset_int("SymbolList.MaxDelta");
     SymbolList sl1{version_map_};
     auto compaction_result = sl1.load<std::set<StreamId>>(version_map_, store_, false);
 

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -94,6 +94,7 @@ ac = Arctic("s3://localhost:9000:my-bucket?access=minioadmin&secret=minioadmin")
 - **Retry logic**: Automatic retry on transient failures
 - **Path prefix**: Organize data under a prefix within the bucket
 - **AWS SDK logging**: AWS SDK logs are routed into the `s3` spdlog stream via `s3_api.cpp:SpdlogLogSystem` (per-message severity mapped to spdlog levels, AWS tag preserved as a `[tag]` prefix), so they interleave with ArcticDB's own logs. The effective level is reconciled in Python (`tools.py:_reconcile_aws_log_level`): the more verbose of `ARCTICDB_s3_loglevel` and the deprecated `ARCTICDB_AWS_LogLevel_int` drives both the AWS SDK emission (`AWS.LogLevel` config, read in `S3ApiInstance::init`) and the `s3` stream level. The `s3` stream is opt-in: defaults to `CRITICAL`, ignores `ARCTICDB_all_loglevel`. Set `AWS.LogToFile` to write to a file in the cwd via `DefaultLogSystem` instead.
+- **Connection-lifetime jitter**: To stop a long-lived client's curl connection pool from locking onto a skewed subset of backend IPs behind a single DNS name (seen against multi-node S3-compatible clusters), `s3_api.cpp:ArcticCurlHttpClient` overrides `CURLOPT_MAXLIFETIME_CONN` with a freshly randomized threshold on every request (base `S3Storage.ConnectionMaxLifetimeSeconds`, default 60s, `<=0` disables it; jittered by `S3Storage.ConnectionMaxLifetimeJitterFraction`, default 0.5). Registered via `Aws::Http::SetHttpClientFactory` before `Aws::InitAPI`; not available on Windows.
 
 ## Azure Blob Storage
 


### PR DESCRIPTION
Full scripts are available in [this branch](https://github.com/man-group/ArcticDB/tree/aseaton/connection-pool-sizing).

## S3: improve CNode distribution on VAST

VAST's DNS answers describe CNode IPs. When we make DNS requests in short bursts (like when ArcticDB establishes its connection pool) we get a non-uniform distribution of connections across CNodes, meaning that connections in our pool actually talk to the same CNodes, and their requests might queue on the CNode. This also leads to a poor distribution of connections across CNodes, which are a limited resource per CNode.

### Root cause

Running `dig +short <vast_hostname>` in a loop gives a uniform distribution, however the DNS server results seem to change on a relatively slow timescale and a C++ client can get "duplicate" results out of the DNS.

A minimal repro ([`dns_clustering_repro.cpp`](https://github.com/man-group/ArcticDB/blob/aseaton/connection-pool-sizing/pool_sizes_testing/dns_clustering_repro.cpp)) completes in ~29ms and produces only 4 distinct answer sets across 100 lookups (repeat counts 32, 32, 29, 7).

### Fix

Apply [CURLOPT_DNS_SHUFFLE_ADDRESSES ](https://curl.se/libcurl/c/CURLOPT_DNS_SHUFFLE_ADDRESSES.html) to the DNS results across all S3 backends. This is discussed below - it simplifies the implementation and did not harm PURE or AWS S3.

Each connection we establish does its own DNS lookup already (the ttl on this DNS is zero, deliberately so we get at least the slower shuffling described above), and this change shuffles those results so we end up with a uniform distribution.

### Measured impact: CNode distribution (VAST, real dev bucket)

Measured with [`profile_s3_dns_shuffle_cnode_trace.py`](https://github.com/man-group/ArcticDB/blob/aseaton/connection-pool-sizing/python/benchmarks/non_asv/profile_s3_dns_shuffle_cnode_trace.py), which parses libcurl TRACE logs for `Trying <ip>...` lines to count distinct CNode IPs touched per trial, with a large connection pool size.

| Metric | Before | After |
|---|---|---|
| Distinct CNode IPs touched | 22 | 41 |
| Top-1 IP share | 18.8% | 7.9% |
| Top-3 IP share | 37.6% | 18.8% |
| Top-5 IP share | 50.5% | 28.7% |

| Pool size | Mean distinct CNodes, before | Mean distinct CNodes, after |
|---|---|---|
| 12 | 3.75 | 9.40 |
| 72 | 22 | 41 |
| 96 | 18.55 | 41.95 |

### Measured impact on VAST

Measured with [`profile_s3_dns_shuffle_ab.py`](https://github.com/man-group/ArcticDB/blob/aseaton/connection-pool-sizing/python/benchmarks/non_asv/profile_s3_dns_shuffle_ab.py). One subprocess per measurement, with the connection pool warmed with a large read first. Interleaved runs with and without the fix.

Pool size = 12 used 8 CPU and 12 IO threads. Pool size = 96 used 64 CPU and 96 IO threads.

#### Testing with large reads

`batch_read_large_multiseg` (8 columns, 100 segments, 10M rows/unit, ~640MB/unit, batch size 32, ~20.5GB/measurement).

These show a significant improvement from the fix on reads.

**`batch_read_large_multiseg`**

| Pool size | n | mean(on), s | mean(off), s | mean(diff=on-off), s | median(diff), s | relative effect | p-value |
|---|---|---|---|---|---|---|---|
| 12 | 15 pairs | 6.7872 | 8.7917 | -2.0044 | -2.1243 | -22.8% | **0.0019** |
| 96 | 20 pairs | 1.8041 | 2.0098 | -0.2057 | -0.0749 | -10.2% | **0.0231** |

**`batch_write_large_multiseg`**

This shows mized results - 10% faster on reasonable pool sizes, 10% slower on extremely large pool sizes.

| Pool size | n | mean(on), s | mean(off), s | mean(diff=on-off), s | median(diff), s | relative effect | p-value |
|---|---|---|---|---|---|---|---|
| 12 | 50 pairs |  | 27.02 | -2.83 | -1.39 | -10.5% | **0.0021** |
| 96 | 50 pairs | | 7.48 | 0.67 | 0.83 | 8.9% | **0.0008** |

#### Testing with relatively small objects

Cells:
- `read_fanout` — single-symbol `read()` fanning out over 2x pool size 2000 row segments (2,000 rows/segment)
- `read_fanout_large` Same but with 200k rows and 32 cols
- `batch_read_small` / `batch_write_small` — `batch_read`/`batch_write` over 2x pool size 2000 row single-segment objects
- `batch_read_large` / `batch_write_large` — `batch_read`/`batch_write` over 24 objects (200,000 rows, 32 columns, ~51MB each)

##### pool_size=12, full run (n=50 pairs/cell)

| Cell | mean(on), s | mean(off), s | mean(diff=on-off), s | p-value | Significant? |
|---|---|---|---|---|---|
| `read_fanout` | 0.1587 | 0.1341 | +0.0246 | 0.0771 | no |
| `batch_read_small` | 0.1958 | 0.1727 | +0.0231 | 0.1599 | no |
| `batch_write_small` | 0.7181 | 0.8058 | -0.0877 | 0.0822 | no |
| `batch_read_large` | 0.4996 | 0.5343 | -0.0347 | 0.0603 | no |
| `batch_write_large` | 1.2371 | 1.4219 | -0.1848 | 0.0017 | **yes** |
| `read_fanout_large` | 0.3329 | 0.3788 | -0.0459 | 0.0001 | **yes** |

###### pool_size=96, full run (n=50 pairs/cell)

| Cell | mean(on), s | mean(off), s | mean(diff=on-off), s | p-value | Significant? |
|---|---|---|---|---|---|
| `read_fanout` | 0.1291 | 0.1256 | +0.0035 | 0.6456 | no |
| `batch_read_small` | 0.3598 | 0.3661 | -0.0063 | 0.6219 | no |
| `batch_write_small` | 1.8413 | 1.7136 | +0.1276 | 0.0218 | **yes** |
| `batch_read_large` | 0.2922 | 0.3032 | -0.0109 | 0.3241 | no |
| `batch_write_large` | 1.2550 | 1.1835 | +0.0715 | 0.1190 | no |
| `read_fanout_large` | 0.3518 | 0.3357 | +0.0162 | 0.1967 | no |

### PURE and AWS S3 are unaffected

- **PURE**: resolves to a fixed set of 5 IPs. Distribution is already near-uniform before the fix (top-1/top-3 = 20.5%/60.9%). Performance measurements on PURE showed no difference with or without this fix.
- **AWS S3**: AWS's own DNS gives back a uniform distribution of DNS records