### PR TITLE
Promote merge update to stable API

### DIFF
--- a/cpp/arcticdb/column_store/column_reslicer.cpp
+++ b/cpp/arcticdb/column_store/column_reslicer.cpp
@@ -12,8 +12,14 @@
 
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/column_store/column_reslicer.hpp>
+#include <arcticdb/entity/type_utils.hpp>
 
 namespace arcticdb {
+
+size_t max_rows_per_segment(size_t rows_per_segment) {
+    // If rows_per_segment_ == 2 max_rows_per_segment_ would be 2 without the std::max
+    return std::max((4 * rows_per_segment) / 3, rows_per_segment + 1);
+}
 
 ColumnReslicer::ColumnReslicer(const size_t num_input_slices, const ReslicingInfo& reslicing_info) :
     reslicing_info_(reslicing_info) {
@@ -259,12 +265,12 @@ std::vector<Column> ColumnReslicer::reslice_by_iteration(std::vector<StringPool>
 
 std::vector<Column> ColumnReslicer::initialise_output_columns() const {
     std::vector<Column> output_columns;
-    output_columns.reserve(reslicing_info_.num_segments);
+    output_columns.reserve(reslicing_info_.num_segments());
     const auto& type = *type_;
     if (sparse_) {
         uint64_t input_values{0};
         // Represents a global bitset for all of the input columns, with 0s where an entire row slice is missing
-        util::BitSet bitset(reslicing_info_.total_rows);
+        util::BitSet bitset(reslicing_info_.total_rows());
         util::BitSet::bulk_insert_iterator inserter(bitset);
         size_t idx{0};
         for (const auto& col_or_rows : cols_or_row_counts_) {
@@ -298,7 +304,7 @@ std::vector<Column> ColumnReslicer::initialise_output_columns() const {
         );
         uint64_t output_values{0};
         uint64_t output_rows{0};
-        for (idx = 0; idx < reslicing_info_.num_segments; ++idx) {
+        for (idx = 0; idx < reslicing_info_.num_segments(); ++idx) {
             auto num_rows = reslicing_info_.rows_in_slice(idx);
             auto set_bits = bitset.count_range(output_rows, output_rows + num_rows - 1, bit_index);
             output_values += set_bits;
@@ -319,7 +325,7 @@ std::vector<Column> ColumnReslicer::initialise_output_columns() const {
                 output_values
         );
     } else {
-        for (size_t idx = 0; idx < reslicing_info_.num_segments; ++idx) {
+        for (size_t idx = 0; idx < reslicing_info_.num_segments(); ++idx) {
             output_columns.emplace_back(
                     type, reslicing_info_.rows_in_slice(idx), AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
             );

--- a/cpp/arcticdb/column_store/column_reslicer.hpp
+++ b/cpp/arcticdb/column_store/column_reslicer.hpp
@@ -14,39 +14,62 @@
 
 #include <arcticdb/column_store/column.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
-#include <arcticdb/entity/type_utils.hpp>
 #include <arcticdb/processing/expression_node.hpp>
 
 namespace arcticdb {
+
+[[nodiscard]] size_t max_rows_per_segment(size_t rows_per_segment);
 
 // Helper class used by both the column and segment reslicer classes
 class ReslicingInfo {
   public:
     ReslicingInfo(uint64_t _total_rows, uint64_t _rows_per_segment) :
-        total_rows(_total_rows),
-        num_segments((total_rows + _rows_per_segment - 1) / _rows_per_segment),
-        rows_per_segment(total_rows / num_segments),
-        num_remainder_segments(total_rows % num_segments),
-        num_exact_segments(num_segments - num_remainder_segments) {
+        total_rows_(_total_rows),
+        num_segments_((total_rows_ + _rows_per_segment - 1) / _rows_per_segment),
+        rows_per_segment(total_rows_ / num_segments_),
+        num_remainder_segments(total_rows_ % num_segments_),
+        num_exact_segments(num_segments_ - num_remainder_segments) {
         auto output_rows = num_exact_segments * rows_per_segment + num_remainder_segments * (rows_per_segment + 1);
         util::check(
-                output_rows == total_rows,
+                output_rows == total_rows_,
                 "SlicingInfo input rows does not match constructed output rows {} != {}",
-                total_rows,
+                total_rows_,
                 output_rows
         );
     }
 
     ARCTICDB_MOVE_COPY_DEFAULT(ReslicingInfo)
 
-    uint64_t rows_in_slice(uint64_t idx) const {
+    [[nodiscard]] uint64_t rows_in_slice(uint64_t idx) const {
         return idx < num_exact_segments ? rows_per_segment : rows_per_segment + 1;
     }
 
-    uint64_t total_rows;
-    uint64_t num_segments;
+    [[nodiscard]] uint64_t num_segments() const { return num_segments_; }
+
+    [[nodiscard]] uint64_t total_rows() const { return total_rows_; }
+
+    /// Inverse of ReslicingInfo::rows_in_slice: given a row index into the combined [0, total_rows) output, returns
+    /// the (slice index, offset within that slice) pair that rows_in_slice's slicing would place it in.
+    [[nodiscard]] std::pair<uint64_t, uint64_t> slice_and_offset_for_row(uint64_t global_row) const {
+        ARCTICDB_DEBUG_CHECK(
+                ErrorCode::E_ASSERTION_FAILURE,
+                global_row < total_rows_,
+                "ReslicingInfo::slice_and_offset_for_row: row {} is out of bounds for {} total rows",
+                global_row,
+                total_rows_
+        );
+        const uint64_t exact_rows = num_exact_segments * rows_per_segment;
+        if (global_row < exact_rows) {
+            return {global_row / rows_per_segment, global_row % rows_per_segment};
+        }
+        const uint64_t remainder_row = global_row - exact_rows;
+        return {num_exact_segments + remainder_row / (rows_per_segment + 1), remainder_row % (rows_per_segment + 1)};
+    }
 
   private:
+    uint64_t total_rows_;
+    uint64_t num_segments_;
+
     // This is how many rows most segments will have
     uint64_t rows_per_segment;
     // This is how many segments will have rows_per_segment+1 rows

--- a/cpp/arcticdb/column_store/segment_reslicer.cpp
+++ b/cpp/arcticdb/column_store/segment_reslicer.cpp
@@ -41,7 +41,7 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
             }
         }
     }
-    std::vector<SegmentInMemory> res(reslicing_info.num_segments);
+    std::vector<SegmentInMemory> res(reslicing_info.num_segments());
     const auto& desc = segments.front().descriptor();
     for (auto& segment : res) {
         // add_column also adds to the FieldCollection, so start with an empty one
@@ -63,7 +63,7 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
     // This ensures that the refcount of the column shared pointers is 1 when they are reset after having their data
     // copied into the result column, and so the memory is freed as early as possible
     segments.clear();
-    std::vector<StringPool> string_pools(reslicing_info.num_segments);
+    std::vector<StringPool> string_pools(reslicing_info.num_segments());
     // We can use string_view keys here as they point to the keys in column_map, which are still live while this
     // variable is in use
     ankerl::unordered_dense::map<std::string_view, std::vector<Column>, util::TransparentStringHash, std::equal_to<>>
@@ -81,16 +81,16 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
     for (const auto& col_name : col_names_in_order) {
         auto& sliced_cols = resliced_column_map.at(col_name);
         util::check(
-                sliced_cols.size() == reslicing_info.num_segments,
+                sliced_cols.size() == reslicing_info.num_segments(),
                 "Mismatched sliced column size {} != {}",
                 sliced_cols.size(),
-                reslicing_info.num_segments
+                reslicing_info.num_segments()
         );
-        for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+        for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
             res.at(idx).add_column(col_name, std::make_shared<Column>(std::move(sliced_cols.at(idx))));
         }
     }
-    for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+    for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
         res.at(idx).set_row_id(reslicing_info.rows_in_slice(idx) - 1);
         res.at(idx).set_string_pool(std::make_shared<StringPool>(std::move(string_pools.at(idx))));
     }

--- a/cpp/arcticdb/entity/types.hpp
+++ b/cpp/arcticdb/entity/types.hpp
@@ -485,6 +485,7 @@ requires std::is_base_of_v<DataTypeTagBase, DT> && std::is_base_of_v<DimensionTa
 struct TypeDescriptorTag {
     using DataTypeTag = DT;
     using DimensionTag = D;
+    using RawType = typename DT::raw_type;
     explicit constexpr operator TypeDescriptor() const { return type_descriptor(); }
 
     [[nodiscard]] static constexpr Dimension dimension() { return DimensionTag::value; }

--- a/cpp/arcticdb/processing/clause.cpp
+++ b/cpp/arcticdb/processing/clause.cpp
@@ -1158,24 +1158,22 @@ std::vector<EntityId> WriteClause::process(std::vector<EntityId>&& entity_ids) c
     }
     const auto proc =
             gather_entities<std::shared_ptr<SegmentInMemory>, std::shared_ptr<RowRange>, std::shared_ptr<ColRange>>(
-                    *component_manager_, std::move(entity_ids)
+                    *component_manager_, entity_ids
             );
-
-    std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> data_segments_to_write;
-    data_segments_to_write.reserve(proc.segments_->size());
 
     for (size_t i = 0; i < proc.segments_->size(); ++i) {
         const SegmentInMemory& segment = *(*proc.segments_)[i];
         const RowRange& row_range = *(*proc.row_ranges_)[i];
         const ColRange& col_range = *(*proc.col_ranges_)[i];
         stream::PartialKey partial_key = create_partial_key(segment, row_range);
-        data_segments_to_write.push_back(
+        component_manager_->add_components(
+                entity_ids[i],
                 std::make_shared<folly::Future<SliceAndKey>>(store_->compress_and_schedule_async_write(
                         std::make_tuple(std::move(partial_key), segment, FrameSlice(col_range, row_range)), dedup_map_
                 ))
         );
     }
-    return component_manager_->add_entities(std::move(data_segments_to_write));
+    return entity_ids;
 }
 
 stream::PartialKey WriteClause::create_partial_key(const SegmentInMemory& segment, const RowRange& row_range) const {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -861,7 +861,10 @@ struct MergeUpdateClause {
     MergeStrategy strategy_;
     std::shared_ptr<InputFrame> source_;
     bool fake_index_name_ = false;
-    MergeUpdateClause(std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source);
+    MergeUpdateClause(
+            std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source,
+            size_t rows_per_segment
+    );
     ARCTICDB_MOVE_COPY_DEFAULT(MergeUpdateClause)
 
     /// Row range indexes require full table scan
@@ -958,6 +961,8 @@ struct MergeUpdateClause {
     std::span<const timestamp> get_source_index(std::pair<size_t, size_t> source_start_end) const;
 
     std::span<const std::byte> get_source_data_bytes(size_t field_index, std::pair<size_t, size_t> range) const;
+
+    size_t rows_per_segment_;
 };
 
 struct CompactDataClause {

--- a/cpp/arcticdb/processing/clause.hpp
+++ b/cpp/arcticdb/processing/clause.hpp
@@ -861,9 +861,13 @@ struct MergeUpdateClause {
     MergeStrategy strategy_;
     std::shared_ptr<InputFrame> source_;
     bool fake_index_name_ = false;
+    /// When false (the default), a missing value (float NaN, string None/NaN, or NaT in a non-index datetime64 on
+    /// column) never matches anything, on either side. When true, NaN matches NaN, string None and  NaN are
+    /// indistinguishable, and NaT matches NaT.
+    bool match_na_ = false;
     MergeUpdateClause(
             std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source,
-            size_t rows_per_segment
+            size_t rows_per_segment, bool match_na
     );
     ARCTICDB_MOVE_COPY_DEFAULT(MergeUpdateClause)
 
@@ -899,7 +903,7 @@ struct MergeUpdateClause {
         void add_match(size_t source_row, size_t target_row_slice, std::span<size_t> target_rows);
         void filter_matching_rows(
                 std::string_view column_name, DataType source_type, DataType target_type, size_t source_offset,
-                std::span<const std::byte> source_data_bytes
+                std::span<const std::byte> source_data_bytes, bool match_na
         );
         void clone_source_match(size_t source_row_src, size_t source_row_dst, size_t row_slice);
         void validate_rows_to_update(const MergeStrategy& strategy) const;

--- a/cpp/arcticdb/processing/clause_compact_data.cpp
+++ b/cpp/arcticdb/processing/clause_compact_data.cpp
@@ -33,7 +33,7 @@ CompactDataClause::CompactDataClause(uint64_t rows_per_segment, std::shared_ptr<
     // If rows_per_segment_ == 1 min_rows_per_segment_ would be 0 without the std::max
     min_rows_per_segment_ = std::max((2 * rows_per_segment_) / 3, uint64_t(1));
     // If rows_per_segment_ == 2 max_rows_per_segment_ would be 2 without the std::max
-    max_rows_per_segment_ = std::max((4 * rows_per_segment_) / 3, rows_per_segment_ + 1);
+    max_rows_per_segment_ = max_rows_per_segment(rows_per_segment_);
     clause_info_.input_structure_ = ProcessingStructure::ONE_COL_SLICE_MULTIPLE_ROW_SLICES;
     clause_info_.output_structure_ = ProcessingStructure::ONE_COL_SLICE_MULTIPLE_ROW_SLICES;
     clause_info_.can_combine_with_column_selection_ = false;
@@ -252,7 +252,7 @@ void CompactDataClause::add_segment_from_frame(
     ReslicingInfo reslicing_info{total_rows, max_rows_per_segment_};
     // Work out how many rows of the frame we need to combine with segments from disk
     uint64_t row_count{0};
-    for (size_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+    for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
         row_count += reslicing_info.rows_in_slice(idx);
         if (row_count > total_rows_without_frame) {
             break;

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -6,6 +6,8 @@
  * will be governed by the Apache License, version 2.0.
  */
 
+#include "util/collection_utils.hpp"
+
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
@@ -15,6 +17,7 @@
 #include <arcticdb/version/schema_checks.hpp>
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/stream/index.hpp>
+#include <arcticdb/column_store/column_reslicer.hpp>
 #include <ankerl/unordered_dense.h>
 #include <boost/regex.hpp>
 
@@ -256,7 +259,7 @@ struct InsertTargetData {
     std::span<ColumnWithStrings> columns;
     TypeDescriptor type;
     TargetRange range;
-    StringPool& new_string_pool;
+    std::span<StringPool> new_string_pools;
 };
 
 std::vector<size_t> compute_target_slice_offset(const InsertTargetData& target) {
@@ -279,30 +282,31 @@ std::vector<size_t> compute_target_slice_offset(const InsertTargetData& target) 
 /// with the same index value. The source and target must have the same index type.
 template<util::type_descriptor_tag TargetColumnTypeDescriptorTag, typename SourceRawType>
 requires(TargetColumnTypeDescriptorTag::dimension() == Dimension::Dim0)
-Column merge(
+std::vector<std::shared_ptr<Column>> merge(
         const InsertSourceData<SourceRawType>& source, const InsertTargetData& target,
-        const MergeUpdateClause::MatchRecord& match_record, const MergeStrategy& strategy
+        const MergeUpdateClause::MatchRecord& match_record, const MergeStrategy& strategy,
+        const ReslicingInfo& reslicing_info
 ) {
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    // One index value can appear in more than one row slice. In that case it can be shared by two processing units,
-    // each working on part of the target data.
-    const size_t num_rows_out_of_target_range =
-            target.range.start_row_in_first_row_slice +
-            (target.columns.back().column_->row_count() - target.range.end_row_in_last_row_slice);
-    const size_t combined_row_count =
-            std::accumulate(
-                    target.columns.begin(),
-                    target.columns.end(),
-                    match_record.total_unmatched_source_rows(),
-                    [](size_t acc, const ColumnWithStrings& col) { return acc + col.column_->row_count(); }
-            ) -
-            num_rows_out_of_target_range;
+    using ColumnRandomAccessorType = ColumnDataRandomAccessor<TargetColumnTypeDescriptorTag>;
     const std::vector<size_t> target_slice_offset = compute_target_slice_offset(target);
 
-    Column new_column(target.type, combined_row_count, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED);
-    ColumnData new_column_data = new_column.data();
-    auto new_column_it = new_column_data.begin<TargetColumnTypeDescriptorTag>();
-    auto new_data = random_accessor<TargetColumnTypeDescriptorTag>(&new_column_data);
+    auto new_columns = util::reserve_vector<std::shared_ptr<Column>>(reslicing_info.num_segments());
+    auto new_column_datas = util::reserve_vector<ColumnData>(reslicing_info.num_segments());
+    auto new_column_accessors = util::reserve_vector<ColumnRandomAccessorType>(reslicing_info.num_segments());
+    for (size_t i = 0; i < reslicing_info.num_segments(); ++i) {
+        new_columns.push_back(std::make_shared<Column>(
+                target.type, reslicing_info.rows_in_slice(i), AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
+        ));
+        new_column_datas.emplace_back(new_columns.back()->data());
+        new_column_accessors.emplace_back(random_accessor<TargetColumnTypeDescriptorTag>(&new_column_datas.back()));
+    }
+    size_t new_column_row_slice_index{};
+    // Offset within the current output column
+    size_t new_column_row_idx{};
+    // Position in the combined [0, total_rows()) output
+    size_t output_row_idx{};
+    auto new_column_it = new_column_datas.front().begin<TargetColumnTypeDescriptorTag>();
 
     size_t target_row_slice = 0;
     ColumnData target_index_data = target.indexes[target_row_slice].column_->data();
@@ -313,7 +317,6 @@ Column merge(
     ColumnData target_column_data = target.columns[target_row_slice].column_->data();
     auto target_data = random_accessor<TargetColumnTypeDescriptorTag>(&target_column_data);
     size_t target_row_idx = target.range.start_row_in_first_row_slice;
-    size_t new_column_row_idx{};
 
     const auto target_index_is_exhausted = [&] {
         return target_row_slice == target.columns.size() - 1 && target_index_it == target_index_end;
@@ -345,7 +348,15 @@ Column merge(
 
     const auto advance_output = [&] {
         ++new_column_row_idx;
+        ++output_row_idx;
         ++new_column_it;
+
+        if (new_column_it == new_column_datas[new_column_row_slice_index].end<TargetColumnTypeDescriptorTag>() &&
+            new_column_row_slice_index + 1 < reslicing_info.num_segments()) [[unlikely]] {
+            ++new_column_row_slice_index;
+            new_column_row_idx = 0;
+            new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
+        }
     };
 
     // GIL will be acquired if there is a string that is not pure ASCII/UTF-8
@@ -361,7 +372,7 @@ Column merge(
                     row,
                     RowRange{source.global_row_range.first, source.global_row_range.second},
                     scoped_gil_lock,
-                    target.new_string_pool,
+                    target.new_string_pools[new_column_row_slice_index],
                     target.columns.front().column_name_
             );
         }
@@ -369,14 +380,16 @@ Column merge(
 
     const auto set_string_from_source_at = [&](size_t source_row, size_t output_row) {
         if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
-            new_data[output_row] = write_py_string_to_pool_or_throw<TargetColumnTypeDescriptorTag>(
-                    source.data[source_row],
-                    source_row,
-                    RowRange{source.global_row_range.first, source.global_row_range.second},
-                    scoped_gil_lock,
-                    target.new_string_pool,
-                    target.columns.front().column_name_
-            );
+            const auto [slice_index, offset_in_slice] = reslicing_info.slice_and_offset_for_row(output_row);
+            new_column_accessors[slice_index][offset_in_slice] =
+                    write_py_string_to_pool_or_throw<TargetColumnTypeDescriptorTag>(
+                            source.data[source_row],
+                            source_row,
+                            RowRange{source.global_row_range.first, source.global_row_range.second},
+                            scoped_gil_lock,
+                            target.new_string_pools[slice_index],
+                            target.columns.front().column_name_
+                    );
         }
     };
 
@@ -386,14 +399,14 @@ Column merge(
             if (is_a_string(offset)) {
                 const StringPool& pool = *target.columns[target_row_slice].string_pool_;
                 const std::string_view string_data = pool.get_const_view(offset);
-                *new_column_it = target.new_string_pool.get(string_data).offset();
+                *new_column_it = target.new_string_pools[new_column_row_slice_index].get(string_data).offset();
             } else {
                 *new_column_it = offset;
             }
         }
     };
 
-    util::BitSet updated(new_column.row_count());
+    util::BitSet updated(reslicing_info.total_rows());
     std::vector<size_t> source_rows_to_insert;
 
     size_t source_row_idx = 0;
@@ -441,7 +454,8 @@ Column merge(
                         if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
                             set_string_from_source_at(source_row_idx, index_in_output);
                         } else {
-                            new_data[index_in_output] = source.data[source_row_idx];
+                            const auto [column, offset] = reslicing_info.slice_and_offset_for_row(index_in_output);
+                            new_column_accessors[column][offset] = source.data[source_row_idx];
                         }
                     }
                 }
@@ -453,7 +467,7 @@ Column merge(
         }
         // Place target values on non-updated output positions
         while (source_has_index_value && !target_index_is_exhausted() && *target_index_it == current_index_value) {
-            if (!updated.test(new_column_row_idx)) {
+            if (!updated.test(output_row_idx)) {
                 if constexpr (is_sequence_type(TargetColumnTypeDescriptorTag::data_type())) {
                     set_string_from_target(target_row_idx);
                 } else {
@@ -508,10 +522,21 @@ Column merge(
             advance_output();
         }
     } else {
-        std::copy(source.data.begin() + source_row_idx, source.data.end(), new_column_it);
+        while (new_column_row_slice_index < new_columns.size()) {
+            const size_t free_elements_in_column =
+                    static_cast<size_t>(new_columns[new_column_row_slice_index]->row_count()) - new_column_row_idx;
+            std::copy_n(source.data.begin() + source_row_idx, free_elements_in_column, new_column_it);
+            source_row_idx += free_elements_in_column;
+            output_row_idx += free_elements_in_column;
+            ++new_column_row_slice_index;
+            new_column_row_idx = 0;
+            if (new_column_row_slice_index < new_columns.size()) {
+                new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
+            }
+        }
     }
 
-    return new_column;
+    return new_columns;
 }
 
 template<util::type_descriptor_tag ScalarType>
@@ -670,6 +695,68 @@ std::span<const timestamp>::iterator source_range_end_for_group(
     return std::ranges::upper_bound(source_range_start, source_index.end(), effective_segment_end - 1);
 }
 
+size_t compute_total_upsert_row_count(
+        std::span<const ColumnWithStrings> target_index_datas, const TargetRange& target_range,
+        const size_t unmatched_source_rows
+) {
+    // One index value can appear in more than one row slice. In that case it can be shared by two processing units,
+    // each working on part of the target data.
+    const size_t num_rows_out_of_target_range =
+            target_range.start_row_in_first_row_slice +
+            (target_index_datas.back().column_->row_count() - target_range.end_row_in_last_row_slice);
+    return std::accumulate(
+                   target_index_datas.begin(),
+                   target_index_datas.end(),
+                   unmatched_source_rows,
+                   [](size_t acc, const ColumnWithStrings& col) { return acc + col.column_->row_count(); }
+           ) -
+           num_rows_out_of_target_range;
+}
+
+void initialize_col_slices(
+        const StreamDescriptor& descriptor, const std::span<const std::shared_ptr<Column>> new_indexes,
+        std::span<ProcessingUnit> dest
+) {
+    for (auto&& [row_slice_idx, row_slice] : folly::enumerate(dest)) {
+        const std::shared_ptr<Column>& index_col = new_indexes[row_slice_idx];
+        row_slice.segments_->emplace_back(std::make_shared<SegmentInMemory>(descriptor, index_col->row_count()));
+        row_slice.segments_->back()->columns()[0] = index_col;
+    }
+}
+
+void finalize_col_slices(
+        const std::span<const std::shared_ptr<Column>> new_indexes, std::vector<StringPool>* new_string_pools,
+        std::span<ProcessingUnit> dest
+) {
+    for (auto&& [row_slice_idx, row_slice] : folly::enumerate(dest)) {
+        row_slice.segments_->back()->set_row_data(new_indexes[row_slice_idx]->row_count() - 1);
+        if (new_string_pools) {
+            row_slice.segments_->back()->string_pool() = std::move((*new_string_pools)[row_slice_idx]);
+            (*new_string_pools)[row_slice_idx].clear();
+        }
+    }
+}
+
+void set_upsert_ranges(
+        const TargetRange& target_range, const std::span<const ProcessingUnit> input_row_slices,
+        std::span<ProcessingUnit> dest
+) {
+    const size_t num_col_slices = input_row_slices.begin()->col_ranges_->size();
+    // Index key is merged in version_core.cpp::merge_update_impl. Since there are multiple parallel writes and the
+    // different processing units are not aware of how many rows were added before we cannot emit "final row ranges".
+    // The row ranges this clause emits are in the "coordinate system" of the unmodified target (meaning they don't
+    // account for insertion). Setting all resulting row ranges to the same values means: "The data that was originally
+    // in range row_range must be replaced by the concatenation of all new row ranges that have row_range set"
+    const auto row_range = std::make_shared<RowRange>(
+            input_row_slices.front().row_ranges_->front()->first + target_range.start_row_in_first_row_slice,
+            input_row_slices.back().row_ranges_->back()->first + target_range.end_row_in_last_row_slice
+    );
+    for (ProcessingUnit& row_slice : dest) {
+        row_slice.row_ranges_ = std::vector(num_col_slices, row_range);
+        row_slice.col_ranges_ = input_row_slices.front().col_ranges_;
+    }
+}
+
 } // namespace
 
 namespace arcticdb {
@@ -678,12 +765,14 @@ namespace ranges = std::ranges;
 using namespace pipelines;
 
 MergeUpdateClause::MergeUpdateClause(
-        std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source
+        std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source,
+        size_t rows_per_segment
 ) :
 
     on_(std::move(on)),
     strategy_(strategy),
-    source_(std::move(source)) {
+    source_(std::move(source)),
+    rows_per_segment_(rows_per_segment) {
     std::erase_if(on_, [&](const std::string& column) { return !on_set_.insert(column).second; });
 }
 
@@ -805,12 +894,13 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
         std::vector<EntityId> res;
         for (ProcessingUnit& row_slice : new_row_slices) {
             const size_t entity_count = row_slice.segments_->size();
+            const MergeUpdateRowSlicingInfoComponent row_slice_info(1, 0, row_slice.segments_->front()->row_count());
             std::vector<EntityId> entts = component_manager_->add_entities(
                     std::move(*row_slice.segments_),
                     std::move(*row_slice.row_ranges_),
                     std::move(*row_slice.col_ranges_),
                     std::vector<EntityFetchCount>(entity_count, 1),
-                    std::vector(entity_count, MergeUpdateInsertedRowsComponent{0})
+                    std::vector(entity_count, row_slice_info)
             );
             res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
         }
@@ -832,12 +922,15 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
             std::vector<EntityId> res;
             for (ProcessingUnit& row_slice : new_row_slices) {
                 const size_t entity_count = row_slice.segments_->size();
+                const MergeUpdateRowSlicingInfoComponent row_slice_info(
+                        1, 0, row_slice.segments_->front()->row_count()
+                );
                 std::vector<EntityId> entts = component_manager_->add_entities(
                         std::move(*row_slice.segments_),
                         std::move(*row_slice.row_ranges_),
                         std::move(*row_slice.col_ranges_),
                         std::vector<EntityFetchCount>(entity_count, 1),
-                        std::vector(entity_count, MergeUpdateInsertedRowsComponent{0}),
+                        std::vector(entity_count, row_slice_info),
                         std::vector(entity_count, unmatched_source_rows_component)
                 );
                 res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
@@ -855,14 +948,19 @@ std::vector<EntityId> MergeUpdateClause::process(std::vector<EntityId>&& entity_
     auto new_row_slices = update_and_insert(matched, target_descriptor, std::move(row_slices), source_start_end);
 
     std::vector<EntityId> res;
-    for (auto& row_slice : new_row_slices) {
+    for (auto&& [row_slice_idx, row_slice] : folly::enumerate(new_row_slices)) {
+        const MergeUpdateRowSlicingInfoComponent row_slice_info(
+                static_cast<int>(new_row_slices.size()),
+                static_cast<int>(row_slice_idx),
+                row_slice.segments_->front()->row_count()
+        );
         const size_t entity_count = row_slice.segments_->size();
         std::vector<EntityId> entts = component_manager_->add_entities(
                 std::move(*row_slice.segments_),
                 std::move(*row_slice.row_ranges_),
                 std::move(*row_slice.col_ranges_),
                 std::vector<EntityFetchCount>(entity_count, 1),
-                std::vector(entity_count, MergeUpdateInsertedRowsComponent{matched.total_unmatched_source_rows()})
+                std::vector(entity_count, row_slice_info)
         );
         res.insert(res.end(), std::make_move_iterator(entts.begin()), std::make_move_iterator(entts.end()));
     }
@@ -1023,32 +1121,36 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
             "All row slices should have the same number of column ranges"
     );
 
-    ProcessingUnit result{};
-    result.segments_.emplace();
-    result.segments_->reserve(num_col_slices);
-    result.col_ranges_ = row_slices.front().col_ranges_;
     std::vector<ColumnWithStrings> target_datas;
     std::vector<ColumnWithStrings> target_index_datas;
     target_index_datas.reserve(row_slices.size());
     std::ranges::transform(row_slices, std::back_inserter(target_index_datas), [&](const auto& proc) {
         return ColumnWithStrings(proc.segments_->front()->column_ptr(0), nullptr, target_descriptor.field(0).name());
     });
-    StringPool new_string_pool;
     bool has_string_column_in_column_slice = false;
     const TargetRange target_range = get_target_start_end(row_slices);
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
-    auto new_index = std::make_shared<Column>(merge<IndexType>(
+    const ReslicingInfo reslicing_info{
+            compute_total_upsert_row_count(
+                    target_index_datas, target_range, match_record.total_unmatched_source_rows()
+            ),
+            max_rows_per_segment(rows_per_segment_)
+    };
+    std::vector<ProcessingUnit> result(reslicing_info.num_segments());
+    std::vector<StringPool> new_string_pools(reslicing_info.num_segments());
+    std::vector<std::shared_ptr<Column>> new_indexes = merge<IndexType>(
             InsertSourceData{.index = source_index, .data = source_index, .global_row_range = source_start_end},
             InsertTargetData{
                     .indexes = target_index_datas,
                     .columns = target_index_datas,
-                    .type = TypeDescriptor{DataType::NANOSECONDS_UTC64, Dimension::Dim0},
+                    .type = IndexType::type_descriptor(),
                     .range = target_range,
-                    .new_string_pool = new_string_pool
+                    .new_string_pools = new_string_pools
             },
             match_record,
-            MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
-    ));
+            MergeStrategy{.not_matched_by_target = MergeAction::INSERT},
+            reslicing_info
+    );
     size_t col_slice_idx = 0;
     const auto [source_start, source_end] = source_start_end;
     for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
@@ -1059,53 +1161,52 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
         std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
             return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
         });
-        Column new_column = details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
-            using TargetDataTDT = ScalarTagType<TypeTag>;
-            has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
-            return merge<TargetDataTDT>(
-                    InsertSourceData{
-                            .index = source_index,
-                            .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
-                                    source_start, source_end - source_start
-                            ),
-                            .global_row_range = source_start_end
-                    },
-                    InsertTargetData{
-                            .indexes = target_index_datas,
-                            .columns = target_datas,
-                            .type = target_field.type(),
-                            .range = target_range,
-                            .new_string_pool = new_string_pool
-                    },
-                    match_record,
-                    // By construction, we cannot update the columns used to perform the match; only inserts are
-                    // allowed
-                    on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
-                                                  : strategy_
-            );
-        });
+        std::vector<std::shared_ptr<Column>> new_column_slices =
+                details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
+                    using TargetDataTDT = ScalarTagType<TypeTag>;
+                    has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
+                    return merge<TargetDataTDT>(
+                            InsertSourceData{
+                                    .index = source_index,
+                                    .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
+                                            source_start, source_end - source_start
+                                    ),
+                                    .global_row_range = source_start_end
+                            },
+                            InsertTargetData{
+                                    .indexes = target_index_datas,
+                                    .columns = target_datas,
+                                    .type = target_field.type(),
+                                    .range = target_range,
+                                    .new_string_pools = new_string_pools
+                            },
+                            match_record,
+                            // By construction, we cannot update the columns used to perform the match; only inserts are
+                            // allowed
+                            on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
+                                                          : strategy_,
+                            reslicing_info
+                    );
+                });
+        // Start working on new column slice.
         if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
-            const StreamDescriptor& desc = (*row_slices.front().segments_)[col_slice_idx]->descriptor();
-            result.segments_->emplace_back(std::make_shared<SegmentInMemory>(desc, new_index->row_count()));
-            result.segments_->back()->columns()[0] = new_index;
+            initialize_col_slices((*row_slices.front().segments_)[col_slice_idx]->descriptor(), new_indexes, result);
         }
+        // For each row slice set the corresponding column.
         const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
-        result.segments_->back()->columns()[col_in_slice] = std::make_shared<Column>(std::move(new_column));
+        for (auto&& [row_slice_idx, row_slice] : folly::enumerate(result)) {
+            row_slice.segments_->back()->columns()[col_in_slice] = std::move(new_column_slices[row_slice_idx]);
+        }
+
+        // The last column in the column slice is processed. Finish working on th segment by setting the string pool and
+        // the row data.
         if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
-            result.segments_->back()->set_row_data(new_index->row_count() - 1);
+            finalize_col_slices(new_indexes, has_string_column_in_column_slice ? &new_string_pools : nullptr, result);
             ++col_slice_idx;
-            if (has_string_column_in_column_slice) {
-                result.segments_->back()->string_pool() = std::move(new_string_pool);
-                new_string_pool.clear();
-                has_string_column_in_column_slice = false;
-            }
+            has_string_column_in_column_slice = false;
         }
     }
-    const auto new_row_range = std::make_shared<RowRange>(
-            row_slices.front().row_ranges_->front()->first + target_range.start_row_in_first_row_slice,
-            row_slices.back().row_ranges_->back()->first + target_range.end_row_in_last_row_slice
-    );
-    result.row_ranges_ = std::vector(num_col_slices, new_row_range);
+    set_upsert_ranges(target_range, row_slices, result);
     return std::vector{std::move(result)};
 }
 

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -25,9 +25,48 @@
 namespace {
 using namespace arcticdb;
 
+template<typename TDT, typename T>
+concept sequience_type_raw_value =
+        util::type_descriptor_tag<TDT> && is_sequence_type(TDT::data_type()) &&
+        util::any_of<std::remove_cvref_t<T>, PyObject*, typename TDT::RawType, std::optional<std::string_view>>;
+
+template<typename TDT, typename T>
+concept raw_value_for_type_descriptor =
+        util::type_descriptor_tag<TDT> &&
+        (std::same_as<T, typename TDT::DataTypeTag::raw_type> || sequience_type_raw_value<TDT, T>);
+
 template<util::type_descriptor_tag TDT>
 using SourceRawType =
         std::conditional_t<is_sequence_type(TDT::data_type()), PyObject* const, typename TDT::DataTypeTag::raw_type>;
+
+/// Type used as the key when target column values of type TDT are indexed for matching.
+template<util::type_descriptor_tag TDT>
+using MatchKeyType = std::conditional_t<
+        is_sequence_type(TDT::data_type()), std::optional<std::string_view>, typename TDT::DataTypeTag::raw_type>;
+
+/// Whether value, one of the representations merge-update uses for a column of type TDT, denotes a missing entry.
+/// TDT is always the type of the column itself. value can be the raw type stored in the target column, or, only for
+/// sequence types, the PyObject* read from the source tensor or the decoded std::optional<std::string_view> match
+/// key.
+template<util::type_descriptor_tag TDT, typename V>
+requires raw_value_for_type_descriptor<TDT, V>
+constexpr bool is_na(V value) {
+    if constexpr (is_floating_point_type(TDT::data_type())) {
+        return std::isnan(value);
+    } else if constexpr (is_time_type(TDT::data_type())) {
+        return value == NaT;
+    } else if constexpr (is_sequence_type(TDT::data_type())) {
+        if constexpr (std::same_as<std::remove_const_t<V>, PyObject*>) {
+            return is_py_none(value) || is_py_nan(value);
+        } else if constexpr (std::same_as<V, std::optional<std::string_view>>) {
+            return !value.has_value();
+        } else {
+            return !is_a_string(value);
+        }
+    } else {
+        return false;
+    }
+}
 
 struct TargetRange {
     size_t start_row_in_first_row_slice{};
@@ -162,85 +201,74 @@ void merge_update_string_column(
     );
 }
 
-struct NaNAwareFloatComparator {
-    template<std::floating_point T>
-    bool operator()(const T a, const T b) const {
-        return a == b || (std::isnan(a) && std::isnan(b));
-    }
-};
-
-struct NaNAwareFloatHasher {
-    using is_avalanching = void;
-    template<std::floating_point T>
-    uint64_t operator()(const T a) const {
-        if (std::isnan(a)) {
-            // IEEE allows multiple different bit representations of NaN. std::isnan is required to return true for all
-            // different bit bit representations of NaN, std::quient_NaN is an implementation defined constant.
-            return ankerl::unordered_dense::hash<T>()(std::numeric_limits<T>::quiet_NaN());
-        } else {
-            return std::hash<T>()(a);
+template<util::type_descriptor_tag TDT>
+struct NaAwareComparator {
+    bool match_na;
+    bool operator()(MatchKeyType<TDT> left, MatchKeyType<TDT> right) const {
+        const bool left_na = is_na<TDT>(left);
+        const bool right_na = is_na<TDT>(right);
+        if (left_na || right_na) {
+            return match_na && left_na && right_na;
         }
+        return left == right;
     }
 };
 
-template<
-        util::type_descriptor_tag SourceTDT, util::type_descriptor_tag TargetTDT,
-        typename SourceValueRawType = TargetTDT::DataTypeTag::raw_type,
-        typename TargetValueRawType = TargetTDT::DataTypeTag::raw_type>
+template<util::type_descriptor_tag TDT>
+struct NaAwareHasher : ankerl::unordered_dense::hash<MatchKeyType<TDT>> {
+    using Base = ankerl::unordered_dense::hash<MatchKeyType<TDT>>;
+    uint64_t operator()(MatchKeyType<TDT> value) const {
+        if constexpr (is_floating_point_type(TDT::data_type())) {
+            if (is_na<TDT>(value)) {
+                // IEEE allows multiple different bit representations of NaN. std::isnan is required to return true
+                // for all different bit representations of NaN, std::quiet_NaN is an implementation defined
+                // constant, so hashing it canonicalises every missing value to the same bucket.
+                return Base::operator()(std::numeric_limits<MatchKeyType<TDT>>::quiet_NaN());
+            }
+        }
+        return Base::operator()(value);
+    }
+};
+
+template<util::type_descriptor_tag SourceTDT, util::type_descriptor_tag TargetTDT>
 requires std::same_as<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>
 std::variant<bool, convert::StringEncodingError> are_merge_values_matching(
-        const SourceValueRawType& source_value, const TargetValueRawType& target_value,
-        const StringPool& target_string_pool, std::optional<ScopedGILLock>& scoped_gil_lock
+        SourceRawType<SourceTDT> source_value, typename TargetTDT::DataTypeTag::raw_type target_value,
+        const StringPool& target_string_pool, std::optional<ScopedGILLock>& scoped_gil_lock, bool match_na
 ) {
+
+    const bool source_is_na = is_na<SourceTDT>(source_value);
+    const bool target_is_na = is_na<TargetTDT>(target_value);
+    if (source_is_na || target_is_na) {
+        return match_na && source_is_na && target_is_na;
+    }
     if constexpr (is_sequence_type(SourceTDT::data_type())) {
-        const bool is_source_null = is_py_none(source_value) || is_py_nan(source_value);
-        const bool is_target_null = !is_a_string(target_value);
-        if (is_source_null ^ is_target_null) {
-            return false;
-        } else if (is_source_null && is_target_null) {
-            return true;
-        } else {
-            return util::variant_match(
-                    create_py_object_wrapper_or_error<TargetTDT::data_type()>(source_value, scoped_gil_lock),
-                    [](convert::StringEncodingError&& err) -> std::variant<bool, convert::StringEncodingError> {
-                        return err;
-                    },
-                    [&](convert::PyStringWrapper&& wrapper) -> std::variant<bool, convert::StringEncodingError> {
-                        return target_string_pool.get_const_view(target_value) ==
-                               std::string_view(wrapper.buffer_, wrapper.length_);
-                    }
-            );
-        }
-    } else if constexpr (is_floating_point_type(SourceTDT::data_type())) {
-        constexpr static NaNAwareFloatComparator comparator;
-        return comparator(source_value, target_value);
+        return util::variant_match(
+                create_py_object_wrapper_or_error<TargetTDT::data_type()>(source_value, scoped_gil_lock),
+                [](convert::StringEncodingError&& err) -> std::variant<bool, convert::StringEncodingError> {
+                    return err;
+                },
+                [&](convert::PyStringWrapper&& wrapper) -> std::variant<bool, convert::StringEncodingError> {
+                    return target_string_pool.get_const_view(target_value) ==
+                           std::string_view(wrapper.buffer_, wrapper.length_);
+                }
+        );
     } else {
         return source_value == target_value;
     }
 }
 
 template<util::type_descriptor_tag TDT>
-auto map_column_values_to_rows(const ColumnWithStrings& column) {
-    constexpr static bool is_target_sequence_type = is_sequence_type(TDT::data_type());
-    constexpr static bool is_target_floating_point_type = is_floating_point_type(TDT::data_type());
-    using TargetRawType = typename TDT::DataTypeTag::raw_type;
-    using TargetValueType = std::conditional_t<is_target_sequence_type, std::optional<std::string_view>, TargetRawType>;
-    using Hasher = std::conditional_t<
-            is_target_floating_point_type,
-            NaNAwareFloatHasher,
-            ankerl::unordered_dense::hash<TargetValueType>>;
-    using Comparator =
-            std::conditional_t<is_target_floating_point_type, NaNAwareFloatComparator, std::equal_to<TargetValueType>>;
-    ankerl::unordered_dense::map<TargetValueType, std::vector<size_t>, Hasher, Comparator> target_values;
+auto map_column_values_to_rows(const ColumnWithStrings& column, bool match_na) {
+    ankerl::unordered_dense::map<MatchKeyType<TDT>, std::vector<size_t>, NaAwareHasher<TDT>, NaAwareComparator<TDT>>
+            target_values(0, NaAwareHasher<TDT>{}, NaAwareComparator<TDT>{match_na});
     arcticdb::for_each_enumerated<TDT>(*column.column_, [&](auto row) {
-        if constexpr (is_target_sequence_type) {
-            if (is_a_string(row.value())) {
+        if (match_na || !is_na<TDT>(row.value())) {
+            if constexpr (is_sequence_type(TDT::data_type())) {
                 target_values[column.string_at_offset(row.value())].emplace_back(row.idx());
             } else {
-                target_values[std::nullopt].emplace_back(row.idx());
+                target_values[row.value()].emplace_back(row.idx());
             }
-        } else {
-            target_values[row.value()].emplace_back(row.idx());
         }
     });
     return target_values;
@@ -771,12 +799,13 @@ using namespace pipelines;
 
 MergeUpdateClause::MergeUpdateClause(
         std::vector<std::string>&& on, MergeStrategy strategy, std::shared_ptr<InputFrame> source,
-        size_t rows_per_segment
+        size_t rows_per_segment, bool match_na
 ) :
 
     on_(std::move(on)),
     strategy_(strategy),
     source_(std::move(source)),
+    match_na_(match_na),
     rows_per_segment_(rows_per_segment) {
     std::erase_if(on_, [&](const std::string& column) { return !on_set_.insert(column).second; });
 }
@@ -999,12 +1028,16 @@ MergeUpdateClause::MatchRecord MergeUpdateClause::initialize_rows_to_update_for_
             details::visit_type(target_column.column_->type().data_type(), [&](auto target_field_dt) {
                 using TargetTDT = ScalarTagType<decltype(target_field_dt)>;
                 if constexpr (std::same_as<std::decay_t<SourceTDT>, std::decay_t<TargetTDT>>) {
-                    auto target_values_to_rows = map_column_values_to_rows<TargetTDT>(target_column);
+                    auto target_values_to_rows = map_column_values_to_rows<TargetTDT>(target_column, match_na_);
                     std::span source_data = source_->get_tensor(source_field_position).span<SourceType>();
                     for (size_t source_row_idx = 0; source_row_idx < source_data.size(); ++source_row_idx) {
                         auto source_value = source_data[source_row_idx];
+                        const bool source_is_na = is_na<SourceTDT>(source_value);
+                        if (!match_na_ && source_is_na) {
+                            continue;
+                        }
                         if constexpr (is_sequence_type(SourceTDT::data_type())) {
-                            if (is_py_none(source_value) || is_py_nan(source_value)) {
+                            if (source_is_na) {
                                 result.add_match(source_row_idx, row_slice_idx, target_values_to_rows[std::nullopt]);
                             } else {
                                 util::variant_match(
@@ -1374,7 +1407,8 @@ MergeUpdateClause::MatchRecord MergeUpdateClause::filter_on_additional_columns_m
                 source_field.type().data_type(),
                 target_field.type().data_type(),
                 source_range.first,
-                get_source_data_bytes(source_field_position, source_range)
+                get_source_data_bytes(source_field_position, source_range),
+                match_na_
         );
     }
     return matched_rows;
@@ -1479,7 +1513,7 @@ void MergeUpdateClause::MatchRecord::add_match(
 
 void MergeUpdateClause::MatchRecord::filter_matching_rows(
         std::string_view column_name, const DataType source_type, const DataType target_type,
-        const size_t source_offset, const std::span<const std::byte> opaque_source_data
+        const size_t source_offset, const std::span<const std::byte> opaque_source_data, const bool match_na
 ) {
     if (total_matched_target_rows_count_ == 0) {
         // This function can only remove matches in case of a mismatch. In case there are no matched
@@ -1515,7 +1549,11 @@ void MergeUpdateClause::MatchRecord::filter_matching_rows(
                                     const TargetRawType target_value = target_column_accessor[target_row];
                                     const auto& source_value = source_data[source_row_idx];
                                     auto are_values_equal = are_merge_values_matching<SourceTDT, TargetTDT>(
-                                            source_value, target_value, *target_column.string_pool_, scoped_gil_lock
+                                            source_value,
+                                            target_value,
+                                            *target_column.string_pool_,
+                                            scoped_gil_lock,
+                                            match_na
                                     );
                                     bool discard_match = false;
                                     if constexpr (is_sequence_type(TargetDataTypeTag::data_type)) {

--- a/cpp/arcticdb/processing/clause_merge_update.cpp
+++ b/cpp/arcticdb/processing/clause_merge_update.cpp
@@ -6,8 +6,6 @@
  * will be governed by the Apache License, version 2.0.
  */
 
-#include "util/collection_utils.hpp"
-
 #include <arcticdb/processing/clause.hpp>
 #include <arcticdb/processing/processing_unit.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
@@ -18,6 +16,7 @@
 #include <arcticdb/pipeline/slicing.hpp>
 #include <arcticdb/stream/index.hpp>
 #include <arcticdb/column_store/column_reslicer.hpp>
+#include <arcticdb/util/collection_utils.hpp>
 #include <ankerl/unordered_dense.h>
 #include <boost/regex.hpp>
 
@@ -306,6 +305,7 @@ std::vector<std::shared_ptr<Column>> merge(
     size_t new_column_row_idx{};
     // Position in the combined [0, total_rows()) output
     size_t output_row_idx{};
+    size_t rows_in_current_slice = reslicing_info.rows_in_slice(0);
     auto new_column_it = new_column_datas.front().begin<TargetColumnTypeDescriptorTag>();
 
     size_t target_row_slice = 0;
@@ -351,9 +351,10 @@ std::vector<std::shared_ptr<Column>> merge(
         ++output_row_idx;
         ++new_column_it;
 
-        if (new_column_it == new_column_datas[new_column_row_slice_index].end<TargetColumnTypeDescriptorTag>() &&
+        if (new_column_row_idx == rows_in_current_slice &&
             new_column_row_slice_index + 1 < reslicing_info.num_segments()) [[unlikely]] {
             ++new_column_row_slice_index;
+            rows_in_current_slice = reslicing_info.rows_in_slice(new_column_row_slice_index);
             new_column_row_idx = 0;
             new_column_it = new_column_datas[new_column_row_slice_index].begin<TargetColumnTypeDescriptorTag>();
         }
@@ -578,11 +579,13 @@ RowRange get_row_range(std::span<const ProcessingUnit> row_slice) {
     return {row_slice.front().row_ranges_->front()->first, row_slice.back().row_ranges_->back()->second};
 }
 
-ssize_t first_different_index_value_position(const ColumnData index) {
+std::optional<ssize_t> first_different_index_value_position(const ColumnData index) {
     using IndexType = ScalarTagType<DataTypeTag<DataType::NANOSECONDS_UTC64>>;
     auto it = index.cbegin<IndexType, IteratorType::ENUMERATED>();
     const timestamp first_source_row = it->value();
-    return exponential_upper_bound(++it, index.cend<IndexType, IteratorType::ENUMERATED>(), first_source_row)->idx();
+    const auto end = index.cend<IndexType, IteratorType::ENUMERATED>();
+    const auto first_different_position = exponential_upper_bound(++it, end, first_source_row);
+    return end == first_different_position ? std::nullopt : std::optional{first_different_position->idx()};
 };
 
 TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
@@ -593,11 +596,13 @@ TargetRange get_target_start_end(std::span<const ProcessingUnit> row_slices) {
     if (row_slices.front().entity_fetch_count_) {
         if (row_slices.front().entity_fetch_count_->front() > 1) {
             const ColumnData index = row_slices.front().segments_->front()->column(0).data();
-            result.start_row_in_first_row_slice = first_different_index_value_position(index);
+            result.start_row_in_first_row_slice = first_different_index_value_position(index).value_or(0);
         }
         if (row_slices.size() > 1 && row_slices.back().entity_fetch_count_->back() > 1) {
             const ColumnData index = row_slices.back().segments_->back()->column(0).data();
-            result.end_row_in_last_row_slice = first_different_index_value_position(index);
+            result.end_row_in_last_row_slice = first_different_index_value_position(index).value_or(
+                    row_slices.back().segments_->back()->row_count()
+            );
         }
     }
     return result;
@@ -1137,6 +1142,9 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
             max_rows_per_segment(rows_per_segment_)
     };
     std::vector<ProcessingUnit> result(reslicing_info.num_segments());
+    for (ProcessingUnit& proc : result) {
+        proc.segments_.emplace(util::reserve_vector<std::shared_ptr<SegmentInMemory>>(num_col_slices));
+    }
     std::vector<StringPool> new_string_pools(reslicing_info.num_segments());
     std::vector<std::shared_ptr<Column>> new_indexes = merge<IndexType>(
             InsertSourceData{.index = source_index, .data = source_index, .global_row_range = source_start_end},
@@ -1151,61 +1159,73 @@ std::vector<ProcessingUnit> MergeUpdateClause::update_and_insert(
             MergeStrategy{.not_matched_by_target = MergeAction::INSERT},
             reslicing_info
     );
-    size_t col_slice_idx = 0;
-    const auto [source_start, source_end] = source_start_end;
-    for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
-         ++field_idx) {
-        const Field& target_field = target_descriptor.field(field_idx);
-        const std::string_view column_name = target_field.name();
-        target_datas.clear();
-        std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
-            return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
-        });
-        std::vector<std::shared_ptr<Column>> new_column_slices =
-                details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
-                    using TargetDataTDT = ScalarTagType<TypeTag>;
-                    has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
-                    return merge<TargetDataTDT>(
-                            InsertSourceData{
-                                    .index = source_index,
-                                    .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
-                                            source_start, source_end - source_start
-                                    ),
-                                    .global_row_range = source_start_end
-                            },
-                            InsertTargetData{
-                                    .indexes = target_index_datas,
-                                    .columns = target_datas,
-                                    .type = target_field.type(),
-                                    .range = target_range,
-                                    .new_string_pools = new_string_pools
-                            },
-                            match_record,
-                            // By construction, we cannot update the columns used to perform the match; only inserts are
-                            // allowed
-                            on_set_.contains(column_name) ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
-                                                          : strategy_,
-                            reslicing_info
-                    );
-                });
-        // Start working on new column slice.
-        if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
-            initialize_col_slices((*row_slices.front().segments_)[col_slice_idx]->descriptor(), new_indexes, result);
-        }
-        // For each row slice set the corresponding column.
-        const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
-        for (auto&& [row_slice_idx, row_slice] : folly::enumerate(result)) {
-            row_slice.segments_->back()->columns()[col_in_slice] = std::move(new_column_slices[row_slice_idx]);
-        }
+    if (target_descriptor.field_count() == target_descriptor.index().field_count()) {
+        // Handle degenerate case of index-only dataframe
+        initialize_col_slices((*row_slices.front().segments_)[0]->descriptor(), new_indexes, result);
+        finalize_col_slices(new_indexes, nullptr, result);
+    } else {
+        size_t col_slice_idx = 0;
+        const auto [source_start, source_end] = source_start_end;
+        for (size_t field_idx = target_descriptor.index().field_count(); field_idx < target_descriptor.field_count();
+             ++field_idx) {
+            const Field& target_field = target_descriptor.field(field_idx);
+            const std::string_view column_name = target_field.name();
+            target_datas.clear();
+            std::ranges::transform(row_slices, std::back_inserter(target_datas), [&](ProcessingUnit& row_slice) {
+                return std::get<ColumnWithStrings>(row_slice.get(ColumnName{column_name}));
+            });
+            std::vector<std::shared_ptr<Column>> new_column_slices =
+                    details::visit_type(target_field.type().data_type(), [&]<typename TypeTag>(TypeTag) {
+                        using TargetDataTDT = ScalarTagType<TypeTag>;
+                        has_string_column_in_column_slice |= is_sequence_type(TargetDataTDT::data_type());
+                        return merge<TargetDataTDT>(
+                                InsertSourceData{
+                                        .index = source_index,
+                                        .data = source_->get_tensor(field_idx).span<SourceRawType<TargetDataTDT>>(
+                                                source_start, source_end - source_start
+                                        ),
+                                        .global_row_range = source_start_end
+                                },
+                                InsertTargetData{
+                                        .indexes = target_index_datas,
+                                        .columns = target_datas,
+                                        .type = target_field.type(),
+                                        .range = target_range,
+                                        .new_string_pools = new_string_pools
+                                },
+                                match_record,
+                                // By construction, we cannot update the columns used to perform the match; only inserts
+                                // are allowed
+                                on_set_.contains(column_name)
+                                        ? MergeStrategy{.not_matched_by_target = MergeAction::INSERT}
+                                        : strategy_,
+                                reslicing_info
+                        );
+                    });
+            // Start working on new column slice.
+            if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->first) {
+                initialize_col_slices(
+                        (*row_slices.front().segments_)[col_slice_idx]->descriptor(), new_indexes, result
+                );
+            }
+            // For each row slice set the corresponding column.
+            const size_t col_in_slice = field_idx - (*row_slices.front().col_ranges_)[col_slice_idx]->first + 1;
+            for (auto&& [row_slice_idx, row_slice] : folly::enumerate(result)) {
+                row_slice.segments_->back()->columns()[col_in_slice] = std::move(new_column_slices[row_slice_idx]);
+            }
 
-        // The last column in the column slice is processed. Finish working on th segment by setting the string pool and
-        // the row data.
-        if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
-            finalize_col_slices(new_indexes, has_string_column_in_column_slice ? &new_string_pools : nullptr, result);
-            ++col_slice_idx;
-            has_string_column_in_column_slice = false;
+            // The last column in the column slice is processed. Finish working on th segment by setting the string pool
+            // and the row data.
+            if (field_idx == (*row_slices.front().col_ranges_)[col_slice_idx]->second - 1) {
+                finalize_col_slices(
+                        new_indexes, has_string_column_in_column_slice ? &new_string_pools : nullptr, result
+                );
+                ++col_slice_idx;
+                has_string_column_in_column_slice = false;
+            }
         }
     }
+
     set_upsert_ranges(target_range, row_slices, result);
     return std::vector{std::move(result)};
 }

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -15,7 +15,6 @@
 
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/constructors.hpp>
-#include <boost/locale/boundary/index.hpp>
 #include <folly/container/Enumerate.h>
 
 namespace arcticdb {

--- a/cpp/arcticdb/processing/component_manager.hpp
+++ b/cpp/arcticdb/processing/component_manager.hpp
@@ -15,6 +15,7 @@
 
 #include <arcticdb/pipeline/frame_slice.hpp>
 #include <arcticdb/util/constructors.hpp>
+#include <boost/locale/boundary/index.hpp>
 #include <folly/container/Enumerate.h>
 
 namespace arcticdb {
@@ -30,11 +31,15 @@ using namespace entt::literals;
 /// clause adding this entity and then after read_modify_write it reads it in order to compute the correct row ranges
 /// accounting for insertion. If any other piece of code adds this entity to the component manager the merge updates
 /// will iterate over them as well, producing wrong results. See merge_update_impl and Monday 12618296803
-struct MergeUpdateInsertedRowsComponent {
-    MergeUpdateInsertedRowsComponent() = default;
-    MergeUpdateInsertedRowsComponent(const size_t inserted_rows) : inserted_rows(inserted_rows) {}
-    operator size_t() const { return inserted_rows; }
-    size_t inserted_rows = 0;
+struct MergeUpdateRowSlicingInfoComponent {
+    MergeUpdateRowSlicingInfoComponent() = default;
+    MergeUpdateRowSlicingInfoComponent(int num_segments, int segment_index, size_t num_rows) :
+        num_segments_(num_segments),
+        segment_index_(segment_index),
+        num_rows_(num_rows) {}
+    int num_segments_ = 1;
+    int segment_index_ = 0;
+    size_t num_rows_ = 0;
 };
 
 /// Used only by the MergeUpdateClause, and only for row-count indexed targets. After the pipeline finishes,
@@ -59,7 +64,7 @@ class ComponentManager {
 
     // Add a single entity with the components defined by args
     template<class... Args>
-    void add_entity(EntityId id, Args... args) {
+    void add_components(EntityId id, Args... args) {
         std::unique_lock lock(mtx_);
         (
                 [&] {
@@ -166,6 +171,13 @@ class ComponentManager {
         }(static_cast<NoRefArgs*>(nullptr));
     }
 
+    template<typename T>
+    requires(!std::same_as<T, EntityFetchCount>)
+    void remove_component(const EntityId entt) {
+        std::unique_lock lock(mtx_);
+        registry_.remove<T>(entt);
+    }
+
   private:
     void decrement_entity_fetch_count(EntityId id);
     void update_entity_fetch_count(EntityId id, EntityFetchCount count);
@@ -180,12 +192,10 @@ class ComponentManager {
             // Using view.get theoretically and empirically faster than registry_.get
             auto view = registry_.view<const Args...>();
 
-            for (auto id : ids) {
-                tuple_res.emplace_back(std::move(view.get(id)));
-            }
+            std::ranges::transform(ids, std::back_inserter(tuple_res), [&](auto id) { return view.get(id); });
 
             if (decrement_ref_count) {
-                for (auto id : ids) {
+                for (const auto id : ids) {
                     decrement_entity_fetch_count(id);
                 }
             }

--- a/cpp/arcticdb/processing/test/benchmark_resample.cpp
+++ b/cpp/arcticdb/processing/test/benchmark_resample.cpp
@@ -146,7 +146,7 @@ std::vector<EntityId> register_segments(
         const auto rows = seg->row_count();
         auto rr = std::make_shared<RowRange>(row_offset, row_offset + rows);
         auto cr = std::make_shared<ColRange>(1, num_value_cols + 1);
-        component_manager.add_entity(ids[i], seg, rr, cr, EntityFetchCount{1});
+        component_manager.add_components(ids[i], seg, rr, cr, EntityFetchCount{1});
         row_offset += rows;
     }
     return ids;

--- a/cpp/arcticdb/processing/test/test_component_manager.cpp
+++ b/cpp/arcticdb/processing/test/test_component_manager.cpp
@@ -28,9 +28,9 @@ TEST(ComponentManager, Simple) {
     uint64_t entity_fetch_count_1{2};
 
     auto ids = component_manager.get_new_entity_ids(2);
-    component_manager.add_entity(ids[0], segment_0, row_range_0, col_range_0, key_0, entity_fetch_count_0);
+    component_manager.add_components(ids[0], segment_0, row_range_0, col_range_0, key_0, entity_fetch_count_0);
 
-    component_manager.add_entity(ids[1], segment_1, row_range_1, col_range_1, key_1, entity_fetch_count_1);
+    component_manager.add_components(ids[1], segment_1, row_range_1, col_range_1, key_1, entity_fetch_count_1);
 
     auto [segments, row_ranges, col_ranges, keys, entity_fetch_counts] =
             component_manager.get_entities_and_decrement_refcount<

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -16,6 +16,8 @@ using namespace arcticdb;
 using namespace std::ranges;
 
 namespace {
+constexpr size_t rows_per_segment = 100'000;
+
 constexpr MergeStrategy update_only_strategy{.matched = MergeAction::UPDATE};
 constexpr MergeStrategy update_and_insert_strategy{
         .matched = MergeAction::UPDATE,
@@ -106,7 +108,9 @@ MergeUpdateClause create_clause(
         const MergeStrategy strategy, std::shared_ptr<ComponentManager> component_manager, InputFrame&& input_frame,
         std::vector<std::string> on = {}
 ) {
-    MergeUpdateClause clause(std::move(on), strategy, std::make_shared<InputFrame>(std::move(input_frame)));
+    MergeUpdateClause clause(
+            std::move(on), strategy, std::make_shared<InputFrame>(std::move(input_frame)), rows_per_segment
+    );
     clause.set_component_manager(std::move(component_manager));
     return clause;
 }

--- a/cpp/arcticdb/processing/test/test_merge_update.cpp
+++ b/cpp/arcticdb/processing/test/test_merge_update.cpp
@@ -106,10 +106,10 @@ void sort_by_rowslice(std::span<RowRange> rows, std::span<ColRange> cols, Other&
 
 MergeUpdateClause create_clause(
         const MergeStrategy strategy, std::shared_ptr<ComponentManager> component_manager, InputFrame&& input_frame,
-        std::vector<std::string> on = {}
+        std::vector<std::string> on = {}, bool match_na = false
 ) {
     MergeUpdateClause clause(
-            std::move(on), strategy, std::make_shared<InputFrame>(std::move(input_frame)), rows_per_segment
+            std::move(on), strategy, std::make_shared<InputFrame>(std::move(input_frame)), rows_per_segment, match_na
     );
     clause.set_component_manager(std::move(component_manager));
     return clause;
@@ -1379,7 +1379,8 @@ TEST_F(MergeUpdateClauseUpdateStrategyRowRange, MatchNaN) {
             std::array{std::numeric_limits<float>::quiet_NaN()},
             std::array<timestamp, 1>{2000}
     );
-    MergeUpdateClause clause = create_clause(std::move(input_frame), {"float32"});
+    MergeUpdateClause clause =
+            ::create_clause(strategy_, component_manager_, std::move(input_frame), {"float32"}, true);
     const std::vector<std::vector<size_t>> structure_indices = clause.structure_for_processing(ranges_and_keys_);
     const size_t row_slices_to_process = structure_indices.size();
     ASSERT_EQ(row_slices_to_process, 3);

--- a/cpp/arcticdb/processing/test/test_resample.cpp
+++ b/cpp/arcticdb/processing/test/test_resample.cpp
@@ -406,9 +406,9 @@ TEST(Resample, ProcessMultipleSegments) {
     auto col_range_2 = std::make_shared<ColRange>(1, 2);
 
     auto ids = component_manager->get_new_entity_ids(3);
-    component_manager->add_entity(ids[0], seg_0, row_range_0, col_range_0, EntityFetchCount(1));
-    component_manager->add_entity(ids[1], seg_1, row_range_1, col_range_1, EntityFetchCount(2));
-    component_manager->add_entity(ids[2], seg_2, row_range_2, col_range_2, EntityFetchCount(1));
+    component_manager->add_components(ids[0], seg_0, row_range_0, col_range_0, EntityFetchCount(1));
+    component_manager->add_components(ids[1], seg_1, row_range_1, col_range_1, EntityFetchCount(2));
+    component_manager->add_components(ids[2], seg_2, row_range_2, col_range_2, EntityFetchCount(1));
 
     std::vector<EntityId> ids_0{ids[0], ids[1]};
     std::vector<EntityId> ids_1{ids[1]};

--- a/cpp/arcticdb/util/collection_utils.hpp
+++ b/cpp/arcticdb/util/collection_utils.hpp
@@ -9,15 +9,17 @@
 #pragma once
 
 #include <memory>
+#include <numeric>
 #include <ranges>
 #include <vector>
+#include <arcticdb/util/preconditions.hpp>
 
 namespace arcticdb {
 
 namespace util {
 
 template<typename T>
-inline std::vector<T> flatten_vectors(std::vector<std::vector<T>>&& vec_of_vecs) {
+std::vector<T> flatten_vectors(std::vector<std::vector<T>>&& vec_of_vecs) {
     size_t res_size = std::accumulate(
             vec_of_vecs.cbegin(),
             vec_of_vecs.cend(),

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -2537,7 +2537,7 @@ void LocalVersionedEngine::_test_set_store(std::shared_ptr<Store> store) { set_s
 
 VersionedItem LocalVersionedEngine::merge_internal(
         const StreamId& stream_id, std::shared_ptr<InputFrame> source, const bool prune_previous_versions,
-        const bool upsert, const MergeStrategy& strategy, std::vector<std::string>&& on
+        const bool upsert, const MergeStrategy& strategy, std::vector<std::string>&& on, const bool match_na
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: merge_update");
     sorting::check<ErrorCode::E_UNSORTED_DATA>(
@@ -2562,6 +2562,7 @@ VersionedItem LocalVersionedEngine::merge_internal(
                                                   IndexPartialKey{stream_id, update_info.next_version_id_},
                                                   std::move(on),
                                                   strategy,
+                                                  match_na,
                                                   std::move(source),
                                                   get_de_dup_map(stream_id, update_info, write_options_)
                                           );

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -420,7 +420,7 @@ class LocalVersionedEngine : public VersionedEngine {
 
     VersionedItem merge_internal(
             const StreamId& stream_id, std::shared_ptr<InputFrame> source, bool prune_previous_versions,
-            const bool upsert, const MergeStrategy& strategy, std::vector<std::string>&& on
+            const bool upsert, const MergeStrategy& strategy, std::vector<std::string>&& on, bool match_na
     ) override;
 
   protected:

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -3244,13 +3244,13 @@ folly::Future<VersionedItem> read_modify_write_impl(
 folly::Future<AtomKey> merge_update_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
-        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
-        std::shared_ptr<DeDupMap> de_dup_map
+        std::vector<std::string>&& on, const MergeStrategy& strategy, const bool match_na,
+        std::shared_ptr<InputFrame> source, std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto read_query = std::make_shared<ReadQuery>();
-    auto merge_update_clause =
-            std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source, write_options.segment_row_size)
-            );
+    auto merge_update_clause = std::make_shared<Clause>(
+            MergeUpdateClause(std::move(on), strategy, source, write_options.segment_row_size, match_na)
+    );
 
     read_query->clauses_.push_back(merge_update_clause);
     VersionIdentifier resolved = VersionedItem{*update_info.previous_index_key_};

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -358,46 +358,69 @@ bool is_fake_index_name(const arcticc::pb2::descriptors_pb2::NormalizationMetada
     return is_fake_datetime_index_name || is_fake_mutliindex_name;
 }
 
+/// A slice emitted by the merge update clause, paired with its position in the group of output row slices that
+/// replaced one consumed target row range. Both items are needed in order to sort the slices and keys.
+struct SliceAndMergeInfo {
+    SliceAndKey slice_and_key;
+    MergeUpdateRowSlicingInfoComponent info;
+};
+
 std::vector<SliceAndKey> merge_slices_and_keys(
-        std::vector<SliceAndKey>&& old_slices, std::vector<SliceAndKey>&& new_slices,
-        ankerl::unordered_dense::map<RowRange, size_t>&& inserted_rows_per_row_range
+        std::vector<SliceAndKey>&& old_slices, std::vector<SliceAndMergeInfo>&& new_slices
 ) {
-    ranges::sort(new_slices);
+    // Every slice carries its own position within its group. (col_range, row_range, segment_index_) is a total
+    // order over new_slices. Sorting on the FrameSlice alone would not be enough because a group's slices deliberately
+    // share one row_range while holding different AtomKeys, so ties would be broken arbitrarily and the row ranges
+    // assigned below would land on the wrong keys.
+    ranges::sort(new_slices, [](const SliceAndMergeInfo& left, const SliceAndMergeInfo& right) {
+        const FrameSlice& l = left.slice_and_key.slice();
+        const FrameSlice& r = right.slice_and_key.slice();
+        return std::tie(l.col_range.first, l.row_range.first, left.info.segment_index_) <
+               std::tie(r.col_range.first, r.row_range.first, right.info.segment_index_);
+    });
     std::vector<SliceAndKey> merged_ranges_and_keys;
     auto new_slice_and_key_it = new_slices.begin();
     auto old_slice_and_key_it = old_slices.begin();
     while (old_slice_and_key_it != old_slices.end()) {
         size_t total_inserted_rows{};
-        ColRange current_col_range = old_slice_and_key_it->slice().col_range;
-        while (old_slice_and_key_it != old_slices.end() && current_col_range == old_slice_and_key_it->slice().col_range
-        ) {
-            if (new_slice_and_key_it == new_slices.end() ||
-                old_slice_and_key_it->slice() < new_slice_and_key_it->slice()) {
+        const ColRange current_col_range = old_slice_and_key_it->slice().col_range;
+        const auto old_column_slice_exhausted = [&] {
+            return old_slice_and_key_it == old_slices.end() ||
+                   old_slice_and_key_it->slice().col_range != current_col_range;
+        };
+        const auto new_column_slice_exhausted = [&] {
+            return new_slice_and_key_it == new_slices.end() ||
+                   new_slice_and_key_it->slice_and_key.slice().col_range != current_col_range;
+        };
+        while (!old_column_slice_exhausted() || !new_column_slice_exhausted()) {
+            if (new_column_slice_exhausted() ||
+                (!old_column_slice_exhausted() &&
+                 old_slice_and_key_it->slice() < new_slice_and_key_it->slice_and_key.slice())) {
                 old_slice_and_key_it->slice().row_range.first += total_inserted_rows;
                 old_slice_and_key_it->slice().row_range.second += total_inserted_rows;
                 merged_ranges_and_keys.emplace_back(std::move(*old_slice_and_key_it));
                 ++old_slice_and_key_it;
-            } else {
-                const RowRange new_row_range = new_slice_and_key_it->slice().row_range;
-                const size_t inserted_rows = inserted_rows_per_row_range.at(new_row_range);
-                new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
-                new_slice_and_key_it->slice().row_range.second += total_inserted_rows + inserted_rows;
-                total_inserted_rows += inserted_rows;
-                merged_ranges_and_keys.emplace_back(std::move(*new_slice_and_key_it));
-                ++new_slice_and_key_it;
-                while (old_slice_and_key_it != old_slices.end() &&
-                       old_slice_and_key_it->slice().col_range == current_col_range &&
-                       old_slice_and_key_it->slice().row_range.first < new_row_range.second) {
-                    ++old_slice_and_key_it;
-                }
+                continue;
             }
-        }
-        while (new_slice_and_key_it != new_slices.end() && new_slice_and_key_it->slice().col_range == current_col_range
-        ) {
-            new_slice_and_key_it->slice().row_range.first += total_inserted_rows;
-            new_slice_and_key_it->slice().row_range.second += total_inserted_rows;
-            merged_ranges_and_keys.emplace_back(std::move(*new_slice_and_key_it));
-            ++new_slice_and_key_it;
+            const RowRange consumed = new_slice_and_key_it->slice_and_key.slice().row_range;
+            // Read the group size before the loop: the body advances new_slice_and_key_it, so re-reading it from
+            // the iterator would take the bound from the next group, or dereference end() on the last group.
+            const size_t group_size = static_cast<size_t>(new_slice_and_key_it->info.num_segments_);
+            const size_t group_start = consumed.first + total_inserted_rows;
+            size_t offset_in_group{};
+            for (size_t position = 0; position < group_size; ++position) {
+                const size_t num_rows = new_slice_and_key_it->info.num_rows_;
+                new_slice_and_key_it->slice_and_key.slice().row_range =
+                        RowRange{group_start + offset_in_group, group_start + offset_in_group + num_rows};
+                offset_in_group += num_rows;
+                merged_ranges_and_keys.emplace_back(std::move(new_slice_and_key_it->slice_and_key));
+                ++new_slice_and_key_it;
+            }
+            const size_t num_new_rows = offset_in_group - consumed.diff();
+            total_inserted_rows += num_new_rows;
+            while (!old_column_slice_exhausted() && old_slice_and_key_it->slice().row_range.first < consumed.second) {
+                ++old_slice_and_key_it;
+            }
         }
     }
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -409,8 +432,7 @@ std::vector<SliceAndKey> merge_slices_and_keys(
     return merged_ranges_and_keys;
 }
 
-std::optional<util::BitSet> source_rows_to_insert_for_row_range_merge_update(const ComponentManager& component_manager
-) {
+util::BitSet source_rows_to_insert_for_row_range_merge_update(const ComponentManager& component_manager) {
     std::optional<util::BitSet> rows_to_insert;
     component_manager.process_entities([&](const MergeUpdateNotMatchedSourceRowsComponent& unmatched_source_rows) {
         if (rows_to_insert) {
@@ -419,7 +441,7 @@ std::optional<util::BitSet> source_rows_to_insert_for_row_range_merge_update(con
             rows_to_insert = *unmatched_source_rows.unmatched_source_rows;
         }
     });
-    return rows_to_insert;
+    return *std::move(rows_to_insert);
 }
 
 std::vector<StreamDescriptor> split_rowrange_descriptor(
@@ -439,76 +461,395 @@ std::vector<StreamDescriptor> split_rowrange_descriptor(
     return descriptors;
 }
 
-folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
-        const InputFrame& source, const ComponentManager& component_manager, const StreamDescriptor& target_descriptor,
-        const size_t columns_per_slice, const IndexPartialKey& target_index_partial_key,
-        const size_t last_row_in_target, Store& store
+/// One instance is the single output data segment covering one column slice's columns for one output row slice's
+/// rows.
+struct MergeUpdateRowRangeInsertInfo {
+    /// Check which source rows within this range must be inserted. Note, not all source rows within this range will be
+    /// inserted.
+    RowRange source_range_to_check_for_appends{};
+    /// The row range in the final result inserted rows from source will be placed
+    RowRange output_row_range{};
+    /// Column slice inside the row slice
+    size_t col_slice_index{};
+};
+
+std::vector<MergeUpdateRowRangeInsertInfo> plan_inserted_segments_for_row_range_merge_update(
+        const util::BitSet& source_rows_to_insert, const ReslicingInfo& reslicing_info, size_t last_row_in_target,
+        size_t num_column_slices
 ) {
-    const std::optional<util::BitSet> source_rows_to_insert =
-            source_rows_to_insert_for_row_range_merge_update(component_manager);
-    const size_t num_rows_to_insert = source_rows_to_insert ? source_rows_to_insert->count() : 0;
+    auto insert_plans =
+            util::reserve_vector<MergeUpdateRowRangeInsertInfo>(num_column_slices * reslicing_info.num_segments());
+    auto set_insert_info_for_col_slices = [&] {
+        MergeUpdateRowRangeInsertInfo current_row_slice = insert_plans.back();
+        for (size_t col_slice_index = 1; col_slice_index < num_column_slices; ++col_slice_index) {
+            current_row_slice.col_slice_index = col_slice_index;
+            insert_plans.push_back(current_row_slice);
+        }
+    };
+    size_t row_slice_index = 0;
+    insert_plans.emplace_back();
+    insert_plans.back().output_row_range = RowRange{last_row_in_target, last_row_in_target};
+    iterate_over_set_positions(source_rows_to_insert, [&](const size_t source_row) {
+        if (insert_plans.back().output_row_range.diff() >= reslicing_info.rows_in_slice(row_slice_index)) {
+            insert_plans.back().source_range_to_check_for_appends.second = source_row;
+            set_insert_info_for_col_slices();
+            const size_t next_output_row_begin = insert_plans.back().output_row_range.second;
+            insert_plans.emplace_back();
+            insert_plans.back().source_range_to_check_for_appends.first = source_row;
+            insert_plans.back().output_row_range = RowRange{next_output_row_begin, next_output_row_begin};
+            ++row_slice_index;
+        }
+        ++insert_plans.back().output_row_range.second;
+    });
+    insert_plans.back().source_range_to_check_for_appends.second = source_rows_to_insert.size();
+    set_insert_info_for_col_slices();
+    return insert_plans;
+}
+
+SegmentInMemory create_segment_for_merge_update_row_range_insert(
+        const StreamDescriptor& col_slice_descriptor, const MergeUpdateRowRangeInsertInfo& insert_info,
+        size_t columns_per_slice, const InputFrame& source, const util::BitSet& source_rows_to_insert
+) {
+    const size_t rows_to_insert = insert_info.output_row_range.diff();
+    SegmentInMemory new_segment(
+            col_slice_descriptor, rows_to_insert, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
+    );
+    const StreamDescriptor& slice_descriptor = new_segment.descriptor();
+    const size_t first_col_idx = insert_info.col_slice_index * columns_per_slice;
+    for (size_t column_in_segment = 0; column_in_segment < slice_descriptor.field_count(); ++column_in_segment) {
+        std::optional<ScopedGILLock> gil_lock;
+        ColumnData col_data = new_segment.column_data(column_in_segment);
+        const Field& field = slice_descriptor.field(column_in_segment);
+        const size_t source_field_pos = first_col_idx + column_in_segment;
+        details::visit_scalar(field.type(), [&]<util::type_descriptor_tag TDT>(TDT) {
+            using SourceRawType = std::conditional_t<
+                    is_sequence_type(TDT::data_type()),
+                    PyObject* const,
+                    typename TDT::DataTypeTag::raw_type>;
+            auto data_it = col_data.begin<TDT>();
+            std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
+            iterate_over_set_positions(
+                    source_rows_to_insert,
+                    insert_info.source_range_to_check_for_appends.first,
+                    insert_info.source_range_to_check_for_appends.second,
+                    [&](size_t source_row) {
+                        if constexpr (is_sequence_type(TDT::data_type())) {
+                            *data_it = write_py_string_to_pool_or_throw<TDT>(
+                                    source_data[source_row],
+                                    source_row,
+                                    RowRange{0, source.num_rows},
+                                    gil_lock,
+                                    new_segment.string_pool(),
+                                    field.name()
+                            );
+                        } else {
+                            *data_it = source_data[source_row];
+                        }
+                        ++data_it;
+                    }
+            );
+        });
+    }
+    new_segment.set_row_data(static_cast<ssize_t>(rows_to_insert) - 1);
+    return new_segment;
+}
+
+folly::SemiFuture<std::vector<SliceAndKey>> write_inserted_row_range_data(
+        std::shared_ptr<InputFrame> source, const ComponentManager& component_manager,
+        const StreamDescriptor& target_descriptor, const WriteOptions& write_opts,
+        const IndexPartialKey& target_index_partial_key, size_t last_row_in_target, Store& store,
+        std::shared_ptr<DeDupMap> de_dup_map
+) {
+    util::BitSet source_rows_to_insert = source_rows_to_insert_for_row_range_merge_update(component_manager);
+    const size_t num_rows_to_insert = source_rows_to_insert.count();
     if (num_rows_to_insert == 0) {
         return folly::makeFuture<std::vector<SliceAndKey>>(std::vector<SliceAndKey>{});
     }
-    std::vector<StreamDescriptor> descriptors = split_rowrange_descriptor(target_descriptor, columns_per_slice);
-    const RowRange new_row_range{last_row_in_target, last_row_in_target + num_rows_to_insert};
-    auto write_data_keys_future = util::reserve_vector<folly::Future<SliceAndKey>>(descriptors.size());
-    for (size_t col_slice = 0; col_slice < descriptors.size(); ++col_slice) {
-        SegmentInMemory new_segment(
-                std::move(descriptors[col_slice]), num_rows_to_insert, AllocationType::PRESIZED, Sparsity::NOT_PERMITTED
-        );
-        const StreamDescriptor& slice_descriptor = new_segment.descriptor();
-        const ColRange col_range{
-                col_slice * columns_per_slice,
-                std::min((col_slice + 1) * columns_per_slice, target_descriptor.field_count())
-        };
-        for (size_t column_in_segment = 0; column_in_segment < slice_descriptor.field_count(); ++column_in_segment) {
-            std::optional<ScopedGILLock> gil_lock;
-            ColumnData col_data = new_segment.column_data(column_in_segment);
-            const Field& field = slice_descriptor.field(column_in_segment);
-            const size_t source_field_pos = col_range.start() + column_in_segment;
-            details::visit_scalar(field.type(), [&]<util::type_descriptor_tag TDT>(TDT) {
-                using SourceRawType = std::conditional_t<
-                        is_sequence_type(TDT::data_type()),
-                        PyObject* const,
-                        typename TDT::DataTypeTag::raw_type>;
-                auto data_it = col_data.begin<TDT>();
-                std::span<const SourceRawType> source_data = source.get_tensor(source_field_pos).span<SourceRawType>();
-                iterate_over_set_positions(*source_rows_to_insert, [&](size_t source_row) {
-                    if constexpr (is_sequence_type(TDT::data_type())) {
-                        *data_it = write_py_string_to_pool_or_throw<TDT>(
-                                source_data[source_row],
-                                source_row,
-                                RowRange{0, source.num_rows},
-                                gil_lock,
-                                new_segment.string_pool(),
-                                field.name()
-                        );
-                    } else {
-                        *data_it = source_data[source_row];
-                    }
-                    ++data_it;
-                });
-            });
-        }
-        new_segment.set_row_data(num_rows_to_insert - 1);
-        write_data_keys_future.push_back(store.compress_and_schedule_async_write(
-                std::make_tuple(
-                        PartialKey{
-                                .key_type = KeyType::TABLE_DATA,
-                                .version_id = target_index_partial_key.version_id,
-                                .stream_id = target_index_partial_key.id,
-                                .start_index = static_cast<timestamp>(new_row_range.first),
-                                .end_index = static_cast<timestamp>(new_row_range.second)
-                        },
-                        std::move(new_segment),
-                        FrameSlice(col_range, new_row_range)
-                ),
-                std::make_shared<DeDupMap>()
-        ));
-    }
-    return folly::collect(std::move(write_data_keys_future));
+    const auto source_rows_to_insert_ptr = std::make_shared<const util::BitSet>(std::move(source_rows_to_insert));
+    const ReslicingInfo reslicing_info{num_rows_to_insert, max_rows_per_segment(write_opts.segment_row_size)};
+    auto column_slice_descriptors = std::make_shared<const std::vector<StreamDescriptor>>(
+            split_rowrange_descriptor(target_descriptor, write_opts.column_group_size)
+    );
+    auto insert_infos = plan_inserted_segments_for_row_range_merge_update(
+            *source_rows_to_insert_ptr, reslicing_info, last_row_in_target, column_slice_descriptors->size()
+    );
+
+    auto write_futures = folly::window(
+            std::move(insert_infos),
+            [source,
+             source_rows_to_insert = source_rows_to_insert_ptr,
+             column_slice_descriptors,
+             de_dup_map,
+             target_index_partial_key,
+             columns_per_slice = write_opts.column_group_size,
+             store = &store](MergeUpdateRowRangeInsertInfo insert_info) {
+                return store->async_write(
+                        folly::via(
+                                &async::cpu_executor(),
+                                [source,
+                                 source_rows_to_insert,
+                                 column_slice_descriptors,
+                                 target_index_partial_key,
+                                 columns_per_slice,
+                                 insert_info]() mutable -> std::tuple<PartialKey, SegmentInMemory, FrameSlice> {
+                                    const StreamDescriptor& slice_descriptor =
+                                            (*column_slice_descriptors)[insert_info.col_slice_index];
+                                    const size_t first_col_idx = insert_info.col_slice_index * columns_per_slice;
+                                    return {PartialKey{
+                                                    .key_type = KeyType::TABLE_DATA,
+                                                    .version_id = target_index_partial_key.version_id,
+                                                    .stream_id = target_index_partial_key.id,
+                                                    .start_index =
+                                                            static_cast<timestamp>(insert_info.output_row_range.first),
+                                                    .end_index =
+                                                            static_cast<timestamp>(insert_info.output_row_range.second)
+                                            },
+                                            create_segment_for_merge_update_row_range_insert(
+                                                    slice_descriptor,
+                                                    insert_info,
+                                                    columns_per_slice,
+                                                    *source,
+                                                    *source_rows_to_insert
+                                            ),
+                                            FrameSlice(
+                                                    ColRange{
+                                                            first_col_idx,
+                                                            first_col_idx + slice_descriptor.field_count()
+                                                    },
+                                                    insert_info.output_row_range
+                                            )};
+                                }
+                        ),
+                        de_dup_map
+                );
+            },
+            write_window_size()
+    );
+    return folly::collect(std::move(write_futures));
 }
+
+std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_context) {
+    std::vector<RangesAndKey> res;
+    res.reserve(pipeline_context.slice_and_keys_.size());
+    bool is_incomplete{false};
+    for (auto it = pipeline_context.begin(); it != pipeline_context.end(); it++) {
+        if (it == pipeline_context.incompletes_begin()) {
+            is_incomplete = true;
+        }
+        auto& sk = it->slice_and_key();
+        // Take a copy here as things like defrag need the keys in pipeline_context->slice_and_keys_ that aren't being
+        // modified at the end
+        auto key = sk.key();
+        res.emplace_back(sk.slice(), std::move(key), is_incomplete);
+    }
+    return res;
+}
+
+StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
+    const StreamDescriptor& desc = pipeline_context.output_descriptor();
+    // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
+    // it to constrain the initial set of columns. If dynamic schema is used and only certain columns must be read we
+    // use the whole descriptor and at the end of the read return only the ones that were selected. This is because
+    // currently dynamic schema cannot handle column dependencies e.g.
+    // columns on disk: col1, col2
+    // q = QueryBuilder()
+    // q = q["col1" < 1]
+    // lib.read(columns=["col2", query_builder=q)
+    // We want to read only col2 but the filtering requires col1, thus the OutputSchema must contain both col1 and col2
+    // in order to satisfy the filter clause.
+    if (pipeline_context.overall_column_bitset_) {
+        FieldCollection fields_to_use;
+        auto overall_fields_it = pipeline_context.overall_column_bitset_->first();
+        const auto overall_fields_end = pipeline_context.overall_column_bitset_->end();
+        while (overall_fields_it != overall_fields_end) {
+            fields_to_use.add(desc.field(*overall_fields_it).ref());
+            ++overall_fields_it;
+        }
+        return StreamDescriptor{desc.data_ptr(), std::make_shared<FieldCollection>(std::move(fields_to_use))};
+    }
+    return desc;
+}
+
+OutputSchema create_initial_output_schema(PipelineContext& pipeline_context) {
+    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
+            pipeline_context.has_normalization(), "Normalization metadata should not be missing during read_and_process"
+    );
+    return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), pipeline_context.normalization()};
+}
+
+OutputSchema generate_output_schema(PipelineContext& pipeline_context, const ReadQuery& read_query) {
+    auto output_schema = modify_schema(create_initial_output_schema(pipeline_context), read_query.clauses_);
+    if (read_query.columns) {
+        std::unordered_set<std::string_view> selected_columns(read_query.columns->begin(), read_query.columns->end());
+        FieldCollection fields_to_use;
+        if (!pipeline_context.filter_columns_) {
+            pipeline_context.filter_columns_ = std::make_shared<FieldCollection>();
+        }
+        for (const Field& field : output_schema.stream_descriptor().fields()) {
+            if (selected_columns.contains(field.name())) {
+                fields_to_use.add(field.ref());
+                if (!pipeline_context.is_in_filter_columns_set(field.name())) {
+                    pipeline_context.filter_columns_->add(field.ref());
+                }
+            }
+        }
+        pipeline_context.filter_columns_set_ = std::move(selected_columns);
+        output_schema.set_stream_descriptor(StreamDescriptor{
+                output_schema.stream_descriptor().data_ptr(),
+                std::make_shared<FieldCollection>(std::move(fields_to_use))
+        });
+    }
+    return output_schema;
+}
+
+std::shared_ptr<std::unordered_set<std::string>> columns_to_decode(
+        const std::shared_ptr<PipelineContext>& pipeline_context
+) {
+    std::shared_ptr<std::unordered_set<std::string>> res;
+    ARCTICDB_DEBUG(
+            log::version(),
+            "Creating columns list with {} bits set",
+            pipeline_context->overall_column_bitset_ ? pipeline_context->overall_column_bitset_->count() : -1
+    );
+    if (pipeline_context->overall_column_bitset_) {
+        res = std::make_shared<std::unordered_set<std::string>>();
+        auto en = pipeline_context->overall_column_bitset_->first();
+        auto en_end = pipeline_context->overall_column_bitset_->end();
+        while (en < en_end) {
+            ARCTICDB_DEBUG(log::version(), "Adding field {}", pipeline_context->on_disk_descriptor().field(*en).name());
+            res->insert(std::string(pipeline_context->on_disk_descriptor().field(*en++).name()));
+        }
+    }
+    return res;
+}
+
+folly::Future<std::vector<EntityId>> read_and_schedule_processing(
+        const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
+        const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
+        std::shared_ptr<ComponentManager> component_manager
+) {
+    const ProcessingConfig processing_config{
+            opt_false(read_options.dynamic_schema()),
+            pipeline_context->rows_,
+            pipeline_context->on_disk_descriptor().index().type()
+    };
+    for (auto& clause : read_query->clauses_) {
+        clause->set_processing_config(processing_config);
+        clause->set_component_manager(component_manager);
+    }
+
+    auto ranges_and_keys = generate_ranges_and_keys(*pipeline_context);
+
+    // Each element of the vector corresponds to one processing unit containing the list of indexes in ranges_and_keys
+    // required for that processing unit i.e. if the first processing unit needs ranges_and_keys[0] and
+    // ranges_and_keys[1], and the second needs ranges_and_keys[2] and ranges_and_keys[3] then the structure will be
+    // {{0, 1}, {2, 3}}
+    std::vector<std::vector<size_t>> processing_unit_indexes;
+    if (read_query->clauses_.empty()) {
+        processing_unit_indexes = structure_by_row_slice(ranges_and_keys);
+    } else {
+        processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
+    }
+
+    const size_t max_processing_units_in_flight = max_resident_processing_units(processing_unit_indexes);
+    const size_t read_window = segment_read_window();
+
+    auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
+    SegmentReader reader = [base_reader = std::move(base_reader),
+                            pipeline_desc = pipeline_context->on_disk_descriptor(),
+                            processing_config](pipelines::RangesAndKey&& rk) {
+        const bool is_incomplete = rk.is_incomplete();
+        return base_reader(std::move(rk))
+                .thenValueInline([pipeline_desc, processing_config, is_incomplete](pipelines::SegmentAndSlice&& r) {
+                    if (is_incomplete && !processing_config.dynamic_schema_) {
+                        auto check = check_schema_matches_incomplete(r.segment_in_memory_.descriptor(), pipeline_desc);
+                        if (std::holds_alternative<Error>(check)) {
+                            std::get<Error>(check).throw_error();
+                        }
+                    }
+                    return std::move(r);
+                });
+    };
+
+    auto admission = std::make_shared<ProcessingUnitAdmissionHandler>(
+            std::move(reader),
+            std::move(ranges_and_keys),
+            std::move(processing_unit_indexes),
+            max_processing_units_in_flight,
+            read_window
+    );
+
+    auto processed = schedule_clause_processing(
+            component_manager, admission, std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
+    );
+
+    return std::move(processed).via(&async::cpu_executor());
+}
+
+folly::Future<std::vector<EntityId>> read_modify_write_data_keys(
+        const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
+        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
+        std::shared_ptr<ComponentManager> component_manager,
+        std::shared_ptr<DeDupMap> de_dup_map = std::make_shared<DeDupMap>()
+) {
+    const auto write_clause_processing_structure =
+            read_query->clauses_.empty() ? ProcessingStructure::ROW_SLICE
+                                         : read_query->clauses_.back()->clause_info().output_structure_;
+    read_query->clauses_.push_back(std::make_shared<Clause>(
+            WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
+    ));
+    pipeline_context->set_output_schema(generate_output_schema(*pipeline_context, *read_query));
+
+    return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
+            .thenValue([component_manager = std::move(component_manager),
+                        read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
+                std::vector<std::shared_ptr<folly::Future<SliceAndKey>>> slice_components =
+                        std::get<0>(component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(
+                                processed_entity_ids
+                        ));
+                auto write_segments_futures = util::reserve_vector<folly::Future<EntityId>>(slice_components.size());
+                for (auto&& [index, slice_future] : folly::enumerate(slice_components)) {
+                    write_segments_futures.push_back(
+                            std::move(*slice_future)
+                                    .thenValueInline([component_manager,
+                                                      entt = processed_entity_ids[index]](SliceAndKey&& slice_and_key) {
+                                        component_manager
+                                                ->remove_component<std::shared_ptr<folly::Future<SliceAndKey>>>(entt);
+                                        slice_and_key.unset_segment();
+                                        component_manager->add_components(entt, std::move(slice_and_key));
+                                        return entt;
+                                    })
+                    );
+                }
+                return folly::collect(std::move(write_segments_futures));
+            });
+}
+
+std::vector<SliceAndMergeInfo> gather_slices_and_infos_for_merge_update_index_construction(
+        const std::vector<EntityId>& processed_entities,
+        std::vector<SliceAndKey>&& row_slices_appended_for_rowcount_index, ComponentManager& component_manager
+) {
+    auto total_slices_and_infos = util::reserve_vector<SliceAndMergeInfo>(
+            processed_entities.size() + row_slices_appended_for_rowcount_index.size()
+    );
+    auto [new_slices, new_infos] =
+            component_manager.get_entities<SliceAndKey, MergeUpdateRowSlicingInfoComponent>(processed_entities);
+    for (size_t i = 0; i < new_slices.size(); ++i) {
+        total_slices_and_infos.emplace_back(std::move(new_slices[i]), new_infos[i]);
+    }
+    new_slices.clear();
+    new_infos.clear();
+    // The appended row-count insert slices are not entities and each occupies its own row
+    // range beyond the target, so each one is a group of a single slice.
+    for (SliceAndKey& slice_and_key : row_slices_appended_for_rowcount_index) {
+        const size_t num_rows = slice_and_key.slice().row_range.diff();
+        total_slices_and_infos.push_back(
+                {.slice_and_key = std::move(slice_and_key), .info = MergeUpdateRowSlicingInfoComponent(1, 0, num_rows)}
+        );
+    }
+    return total_slices_and_infos;
+}
+
 } // namespace
 
 VersionedItem delete_range_impl(
@@ -843,7 +1184,7 @@ void add_slice_to_component_manager(
         std::shared_ptr<ComponentManager> component_manager, EntityFetchCount fetch_count
 ) {
     ARCTICDB_DEBUG(log::memory(), "Adding entity id {}", entity_id);
-    component_manager->add_entity(
+    component_manager->add_components(
             entity_id,
             std::make_shared<SegmentInMemory>(std::move(segment_and_slice.segment_in_memory_)),
             std::make_shared<RowRange>(std::move(segment_and_slice.ranges_and_key_.row_range_)),
@@ -1092,164 +1433,6 @@ folly::Future<std::vector<EntityId>> schedule_clause_processing(
         remove_processed_clauses(*clauses);
         return schedule_remaining_iterations(std::move(entity_ids_vec), clauses);
     });
-}
-
-std::shared_ptr<std::unordered_set<std::string>> columns_to_decode(
-        const std::shared_ptr<PipelineContext>& pipeline_context
-) {
-    std::shared_ptr<std::unordered_set<std::string>> res;
-    ARCTICDB_DEBUG(
-            log::version(),
-            "Creating columns list with {} bits set",
-            pipeline_context->overall_column_bitset_ ? pipeline_context->overall_column_bitset_->count() : -1
-    );
-    if (pipeline_context->overall_column_bitset_) {
-        res = std::make_shared<std::unordered_set<std::string>>();
-        auto en = pipeline_context->overall_column_bitset_->first();
-        auto en_end = pipeline_context->overall_column_bitset_->end();
-        while (en < en_end) {
-            ARCTICDB_DEBUG(log::version(), "Adding field {}", pipeline_context->on_disk_descriptor().field(*en).name());
-            res->insert(std::string(pipeline_context->on_disk_descriptor().field(*en++).name()));
-        }
-    }
-    return res;
-}
-
-std::vector<RangesAndKey> generate_ranges_and_keys(PipelineContext& pipeline_context) {
-    std::vector<RangesAndKey> res;
-    res.reserve(pipeline_context.slice_and_keys_.size());
-    bool is_incomplete{false};
-    for (auto it = pipeline_context.begin(); it != pipeline_context.end(); it++) {
-        if (it == pipeline_context.incompletes_begin()) {
-            is_incomplete = true;
-        }
-        auto& sk = it->slice_and_key();
-        // Take a copy here as things like defrag need the keys in pipeline_context->slice_and_keys_ that aren't being
-        // modified at the end
-        auto key = sk.key();
-        res.emplace_back(sk.slice(), std::move(key), is_incomplete);
-    }
-    return res;
-}
-
-static StreamDescriptor generate_initial_output_schema_descriptor(const PipelineContext& pipeline_context) {
-    const StreamDescriptor& desc = pipeline_context.output_descriptor();
-    // pipeline_context.overall_column_bitset_ can be different from std::nullopt only in case of static schema. We use
-    // it to constrain the initial set of columns. If dynamic schema is used and only certain columns must be read we
-    // use the whole descriptor and at the end of the read return only the ones that were selected. This is because
-    // currently dynamic schema cannot handle column dependencies e.g.
-    // columns on disk: col1, col2
-    // q = QueryBuilder()
-    // q = q["col1" < 1]
-    // lib.read(columns=["col2", query_builder=q)
-    // We want to read only col2 but the filtering requires col1, thus the OutputSchema must contain both col1 and col2
-    // in order to satisfy the filter clause.
-    if (pipeline_context.overall_column_bitset_) {
-        FieldCollection fields_to_use;
-        auto overall_fields_it = pipeline_context.overall_column_bitset_->first();
-        const auto overall_fields_end = pipeline_context.overall_column_bitset_->end();
-        while (overall_fields_it != overall_fields_end) {
-            fields_to_use.add(desc.field(*overall_fields_it).ref());
-            ++overall_fields_it;
-        }
-        return StreamDescriptor{desc.data_ptr(), std::make_shared<FieldCollection>(std::move(fields_to_use))};
-    }
-    return desc;
-}
-
-static OutputSchema create_initial_output_schema(PipelineContext& pipeline_context) {
-    internal::check<ErrorCode::E_ASSERTION_FAILURE>(
-            pipeline_context.has_normalization(), "Normalization metadata should not be missing during read_and_process"
-    );
-    return OutputSchema{generate_initial_output_schema_descriptor(pipeline_context), pipeline_context.normalization()};
-}
-
-static OutputSchema generate_output_schema(PipelineContext& pipeline_context, const ReadQuery& read_query) {
-    auto output_schema = modify_schema(create_initial_output_schema(pipeline_context), read_query.clauses_);
-    if (read_query.columns) {
-        std::unordered_set<std::string_view> selected_columns(read_query.columns->begin(), read_query.columns->end());
-        FieldCollection fields_to_use;
-        if (!pipeline_context.filter_columns_) {
-            pipeline_context.filter_columns_ = std::make_shared<FieldCollection>();
-        }
-        for (const Field& field : output_schema.stream_descriptor().fields()) {
-            if (selected_columns.contains(field.name())) {
-                fields_to_use.add(field.ref());
-                if (!pipeline_context.is_in_filter_columns_set(field.name())) {
-                    pipeline_context.filter_columns_->add(field.ref());
-                }
-            }
-        }
-        pipeline_context.filter_columns_set_ = std::move(selected_columns);
-        output_schema.set_stream_descriptor(StreamDescriptor{
-                output_schema.stream_descriptor().data_ptr(),
-                std::make_shared<FieldCollection>(std::move(fields_to_use))
-        });
-    }
-    return output_schema;
-}
-
-folly::Future<std::vector<EntityId>> read_and_schedule_processing(
-        const std::shared_ptr<Store>& store, const std::shared_ptr<PipelineContext>& pipeline_context,
-        const std::shared_ptr<ReadQuery>& read_query, const ReadOptions& read_options,
-        std::shared_ptr<ComponentManager> component_manager
-) {
-    const ProcessingConfig processing_config{
-            opt_false(read_options.dynamic_schema()),
-            pipeline_context->rows_,
-            pipeline_context->on_disk_descriptor().index().type()
-    };
-    for (auto& clause : read_query->clauses_) {
-        clause->set_processing_config(processing_config);
-        clause->set_component_manager(component_manager);
-    }
-
-    auto ranges_and_keys = generate_ranges_and_keys(*pipeline_context);
-
-    // Each element of the vector corresponds to one processing unit containing the list of indexes in ranges_and_keys
-    // required for that processing unit i.e. if the first processing unit needs ranges_and_keys[0] and
-    // ranges_and_keys[1], and the second needs ranges_and_keys[2] and ranges_and_keys[3] then the structure will be
-    // {{0, 1}, {2, 3}}
-    std::vector<std::vector<size_t>> processing_unit_indexes;
-    if (read_query->clauses_.empty()) {
-        processing_unit_indexes = structure_by_row_slice(ranges_and_keys);
-    } else {
-        processing_unit_indexes = read_query->clauses_[0]->structure_for_processing(ranges_and_keys);
-    }
-
-    const size_t max_processing_units_in_flight = max_resident_processing_units(processing_unit_indexes);
-    const size_t read_window = segment_read_window();
-
-    auto base_reader = store->make_uncompressed_reader(columns_to_decode(pipeline_context));
-    SegmentReader reader = [base_reader = std::move(base_reader),
-                            pipeline_desc = pipeline_context->on_disk_descriptor(),
-                            processing_config](pipelines::RangesAndKey&& rk) {
-        const bool is_incomplete = rk.is_incomplete();
-        return base_reader(std::move(rk))
-                .thenValueInline([pipeline_desc, processing_config, is_incomplete](pipelines::SegmentAndSlice&& r) {
-                    if (is_incomplete && !processing_config.dynamic_schema_) {
-                        auto check = check_schema_matches_incomplete(r.segment_in_memory_.descriptor(), pipeline_desc);
-                        if (std::holds_alternative<Error>(check)) {
-                            std::get<Error>(check).throw_error();
-                        }
-                    }
-                    return std::move(r);
-                });
-    };
-
-    auto admission = std::make_shared<ProcessingUnitAdmissionHandler>(
-            std::move(reader),
-            std::move(ranges_and_keys),
-            std::move(processing_unit_indexes),
-            max_processing_units_in_flight,
-            read_window
-    );
-
-    auto processed = schedule_clause_processing(
-            component_manager, admission, std::make_shared<std::vector<std::shared_ptr<Clause>>>(read_query->clauses_)
-    );
-
-    return std::move(processed).via(&async::cpu_executor());
 }
 
 /*
@@ -3006,49 +3189,19 @@ folly::Future<ReadVersionOutput> read_frame_for_version(
     return start_pipeline(VersionIdentifier{version_info});
 }
 
-folly::Future<std::vector<SliceAndKey>> read_modify_write_data_keys(
-        const std::shared_ptr<Store>& store, std::shared_ptr<ReadQuery> read_query, const ReadOptions& read_options,
-        const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
-        std::shared_ptr<ComponentManager> component_manager = std::make_shared<ComponentManager>(),
-        std::shared_ptr<DeDupMap> de_dup_map = std::make_shared<DeDupMap>()
-) {
-    auto write_clause_processing_structure = read_query->clauses_.empty()
-                                                     ? ProcessingStructure::ROW_SLICE
-                                                     : read_query->clauses_.back()->clause_info().output_structure_;
-    read_query->clauses_.push_back(std::make_shared<Clause>(
-            WriteClause(target_partial_index_key, std::move(de_dup_map), store, write_clause_processing_structure)
-    ));
-    pipeline_context->set_output_schema(generate_output_schema(*pipeline_context, *read_query));
-
-    return read_and_schedule_processing(store, pipeline_context, read_query, read_options, component_manager)
-            .thenValue([component_manager = std::move(component_manager),
-                        pipeline_context,
-                        read_query = std::move(read_query)](std::vector<EntityId>&& processed_entity_ids) {
-                std::vector<folly::Future<SliceAndKey>> write_segments_futures;
-                ranges::transform(
-                        std::get<0>(component_manager->get_entities<std::shared_ptr<folly::Future<SliceAndKey>>>(
-                                processed_entity_ids
-                        )),
-                        std::back_inserter(write_segments_futures),
-                        [](const std::shared_ptr<folly::Future<SliceAndKey>>& fut) {
-                            return std::move(*fut).thenValueInline([](SliceAndKey&& slice_and_key) {
-                                slice_and_key.unset_segment();
-                                return slice_and_key;
-                            });
-                        }
-                );
-                return folly::collect(std::move(write_segments_futures));
-            });
-}
-
 folly::Future<VersionedItem> read_modify_write_impl(
         const std::shared_ptr<Store>& store, const std::shared_ptr<ReadQuery>& read_query,
         const ReadOptions& read_options, const WriteOptions& write_options,
         const IndexPartialKey& target_partial_index_key, const std::shared_ptr<PipelineContext>& pipeline_context,
         std::optional<proto::descriptors::UserDefinedMetadata>&& user_meta_proto
 ) {
-    return read_modify_write_data_keys(store, read_query, read_options, target_partial_index_key, pipeline_context)
-            .thenValue([&](std::vector<SliceAndKey>&& data_keys_and_slices) {
+    auto component_manager = std::make_shared<ComponentManager>();
+    return read_modify_write_data_keys(
+                   store, read_query, read_options, target_partial_index_key, pipeline_context, component_manager
+    )
+            .thenValue([&](std::vector<EntityId>&& entities) {
+                std::vector<SliceAndKey> data_keys_and_slices =
+                        std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
                 ARCTICDB_DEBUG_CHECK(
                         ErrorCode::E_ASSERTION_FAILURE,
                         std::ranges::all_of(
@@ -3090,7 +3243,10 @@ folly::Future<AtomKey> merge_update_impl(
         std::shared_ptr<DeDupMap> de_dup_map
 ) {
     auto read_query = std::make_shared<ReadQuery>();
-    auto merge_update_clause = std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source));
+    auto merge_update_clause =
+            std::make_shared<Clause>(MergeUpdateClause(std::move(on), strategy, source, write_options.segment_row_size)
+            );
+
     read_query->clauses_.push_back(merge_update_clause);
     VersionIdentifier resolved = VersionedItem{*update_info.previous_index_key_};
     if (auto* vi = std::get_if<VersionedItem>(&resolved)) {
@@ -3144,7 +3300,7 @@ folly::Future<AtomKey> merge_update_impl(
                    target_partial_index_key,
                    pipeline_context,
                    component_manager,
-                   std::move(de_dup_map)
+                   de_dup_map
     )
             .thenValue([pipeline_context = std::move(pipeline_context),
                         component_manager = std::move(component_manager),
@@ -3152,18 +3308,20 @@ folly::Future<AtomKey> merge_update_impl(
                         write_options,
                         source = std::move(source),
                         target_partial_index_key,
-                        strategy](std::vector<SliceAndKey>&& data_keys_and_slices) {
+                        strategy,
+                        de_dup_map](std::vector<EntityId>&& processed_entities) {
                 const StreamDescriptor& target_descriptor = pipeline_context->output_descriptor();
                 folly::SemiFuture<std::vector<SliceAndKey>> inserted_row_slices_fut =
                         (target_descriptor.index().type() == IndexDescriptor::Type::ROWCOUNT && strategy.insert())
                                 ? write_inserted_row_range_data(
-                                          *source,
+                                          source,
                                           *component_manager,
                                           target_descriptor,
-                                          write_options.column_group_size,
+                                          write_options,
                                           target_partial_index_key,
                                           pipeline_context->last_row(),
-                                          *store
+                                          *store,
+                                          de_dup_map
                                   )
                                 : folly::makeSemiFuture(std::vector<SliceAndKey>{});
                 return std::move(inserted_row_slices_fut)
@@ -3174,24 +3332,14 @@ folly::Future<AtomKey> merge_update_impl(
                                     write_options,
                                     source,
                                     target_partial_index_key,
-                                    data_keys_and_slices = std::move(data_keys_and_slices
+                                    processed_entities = std::move(processed_entities
                                     )](std::vector<SliceAndKey>&& inserted_row_slices) mutable {
-                            ankerl::unordered_dense::map<RowRange, size_t> inserted_rows_per_row_range;
-                            component_manager->process_entities(
-                                    [&](const MergeUpdateInsertedRowsComponent& inserted_rows,
-                                        const std::shared_ptr<RowRange>& row_range) {
-                                        inserted_rows_per_row_range.emplace(*row_range, inserted_rows);
-                                    }
-                            );
-                            data_keys_and_slices.insert(
-                                    data_keys_and_slices.end(),
-                                    std::make_move_iterator(inserted_row_slices.begin()),
-                                    std::make_move_iterator(inserted_row_slices.end())
-                            );
+                            std::vector<SliceAndMergeInfo> new_slices =
+                                    gather_slices_and_infos_for_merge_update_index_construction(
+                                            processed_entities, std::move(inserted_row_slices), *component_manager
+                                    );
                             std::vector<SliceAndKey> merged_ranges_and_keys = merge_slices_and_keys(
-                                    std::move(pipeline_context->slice_and_keys_),
-                                    std::move(data_keys_and_slices),
-                                    std::move(inserted_rows_per_row_range)
+                                    std::move(pipeline_context->slice_and_keys_), std::move(new_slices)
                             );
                             pipeline_context->slice_and_keys_.clear();
                             const size_t row_count =
@@ -3272,7 +3420,7 @@ folly::Future<CompactDataInfo> compact_data_explain_plan_impl(
                     row_slices_after.emplace_back(0);
                     for (const auto& row_range : processing_row_ranges) {
                         ReslicingInfo reslicing_info(row_range.diff(), clause.max_rows_per_segment_);
-                        for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+                        for (uint64_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
                             row_slices_after.emplace_back(row_slices_after.back() + reslicing_info.rows_in_slice(idx));
                         }
                     }
@@ -3296,8 +3444,8 @@ static folly::Future<std::vector<SliceAndKey>> slice_and_write_frame_remainder(
 ) {
     auto remaining_rows_to_write = (frame->offset + frame->num_rows) - start_row;
     ReslicingInfo reslicing_info{remaining_rows_to_write, max_rows_per_segment};
-    auto row_ranges = util::reserve_vector<RowRange>(reslicing_info.num_segments);
-    for (uint64_t idx = 0; idx < reslicing_info.num_segments; ++idx) {
+    auto row_ranges = util::reserve_vector<RowRange>(reslicing_info.num_segments());
+    for (uint64_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
         row_ranges.emplace_back(start_row, start_row + reslicing_info.rows_in_slice(idx));
         start_row += reslicing_info.rows_in_slice(idx);
     }
@@ -3449,8 +3597,14 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                 IndexPartialKey target_partial_index_key{stream_id, update_info.next_version_id_};
                 ReadOptions read_options;
                 read_options.set_dynamic_schema(dynamic_schema);
+                auto component_manager = std::make_shared<ComponentManager>();
                 return read_modify_write_data_keys(
-                               store, read_query, read_options, target_partial_index_key, pipeline_context
+                               store,
+                               read_query,
+                               read_options,
+                               target_partial_index_key,
+                               pipeline_context,
+                               component_manager
                 )
                         .thenValue(
                                 [pipeline_context = std::move(pipeline_context),
@@ -3459,8 +3613,11 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                                  target_partial_index_key,
                                  read_query,
                                  tsd,
-                                 frame](std::vector<SliceAndKey>&& slices_and_keys
+                                 frame,
+                                 component_manager](std::vector<EntityId>&& entities
                                 ) -> folly::Future<std::optional<AtomKey>> {
+                                    std::vector<SliceAndKey> slices_and_keys =
+                                            std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
                                     if (slices_and_keys.empty() && !frame) {
                                         return folly::makeFuture(std::optional<AtomKey>());
                                     }
@@ -3477,7 +3634,8 @@ folly::Future<std::optional<AtomKey>> async_compact_data_impl(
                                             std::make_move_iterator(unchanged_slices.begin()),
                                             std::make_move_iterator(unchanged_slices.end())
                                     );
-                                    // This implies there are more rows in frame that have not yet been written to disk
+                                    // This implies there are more rows in frame that have not yet been written
+                                    // to disk
                                     auto remaining_slice_and_keys_fut =
                                             frame && last_row_on_disk < frame->offset + frame->num_rows
                                                     ? slice_and_write_frame_remainder(

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -441,7 +441,7 @@ util::BitSet source_rows_to_insert_for_row_range_merge_update(const ComponentMan
             rows_to_insert = *unmatched_source_rows.unmatched_source_rows;
         }
     });
-    return *std::move(rows_to_insert);
+    return std::move(rows_to_insert).value_or(util::BitSet{});
 }
 
 std::vector<StreamDescriptor> split_rowrange_descriptor(
@@ -3199,7 +3199,12 @@ folly::Future<VersionedItem> read_modify_write_impl(
     return read_modify_write_data_keys(
                    store, read_query, read_options, target_partial_index_key, pipeline_context, component_manager
     )
-            .thenValue([&](std::vector<EntityId>&& entities) {
+            .thenValue([component_manager,
+                        pipeline_context,
+                        user_meta_proto = std::move(user_meta_proto),
+                        write_options,
+                        store,
+                        target_partial_index_key](std::vector<EntityId>&& entities) mutable {
                 std::vector<SliceAndKey> data_keys_and_slices =
                         std::get<0>(component_manager->get_entities<SliceAndKey>(entities));
                 ARCTICDB_DEBUG_CHECK(

--- a/cpp/arcticdb/version/version_core.hpp
+++ b/cpp/arcticdb/version/version_core.hpp
@@ -193,8 +193,8 @@ folly::Future<VersionedItem> read_modify_write_impl(
 folly::Future<AtomKey> merge_update_impl(
         const std::shared_ptr<Store>& store, const UpdateInfo& update_info, const ReadOptions& read_options,
         const WriteOptions& write_options, const IndexPartialKey& target_partial_index_key,
-        std::vector<std::string>&& on, const MergeStrategy& strategy, std::shared_ptr<InputFrame> source,
-        std::shared_ptr<DeDupMap> de_dup_map
+        std::vector<std::string>&& on, const MergeStrategy& strategy, const bool match_na,
+        std::shared_ptr<InputFrame> source, std::shared_ptr<DeDupMap> de_dup_map
 );
 
 folly::Future<CompactDataInfo> compact_data_explain_plan_impl(

--- a/cpp/arcticdb/version/version_store_api.cpp
+++ b/cpp/arcticdb/version/version_store_api.cpp
@@ -1553,7 +1553,7 @@ void PythonVersionStore::force_delete_symbol(const StreamId& stream_id) {
 VersionedItem PythonVersionStore::merge(
         const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& source, const py::object& norm,
         const py::object& user_meta, const bool prune_previous_versions, const bool upsert,
-        const py::tuple& py_strategy, std::vector<std::string> on
+        const py::tuple& py_strategy, std::vector<std::string> on, const bool match_na
 ) {
     const MergeStrategy strategy{
             .matched = py_strategy[0].cast<MergeAction>(), .not_matched_by_target = py_strategy[1].cast<MergeAction>()
@@ -1571,7 +1571,8 @@ VersionedItem PythonVersionStore::merge(
             prune_previous_versions,
             upsert,
             strategy,
-            std::move(on)
+            std::move(on),
+            match_na
     );
 }
 

--- a/cpp/arcticdb/version/version_store_api.hpp
+++ b/cpp/arcticdb/version/version_store_api.hpp
@@ -290,7 +290,7 @@ class PythonVersionStore : public LocalVersionedEngine {
     VersionedItem merge(
             const StreamId& stream_id, const std::shared_ptr<convert::PandasData>& source, const py::object& norm,
             const py::object& user_meta, const bool prune_previous_versions, const bool upsert,
-            const py::tuple& py_strategy, std::vector<std::string> on
+            const py::tuple& py_strategy, std::vector<std::string> on, const bool match_na
     );
 
     CompactDataInfo compact_data_explain_plan(const StreamId& stream_id, std::optional<uint64_t> rows_per_segment);

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -180,7 +180,7 @@ class VersionedEngine {
 
     virtual VersionedItem merge_internal(
             const StreamId& stream_id, std::shared_ptr<InputFrame> source, bool prune_previous_versions, bool upsert,
-            const MergeStrategy& strategy, std::vector<std::string>&& on
+            const MergeStrategy& strategy, std::vector<std::string>&& on, bool match_na
     ) = 0;
 };
 

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -15,9 +15,6 @@
    "metadata": {},
    "source": [
     "# ArcticDB Merge\n",
-    "<div role=\"alert\" style=\"background-color:#FFF3CD;color:#856404;border:1px solid #FFEEBA;border-radius:10px;padding:12px 16px;font-size:14px;line-height:1.4;font-family:system-ui,-apple-system,Segoe UI,Roboto,'Helvetica Neue',Arial;display:flex;align-items:center;gap:8px;box-shadow:0 1px 0 rgba(0,0,0,0.04);\">\n",
-    "  ⚠️ <span style=\"font-weight:600;margin-left:6px;\">Warning:</span> The merge API is under development and subject to change. Additional features will be introduced in the future. The API is not subject to semver and can change in minor or patch releases. Stay tuned for updates! The API call at the moment is named merge_experimental but it will be changed to merge when the API becomes stable.\n",
-    "</div>\n",
     "\n",
     "## Motivation\n",
     "The merge API offers a straightforward way for users to modify or insert specific rows in their data. Data providers often issue corrections for particular entries, and the merge functionality can efficiently apply these updates.\n",
@@ -282,7 +279,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1787695294073635071)"
+       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1787736534234255452)"
       ]
      },
      "execution_count": 4,
@@ -668,7 +665,7 @@
     }
    ],
    "source": [
-    "lib.merge_experimental(\"daily_prices\", daily_prices_correction, strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"))\n",
+    "lib.merge(\"daily_prices\", daily_prices_correction, strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"))\n",
     "print(\"Merged result\")\n",
     "display(lib.read(\"daily_prices\").data)\n",
     "print(\"Diff between merged and original data\")\n",
@@ -812,7 +809,7 @@
     "Merge works by performing a join between `target` and `source` on a subset of columns, and updating `target` based on the `strategy` parameter. If `target` is a time series, the index will **always** be included among the join columns. This is done to ensure that ordered date-time indexes stay ordered after performing a merge. Otherwise the following would be possible\n",
     "```python\n",
     "lib.write(\"sym\", pd.DataFrame({\"a\": [1, 2, 3]}, index=pd.DatetimeIndex([pd.Timestamp(1), pd.Timestamp(2), pd.Timestamp(3)])))\n",
-    "lib.merge_experimental(\"sym\", pd.DataFrame({\"a\": [2]}, index=pd.DatetimeIndex([pd.Timestamp(10)])), on=[\"a\"])\n",
+    "lib.merge(\"sym\", pd.DataFrame({\"a\": [2]}, index=pd.DatetimeIndex([pd.Timestamp(10)])), on=[\"a\"])\n",
     "print(lib.read(\"sym\").data)\n",
     "                               a\n",
     "1970-01-01 00:00:00.000000001  1\n",
@@ -981,7 +978,7 @@
     "lib.write(\"merge_update_with_duplicates\", data_with_duplicates)\n",
     "print(\"Original data\")\n",
     "display(lib.read(\"merge_update_with_duplicates\").data)\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"merge_update_with_duplicates\",\n",
     "    pd.DataFrame(\n",
     "        {\"Bid\": [105, 102], \"Ask\": [105.3, 102]},\n",
@@ -1148,7 +1145,7 @@
     "lib.write(\"merge_update_with_duplicates\", data_with_duplicates)\n",
     "print(\"Original data\")\n",
     "display(lib.read(\"merge_update_with_duplicates\").data)\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"merge_update_with_duplicates\",\n",
     "    pd.DataFrame(\n",
     "        {\"Bid\": [105, 102], \"Ask\": [105.3, 102]},\n",
@@ -1391,7 +1388,7 @@
     "display(source_data)\n",
     "\n",
     "# Insert only — the matching row (2025-01-02) is ignored, new rows are inserted\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"insert_only_example\",\n",
     "    source_data,\n",
     "    strategy=MergeStrategy(matched=\"do_nothing\", not_matched_by_target=\"insert\")\n",
@@ -1618,7 +1615,7 @@
     "display(source_data)\n",
     "\n",
     "# Update and insert — the matching row is updated, the new row is inserted\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"upsert_example\",\n",
     "    source_data,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"insert\")\n",
@@ -1874,7 +1871,7 @@
     "display(correction)\n",
     "\n",
     "# Merge using on=[\"Exchange\"] so only the NYSE row at 09:00 is updated\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"multi_exchange\",\n",
     "    correction,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -2209,7 +2206,7 @@
     "display(correction_nan)\n",
     "\n",
     "# match_na=False (the default): NaN never matches NaN, so nothing is updated\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"float_nan_example\",\n",
     "    correction_nan,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -2220,7 +2217,7 @@
     "\n",
     "# Reset the target, then merge again with match_na=True to demonstrate the matching mode\n",
     "lib.write(\"float_nan_example\", float_nan_data)\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"float_nan_example\",\n",
     "    correction_nan,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -2380,7 +2377,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260826 01:01:34.479022 107523 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260826 12:28:54.692326 27260 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {
@@ -2455,7 +2452,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260826 01:01:34.498035 107523 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260826 12:28:54.714966 27260 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {
@@ -2550,7 +2547,7 @@
     "display(correction_none)\n",
     "\n",
     "# match_na=False (the default): None matches neither the target's NaN nor its None\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"string_none_example\",\n",
     "    correction_none,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -2561,7 +2558,7 @@
     "\n",
     "# Reset the target, then merge again with match_na=True to demonstrate the matching mode\n",
     "lib.write(\"string_none_example\", string_none_data)\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"string_none_example\",\n",
     "    correction_none,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -2877,7 +2874,7 @@
     "display(correction_nat)\n",
     "\n",
     "# match_na=False (the default): NaT never matches NaT, so nothing is updated\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"datetime_nat_example\",\n",
     "    correction_nat,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -2888,7 +2885,7 @@
     "\n",
     "# Reset the target, then merge again with match_na=True to demonstrate the matching mode\n",
     "lib.write(\"datetime_nat_example\", datetime_nat_data)\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"datetime_nat_example\",\n",
     "    correction_nat,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -3180,7 +3177,7 @@
     "display(source_correction)\n",
     "\n",
     "# Merge: matches on datetime (first level), updates the Exchange level and Price\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"multi_datetime\",\n",
     "    source_correction,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\")\n",
@@ -3442,7 +3439,7 @@
     "display(source_nyse_only)\n",
     "\n",
     "# Merge with on=[\"Exchange\"] — matches on datetime AND Exchange\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"multi_datetime_on\",\n",
     "    source_nyse_only,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -3709,7 +3706,7 @@
     "display(source_update)\n",
     "\n",
     "# Merge with on=[\"Name\"] — matches on the Name column\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"catalog\",\n",
     "    source_update,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
@@ -3973,7 +3970,7 @@
     "display(new_stock)\n",
     "\n",
     "# Insert only — matching SKU B2 is left unchanged, new SKUs are appended in source order\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"inventory_insert\",\n",
     "    new_stock,\n",
     "    strategy=MergeStrategy(matched=\"do_nothing\", not_matched_by_target=\"insert\"),\n",
@@ -4206,7 +4203,7 @@
     "print(\"Source data\")\n",
     "display(new_stock)\n",
     "\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"inventory_upsert\",\n",
     "    new_stock,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"insert\"),\n",
@@ -4427,7 +4424,7 @@
     "print(\"Source data\")\n",
     "display(new_stock)\n",
     "\n",
-    "lib.merge_experimental(\n",
+    "lib.merge(\n",
     "    \"inventory_update_only\",\n",
     "    new_stock,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",

--- a/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
+++ b/docs/mkdocs/docs/notebooks/ArcticDB_merge.ipynb
@@ -282,7 +282,7 @@
     {
      "data": {
       "text/plain": [
-       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1786453888142165015)"
+       "VersionedItem(symbol='daily_prices', library='prices', data=n/a, version=0, metadata=None, host='LMDB(path=/home/vasil/Documents/source/ArcticDB/docs/mkdocs/docs/notebooks/merge_example)', timestamp=1787695294073635071)"
       ]
      },
      "execution_count": 4,
@@ -1899,10 +1899,21 @@
    "id": "pj8nbwejxxk",
    "metadata": {},
    "source": [
-    "### Equality Semantics for `NaN` and `None` in `on` Columns\n",
+    "### The `match_na` Option: Matching Missing Values in `on` Columns\n",
     "\n",
-    "- **Float columns**: `NaN` is considered equal to `NaN`. This differs from the IEEE 754 standard where `NaN != NaN`.\n",
-    "- **String columns**: `None` and `NaN` are **indistinguishable**. All of the following are treated as matches: `NaN == NaN`, `NaN == None`, `None == NaN`, `None == None`.\n",
+    "By default (`match_na=False`), a missing value in an `on` column never matches anything, on either side, following SQL-NULL-like semantics:\n",
+    "\n",
+    "- **Float columns**: `NaN` never matches, not even another `NaN` (plain IEEE 754 equality, where `NaN != NaN`).\n",
+    "- **String columns**: `None` and `NaN` each match nothing, so `None` does not match `None` and `NaN` does not match `NaN`.\n",
+    "- **`datetime64` `on` columns**: `NaT` matches nothing, including another `NaT`.\n",
+    "\n",
+    "Non-missing values are always compared by plain equality, in both modes.\n",
+    "\n",
+    "Set `match_na=True` for missing values to match each other instead:\n",
+    "\n",
+    "- **Float columns**: `NaN` is considered equal to `NaN`.\n",
+    "- **String columns**: `None` and `NaN` are indistinguishable. All of the following are treated as matches: `NaN == NaN`, `NaN == None`, `None == NaN`, `None == None`.\n",
+    "- **`datetime64` `on` columns**: `NaT` is considered equal to `NaT`.\n",
     "\n",
     "#### Example: NaN Matching in Float Columns"
    ]
@@ -2035,7 +2046,75 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data after merge - NaN matched NaN in the float Sector column\n"
+      "Data after merge with match_na=False (default) - NaN did not match NaN, nothing changed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sector</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>1.0</td>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>300.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>2.0</td>\n",
+       "      <td>400.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            Sector  Price\n",
+       "2025-01-01     NaN  100.0\n",
+       "2025-01-01     1.0  200.0\n",
+       "2025-01-02     NaN  300.0\n",
+       "2025-01-02     2.0  400.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge with match_na=True - NaN matched NaN in the float Sector column\n"
      ]
     },
     {
@@ -2129,14 +2208,26 @@
     "print(\"Correction data (NaN in Sector)\")\n",
     "display(correction_nan)\n",
     "\n",
-    "# NaN == NaN in float columns, so the NaN row at 2025-01-01 will match\n",
+    "# match_na=False (the default): NaN never matches NaN, so nothing is updated\n",
     "lib.merge_experimental(\n",
     "    \"float_nan_example\",\n",
     "    correction_nan,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
     "    on=[\"Sector\"]\n",
     ")\n",
-    "print(\"Data after merge - NaN matched NaN in the float Sector column\")\n",
+    "print(\"Data after merge with match_na=False (default) - NaN did not match NaN, nothing changed\")\n",
+    "display(lib.read(\"float_nan_example\").data)\n",
+    "\n",
+    "# Reset the target, then merge again with match_na=True to demonstrate the matching mode\n",
+    "lib.write(\"float_nan_example\", float_nan_data)\n",
+    "lib.merge_experimental(\n",
+    "    \"float_nan_example\",\n",
+    "    correction_nan,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
+    "    on=[\"Sector\"],\n",
+    "    match_na=True\n",
+    ")\n",
+    "print(\"Data after merge with match_na=True - NaN matched NaN in the float Sector column\")\n",
     "display(lib.read(\"float_nan_example\").data)"
    ]
   },
@@ -2145,11 +2236,13 @@
    "id": "h6sltmcossa",
    "metadata": {},
    "source": [
-    "The `NaN` value in the `Sector` column matched between `source` and `target` at `2025-01-01`, so only that row was updated. The row with `Sector=1.0` at the same timestamp was not affected.\n",
+    "With `match_na=False` (the default), the `NaN` correction did not match either `NaN` row in `target`'s `Sector` column, so nothing was updated.\n",
     "\n",
-    "#### Example: None and NaN Are Indistinguishable in String Columns\n",
+    "With `match_na=True`, the `NaN` value in the `Sector` column matched between `source` and `target` at `2025-01-01`, so only that row was updated. The row with `Sector=1.0` at the same timestamp was not affected.\n",
     "\n",
-    "In string columns, `None` and `NaN` are treated as the same value. A `source` row with `None` in a string `on` column will match a `target` row with `NaN` in the same column (and vice versa)."
+    "#### Example: None and NaN Matching in String Columns\n",
+    "\n",
+    "In string columns, whether `None` and `NaN` match each other depends on `match_na`."
    ]
   },
   {
@@ -2280,14 +2373,89 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data after merge - None in source matched NaN in target's string column\n"
+      "Data after merge with match_na=False (default) - None matched nothing, nothing changed\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "20260811 16:11:28.381648 18717 I arcticdb | Column Exchange does not have non null elements.\n"
+      "20260826 01:01:34.479022 107523 I arcticdb | Column Exchange does not have non null elements.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Exchange</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>NaN</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>LSE</td>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>None</td>\n",
+       "      <td>300.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>LSE</td>\n",
+       "      <td>400.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Exchange  Price\n",
+       "2025-01-01      NaN  100.0\n",
+       "2025-01-01      LSE  200.0\n",
+       "2025-01-02     None  300.0\n",
+       "2025-01-02      LSE  400.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge with match_na=True - None in source matched NaN in target's string column\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "20260826 01:01:34.498035 107523 I arcticdb | Column Exchange does not have non null elements.\n"
      ]
     },
     {
@@ -2370,7 +2538,7 @@
     "print(\"Original data (NaN at 2025-01-01, None at 2025-01-02 in Exchange)\")\n",
     "display(lib.read(\"string_none_example\").data)\n",
     "\n",
-    "# Source: correction with None in the string column - will match both NaN and None in target\n",
+    "# Source: a None value in the string column\n",
     "correction_none = pd.DataFrame(\n",
     "    {\n",
     "        \"Exchange\": [None],\n",
@@ -2381,14 +2549,26 @@
     "print(\"Correction data (None in Exchange)\")\n",
     "display(correction_none)\n",
     "\n",
-    "# None in source matches NaN in target for string columns\n",
+    "# match_na=False (the default): None matches neither the target's NaN nor its None\n",
     "lib.merge_experimental(\n",
     "    \"string_none_example\",\n",
     "    correction_none,\n",
     "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
     "    on=[\"Exchange\"]\n",
     ")\n",
-    "print(\"Data after merge - None in source matched NaN in target's string column\")\n",
+    "print(\"Data after merge with match_na=False (default) - None matched nothing, nothing changed\")\n",
+    "display(lib.read(\"string_none_example\").data)\n",
+    "\n",
+    "# Reset the target, then merge again with match_na=True to demonstrate the matching mode\n",
+    "lib.write(\"string_none_example\", string_none_data)\n",
+    "lib.merge_experimental(\n",
+    "    \"string_none_example\",\n",
+    "    correction_none,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
+    "    on=[\"Exchange\"],\n",
+    "    match_na=True\n",
+    ")\n",
+    "print(\"Data after merge with match_na=True - None in source matched NaN in target's string column\")\n",
     "display(lib.read(\"string_none_example\").data)"
    ]
   },
@@ -2397,7 +2577,336 @@
    "id": "u2sxjwi45t",
    "metadata": {},
    "source": [
-    "The `target` had `NaN` in the `Exchange` column at `2025-01-01` and `None` at `2025-01-02`. The `source` contained `None` in `Exchange` at `2025-01-01`. Because `None` and `NaN` are indistinguishable in string columns, the `source` row matched the `target` row at `2025-01-01` (where the `target` had `NaN`). The row at `2025-01-02` was not affected because the index did not match."
+    "With `match_na=False` (the default), the `None` value in `source` matched neither the `NaN` row nor the `None` row in `target`'s `Exchange` column, so nothing was updated.\n",
+    "\n",
+    "With `match_na=True`, `None` and `NaN` are indistinguishable in string columns, so the `source` row matched the `target` row at `2025-01-01` (where the `target` had `NaN`). The row at `2025-01-02` was not affected because the index did not match.\n",
+    "\n",
+    "`NaT` in `datetime64` `on` columns follows the same pattern.\n",
+    "\n",
+    "#### Example: NaT Matching in `datetime64` Columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "ip9ey7ea9j",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Original data\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SettlementDate</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>2025-01-05</td>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>300.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>2025-01-06</td>\n",
+       "      <td>400.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           SettlementDate  Price\n",
+       "2025-01-01            NaT  100.0\n",
+       "2025-01-01     2025-01-05  200.0\n",
+       "2025-01-02            NaT  300.0\n",
+       "2025-01-02     2025-01-06  400.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Correction data (NaT in SettlementDate)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SettlementDate</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           SettlementDate  Price\n",
+       "2025-01-01            NaT  999.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge with match_na=False (default) - NaT did not match NaT, nothing changed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SettlementDate</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>100.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>2025-01-05</td>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>300.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>2025-01-06</td>\n",
+       "      <td>400.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           SettlementDate  Price\n",
+       "2025-01-01            NaT  100.0\n",
+       "2025-01-01     2025-01-05  200.0\n",
+       "2025-01-02            NaT  300.0\n",
+       "2025-01-02     2025-01-06  400.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Data after merge with match_na=True - NaT matched NaT in the SettlementDate column\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SettlementDate</th>\n",
+       "      <th>Price</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>999.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-01</th>\n",
+       "      <td>2025-01-05</td>\n",
+       "      <td>200.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>NaT</td>\n",
+       "      <td>300.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2025-01-02</th>\n",
+       "      <td>2025-01-06</td>\n",
+       "      <td>400.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           SettlementDate  Price\n",
+       "2025-01-01            NaT  999.0\n",
+       "2025-01-01     2025-01-05  200.0\n",
+       "2025-01-02            NaT  300.0\n",
+       "2025-01-02     2025-01-06  400.0"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Target: data with NaT in a datetime64 column\n",
+    "datetime_nat_data = pd.DataFrame(\n",
+    "    {\n",
+    "        \"SettlementDate\": [pd.NaT, pd.Timestamp(\"2025-01-05\"), pd.NaT, pd.Timestamp(\"2025-01-06\")],\n",
+    "        \"Price\": [100.0, 200.0, 300.0, 400.0],\n",
+    "    },\n",
+    "    index=pd.DatetimeIndex([\n",
+    "        pd.Timestamp(\"2025-01-01\"),\n",
+    "        pd.Timestamp(\"2025-01-01\"),\n",
+    "        pd.Timestamp(\"2025-01-02\"),\n",
+    "        pd.Timestamp(\"2025-01-02\"),\n",
+    "    ])\n",
+    ")\n",
+    "lib.write(\"datetime_nat_example\", datetime_nat_data)\n",
+    "print(\"Original data\")\n",
+    "display(lib.read(\"datetime_nat_example\").data)\n",
+    "\n",
+    "# Source: a NaT value in the datetime64 column\n",
+    "correction_nat = pd.DataFrame(\n",
+    "    {\n",
+    "        \"SettlementDate\": [pd.NaT],\n",
+    "        \"Price\": [999.0],\n",
+    "    },\n",
+    "    index=pd.DatetimeIndex([pd.Timestamp(\"2025-01-01\")])\n",
+    ")\n",
+    "print(\"Correction data (NaT in SettlementDate)\")\n",
+    "display(correction_nat)\n",
+    "\n",
+    "# match_na=False (the default): NaT never matches NaT, so nothing is updated\n",
+    "lib.merge_experimental(\n",
+    "    \"datetime_nat_example\",\n",
+    "    correction_nat,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
+    "    on=[\"SettlementDate\"]\n",
+    ")\n",
+    "print(\"Data after merge with match_na=False (default) - NaT did not match NaT, nothing changed\")\n",
+    "display(lib.read(\"datetime_nat_example\").data)\n",
+    "\n",
+    "# Reset the target, then merge again with match_na=True to demonstrate the matching mode\n",
+    "lib.write(\"datetime_nat_example\", datetime_nat_data)\n",
+    "lib.merge_experimental(\n",
+    "    \"datetime_nat_example\",\n",
+    "    correction_nat,\n",
+    "    strategy=MergeStrategy(matched=\"update\", not_matched_by_target=\"do_nothing\"),\n",
+    "    on=[\"SettlementDate\"],\n",
+    "    match_na=True\n",
+    ")\n",
+    "print(\"Data after merge with match_na=True - NaT matched NaT in the SettlementDate column\")\n",
+    "display(lib.read(\"datetime_nat_example\").data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ubcq3wcxej",
+   "metadata": {},
+   "source": [
+    "With `match_na=False` (the default), the `NaT` correction did not match either `NaT` row in `target`'s `SettlementDate` column, so nothing was updated.\n",
+    "\n",
+    "With `match_na=True`, the `NaT` value in the `SettlementDate` column matched between `source` and `target` at `2025-01-01`, so only that row was updated. The row with `SettlementDate=2025-01-05` at the same timestamp was not affected, and the `NaT` row at `2025-01-02` was not affected because the index did not match."
    ]
   },
   {
@@ -2419,7 +2928,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "n7oi7kz5fwk",
    "metadata": {},
    "outputs": [
@@ -2692,7 +3201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "k5hu3rkcs8k",
    "metadata": {},
    "outputs": [
@@ -2957,7 +3466,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "854s59ew9gj",
    "metadata": {},
    "outputs": [
@@ -3242,7 +3751,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "rr1insert1code",
    "metadata": {},
    "outputs": [
@@ -3486,7 +3995,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "rr3insert3code",
    "metadata": {},
    "outputs": [
@@ -3719,7 +4228,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "rr5insert5code",
    "metadata": {},
    "outputs": [

--- a/python/arcticdb/util/test.py
+++ b/python/arcticdb/util/test.py
@@ -1656,3 +1656,38 @@ def merge(
 
 def query_stats_operation_count(stats, operation, key_type):
     return stats.get("storage_operations", {}).get(operation, {}).get(key_type, {}).get("count", 0)
+
+
+def max_rows_per_segment(rows_per_segment: int) -> int:
+    """Upper bound on the number of rows the C++ ColumnReslicer can put in a single row slice when resegmenting,
+    given a target of `rows_per_segment`. Mirrors cpp/arcticdb/column_store/column_reslicer.cpp."""
+    return max((4 * rows_per_segment) // 3, rows_per_segment + 1)
+
+
+def assert_index_key_structure_static_schema(index_df: pd.DataFrame, rows_per_segment: int) -> None:
+    max_slice = max_rows_per_segment(rows_per_segment)
+    row_ranges = {}
+    prev_col_range = None
+
+    is_continuous_range = lambda lst: all(lst[i][0] == lst[i - 1][1] for i in range(1, len(lst)))
+    is_row_range_size_within_bounds = lambda rr: 1 <= rr[1] - rr[0] <= max_slice
+
+    for start_col, end_col, start_row, end_row in zip(
+        index_df["start_col"], index_df["end_col"], index_df["start_row"], index_df["end_row"]
+    ):
+        col_range, row_range = (start_col, end_col), (start_row, end_row)
+        row_ranges.setdefault(row_range, []).append(col_range)
+        if col_range != prev_col_range:
+            if prev_col_range is not None:
+                # Non decreasing column major order
+                assert col_range[0] == prev_col_range[1]
+            prev_col_range = col_range
+
+    if not row_ranges:
+        return
+
+    reference_col_slices = next(iter(row_ranges.values()))
+    assert is_continuous_range(reference_col_slices)
+    assert is_continuous_range(list(row_ranges.keys()))
+    assert all(is_row_range_size_within_bounds(row_range) for row_range in row_ranges.keys())
+    assert all(col_slices == reference_col_slices for col_slices in row_ranges.values())

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4399,7 +4399,7 @@ class NativeVersionStore:
     def library_tool(self) -> LibraryTool:
         return LibraryTool(self._library, self)
 
-    def merge_experimental(
+    def merge(
         self,
         symbol: str,
         source: Any,
@@ -4416,9 +4416,6 @@ class NativeVersionStore:
         See [Merge Notebook](../notebooks/ArcticDB_merge.ipynb) for usage examples.
 
         !!! warning
-            This API is under development and is subject to change. The API is not subject to semver and can change in
-            minor or patch releases.
-
             Dynamic schema is not supported.
 
         Parameters
@@ -4496,7 +4493,7 @@ class NativeVersionStore:
         --------
 
         >>> lib.write("symbol", pd.DataFrame({'a': [1, 2, 3]}, index=pd.DatetimeIndex([pd.Timestamp(1), pd.Timestamp(2), pd.Timestamp(3)])))
-        >>> lib.merge_experimental("symbol", pd.DataFrame({"a": [100, 200]}, index=pd.DatetimeIndex([pd.Timestamp(2), pd.Timestamp(4)])), strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"))))
+        >>> lib.merge("symbol", pd.DataFrame({"a": [100, 200]}, index=pd.DatetimeIndex([pd.Timestamp(2), pd.Timestamp(4)])), strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"))))
         >>> lib.read("symbol").data
                                        a
         1970-01-01 00:00:00.000000001  1

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -4408,6 +4408,7 @@ class NativeVersionStore:
         metadata: Any = None,
         prune_previous_versions: bool = False,
         upsert: bool = False,
+        match_na: bool = False,
     ):
         """
         Merge new data into an existing symbol's DataFrame according to a specified strategy.
@@ -4442,9 +4443,19 @@ class NativeVersionStore:
             IMPORTANT: For date-time indexed data, the index is always included in matching and cannot be excluded.
 
             Note on equality semantics:
+                By default (`match_na=False`), a missing value in an `on` column never matches anything, on either
+                side:
+                - In float columns, NaN never matches (plain IEEE equality), including NaN against NaN.
+                - In string columns, None and NaN match nothing, so None does not match None and NaN does not
+                  match NaN.
+                - In datetime64 `on` columns, NaT matches nothing, including NaT against NaT.
+                Non-missing values are compared by plain equality in both modes.
+
+                Set `match_na=True` for missing values to match each other instead:
                 - In float columns, NaN is considered equal to NaN.
                 - In string columns, None and NaN are indistinguishable. NaN == None, NaN == NaN, None == None,
                   and None == NaN all evaluate to True.
+                - In datetime64 `on` columns, NaT is considered equal to NaT.
 
             If a column name appears more than once in the source or the target it must not be added in the on
             parameter.
@@ -4459,6 +4470,9 @@ class NativeVersionStore:
             If True and the symbol does not exist, create it by writing `source` to the store. Requires a strategy
             with `not_matched_by_target="insert"`; combining it with an update-only strategy raises
             `UserInputException` as the newly created symbol would be empty.
+        match_na : bool, default False
+            Controls whether a missing value (float NaN, string None/NaN, or NaT in a datetime64 `on`
+            column) can match another missing value in the `on` columns. See "Note on equality semantics" above.
 
         Returns
         -------
@@ -4501,7 +4515,9 @@ class NativeVersionStore:
             norm_failure_options_msg="Source data must be normalizable in order to merge it into existing dataframe",
         )
         on = [] if on is None else on
-        vit = self.version_store.merge(symbol, item, norm_meta, udm, prune_previous_versions, upsert, strategy, on)
+        vit = self.version_store.merge(
+            symbol, item, norm_meta, udm, prune_previous_versions, upsert, strategy, on, match_na
+        )
         return self._convert_thin_cxx_item_to_python(vit, metadata)
 
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3506,6 +3506,7 @@ class Library:
         metadata: Any = None,
         prune_previous_versions: bool = False,
         upsert: bool = False,
+        match_na: bool = False,
     ):
         """
         Merge new data into an existing symbol's DataFrame according to a specified strategy.
@@ -3540,9 +3541,19 @@ class Library:
             IMPORTANT: For date-time indexed data, the index is always included in matching and cannot be excluded.
 
             Note on equality semantics:
+                By default (`match_na=False`), a missing value in an `on` column never matches anything, on either
+                side:
+                - In float columns, NaN never matches (plain IEEE equality), including NaN against NaN.
+                - In string columns, None and NaN match nothing, so None does not match None and NaN does not
+                  match NaN.
+                - In datetime64 `on` columns, NaT matches nothing, including NaT against NaT.
+                Non-missing values are compared by plain equality in both modes.
+
+                Set `match_na=True` for missing values to match each other instead:
                 - In float columns, NaN is considered equal to NaN.
                 - In string columns, None and NaN are indistinguishable. NaN == None, NaN == NaN, None == None,
                   and None == NaN all evaluate to True.
+                - In datetime64 `on` columns, NaT is considered equal to NaT.
 
             If a column name appears more than once in the source or the target it must not be added in the on
             parameter.
@@ -3557,6 +3568,9 @@ class Library:
             If True and the symbol does not exist, create it by writing `source` to the store. Requires a strategy
             with `not_matched_by_target="insert"`; combining it with an update-only strategy raises
             `UserInputException` as the newly created symbol would be empty.
+        match_na : bool, default False
+            Controls whether a missing value (float NaN, string None/NaN, or NaT in a datetime64 `on`
+            column) can match another missing value in the `on` columns. See "Note on equality semantics" above.
 
         Returns
         -------
@@ -3595,6 +3609,7 @@ class Library:
             metadata=metadata,
             prune_previous_versions=prune_previous_versions,
             upsert=upsert,
+            match_na=match_na,
         )
 
     @property

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -3497,7 +3497,7 @@ class Library:
         """
         return self._nvs.defragment_symbol_data(symbol, segment_size, prune_previous_versions)
 
-    def merge_experimental(
+    def merge(
         self,
         symbol: str,
         source: NormalizableType,
@@ -3514,9 +3514,6 @@ class Library:
         See [Merge Notebook](../notebooks/ArcticDB_merge.ipynb) for usage examples.
 
         !!! warning
-            This API is under development and is subject to change. The API is not subject to semver and can change in
-            minor or patch releases.
-
             Dynamic schema is not supported.
 
         Parameters
@@ -3594,14 +3591,14 @@ class Library:
         --------
 
         >>> lib.write("symbol", pd.DataFrame({'a': [1, 2, 3]}, index=pd.DatetimeIndex([pd.Timestamp(1), pd.Timestamp(2), pd.Timestamp(3)])))
-        >>> lib.merge_experimental("symbol", pd.DataFrame({"a": [100, 200]}, index=pd.DatetimeIndex([pd.Timestamp(2), pd.Timestamp(4)])), strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"))))
+        >>> lib.merge("symbol", pd.DataFrame({"a": [100, 200]}, index=pd.DatetimeIndex([pd.Timestamp(2), pd.Timestamp(4)])), strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"))))
         >>> lib.read("symbol").data
                                        a
         1970-01-01 00:00:00.000000001  1
         1970-01-01 00:00:00.000000002  100
         1970-01-01 00:00:00.000000003  3
         """
-        return self._nvs.merge_experimental(
+        return self._nvs.merge(
             symbol=symbol,
             source=source,
             strategy=strategy,

--- a/python/benchmarks/merge_functions.py
+++ b/python/benchmarks/merge_functions.py
@@ -173,7 +173,7 @@ class MergeBase:
 
     def __init__(self):
         self.rounds = 1
-        # merge_experimental is destructive, so we must restore a fresh base and run once per measurement
+        # merge is destructive, so we must restore a fresh base and run once per measurement
         self.number = 1
         self.warmup_time = 0
         self.repeat = 10
@@ -240,7 +240,7 @@ class MergeBase:
             self._source_key = key
 
     def merge(self, strategy):
-        self.lib.merge_experimental(self.SYM, self.source, strategy=self.STRATEGIES[strategy], on=self.on)
+        self.lib.merge(self.SYM, self.source, strategy=self.STRATEGIES[strategy], on=self.on)
 
 
 class MergeThinDatetime(MergeBase):

--- a/python/tests/compat/arcticdb/test_compatibility.py
+++ b/python/tests/compat/arcticdb/test_compatibility.py
@@ -524,7 +524,7 @@ def test_compat_merge_old_updated_data(pandas_v1_venv, s3_ssl_disabled_storage, 
     # There was a bug where data written using update and old versions of ArcticDB produced data keys where the
     # end_index value was not 1 nanosecond larger than the last index value in the segment (as it should be), but
     # instead contained the start of the date_range passed into the update call.
-    # We want to verify merge_experimental works correctly with such data.
+    # We want to verify merge works correctly with such data.
     arctic_uri = s3_ssl_disabled_storage.arctic_uri
     with CompatLibrary(pandas_v1_venv, arctic_uri, lib_name) as compat:
         sym = "sym"
@@ -559,7 +559,7 @@ def test_compat_merge_old_updated_data(pandas_v1_venv, s3_ssl_disabled_storage, 
             target = curr.lib.read(sym).data
             expected = merge(target, source, strategy)
 
-            curr.lib.merge_experimental(sym, source, strategy=strategy)
+            curr.lib.merge(sym, source, strategy=strategy)
 
             result = curr.lib.read(sym).data
             assert_frame_equal(result, expected)
@@ -609,7 +609,7 @@ def test_compat_merge_rowrange_write_new_read_old(old_venv_and_arctic_uri, lib_n
             curr.lib = curr.ac.get_library(lib_name)
 
             curr.lib.write(sym, target)
-            curr.lib.merge_experimental(sym, source, strategy=strategy, on=["a"])
+            curr.lib.merge(sym, source, strategy=strategy, on=["a"])
 
         if (arctic_uri.startswith("s3") or arctic_uri.startswith("azure")) and "1.6.2" in old_venv.version:
             pytest.skip("Reading the new library on s3 or azure with 1.6.2 requires some work arounds")

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -40,17 +40,6 @@ MAX_DATE = np.datetime64("2025-01-01")
 
 
 @st.composite
-def ordered_dataframe_list(
-    draw, column_names, column_dtypes, min_date=MIN_DATE, max_date=MAX_DATE
-) -> List[pd.DataFrame]:
-    index_ranges = sorted(draw(st.lists(date(min_date=min_date, max_date=max_date, unit="s"), min_size=2)))
-    return [
-        draw(dataframe(column_names, column_dtypes, index_ranges[i], index_ranges[i + 1]))
-        for i in range(len(index_ranges) - 1)
-    ]
-
-
-@st.composite
 def source_for_merge(
     draw, target: pd.DataFrame, min_date=MIN_DATE, max_date=MAX_DATE, on: List[str] = None
 ) -> pd.DataFrame:

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -9,7 +9,6 @@ from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,
     DataframeStrategyIndexType,
 )
-from arcticdb.exceptions import DuplicateKeyException, UserInputException
 from arcticdb.version_store._store import MergeStrategy, MergeAction, normalize_merge_action
 from hypothesis import assume, strategies as st, given, settings, HealthCheck
 from typing import List, Tuple, Optional
@@ -17,7 +16,6 @@ from typing import List, Tuple, Optional
 from arcticdb.util.test import (
     assert_frame_equal,
     assert_index_key_structure_static_schema,
-    merge,
     random_strings_of_length_with_nan,
 )
 from tests.util.mark import MACOS, WINDOWS
@@ -103,104 +101,93 @@ def source_for_merge(
 
 
 @st.composite
-def merge_arguments(
-    draw,
-    column_names,
-    column_dtypes,
-    min_date=MIN_DATE,
-    max_date=MAX_DATE,
-    index_type=DataframeStrategyIndexType.DATETIME,
-) -> Tuple[List[pd.DataFrame], pd.DataFrame, List[str]]:
-
-    if index_type == DataframeStrategyIndexType.DATETIME:
-        target_list = draw(ordered_dataframe_list(column_names, column_dtypes, min_date, max_date))
-        target = pd.concat(target_list)
-        on_columns_min_size = 0
+def merge_update_arguments(draw, index_type=DataframeStrategyIndexType.DATETIME):
+    rowrange = index_type == DataframeStrategyIndexType.ROWRANGE
+    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True, min_size=1 if rowrange else 0))
+    # Drawn independently of index type and data, so both semantics are exercised regardless of what else is drawn.
+    match_na = draw(st.booleans())
+    strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
+    target, source, expected = draw(
+        merge_dataframes_from_result(
+            COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on, strategy, index_type=index_type, match_na=match_na
+        )
+    )
+    assume(not target.empty)
+    if rowrange:
+        target_list = [target]
     else:
-        target_list = [draw(dataframe(column_names, column_dtypes, min_date, max_date, index_type=index_type))]
-        target = target_list[0]
-        on_columns_min_size = 1
-    on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True, min_size=on_columns_min_size))
-    source = draw(source_for_merge(target, on=on))
-    return target_list, source, on
+        # Split the target into chunks appended in separate writes, at strictly increasing index positions only, so
+        # each appended chunk starts strictly after the previous one ends and the sorted-append validation holds.
+        valid = [i for i in range(1, len(target)) if target.index[i] > target.index[i - 1]]
+        bounds = sorted(draw(st.lists(st.sampled_from(valid), unique=True, max_size=3))) if valid else []
+        target_list = [target.iloc[start:stop] for start, stop in zip([0] + bounds, bounds + [len(target)])]
+    return target_list, source, expected, on, match_na
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
-@given(merge_args=merge_arguments(COL_NAMES, DTYPES))
+@given(merge_args=merge_update_arguments())
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
 def test_timeseries_merge_update(s3_version_store_v1, merge_args):
-    target_list, source, on = merge_args
+    target_list, source, expected, on, match_na = merge_args
     lib = s3_version_store_v1
     symbol = "test_merge_update"
     lib.version_store.force_delete_symbol(symbol)
-    strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
     for df in target_list:
         lib.append(symbol, df)
-    try:
-        lib.merge_experimental(symbol, source, strategy=strategy, on=on)
-    except UserInputException as e:
-        if "Multiple source rows match the same target row" not in str(e):
-            raise
-        with pytest.raises(ValueError, match="Multiple source rows match the same target row"):
-            merge(pd.concat(target_list), source, strategy=strategy, on=on)
-        return
-    result = lib.read(symbol).data
-    expected = merge(pd.concat(target_list), source, strategy=strategy, on=on)
-    assert_frame_equal(result, expected)
+    lib.merge_experimental(
+        symbol,
+        source,
+        strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
+        on=on,
+        match_na=match_na,
+    )
+    assert_frame_equal(lib.read(symbol).data, expected)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @given(
-    merge_args=merge_arguments(COL_NAMES, DTYPES),
+    merge_args=merge_update_arguments(),
     cols_to_promote=st.lists(st.sampled_from(COL_NAMES), unique=True, min_size=1),
 )
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
 def test_multiindex_merge_update(s3_version_store_v1, merge_args, cols_to_promote):
-    target_list, source, on = merge_args
+    target_list, source, expected, on, match_na = merge_args
     target_list = [df.set_index(cols_to_promote, append=True) for df in target_list]
     source = source.set_index(cols_to_promote, append=True)
+    expected = expected.set_index(cols_to_promote, append=True)
 
     lib = s3_version_store_v1
     symbol = "test_multiindex_merge_update"
     lib.version_store.force_delete_symbol(symbol)
     for df in target_list:
         lib.append(symbol, df)
-    strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
-    try:
-        lib.merge_experimental(symbol, source, strategy=strategy, on=on)
-    except UserInputException as e:
-        if "Multiple source rows match the same target row" not in str(e):
-            raise
-        with pytest.raises(ValueError, match="Multiple source rows match the same target row"):
-            merge(pd.concat(target_list), source, strategy=strategy, on=on)
-        return
-    result = lib.read(symbol).data
-    expected = merge(pd.concat(target_list), source, strategy=strategy, on=on)
-    assert_frame_equal(result, expected)
+    lib.merge_experimental(
+        symbol,
+        source,
+        strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
+        on=on,
+        match_na=match_na,
+    )
+    assert_frame_equal(lib.read(symbol).data, expected)
 
 
 @use_of_function_scoped_fixtures_in_hypothesis_checked
-@given(merge_args=merge_arguments(COL_NAMES, DTYPES, index_type=DataframeStrategyIndexType.ROWRANGE))
+@given(merge_args=merge_update_arguments(index_type=DataframeStrategyIndexType.ROWRANGE))
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
 def test_rowrange_merge_update(s3_version_store_v1, merge_args):
-    target, source, on = merge_args
-    assert len(target) == 1
+    target_list, source, expected, on, match_na = merge_args
     lib = s3_version_store_v1
     symbol = "test_merge_update"
     lib.version_store.force_delete_symbol(symbol)
-    strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
-    lib.write(symbol, target[0])
-    try:
-        lib.merge_experimental(symbol, source, strategy=strategy, on=on)
-    except UserInputException as e:
-        if "Multiple source rows match the same target row" not in str(e):
-            raise
-        with pytest.raises(ValueError, match="Multiple source rows match the same target row"):
-            merge(target[0], source, strategy=strategy, on=on)
-        return
-    result = lib.read(symbol).data
-    expected = merge(target[0], source, strategy=strategy, on=on)
-    assert_frame_equal(result, expected)
+    lib.write(symbol, target_list[0])
+    lib.merge_experimental(
+        symbol,
+        source,
+        strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
+        on=on,
+        match_na=match_na,
+    )
+    assert_frame_equal(lib.read(symbol).data, expected)
 
 
 ########################################################################################
@@ -232,13 +219,16 @@ def test_rowrange_merge_update(s3_version_store_v1, merge_args):
 # In both cases the expected result is simply the end result from step 1, reordered so inserted rows follow the
 # target rows sharing their timestamp.
 
-# Single sentinel used only when building match keys: None/NaN/NaT collapse to it so they compare equal, mirroring the
-# way the merge treats missing values (a source None matches a target NaN and vice versa). It is never written into the
-# data - target/source/expected are slices/reorders of the generated frame, so the real None/NaN values are preserved.
+# Single sentinel used when match_na=True: None/NaN/NaT collapse to it so they compare equal, mirroring how the merge
+# compares missing values when match_na=True (a source None matches a target NaN and vice versa). Under match_na=False
+# each missing cell gets a fresh, per-cell-unique object() instead (see match_keys), so it matches nothing else,
+# including another missing cell with the same underlying PyObject sliced from the same generated frame. Never
+# written into the data - target/source/expected are slices/reorders of the generated frame, so the real None/NaN
+# values are preserved.
 _MISSING = object()
 
 
-def match_keys(frame, on, include_index=True):
+def match_keys(frame, on, include_index=True, match_na=True):
     # Datetime index matches on (index, *on). Row range index has no meaningful index to match on, so it matches on
     # the "on" columns only.
     columns = [frame[col] for col in on]
@@ -246,7 +236,7 @@ def match_keys(frame, on, include_index=True):
         [
             (
                 *((index,) if include_index else ()),
-                *(_MISSING if pd.isna(col.iat[pos]) else col.iat[pos] for col in columns),
+                *((_MISSING if match_na else object()) if pd.isna(col.iat[pos]) else col.iat[pos] for col in columns),
             )
             for pos, index in enumerate(frame.index)
         ]
@@ -259,9 +249,9 @@ def generate_rows_to_insert(draw, keys):
     return keys.isin(inserted_keys).to_numpy()
 
 
-def generate_matched_rows(draw, keys, is_inserted):
+def generate_matched_rows(draw, keys, is_inserted, can_be_matched):
     remaining = np.flatnonzero(~is_inserted)
-    matchable = remaining[~keys.iloc[remaining].duplicated(keep=False).to_numpy()]
+    matchable = remaining[~keys.iloc[remaining].duplicated(keep=False).to_numpy() & can_be_matched[remaining]]
     positions = draw(st.lists(st.sampled_from(matchable), unique=True)) if len(matchable) else []
     is_matched = np.zeros(len(is_inserted), dtype=bool)
     is_matched[positions] = True
@@ -296,39 +286,61 @@ def randomize_values(frame, positions, columns):
 
 
 @st.composite
-def merge_insert_dataframes(
-    draw, column_names, column_dtypes, min_date, max_date, on, strategy, index_type=DataframeStrategyIndexType.DATETIME
+def merge_dataframes_from_result(
+    draw,
+    column_names,
+    column_dtypes,
+    min_date,
+    max_date,
+    on,
+    strategy,
+    index_type=DataframeStrategyIndexType.DATETIME,
+    match_na=True,
 ):
     rowrange = index_type == DataframeStrategyIndexType.ROWRANGE
     merged = draw(dataframe(column_names, column_dtypes, min_date, max_date, index_type=index_type)).sort_index()
-    keys = match_keys(merged, on, include_index=not rowrange)
-    is_inserted = generate_rows_to_insert(draw, keys)
-    is_matched = generate_matched_rows(draw, keys, is_inserted)
-    is_source = is_inserted | is_matched
-    target = merged[~is_inserted].copy(deep=True)
+    keys = match_keys(merged, on, include_index=not rowrange, match_na=match_na)
+    # Rows removed from target and present only in source: inserted under an insert strategy, dropped under
+    # not_matched_by_target=do_nothing.
+    is_source_only = generate_rows_to_insert(draw, keys)
+    can_be_matched = (
+        np.ones(len(merged), dtype=bool) if (match_na or not on) else ~merged[on].isna().any(axis=1).to_numpy()
+    )
+    is_matched = generate_matched_rows(draw, keys, is_source_only, can_be_matched)
+    is_source = is_source_only | is_matched
+    target = merged[~is_source_only].copy(deep=True)
     source = merged[is_source].copy(deep=True)
     non_on_columns = [col for col in merged.columns if col not in on]
     if normalize_merge_action(strategy.matched) == MergeAction.UPDATE:
         # merge overwrites target with source, so randomize target to prove the merge actually updates it.
-        randomize_values(target, np.flatnonzero(is_matched[~is_inserted]), non_on_columns)
+        randomize_values(target, np.flatnonzero(is_matched[~is_source_only]), non_on_columns)
     else:
         # matched=do_nothing: merge ignores source, so randomize source to prove the merge doesn't use it.
         randomize_values(source, np.flatnonzero(is_matched[is_source]), non_on_columns)
 
-    if rowrange:
-        # Row range index has no ordering key: unmatched rows are appended after all target rows in source order and
-        # the result is re-indexed with a fresh RangeIndex. A stable sort by the inserted flag keeps target rows in
-        # their original order followed by the inserted rows in theirs. target/source are slices of a RangeIndex, so
-        # they need a fresh contiguous RangeIndex before being written/merged.
-        order = sorted(range(len(merged)), key=lambda i: bool(is_inserted[i]))
-        expected = merged.iloc[order]
-        for frame in (target, source, expected):
-            frame.index = pd.RangeIndex(len(frame))
-            frame.index.name = "index"
+    if normalize_merge_action(strategy.not_matched_by_target) == MergeAction.INSERT:
+        if rowrange:
+            # Row range index has no ordering key: unmatched rows are appended after all target rows in source order
+            # and the result is re-indexed with a fresh RangeIndex. A stable sort by the inserted flag keeps target
+            # rows in their original order followed by the inserted rows in theirs. target/source are slices of a
+            # RangeIndex, so they need a fresh contiguous RangeIndex before being written/merged.
+            order = sorted(range(len(merged)), key=lambda i: bool(is_source_only[i]))
+            expected = merged.iloc[order]
+            for frame in (target, source, expected):
+                frame.index = pd.RangeIndex(len(frame))
+                frame.index.name = "index"
+        else:
+            # Reorder so inserted rows follow the target rows sharing their timestamp
+            order = sorted(range(len(merged)), key=lambda i: (merged.index[i], bool(is_source_only[i])))
+            expected = merged.iloc[order]
     else:
-        # Reorder so inserted rows follow the target rows sharing their timestamp
-        order = sorted(range(len(merged)), key=lambda i: (merged.index[i], bool(is_inserted[i])))
-        expected = merged.iloc[order]
+        # not_matched_by_target=do_nothing: source-only rows match nothing and are dropped from the expected result
+        # instead of being reordered into it.
+        expected = merged[~is_source_only].copy(deep=True)
+        if rowrange:
+            for frame in (target, source, expected):
+                frame.index = pd.RangeIndex(len(frame))
+                frame.index.name = "index"
 
     return target, source, expected
 
@@ -338,12 +350,15 @@ def merge_insert_arguments(draw, strategy, index_type=DataframeStrategyIndexType
     # Row range index cannot match on the index, so at least one "on" column is required.
     on_min_size = 1 if index_type == DataframeStrategyIndexType.ROWRANGE else 0
     on = draw(st.lists(st.sampled_from(COL_NAMES), unique=True, min_size=on_min_size))
+    match_na = draw(st.booleans())
     target, source, expected = draw(
-        merge_insert_dataframes(COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on, strategy, index_type=index_type)
+        merge_dataframes_from_result(
+            COL_NAMES, DTYPES, MIN_DATE, MAX_DATE, on, strategy, index_type=index_type, match_na=match_na
+        )
     )
     rows_per_segment = draw(st.integers(1, len(expected)))
     cols_per_segment = draw(st.integers(1, len(COL_NAMES)))
-    return target, source, expected, strategy, on, cols_per_segment, rows_per_segment
+    return target, source, expected, strategy, on, cols_per_segment, rows_per_segment, match_na
 
 
 @pytest.mark.parametrize(
@@ -363,7 +378,7 @@ def merge_insert_arguments(draw, strategy, index_type=DataframeStrategyIndexType
 @given(data=st.data())
 @settings(deadline=None, suppress_health_check=[HealthCheck.data_too_large])
 def test_insert(s3_storage, strategy, index_type, data):
-    target, source, expected, _, on, cols_per_segment, rows_per_segment = data.draw(
+    target, source, expected, _, on, cols_per_segment, rows_per_segment, match_na = data.draw(
         merge_insert_arguments(strategy, index_type=index_type)
     )
     ac = s3_storage.create_arctic()
@@ -374,7 +389,7 @@ def test_insert(s3_storage, strategy, index_type, data):
         name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
     )
     lib.write("symbol", target)
-    lib.merge_experimental("symbol", source, strategy=strategy, on=on)
+    lib.merge_experimental("symbol", source, strategy=strategy, on=on, match_na=match_na)
     index_df = lib._dev_tools.library_tool().read_index("symbol")
     assert_index_key_structure_static_schema(index_df, rows_per_segment=rows_per_segment)
     result = lib.read("symbol").data

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -123,7 +123,7 @@ def test_timeseries_merge_update(s3_version_store_v1, merge_args):
     lib.version_store.force_delete_symbol(symbol)
     for df in target_list:
         lib.append(symbol, df)
-    lib.merge_experimental(
+    lib.merge(
         symbol,
         source,
         strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
@@ -150,7 +150,7 @@ def test_multiindex_merge_update(s3_version_store_v1, merge_args, cols_to_promot
     lib.version_store.force_delete_symbol(symbol)
     for df in target_list:
         lib.append(symbol, df)
-    lib.merge_experimental(
+    lib.merge(
         symbol,
         source,
         strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
@@ -169,7 +169,7 @@ def test_rowrange_merge_update(s3_version_store_v1, merge_args):
     symbol = "test_merge_update"
     lib.version_store.force_delete_symbol(symbol)
     lib.write(symbol, target_list[0])
-    lib.merge_experimental(
+    lib.merge(
         symbol,
         source,
         strategy=MergeStrategy(matched="update", not_matched_by_target="do_nothing"),
@@ -378,7 +378,7 @@ def test_insert(s3_storage, strategy, index_type, data):
         name, library_options=LibraryOptions(rows_per_segment=rows_per_segment, columns_per_segment=cols_per_segment)
     )
     lib.write("symbol", target)
-    lib.merge_experimental("symbol", source, strategy=strategy, on=on, match_na=match_na)
+    lib.merge("symbol", source, strategy=strategy, on=on, match_na=match_na)
     index_df = lib._dev_tools.library_tool().read_index("symbol")
     assert_index_key_structure_static_schema(index_df, rows_per_segment=rows_per_segment)
     result = lib.read("symbol").data

--- a/python/tests/hypothesis/arcticdb/test_merge_update.py
+++ b/python/tests/hypothesis/arcticdb/test_merge_update.py
@@ -14,7 +14,12 @@ from arcticdb.version_store._store import MergeStrategy, MergeAction, normalize_
 from hypothesis import assume, strategies as st, given, settings, HealthCheck
 from typing import List, Tuple, Optional
 
-from arcticdb.util.test import assert_frame_equal, merge, random_strings_of_length_with_nan
+from arcticdb.util.test import (
+    assert_frame_equal,
+    assert_index_key_structure_static_schema,
+    merge,
+    random_strings_of_length_with_nan,
+)
 from tests.util.mark import MACOS, WINDOWS
 
 from arcticdb.options import LibraryOptions
@@ -280,37 +285,6 @@ def random_values_for_dtype(dtype, count):
     return np.random.randint(low, high, size=count, dtype=np.int64).astype(dtype)
 
 
-def assert_valid_index(index_df):
-    # Every column slice must be split into the exact same set of contiguous row ranges.
-    first_slice_row_ranges = None
-    current_col_range = None
-    current_row_ranges = []
-    prev_row_range = None
-
-    for start_col, end_col, start_row, end_row in zip(
-        index_df["start_col"], index_df["end_col"], index_df["start_row"], index_df["end_row"]
-    ):
-        col_range, row_range = (start_col, end_col), (start_row, end_row)
-        if current_col_range is None:
-            current_col_range = col_range
-        elif col_range != current_col_range:
-            assert col_range[0] == current_col_range[1]
-            if first_slice_row_ranges is None:
-                first_slice_row_ranges = current_row_ranges[:]
-            else:
-                assert current_row_ranges == first_slice_row_ranges
-            current_row_ranges, prev_row_range, current_col_range = [], None, col_range
-        if prev_row_range is not None:
-            assert row_range[0] == prev_row_range[1]
-        current_row_ranges.append(row_range)
-        prev_row_range = row_range
-
-    if first_slice_row_ranges is None:
-        first_slice_row_ranges = current_row_ranges
-    else:
-        assert current_row_ranges == first_slice_row_ranges
-
-
 def randomize_values(frame, positions, columns):
     if not len(positions) or not columns:
         return
@@ -401,6 +375,7 @@ def test_insert(s3_storage, strategy, index_type, data):
     )
     lib.write("symbol", target)
     lib.merge_experimental("symbol", source, strategy=strategy, on=on)
-    assert_valid_index(lib._dev_tools.library_tool().read_index("symbol"))
+    index_df = lib._dev_tools.library_tool().read_index("symbol")
+    assert_index_key_structure_static_schema(index_df, rows_per_segment=rows_per_segment)
     result = lib.read("symbol").data
     assert_frame_equal(result, expected)

--- a/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
@@ -91,7 +91,7 @@ class TestStressTimeseriesMergeUpdate:
         source = make_matching_source(self.__class__.data, segments_to_update, self.__class__.rows_per_segment)
         strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         expected_table_data_read_count = len(segments_to_update) * self.__class__.col_slices
         assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == expected_table_data_read_count
@@ -115,7 +115,7 @@ class TestStressTimeseriesMergeUpdate:
         )
         strategy = MergeStrategy(matched="update", not_matched_by_target="do_nothing")
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=on)
+            lib.merge("sym", source, strategy=strategy, on=on)
         stats = qs.get_query_stats()
         expected_table_data_read_count = len(segments_to_update) * self.__class__.col_slices
         expected_table_data_write_count = (

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -7,6 +7,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import arcticdb
+import os
 from typing import List, Optional, Union
 import arcticdb.toolbox.query_stats as qs
 import numpy as np

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -6,26 +6,25 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
-import os
-import pytest
-import pandas as pd
-from arcticdb.util.test import assert_frame_equal, assert_vit_equals_except_data, merge, query_stats_operation_count
 import arcticdb
+from typing import List, Optional, Union
+import arcticdb.toolbox.query_stats as qs
+import numpy as np
+import pandas as pd
+import pytest
+from arcticdb.exceptions import ArcticException, StorageException, UnsortedDataException, UserInputException
+from arcticdb.util.test import (
+    assert_frame_equal,
+    assert_index_key_structure_static_schema,
+    assert_vit_equals_except_data,
+    merge,
+    query_stats_operation_count,
+)
 from arcticdb.version_store import VersionedItem
+from arcticdb.version_store._store import normalize_merge_action
+from arcticdb.version_store.library import MergeAction, MergeStrategy
 from arcticdb_ext.exceptions import SchemaException
 from arcticdb_ext.storage import KeyType
-import numpy as np
-from arcticdb.exceptions import (
-    UserInputException,
-    UnsortedDataException,
-    StorageException,
-    ArcticException,
-)
-from arcticdb.version_store.library import MergeAction, MergeStrategy
-from arcticdb.version_store._store import normalize_merge_action
-from typing import Union, List, Optional
-import arcticdb.toolbox.query_stats as qs
-
 from arcticdb_ext.version_store import MergeAction
 
 pytestmark = [
@@ -3172,6 +3171,780 @@ class TestMergeRowrangeUpdateAndInsert:
         lib.write("sym", target)
         with pytest.raises(UserInputException):
             lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)],
+    ids=["do_nothing_insert", "update_insert"],
+)
+class TestMergeInsertRowSlicingRowRange:
+
+    def test_insert_splits_into_multiple_row_slices(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": ["a", "b", "c", "d", "e", "f"]})
+        source = pd.DataFrame(
+            {
+                "a": [1, 101, 102, 103, 104, 105, 106, 107, 108, 109],
+                "b": ["Z", "A", "B", "C", "D", "E", "F", "G", "H", "I"],
+            }
+        )
+        lib.write("sym", target)
+        # With update the first segment is rewritten
+        # Inserts slices unmatched rows and appends them at the back
+        expected_data_key_writes = 4 if strategy.matched == MergeAction.UPDATE else 3
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105, 106, 107, 108, 109],
+                    "b": [
+                        "Z",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                        "F",
+                        "G",
+                        "H",
+                        "I",
+                    ],
+                }
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105, 106, 107, 108, 109],
+                    "b": [
+                        "a",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                        "F",
+                        "G",
+                        "H",
+                        "I",
+                    ],
+                }
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    @pytest.mark.parametrize(
+        "num_unmatched, source_a, source_b, expected_a, expected_b, expected_num_segments, expected_data_key_writes",
+        [
+            (
+                3,
+                [100, 101, 102],
+                ["A", "B", "C"],
+                [1, 2, 100, 101, 102],
+                ["a", "b", "A", "B", "C"],
+                2,
+                1,
+            ),
+            (
+                4,
+                [100, 101, 102, 103],
+                ["A", "B", "C", "D"],
+                [1, 2, 100, 101, 102, 103],
+                ["a", "b", "A", "B", "C", "D"],
+                2,
+                1,
+            ),
+            (
+                5,
+                [100, 101, 102, 103, 104],
+                ["A", "B", "C", "D", "E"],
+                [1, 2, 100, 101, 102, 103, 104],
+                ["a", "b", "A", "B", "C", "D", "E"],
+                3,
+                2,
+            ),
+        ],
+        ids=["max_minus_one", "max", "max_plus_one"],
+    )
+    def test_insert_at_max_boundary(
+        self,
+        mem_library_factory,
+        strategy,
+        num_unmatched,
+        source_a,
+        source_b,
+        expected_a,
+        expected_b,
+        expected_num_segments,
+        expected_data_key_writes,
+    ):
+        """
+        Rows per segment is 3. Using the formula for max allowed rows for reslicing
+        max((4 * rows_per_segment) / 3, rows_per_segment + 1) the maximum allowed rows are 4. Test with row slice size
+        around that value (one less, exactly the same and one more) to catch off-by-one errors
+        """
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1, 2], "b": ["a", "b"]})
+        source = pd.DataFrame({"a": source_a, "b": source_b})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        expected = pd.DataFrame({"a": expected_a, "b": expected_b})
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_alternating_matched_unmatched(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]}
+        )
+        source = pd.DataFrame(
+            {
+                "a": [1, 101, 3, 103, 5, 105, 7, 107, 9, 109],
+                "b": ["Z", "A", "Y", "B", "X", "C", "W", "D", "V", "E"],
+            }
+        )
+        lib.write("sym", target)
+        # All four segments on disk are matched
+        # Inserted data is sliced into two segments and apended
+        expected_data_key_writes = 6 if strategy.matched == MergeAction.UPDATE else 2
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 101, 103, 105, 107, 109],
+                    "b": [
+                        "a",
+                        "Z",
+                        "c",
+                        "Y",
+                        "e",
+                        "X",
+                        "g",
+                        "W",
+                        "i",
+                        "V",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                    ],
+                }
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 101, 103, 105, 107, 109],
+                    "b": [
+                        "a",
+                        "b",
+                        "c",
+                        "d",
+                        "e",
+                        "f",
+                        "g",
+                        "h",
+                        "i",
+                        "j",
+                        "A",
+                        "B",
+                        "C",
+                        "D",
+                        "E",
+                    ],
+                }
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_all_source_rows_unmatched(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1, 2, 3, 4, 5, 6], "b": ["a", "b", "c", "d", "e", "f"]})
+        source = pd.DataFrame({"a": [101, 102, 103, 104, 105, 106, 107], "b": ["A", "B", "C", "D", "E", "F", "G"]})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105, 106, 107],
+                "b": ["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F", "G"],
+            }
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_target_empty(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": np.array([], dtype=np.int64), "b": np.array([], dtype=np.float64)})
+        source = pd.DataFrame({"a": [10, 20, 30, 40, 50], "b": [10.0, 20.0, 30.0, 40.0, 50.0]})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame({"a": [10, 20, 30, 40, 50], "b": [10.0, 20.0, 30.0, 40.0, 50.0]})
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_with_column_slicing(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, columns_per_segment=2))
+        target = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6],
+                "b": ["a", "b", "c", "d", "e", "f"],
+                "c": [10, 20, 30, 40, 50, 60],
+                "d": ["aa", "bb", "cc", "dd", "ee", "ff"],
+                "e": [100, 200, 300, 400, 500, 600],
+                "f": ["aaa", "bbb", "ccc", "ddd", "eee", "fff"],
+            }
+        )
+        source = pd.DataFrame(
+            {
+                "a": [3, 101, 102, 103, 104, 105],
+                "b": ["Z", "A", "B", "C", "D", "E"],
+                "c": [3000, 110, 120, 130, 140, 150],
+                "d": ["ZZ", "AA", "BB", "CC", "DD", "EE"],
+                "e": [30000, 1100, 1200, 1300, 1400, 1500],
+                "f": ["ZZZ", "AAA", "BBB", "CCC", "DDD", "EEE"],
+            }
+        )
+        lib.write("sym", target)
+        expected_data_key_writes = 9 if strategy.matched == MergeAction.UPDATE else 6
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105],
+                    "b": ["a", "b", "Z", "d", "e", "f", "A", "B", "C", "D", "E"],
+                    "c": [10, 20, 3000, 40, 50, 60, 110, 120, 130, 140, 150],
+                    "d": ["aa", "bb", "ZZ", "dd", "ee", "ff", "AA", "BB", "CC", "DD", "EE"],
+                    "e": [100, 200, 30000, 400, 500, 600, 1100, 1200, 1300, 1400, 1500],
+                    "f": [
+                        "aaa",
+                        "bbb",
+                        "ZZZ",
+                        "ddd",
+                        "eee",
+                        "fff",
+                        "AAA",
+                        "BBB",
+                        "CCC",
+                        "DDD",
+                        "EEE",
+                    ],
+                }
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 101, 102, 103, 104, 105],
+                    "b": ["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E"],
+                    "c": [10, 20, 30, 40, 50, 60, 110, 120, 130, 140, 150],
+                    "d": ["aa", "bb", "cc", "dd", "ee", "ff", "AA", "BB", "CC", "DD", "EE"],
+                    "e": [100, 200, 300, 400, 500, 600, 1100, 1200, 1300, 1400, 1500],
+                    "f": ["aaa", "bbb", "ccc", "ddd", "eee", "fff", "AAA", "BBB", "CCC", "DDD", "EEE"],
+                }
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_duplicate_unmatched_on_values_across_slice_boundary(self, mem_library_factory, strategy):
+        """Unmatched rows are inserted in order even when there are duplicates"""
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"a": [1], "b": ["a"]})
+        source = pd.DataFrame({"a": [7, 7, 7, 7, 7, 8], "b": ["A", "B", "C", "D", "E", "F"]})
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame({"a": [1, 7, 7, 7, 7, 7, 8], "b": ["a", "A", "B", "C", "D", "E", "F"]})
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+
+@pytest.mark.parametrize(
+    "strategy",
+    [MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)],
+    ids=["do_nothing_insert", "update_insert"],
+)
+class TestMergeDatetimeInsertRowSlicing:
+
+    def test_interleaved_insert_slices_touched_groups(self, mem_library_factory, strategy):
+        """
+        When inserting values in a middle of the segment, the segment must be split.
+        """
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"b": [1.0, 3.0, 5.0, 7.0, 9.0, 11.0], "s": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-03", "2024-01-05", "2024-01-07", "2024-01-09", "2024-01-11"]
+            ),
+        )
+        source = pd.DataFrame(
+            {"b": [2.0, 6.0, 8.0, 10.0], "s": ["A", "B", "C", "D"]},
+            index=pd.DatetimeIndex(["2024-01-02", "2024-01-06", "2024-01-08", "2024-01-10"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
+        expected = pd.DataFrame(
+            {
+                "b": [1.0, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+                "s": ["a", "A", "b", "c", "B", "d", "C", "e", "D", "f"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-05",
+                    "2024-01-06",
+                    "2024-01-07",
+                    "2024-01-08",
+                    "2024-01-09",
+                    "2024-01-10",
+                    "2024-01-11",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    @pytest.mark.parametrize(
+        "target_index, target_b, target_s, expected_index, expected_b, expected_s, expected_num_segments",
+        [
+            (
+                pd.date_range("2024-01-01", periods=6),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                ["a", "b", "c", "d", "e", "f"],
+                pd.DatetimeIndex(
+                    [
+                        "2024-01-01",
+                        "2024-01-02",
+                        "2024-01-03",
+                        "2024-01-04",
+                        "2024-01-05",
+                        "2024-01-06",
+                        "2024-01-10",
+                        "2024-01-11",
+                        "2024-01-12",
+                        "2024-01-13",
+                        "2024-01-14",
+                        "2024-01-15",
+                        "2024-01-16",
+                    ]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                ["a", "b", "c", "d", "e", "f", "A", "B", "C", "D", "E", "F", "G"],
+                4,
+            ),
+            (
+                pd.date_range("2024-01-01", periods=5),
+                [1.0, 2.0, 3.0, 4.0, 5.0],
+                ["a", "b", "c", "d", "e"],
+                pd.DatetimeIndex(
+                    [
+                        "2024-01-01",
+                        "2024-01-02",
+                        "2024-01-03",
+                        "2024-01-04",
+                        "2024-01-05",
+                        "2024-01-10",
+                        "2024-01-11",
+                        "2024-01-12",
+                        "2024-01-13",
+                        "2024-01-14",
+                        "2024-01-15",
+                        "2024-01-16",
+                    ]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0],
+                ["a", "b", "c", "d", "e", "A", "B", "C", "D", "E", "F", "G"],
+                4,
+            ),
+        ],
+        ids=["full_last_segment", "partial_last_segment"],
+    )
+    def test_insert_after_last_timestamp_slices_tail(
+        self,
+        mem_library_factory,
+        strategy,
+        target_index,
+        target_b,
+        target_s,
+        expected_index,
+        expected_b,
+        expected_s,
+        expected_num_segments,
+    ):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"b": target_b, "s": target_s}, index=target_index)
+        source = pd.DataFrame(
+            {"b": [10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0], "s": ["A", "B", "C", "D", "E", "F", "G"]},
+            index=pd.date_range("2024-01-10", periods=7),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 3
+        expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    @pytest.mark.parametrize(
+        "target_index, target_b, target_s, expected_index, expected_b, expected_s, expected_num_segments",
+        [
+            (
+                pd.date_range("2024-01-10", periods=6),
+                [10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                ["a", "b", "c", "d", "e", "f"],
+                pd.DatetimeIndex(
+                    [
+                        "2024-01-01",
+                        "2024-01-02",
+                        "2024-01-03",
+                        "2024-01-04",
+                        "2024-01-05",
+                        "2024-01-10",
+                        "2024-01-11",
+                        "2024-01-12",
+                        "2024-01-13",
+                        "2024-01-14",
+                        "2024-01-15",
+                    ]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0],
+                ["A", "B", "C", "D", "E", "a", "b", "c", "d", "e", "f"],
+                3,
+            ),
+            (
+                pd.DatetimeIndex(["2024-01-10", "2024-01-11"]),
+                [10.0, 11.0],
+                ["a", "b"],
+                pd.DatetimeIndex(
+                    ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-10", "2024-01-11"]
+                ),
+                [1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 11.0],
+                ["A", "B", "C", "D", "E", "a", "b"],
+                2,
+            ),
+        ],
+        ids=["full_first_segment", "partial_first_segment"],
+    )
+    def test_insert_before_first_timestamp(
+        self,
+        mem_library_factory,
+        strategy,
+        target_index,
+        target_b,
+        target_s,
+        expected_index,
+        expected_b,
+        expected_s,
+        expected_num_segments,
+    ):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame({"b": target_b, "s": target_s}, index=target_index)
+        source = pd.DataFrame(
+            {"b": [1.0, 2.0, 3.0, 4.0, 5.0], "s": ["A", "B", "C", "D", "E"]},
+            index=pd.date_range("2024-01-01", periods=5),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_index_value_spanning_two_slices(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6], "b": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-02", "2024-01-02", "2024-01-02", "2024-01-03", "2024-01-04"]
+            ),
+        )
+        # on=["a"] means the Jan2 source rows are unmatched despite the equal timestamps.
+        source = pd.DataFrame(
+            {"a": [20, 21, 22, 50], "b": ["A", "B", "C", "D"]},
+            index=pd.DatetimeIndex(["2024-01-02", "2024-01-02", "2024-01-02", "2024-01-05"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 3
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 20, 21, 22, 5, 6, 50],
+                "b": ["a", "b", "c", "d", "A", "B", "C", "e", "f", "D"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-04",
+                    "2024-01-05",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_index_value_spanning_three_slices(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"a": [1, 2, 3, 4, 5, 6, 7, 8, 9], "b": ["a", "b", "c", "d", "e", "f", "g", "h", "i"]},
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-04",
+                ]
+            ),
+        )
+        source = pd.DataFrame({"a": [999], "b": ["A"]}, index=pd.DatetimeIndex(["2024-01-03"]))
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
+        expected = pd.DataFrame(
+            {
+                "a": [1, 2, 3, 4, 5, 6, 7, 8, 999, 9],
+                "b": ["a", "b", "c", "d", "e", "f", "g", "h", "A", "i"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-03",
+                    "2024-01-04",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_matched_update_inside_resliced_group(self, mem_library_factory, strategy):
+        """Update happens in a row slice that is being resliced"""
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        target = pd.DataFrame(
+            {"b": [1.0, 2.0, 5.0, 6.0, 7.0, 8.0], "s": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-02", "2024-01-05", "2024-01-06", "2024-01-07", "2024-01-08"]
+            ),
+        )
+        source = pd.DataFrame(
+            {"b": [10.0, 1.25, 1.5], "s": ["Z", "A", "B"]},
+            index=pd.DatetimeIndex(["2024-01-01", "2024-01-01 06:00:00", "2024-01-01 12:00:00"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected_index = pd.DatetimeIndex(
+            [
+                "2024-01-01",
+                "2024-01-01 06:00:00",
+                "2024-01-01 12:00:00",
+                "2024-01-02",
+                "2024-01-05",
+                "2024-01-06",
+                "2024-01-07",
+                "2024-01-08",
+            ]
+        )
+        if strategy.matched == MergeAction.UPDATE:
+            expected_b = [10.0, 1.25, 1.5, 2.0, 5.0, 6.0, 7.0, 8.0]
+            expected_s = ["Z", "A", "B", "b", "c", "d", "e", "f"]
+        else:
+            expected_b = [1.0, 1.25, 1.5, 2.0, 5.0, 6.0, 7.0, 8.0]
+            expected_s = ["a", "A", "B", "b", "c", "d", "e", "f"]
+        expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_with_column_slicing(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, columns_per_segment=2))
+        target = pd.DataFrame(
+            {
+                "a": [1, 4, 8],
+                "b": ["a", "b", "c"],
+                "c": [10, 40, 80],
+                "d": ["aa", "bb", "cc"],
+                "e": [100, 400, 800],
+                "f": ["aaa", "bbb", "ccc"],
+            },
+            index=pd.DatetimeIndex(["2024-01-01", "2024-01-04", "2024-01-08"]),
+        )
+        source = pd.DataFrame(
+            {
+                "a": [2, 3, 400, 5, 6, 7],
+                "b": ["A", "B", "Z", "C", "D", "E"],
+                "c": [20, 30, 440, 50, 60, 70],
+                "d": ["AA", "BB", "ZZ", "CC", "DD", "EE"],
+                "e": [200, 300, 4400, 500, 600, 700],
+                "f": ["AAA", "BBB", "ZZZ", "CCC", "DDD", "EEE"],
+            },
+            index=pd.DatetimeIndex(
+                ["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06", "2024-01-07"]
+            ),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 6
+        if strategy.matched == MergeAction.UPDATE:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 400, 5, 6, 7, 8],
+                    "b": ["a", "A", "B", "Z", "C", "D", "E", "c"],
+                    "c": [10, 20, 30, 440, 50, 60, 70, 80],
+                    "d": ["aa", "AA", "BB", "ZZ", "CC", "DD", "EE", "cc"],
+                    "e": [100, 200, 300, 4400, 500, 600, 700, 800],
+                    "f": ["aaa", "AAA", "BBB", "ZZZ", "CCC", "DDD", "EEE", "ccc"],
+                },
+                index=pd.date_range("2024-01-01", periods=8),
+            )
+        else:
+            expected = pd.DataFrame(
+                {
+                    "a": [1, 2, 3, 4, 5, 6, 7, 8],
+                    "b": ["a", "A", "B", "b", "C", "D", "E", "c"],
+                    "c": [10, 20, 30, 40, 50, 60, 70, 80],
+                    "d": ["aa", "AA", "BB", "bb", "CC", "DD", "EE", "cc"],
+                    "e": [100, 200, 300, 400, 500, 600, 700, 800],
+                    "f": ["aaa", "AAA", "BBB", "bbb", "CCC", "DDD", "EEE", "ccc"],
+                },
+                index=pd.date_range("2024-01-01", periods=8),
+            )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
+
+    def test_merging_touches_only_first_row_slice(self, mem_library_factory, strategy):
+        lib = mem_library_factory(arcticdb.LibraryOptions(rows_per_segment=3))
+        # Row slices [0,3) = [Jan1, Jan8, Jan9], [3,6) = [Jan20, Jan21, Jan22].
+        target = pd.DataFrame(
+            {"b": [1.0, 8.0, 9.0, 20.0, 21.0, 22.0], "s": ["a", "b", "c", "d", "e", "f"]},
+            index=pd.DatetimeIndex(
+                ["2024-01-01", "2024-01-08", "2024-01-09", "2024-01-20", "2024-01-21", "2024-01-22"]
+            ),
+        )
+        # 5 unmatched rows, all inside the first group's index range. Second slice is untouched. The result from
+        # inserting in the first slice is resliced
+        source = pd.DataFrame(
+            {"b": [2.0, 3.0, 4.0, 5.0, 6.0], "s": ["A", "B", "C", "D", "E"]},
+            index=pd.DatetimeIndex(["2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05", "2024-01-06"]),
+        )
+        lib.write("sym", target)
+        qs.reset_stats()
+        with qs.query_stats():
+            lib.merge_experimental("sym", source, strategy=strategy)
+        stats = qs.get_query_stats()
+        assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
+        expected = pd.DataFrame(
+            {
+                "b": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 9.0, 20.0, 21.0, 22.0],
+                "s": ["a", "A", "B", "C", "D", "E", "b", "c", "d", "e", "f"],
+            },
+            index=pd.DatetimeIndex(
+                [
+                    "2024-01-01",
+                    "2024-01-02",
+                    "2024-01-03",
+                    "2024-01-04",
+                    "2024-01-05",
+                    "2024-01-06",
+                    "2024-01-08",
+                    "2024-01-09",
+                    "2024-01-20",
+                    "2024-01-21",
+                    "2024-01-22",
+                ]
+            ),
+        )
+        assert_frame_equal(lib.read("sym").data, expected)
+        index_df = lib._dev_tools.library_tool().read_index("sym")
+        assert_index_key_structure_static_schema(index_df, rows_per_segment=3)
 
 
 class TestMergeMultiindexUpdate:

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -794,31 +794,6 @@ class TestMergeTimeseriesUpdate:
         expected = target.copy()
         generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a", "b"])
 
-    def test_match_on_string_none_nan_indistinguishable(self, lmdb_version_store_v1):
-        lib = lmdb_version_store_v1
-        target = pd.DataFrame(
-            {"a": ["a", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5]}, index=pd.date_range("2024-01-01", periods=5)
-        )
-        source = pd.DataFrame(
-            {"a": ["a", np.nan, None, None, np.nan], "b": [10, 20, 30, 40, 50]},
-            index=pd.date_range("2024-01-01", periods=5),
-        )
-        expected = pd.DataFrame(
-            {"a": ["a", np.nan, None, np.nan, None], "b": [10, 20, 30, 40, 50]},
-            index=pd.date_range("2024-01-01", periods=5),
-        )
-        generic_merge_test(lib, "sym", target, source, self.strategy, expected)
-
-    def test_match_on_float_nan(self, lmdb_version_store_v1):
-        lib = lmdb_version_store_v1
-        target = pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 2, 3]}, index=pd.date_range("2024-01-01", periods=3))
-        source = pd.DataFrame({"a": [np.nan], "b": [20]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-02")]))
-        # NaN matches NaN at Jan2 → update b=20
-        expected = pd.DataFrame(
-            {"a": [1.0, np.nan, 3.0], "b": [1, 20, 3]}, index=pd.date_range("2024-01-01", periods=3)
-        )
-        generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a"])
-
     def test_on_column_one_source_row_matches_multiple_target_rows(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame(
@@ -932,20 +907,6 @@ class TestMergeTimeseriesUpdate:
         source = pd.DataFrame(
             {"a": [2, 2], "b": [10.0, 20.0]},
             index=pd.DatetimeIndex([pd.Timestamp(1), pd.Timestamp(1)]),
-        )
-        lib.write("sym", target)
-        with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
-
-    def test_throws_when_multiple_source_rows_match_same_target_row_via_nan(self, lmdb_library):
-        lib = lmdb_library
-        target = pd.DataFrame(
-            {"a": [None, "x", "y"], "b": [1.0, 2.0, 3.0]},
-            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(1), pd.Timestamp(2)]),
-        )
-        source = pd.DataFrame(
-            {"a": np.array([None, np.nan], dtype=object), "b": [10.0, 20.0]},
-            index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0)]),
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
@@ -2808,22 +2769,6 @@ class TestMergeRowrangeUpdate:
         )
         generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a"])
 
-    def test_match_on_float_nan(self, lmdb_version_store_v1):
-        lib = lmdb_version_store_v1
-        target = pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 2, 3]})
-        source = pd.DataFrame({"a": [np.nan], "b": [20]})
-        # NaN matches NaN → update b=20
-        expected = pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 20, 3]})
-        generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a"])
-
-    def test_match_on_string_none_nan_indistinguishable(self, lmdb_version_store_v1):
-        lib = lmdb_version_store_v1
-        target = pd.DataFrame({"a": ["x", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5], "c": [1, 2, 3, 4, 5]})
-        source = pd.DataFrame({"a": ["x", np.nan, None, None, np.nan], "b": [4, 5, 3, 2, 1], "c": [10, 20, 30, 40, 50]})
-        # Match on (a,b): (NaN,5)→row4, (NaN,3)→row2, (NaN,2)→row1; "x" b mismatch, (NaN,1) no match
-        expected = pd.DataFrame({"a": ["x", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5], "c": [1, 40, 30, 4, 20]})
-        generic_merge_test(lib, "sym", target, source, self.strategy, expected, on=["a", "b"])
-
     def test_all_columns_in_on(self, lmdb_library):
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
@@ -2946,14 +2891,6 @@ class TestMergeRowrangeUpdate:
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         source = pd.DataFrame({"a": [2, 2], "b": [10.0, 20.0]})
-        lib.write("sym", target)
-        with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
-
-    def test_throws_when_multiple_source_rows_match_same_target_row_via_nan(self, lmdb_library):
-        lib = lmdb_library
-        target = pd.DataFrame({"a": [None, "x", "y"], "b": [1.0, 2.0, 3.0]})
-        source = pd.DataFrame({"a": np.array([np.nan, None], dtype=object), "b": [10.0, 20.0]})
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
             lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
@@ -4787,3 +4724,195 @@ class TestMergeMultiindexInsert:
         sym = f"nonexistent_{is_datetime}"
         lib.merge_experimental(sym, source, strategy=strategy, upsert=True, on=on)
         assert_frame_equal(lib.read(sym).data, source)
+
+
+# ---- match_na semantics (consolidated from TestMergeTimeseriesUpdate /
+# TestMergeRowrangeUpdate duplicates, plus requester-approved NaT and insert-path
+# additions) ----
+
+
+@pytest.mark.parametrize("match_na", [True, False], ids=["match_na_true", "match_na_false"])
+@pytest.mark.parametrize(
+    "target, source, expected_match_na_true, expected_match_na_false",
+    [
+        (
+            pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 2, 3]}, index=pd.date_range("2024-01-01", periods=3)),
+            pd.DataFrame(
+                {"a": [np.nan, 3.0], "b": [20, 30]},
+                index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")]),
+            ),
+            pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 20, 30]}, index=pd.date_range("2024-01-01", periods=3)),
+            pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 2, 30]}, index=pd.date_range("2024-01-01", periods=3)),
+        ),
+        (
+            pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 2, 3]}),
+            pd.DataFrame({"a": [np.nan, 3.0], "b": [20, 30]}),
+            pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 20, 30]}),
+            pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [1, 2, 30]}),
+        ),
+    ],
+    ids=["datetime", "rowrange"],
+)
+def test_match_on_float_nan(lmdb_library, match_na, target, source, expected_match_na_true, expected_match_na_false):
+    lib = lmdb_library
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
+    lib.write("sym", target)
+    lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+    expected = expected_match_na_true if match_na else expected_match_na_false
+    assert_frame_equal(lib.read("sym").data, expected)
+    lt = lib._dev_tools.library_tool()
+    assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2
+
+
+@pytest.mark.parametrize("match_na", [True, False], ids=["match_na_true", "match_na_false"])
+@pytest.mark.parametrize(
+    "target, source, on, expected_match_na_true, expected_match_na_false",
+    [
+        (
+            pd.DataFrame(
+                {"a": ["x", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5]},
+                index=pd.date_range("2024-01-01", periods=5),
+            ),
+            pd.DataFrame(
+                {"a": ["x", np.nan, None, None, np.nan], "b": [10, 20, 30, 40, 50]},
+                index=pd.date_range("2024-01-01", periods=5),
+            ),
+            ["a"],
+            pd.DataFrame(
+                {"a": ["x", np.nan, None, np.nan, None], "b": [10, 20, 30, 40, 50]},
+                index=pd.date_range("2024-01-01", periods=5),
+            ),
+            pd.DataFrame(
+                {"a": ["x", np.nan, None, np.nan, None], "b": [10, 2, 3, 4, 5]},
+                index=pd.date_range("2024-01-01", periods=5),
+            ),
+        ),
+        (
+            pd.DataFrame({"a": ["x", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5], "c": [1, 2, 3, 4, 5]}),
+            pd.DataFrame({"a": ["x", np.nan, None, None, np.nan], "b": [1, 2, 3, 4, 5], "c": [10, 20, 30, 40, 50]}),
+            ["a", "b"],
+            pd.DataFrame({"a": ["x", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5], "c": [10, 20, 30, 40, 50]}),
+            pd.DataFrame({"a": ["x", np.nan, None, np.nan, None], "b": [1, 2, 3, 4, 5], "c": [10, 2, 3, 4, 5]}),
+        ),
+    ],
+    ids=["datetime", "rowrange"],
+)
+def test_match_on_string_none_nan(
+    lmdb_version_store_v1, match_na, target, source, on, expected_match_na_true, expected_match_na_false
+):
+    lib = lmdb_version_store_v1
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
+    lib.write("sym", target)
+    lib.merge_experimental("sym", source, strategy=strategy, on=on, match_na=match_na)
+    expected = expected_match_na_true if match_na else expected_match_na_false
+    assert_frame_equal(lib.read("sym").data, expected)
+
+
+@pytest.mark.parametrize("match_na", [True, False], ids=["match_na_true", "match_na_false"])
+@pytest.mark.parametrize(
+    "target, source",
+    [
+        (
+            pd.DataFrame(
+                {"a": [None, "x", "y"], "b": [1.0, 2.0, 3.0]},
+                index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(1), pd.Timestamp(2)]),
+            ),
+            pd.DataFrame(
+                {"a": np.array([None, np.nan], dtype=object), "b": [10.0, 20.0]},
+                index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0)]),
+            ),
+        ),
+        (
+            pd.DataFrame({"a": [None, "x", "y"], "b": [1.0, 2.0, 3.0]}),
+            pd.DataFrame({"a": np.array([np.nan, None], dtype=object), "b": [10.0, 20.0]}),
+        ),
+    ],
+    ids=["datetime", "rowrange"],
+)
+def test_multiple_source_rows_match_via_missing(lmdb_library, match_na, target, source):
+    lib = lmdb_library
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
+    lib.write("sym", target)
+    if match_na:
+        with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
+            lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+    else:
+        lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+        assert_frame_equal(lib.read("sym").data, target)
+
+
+@pytest.mark.parametrize("match_na", [True, False], ids=["match_na_true", "match_na_false"])
+@pytest.mark.parametrize(
+    "target, source, expected_match_na_true, expected_match_na_false",
+    [
+        (
+            pd.DataFrame(
+                {"a": [pd.Timestamp("2024-01-01"), pd.NaT, pd.Timestamp("2024-01-03")], "b": [1, 2, 3]},
+                index=pd.date_range("2024-06-01", periods=3),
+            ),
+            pd.DataFrame(
+                {"a": [pd.NaT, pd.Timestamp("2024-01-03")], "b": [20, 30]},
+                index=pd.DatetimeIndex([pd.Timestamp("2024-06-02"), pd.Timestamp("2024-06-03")]),
+            ),
+            pd.DataFrame(
+                {"a": [pd.Timestamp("2024-01-01"), pd.NaT, pd.Timestamp("2024-01-03")], "b": [1, 20, 30]},
+                index=pd.date_range("2024-06-01", periods=3),
+            ),
+            pd.DataFrame(
+                {"a": [pd.Timestamp("2024-01-01"), pd.NaT, pd.Timestamp("2024-01-03")], "b": [1, 2, 30]},
+                index=pd.date_range("2024-06-01", periods=3),
+            ),
+        ),
+        (
+            pd.DataFrame({"a": [pd.Timestamp("2024-01-01"), pd.NaT, pd.Timestamp("2024-01-03")], "b": [1, 2, 3]}),
+            pd.DataFrame({"a": [pd.NaT, pd.Timestamp("2024-01-03")], "b": [20, 30]}),
+            pd.DataFrame({"a": [pd.Timestamp("2024-01-01"), pd.NaT, pd.Timestamp("2024-01-03")], "b": [1, 20, 30]}),
+            pd.DataFrame({"a": [pd.Timestamp("2024-01-01"), pd.NaT, pd.Timestamp("2024-01-03")], "b": [1, 2, 30]}),
+        ),
+    ],
+    ids=["datetime", "rowrange"],
+)
+def test_match_on_datetime_nat(lmdb_library, match_na, target, source, expected_match_na_true, expected_match_na_false):
+    lib = lmdb_library
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
+    lib.write("sym", target)
+    lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+    expected = expected_match_na_true if match_na else expected_match_na_false
+    assert_frame_equal(lib.read("sym").data, expected)
+
+
+@pytest.mark.parametrize(
+    "target, source, expected",
+    [
+        (
+            pd.DataFrame(
+                {"a": [1.0, np.nan], "b": [1, 2]},
+                index=pd.DatetimeIndex([pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")]),
+            ),
+            pd.DataFrame(
+                {"a": [np.nan, 1.0], "b": [20, 10]},
+                index=pd.DatetimeIndex([pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01")]),
+            ),
+            # the inserted NaN row follows the target row sharing its timestamp
+            pd.DataFrame(
+                {"a": [1.0, np.nan, np.nan], "b": [10, 20, 2]},
+                index=pd.DatetimeIndex(
+                    [pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-01"), pd.Timestamp("2024-01-02")]
+                ),
+            ),
+        ),
+        (
+            pd.DataFrame({"a": [1.0, np.nan], "b": [1, 2]}),
+            pd.DataFrame({"a": [np.nan, 1.0], "b": [20, 10]}),
+            # unmatched rows append after all target rows in source order
+            pd.DataFrame({"a": [1.0, np.nan, np.nan], "b": [10, 2, 20]}),
+        ),
+    ],
+    ids=["datetime", "rowrange"],
+)
+def test_unmatched_nan_source_rows_inserted_default(lmdb_library, target, source, expected):
+    lib = lmdb_library
+    strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
+    lib.write("sym", target)
+    lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+    assert_frame_equal(lib.read("sym").data, expected)

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -58,7 +58,7 @@ def generic_merge_test(
     lib.write(sym, target[0])
     for df in target[1:]:
         lib.append(sym, df)
-    lib.merge_experimental(sym, source, strategy=strategy, on=on)
+    lib.merge(sym, source, strategy=strategy, on=on)
     read_vit = lib.read(sym)
     assert_frame_equal(read_vit.data, expected)
     oracle_expected = merge(concat_target, source, strategy, on=on)
@@ -110,7 +110,7 @@ class TestMergeTimeseriesCommon:
 
         metadata = {"meta": "data"}
 
-        merge_vit = lib.merge_experimental("sym", source, metadata=metadata, strategy=strategy)
+        merge_vit = lib.merge("sym", source, metadata=metadata, strategy=strategy)
         assert merge_vit.version == 1
         assert merge_vit.symbol == write_vit.symbol
         assert merge_vit.metadata == metadata
@@ -132,7 +132,7 @@ class TestMergeTimeseriesCommon:
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target, metadata="v0")
-        merge_vit = lib.merge_experimental("sym", pd.DataFrame(), metadata=metadata, strategy=strategy)
+        merge_vit = lib.merge("sym", pd.DataFrame(), metadata=metadata, strategy=strategy)
         assert merge_vit.metadata is None if metadata is None else merge_vit.metadata == metadata
         lt = lib._dev_tools.library_tool()
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
@@ -181,7 +181,7 @@ class TestMergeTimeseriesCommon:
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target)
         with pytest.raises(SchemaException):
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
 
     def test_throws_if_source_is_not_sorted(self, lmdb_library, strategy):
         # This requirement can be lifted, however, passing a sorted source will be faster. We can start with it and
@@ -198,7 +198,7 @@ class TestMergeTimeseriesCommon:
         )
 
         with pytest.raises(UnsortedDataException):
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
 
 
 class TestMergeTimeseriesUpdate:
@@ -228,7 +228,7 @@ class TestMergeTimeseriesUpdate:
             index=pd.DatetimeIndex(["2024-01-01 10:00:00", "2024-01-02", "2024-01-04"]),
         )
 
-        merge_vit = lib.merge_experimental("sym", source, strategy=strategy)
+        merge_vit = lib.merge("sym", source, strategy=strategy)
         assert merge_vit.version == 1
         assert merge_vit.symbol == write_vit.symbol
         assert merge_vit.metadata == write_vit.metadata
@@ -260,9 +260,7 @@ class TestMergeTimeseriesUpdate:
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]}, index=pd.date_range("2024-01-01", periods=3))
         lib.write("sym", target)
         source = pd.DataFrame({"a": [4, 5], "b": [4.0, 5.0]}, index=pd.date_range("2023-01-01", periods=2))
-        merge_vit = lib.merge_experimental(
-            "sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING)
-        )
+        merge_vit = lib.merge("sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING))
         assert merge_vit.version == 1
 
         read_vit = lib.read("sym")
@@ -337,7 +335,7 @@ class TestMergeTimeseriesUpdate:
             {"a": [20, 30], "b": [20.0, 30.0], "c": [20, 30], "d": [200.0, 300.0]},
             index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-03")]),
         )
-        lib.merge_experimental("sym", source, strategy=self.strategy)
+        lib.merge("sym", source, strategy=self.strategy)
         expected = pd.DataFrame(
             {"a": [1, 20, 30], "b": [1.0, 20.0, 30.0], "c": [10, 20, 30], "d": [100.0, 200.0, 300.0]},
             index=pd.date_range("2024-01-01", periods=3),
@@ -363,7 +361,7 @@ class TestMergeTimeseriesUpdate:
         source = pd.DataFrame({"a": [999], "b": [99.0]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-03")]))
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, self.strategy, on=["a"])
+            lib.merge("sym", source, self.strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 0
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_INDEX") == 1
@@ -567,7 +565,7 @@ class TestMergeTimeseriesUpdate:
             ),
         )
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=self.strategy)
+            lib.merge("sym", source, strategy=self.strategy)
 
     @pytest.mark.parametrize("merge_metadata", (None, "meta"))
     def test_target_is_empty(self, lmdb_library, merge_metadata):
@@ -575,7 +573,7 @@ class TestMergeTimeseriesUpdate:
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
         lib.write("sym", target)
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        merge_vit = lib.merge_experimental(
+        merge_vit = lib.merge(
             "sym", source, strategy=MergeStrategy(not_matched_by_target=MergeAction.DO_NOTHING), metadata=merge_metadata
         )
         assert merge_vit.metadata is None if merge_metadata is None else merge_vit.metadata == merge_metadata
@@ -603,9 +601,7 @@ class TestMergeTimeseriesUpdate:
 
         expected_exception = UserInputException if upsert else StorageException
         with pytest.raises(expected_exception):
-            lib.merge_experimental(
-                "sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING), upsert=upsert
-            )
+            lib.merge("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING), upsert=upsert)
         assert not lib.has_symbol("sym")
 
     def test_upsert_with_existing_symbol(self, lmdb_library):
@@ -616,7 +612,7 @@ class TestMergeTimeseriesUpdate:
         source = pd.DataFrame(
             {"a": [20, 40]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-04")])
         )
-        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, upsert=True)
+        merge_vit = lib.merge("sym", source, strategy=self.strategy, upsert=True)
         assert merge_vit.version == 1
         expected = pd.DataFrame({"a": [1, 20, 3]}, index=pd.date_range("2024-01-01", periods=3))
         assert_frame_equal(lib.read("sym").data, expected)
@@ -645,7 +641,7 @@ class TestMergeTimeseriesUpdate:
         )
 
         # The merge will be performed on the latest undeleted version
-        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy)
+        merge_vit = lib.merge("sym", source, strategy=self.strategy)
         # Only Jan2 matches → update row 1 with source values
         expected = pd.DataFrame(
             {"a": [1, 5, 3], "b": [1.0, 8.0, 3.0], "c": ["a", "B", "c"]},
@@ -681,7 +677,7 @@ class TestMergeTimeseriesUpdate:
 
         # The merge will be performed on the latest undeleted version
         with pytest.raises(StorageException):
-            lib.merge_experimental("sym", source, strategy=self.strategy)
+            lib.merge("sym", source, strategy=self.strategy)
 
     def test_two_segments_with_same_index_value(self, s3_version_store_v1):
         # The merge operation will write two segments with the same index range and the same content in parallel,
@@ -696,7 +692,7 @@ class TestMergeTimeseriesUpdate:
         source = pd.DataFrame({"a": [3]}, index=[pd.Timestamp(0)])
         for df in target:
             lib.append("sym", df)
-        lib.merge_experimental("sym", source, strategy=self.strategy)
+        lib.merge("sym", source, strategy=self.strategy)
         result = lib.read("sym").data
         # Both target rows at Ts0 match source at Ts0 → both updated to a=3
         expected = pd.DataFrame({"a": [3, 3]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(0)]))
@@ -711,7 +707,7 @@ class TestMergeTimeseriesUpdate:
         source = pd.DataFrame({"a": [5, 6]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)]))
         for tgt in target_list:
             lib.append("test", tgt)
-        lib.merge_experimental("test", source, strategy=self.strategy)
+        lib.merge("test", source, strategy=self.strategy)
         res = lib.read("test").data
         # Ts0 from source matches target rows 0 and 1 → both updated to a=5; Ts5 no match → do_nothing
         expected = pd.DataFrame(
@@ -848,7 +844,7 @@ class TestMergeTimeseriesUpdate:
         lib.write("sym", target)
         source = pd.DataFrame({"a": [1], "b": [10.0]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")]))
         with pytest.raises(UserInputException) as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["nonexistent"])
+            lib.merge("sym", source, strategy=self.strategy, on=["nonexistent"])
         assert '"nonexistent"' in str(exc_info.value)
 
     def test_on_with_repeated_index_values(self, lmdb_library):
@@ -896,7 +892,7 @@ class TestMergeTimeseriesUpdate:
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
-            lib.merge_experimental("sym", source, strategy=self.strategy)
+            lib.merge("sym", source, strategy=self.strategy)
 
     def test_throws_when_multiple_source_rows_match_same_target_row_with_on(self, lmdb_library):
         lib = lmdb_library
@@ -910,7 +906,7 @@ class TestMergeTimeseriesUpdate:
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+            lib.merge("sym", source, strategy=self.strategy, on=["a"])
 
     def test_two_segments_same_timestamp_repeated_source_values(self, lmdb_library):
         lib = lmdb_library
@@ -939,7 +935,7 @@ class TestMergeTimeseriesUpdate:
         )
         lib.write("sym", target)
         with pytest.raises(TypeError):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
 
     def test_match_on_column_named_index_and_unnamed_index(self, lmdb_library):
         lib = lmdb_library
@@ -978,7 +974,7 @@ class TestMergeTimeseriesUpdate:
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException) as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["index"])
+            lib.merge("sym", source, strategy=self.strategy, on=["index"])
         assert "E_COLUMN_NOT_FOUND" in str(exc_info.value)
 
     def test_match_on_column_named_index_and_unnamed_index_with_duplicates(self, lmdb_library):
@@ -994,7 +990,7 @@ class TestMergeTimeseriesUpdate:
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="E_DUPLICATE_COLUMN") as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["index"])
+            lib.merge("sym", source, strategy=self.strategy, on=["index"])
 
     @pytest.mark.parametrize("index_name", ("index", "some_name"))
     @pytest.mark.parametrize("column_name", ("index", "some_name"))
@@ -1018,7 +1014,7 @@ class TestMergeTimeseriesUpdate:
         source.index.name = index_name
         lib.write("sym", target)
         with pytest.raises(UserInputException) as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=[index_name])
+            lib.merge("sym", source, strategy=self.strategy, on=[index_name])
         assert f'"{index_name}"' in str(exc_info.value)
         assert "not contain the datetime index column" in str(exc_info.value)
 
@@ -1036,7 +1032,7 @@ class TestMergeTimeseriesUpdate:
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="E_DUPLICATE_COLUMN") as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["my_duplicated_column"])
+            lib.merge("sym", source, strategy=self.strategy, on=["my_duplicated_column"])
 
     def test_on_colum_reorders_matched_rows(self, lmdb_library):
         lib = lmdb_library
@@ -1078,7 +1074,7 @@ class TestMergeTimeseriesInsert:
             {"a": [100, 101]},
             index=pd.DatetimeIndex([pd.Timestamp(15), pd.Timestamp(25)]),
         )
-        lib.merge_experimental("sym", source, strategy=self.strategy)
+        lib.merge("sym", source, strategy=self.strategy)
         expected = pd.DataFrame(
             {"a": [0, 100, 1, 101, 2]},
             index=pd.DatetimeIndex(
@@ -1102,7 +1098,7 @@ class TestMergeTimeseriesInsert:
             index=pd.DatetimeIndex(["2023-01-01", "2024-01-01 10:00:00", "2025-01-04"]),
         )
 
-        merge_vit = lib.merge_experimental("sym", source, strategy=strategy)
+        merge_vit = lib.merge("sym", source, strategy=strategy)
         assert merge_vit.version == 1
         assert merge_vit.symbol == write_vit.symbol
         assert merge_vit.metadata == write_vit.metadata
@@ -1122,9 +1118,7 @@ class TestMergeTimeseriesInsert:
         source = pd.DataFrame(
             {"a": [10, 20, 30], "b": [10.0, 20.0, 30.0]}, index=pd.date_range("2024-01-01", periods=3)
         )
-        merge_vit = lib.merge_experimental(
-            "sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
-        )
+        merge_vit = lib.merge("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
         assert merge_vit.version == 1
 
         read_vit = lib.read("sym")
@@ -1152,9 +1146,7 @@ class TestMergeTimeseriesInsert:
                 ]
             ),
         )
-        lib.merge_experimental(
-            "sym", source, on=["a"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
-        )
+        lib.merge("sym", source, on=["a"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
 
         # The first row is matched, but the strategy for matched rows is DO_NOTHING, so no update
         # the rest rows are inserted
@@ -1195,9 +1187,7 @@ class TestMergeTimeseriesInsert:
             ),
         )
 
-        lib.merge_experimental(
-            "sym", source, on=["b", "d", "e"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT)
-        )
+        lib.merge("sym", source, on=["b", "d", "e"], strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
         expected = pd.concat([target, source.tail(len(source) - 1)]).sort_index()
         received = lib.read("sym").data
         assert_frame_equal(received, expected)
@@ -1218,7 +1208,7 @@ class TestMergeTimeseriesInsert:
             ),
         )
 
-        lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
+        lib.merge("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT))
         expected = pd.DataFrame(
             {
                 "a": [
@@ -1247,7 +1237,7 @@ class TestMergeTimeseriesInsert:
         write_vit = lib.write("sym", target, metadata={"meta": "data"})
         assert write_vit.version == 0
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        merge_vit = lib.merge_experimental(
+        merge_vit = lib.merge(
             "sym", source, strategy=MergeStrategy("do_nothing", "insert"), metadata={"new_meta": "new_data"}
         )
         assert merge_vit.version == 1
@@ -1275,7 +1265,7 @@ class TestMergeTimeseriesInsert:
                 ]
             ),
         )
-        lib.merge_experimental("sym", source, self.strategy)
+        lib.merge("sym", source, self.strategy)
         expected = pd.concat([target, source]).sort_index()
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -1380,7 +1370,7 @@ class TestMergeTimeseriesInsert:
         )
         target = pd.DataFrame({"a": range(len(index)), "b": np.linspace(0, len(index) - 1, len(index))}, index=index)
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        lib.merge("sym", source, self.strategy, on=["a"])
         assert_frame_equal(lib.read("sym").data, expected)
 
     @pytest.mark.parametrize(
@@ -1411,7 +1401,7 @@ class TestMergeTimeseriesInsert:
             index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)]),
         )
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, self.strategy)
+        lib.merge("sym", source, self.strategy)
         assert_frame_equal(lib.read("sym").data, target)
 
     @pytest.mark.parametrize(
@@ -1468,7 +1458,7 @@ class TestMergeTimeseriesInsert:
         )
         lib.append("sym", seg1)
         expected = pd.concat([seg0, seg1, source]).sort_index()
-        lib.merge_experimental("sym", source, self.strategy)
+        lib.merge("sym", source, self.strategy)
         assert_frame_equal(lib.read("sym").data, expected)
 
     @pytest.mark.parametrize(
@@ -1490,7 +1480,7 @@ class TestMergeTimeseriesInsert:
         )
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, self.strategy)
+            lib.merge("sym", source, self.strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
@@ -1520,7 +1510,7 @@ class TestMergeTimeseriesInsert:
         )
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, self.strategy)
+            lib.merge("sym", source, self.strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
@@ -1558,7 +1548,7 @@ class TestMergeTimeseriesInsert:
                 ]
             ),
         )
-        lib.merge_experimental("sym", source, self.strategy)
+        lib.merge("sym", source, self.strategy)
         assert_frame_equal(lib.read("sym").data, pd.concat(target + [source]).sort_index())
 
     def test_insert_between_two_segments_appends_to_first(self, in_memory_store_factory):
@@ -1570,7 +1560,7 @@ class TestMergeTimeseriesInsert:
         source = pd.DataFrame({"a": [100, 200]}, index=pd.DatetimeIndex([pd.Timestamp(6), pd.Timestamp(7)]))
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, self.strategy)
+            lib.merge("sym", source, self.strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_GetObject", "TABLE_DATA") == 1
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
@@ -1608,11 +1598,7 @@ class TestMergeTimeseriesUpdateAndInsert:
             ),
         )
 
-        merge_vit = (
-            lib.merge_experimental("sym", source, strategy=strategy)
-            if strategy
-            else lib.merge_experimental("sym", source)
-        )
+        merge_vit = lib.merge("sym", source, strategy=strategy) if strategy else lib.merge("sym", source)
         assert merge_vit.version == 1
         assert merge_vit.symbol == write_vit.symbol
         assert merge_vit.metadata == write_vit.metadata
@@ -1662,10 +1648,10 @@ class TestMergeTimeseriesUpdateAndInsert:
 
         if not upsert:
             with pytest.raises(StorageException):
-                lib.merge_experimental("sym", source, strategy=strategy, upsert=upsert, metadata=metadata)
+                lib.merge("sym", source, strategy=strategy, upsert=upsert, metadata=metadata)
             assert not lib.has_symbol("sym")
         else:
-            merge_vit = lib.merge_experimental("sym", source, strategy=strategy, upsert=upsert, metadata=metadata)
+            merge_vit = lib.merge("sym", source, strategy=strategy, upsert=upsert, metadata=metadata)
             assert merge_vit.version == 0
             assert merge_vit.metadata == metadata
             assert lib.list_symbols() == ["sym"]
@@ -1681,7 +1667,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         source = pd.DataFrame(
             {"a": [20, 40]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-02"), pd.Timestamp("2024-01-04")])
         )
-        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, upsert=True)
+        merge_vit = lib.merge("sym", source, strategy=self.strategy, upsert=True)
         assert merge_vit.version == 1
         expected = pd.DataFrame(
             {"a": [1, 20, 3, 40]},
@@ -1705,7 +1691,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         assert not len(lib.list_symbols())
         num_symbol_list_keys = len(lib_tool.find_keys(KeyType.SYMBOL_LIST))
         source = pd.DataFrame({"a": [10]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-05")]))
-        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, upsert=True)
+        merge_vit = lib.merge("sym", source, strategy=self.strategy, upsert=True)
         assert merge_vit.version == 1
         assert_frame_equal(lib.read("sym").data, source)
         assert len(lib_tool.find_keys(KeyType.SYMBOL_LIST)) == num_symbol_list_keys + 1
@@ -1729,7 +1715,7 @@ class TestMergeTimeseriesUpdateAndInsert:
                 ]
             ),
         )
-        lib.merge_experimental("sym", source, on=["a"])
+        lib.merge("sym", source, on=["a"])
 
         expected = pd.DataFrame(
             {"a": [1, 2, 2, 3, 30, 40], "b": [10.0, 2.0, 20.0, 3.0, 30.0, 40.0], "c": ["A", "b", "B", "c", "A", "C"]},
@@ -1781,7 +1767,7 @@ class TestMergeTimeseriesUpdateAndInsert:
             ),
         )
 
-        lib.merge_experimental("sym", source, on=["b", "d", "e"])
+        lib.merge("sym", source, on=["b", "d", "e"])
         expected = pd.DataFrame(
             {
                 "a": [10, 2, 20, 3, 30, 4, 40, 50],
@@ -1811,7 +1797,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)}, index=pd.DatetimeIndex([]))
         write_vit = lib.write("sym", target)
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)}, index=pd.date_range("2024-01-01", periods=2))
-        merge_vit = lib.merge_experimental("sym", source)
+        merge_vit = lib.merge("sym", source)
         expected = source
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(merge_vit, read_vit)
@@ -1843,7 +1829,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         )
         lib.write("sym", target)
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=self.strategy)
+            lib.merge("sym", source, strategy=self.strategy)
 
     @pytest.mark.parametrize(
         "source,expected",
@@ -1946,14 +1932,14 @@ class TestMergeTimeseriesUpdateAndInsert:
         )
         target = pd.DataFrame({"a": range(len(index)), "b": np.linspace(0, len(index) - 1, len(index))}, index=index)
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        lib.merge("sym", source, self.strategy, on=["a"])
         assert_frame_equal(lib.read("sym").data, expected)
 
     def test_insert_before_first_segment_start_and_update_first_value(self, lmdb_library):
         lib = lmdb_library
         lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
         source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0)]))
-        lib.merge_experimental("sym", source, self.strategy)
+        lib.merge("sym", source, self.strategy)
         expected = pd.DataFrame(
             {"a": [10, 20, 2]}, index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0), pd.Timestamp(5)])
         )
@@ -1963,7 +1949,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         lib = lmdb_library
         lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
         source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0)]))
-        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        lib.merge("sym", source, self.strategy, on=["a"])
         expected = pd.DataFrame(
             {"a": [10, 1, 20, 2]},
             index=pd.DatetimeIndex([pd.Timestamp(-5), pd.Timestamp(0), pd.Timestamp(0), pd.Timestamp(5)]),
@@ -1974,7 +1960,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         lib = lmdb_library
         lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
         source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(5), pd.Timestamp(10)]))
-        lib.merge_experimental("sym", source, self.strategy)
+        lib.merge("sym", source, self.strategy)
         expected = pd.DataFrame(
             {"a": [1, 10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(10)])
         )
@@ -1984,7 +1970,7 @@ class TestMergeTimeseriesUpdateAndInsert:
         lib = lmdb_library
         lib.write("sym", pd.DataFrame({"a": [1, 2]}, index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5)])))
         source = pd.DataFrame({"a": [10, 20]}, index=pd.DatetimeIndex([pd.Timestamp(5), pd.Timestamp(10)]))
-        lib.merge_experimental("sym", source, self.strategy, on=["a"])
+        lib.merge("sym", source, self.strategy, on=["a"])
         expected = pd.DataFrame(
             {"a": [1, 2, 10, 20]},
             index=pd.DatetimeIndex([pd.Timestamp(0), pd.Timestamp(5), pd.Timestamp(5), pd.Timestamp(10)]),
@@ -2004,7 +1990,7 @@ class TestMergeUpdateInsertIndexSpansMultipleSegments:
     def _run(self, lmdb_library_factory, target, source, expected, on):
         lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=5, columns_per_segment=1))
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+        lib.merge("sym", source, strategy=self.strategy, on=on)
         assert_frame_equal(lib.read("sym").data, expected)
 
     def test_last_index_value_same_as_next_segment_first_two_overlapping_segments(self, lmdb_library_factory):
@@ -2450,7 +2436,7 @@ class TestMergeUpdateInsertIndexSpansMultipleSegmentsChain:
     def _run(self, lmdb_library_factory, source, expected, on):
         lib = lmdb_library_factory(arcticdb.LibraryOptions(rows_per_segment=3, columns_per_segment=1))
         lib.write("sym", self._chain_target())
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+        lib.merge("sym", source, strategy=self.strategy, on=on)
         assert_frame_equal(lib.read("sym").data, expected)
 
     def test_source_in_row_slice_0(self, lmdb_library_factory):
@@ -2598,7 +2584,7 @@ class TestMergeRowrangeCommon:
 
         metadata = {"meta": "data"}
 
-        merge_vit = lib.merge_experimental("sym", source, metadata=metadata, strategy=strategy, on=["a"])
+        merge_vit = lib.merge("sym", source, metadata=metadata, strategy=strategy, on=["a"])
         assert merge_vit.version == 1
         assert merge_vit.symbol == write_vit.symbol
         assert merge_vit.metadata == metadata
@@ -2623,7 +2609,7 @@ class TestMergeRowrangeCommon:
         lib = lmdb_library
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         lib.write("sym", target)
-        merge_vit = lib.merge_experimental("sym", pd.DataFrame(), metadata=metadata, strategy=strategy, on=["a"])
+        merge_vit = lib.merge("sym", pd.DataFrame(), metadata=metadata, strategy=strategy, on=["a"])
         assert merge_vit.metadata is None if metadata is None else merge_vit.metadata == metadata
         lt = lib._dev_tools.library_tool()
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
@@ -2651,7 +2637,7 @@ class TestMergeRowrangeCommon:
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         lib.write("sym", target)
         with pytest.raises(SchemaException):
-            lib.merge_experimental("sym", source, strategy=strategy, on=["b"])
+            lib.merge("sym", source, strategy=strategy, on=["b"])
 
     def test_requires_on_column_none(self, lmdb_library, strategy):
         lib = lmdb_library
@@ -2659,7 +2645,7 @@ class TestMergeRowrangeCommon:
         lib.write("sym", target)
         source = pd.DataFrame({"a": [1], "b": [10.0]})
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=strategy, on=None)
+            lib.merge("sym", source, strategy=strategy, on=None)
 
     def test_requires_on_column_empty_list(self, lmdb_library, strategy):
         lib = lmdb_library
@@ -2667,7 +2653,7 @@ class TestMergeRowrangeCommon:
         lib.write("sym", target)
         source = pd.DataFrame({"a": [1], "b": [10.0]})
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=strategy, on=[])
+            lib.merge("sym", source, strategy=strategy, on=[])
 
     def test_on_nonexistent_column_raises(self, lmdb_library, strategy):
         lib = lmdb_library
@@ -2675,7 +2661,7 @@ class TestMergeRowrangeCommon:
         lib.write("sym", target)
         source = pd.DataFrame({"a": [1], "b": [10.0]})
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=strategy, on=["nonexistent"])
+            lib.merge("sym", source, strategy=strategy, on=["nonexistent"])
 
 
 class TestMergeRowrangeUpdate:
@@ -2788,7 +2774,7 @@ class TestMergeRowrangeUpdate:
         target = pd.DataFrame({"a": np.array([], dtype=np.int64)})
         lib.write("sym", target)
         source = pd.DataFrame({"a": np.array([1, 2], dtype=np.int64)})
-        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, metadata=merge_metadata, on=["a"])
+        merge_vit = lib.merge("sym", source, strategy=self.strategy, metadata=merge_metadata, on=["a"])
         expected = target
         read_vit = lib.read("sym")
         assert_vit_equals_except_data(merge_vit, read_vit)
@@ -2798,7 +2784,7 @@ class TestMergeRowrangeUpdate:
         lib = lmdb_library
         source = pd.DataFrame({"a": [1], "b": [10.0]})
         with pytest.raises(StorageException):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+            lib.merge("sym", source, strategy=self.strategy, on=["a"])
 
     # The row slice is not re-emitted when unchanged, so no second data key is written regardless of dedup.
     @pytest.mark.parametrize("dedup, expected_data_keys", [(False, 1), (True, 1)])
@@ -2807,7 +2793,7 @@ class TestMergeRowrangeUpdate:
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         lib.write("sym", target)
         source = pd.DataFrame({"a": [10, 20], "b": [10.0, 20.0]})
-        merge_vit = lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        merge_vit = lib.merge("sym", source, strategy=self.strategy, on=["a"])
         assert merge_vit.version == 1
 
         read_vit = lib.read("sym")
@@ -2893,7 +2879,7 @@ class TestMergeRowrangeUpdate:
         source = pd.DataFrame({"a": [2, 2], "b": [10.0, 20.0]})
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+            lib.merge("sym", source, strategy=self.strategy, on=["a"])
 
     def test_on_column_named_same_as_index(self, lmdb_library):
         """Row-range index name is protobuf-only and does not collide with data columns.
@@ -2904,7 +2890,7 @@ class TestMergeRowrangeUpdate:
         source = pd.DataFrame({"col": [2], "val": [99.0]})
         source.index.name = "col"
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["col"])
+        lib.merge("sym", source, strategy=self.strategy, on=["col"])
         result = lib.read("sym").data
         expected = pd.DataFrame({"col": [1, 2, 3], "val": [10.0, 99.0, 30.0]})
         expected.index.name = "col"
@@ -2928,7 +2914,7 @@ class TestMergeRowrangeUpdate:
             source.index.name = index_name
         lib.write("sym", target)
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["col"])
+            lib.merge("sym", source, strategy=self.strategy, on=["col"])
 
     @pytest.mark.parametrize("on", ([None], ["a", None]))
     def test_match_on_column_named_none(self, lmdb_library, on):
@@ -2937,7 +2923,7 @@ class TestMergeRowrangeUpdate:
         source = pd.DataFrame({"a": [10, 20, 30], None: [10.0, 20.0, 30.0]})
         lib.write("sym", target)
         with pytest.raises(TypeError):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
 
     def test_row_range_index_name_is_not_an_actual_column(self, lmdb_library):
         lib = lmdb_library
@@ -2947,7 +2933,7 @@ class TestMergeRowrangeUpdate:
         source.index.name = "my_index"
         lib.write("sym", target)
         with pytest.raises(UserInputException) as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["my_index"])
+            lib.merge("sym", source, strategy=self.strategy, on=["my_index"])
         assert "E_COLUMN_NOT_FOUND" in str(exc_info.value)
         assert "my_index" in str(exc_info.value)
 
@@ -2978,7 +2964,7 @@ class TestMergeRowrangeInsert:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+            lib.merge("sym", source, strategy=self.strategy, on=["a"])
         stats = qs.get_query_stats()
         # a single-column-slice target's unmatched rows are appended as exactly one new data segment.
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 1
@@ -2990,7 +2976,7 @@ class TestMergeRowrangeInsert:
         target = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 3.0]})
         source = pd.DataFrame({"a": [10, 20], "b": [10.0, 20.0]})
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         expected = pd.DataFrame({"a": [1, 2, 3, 10, 20], "b": [1.0, 2.0, 3.0, 10.0, 20.0]})
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -3001,7 +2987,7 @@ class TestMergeRowrangeInsert:
         lib.write("sym", target)
         lt = lib._dev_tools.library_tool()
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         # do_nothing on matched means no row slice is rewritten, and every source row matched means nothing is
         # inserted, so no new data key is created.
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 1
@@ -3014,7 +3000,7 @@ class TestMergeRowrangeInsert:
         # ORed across all units, so a=3 must NOT be inserted even though the first slice's unit did not match it.
         source = pd.DataFrame({"a": [3, 5], "b": [30.0, 50.0]})
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         expected = pd.DataFrame({"a": [1, 2, 3, 4, 5], "b": [1.0, 2.0, 3.0, 4.0, 50.0]})
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -3023,7 +3009,7 @@ class TestMergeRowrangeInsert:
         target = pd.DataFrame({"a": [1], "b": [1.0]})
         source = pd.DataFrame({"a": [7, 7], "b": [70.0, 71.0]})
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         expected = pd.DataFrame({"a": [1, 7, 7], "b": [1.0, 70.0, 71.0]})
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -3033,7 +3019,7 @@ class TestMergeRowrangeInsert:
         # Non-ASCII string exercises the GIL/string-pool path in build_row_range_insert_segments.
         source = pd.DataFrame({"a": [1, 3, 4], "s": ["x", "café", None]})
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         expected = pd.DataFrame({"a": [1, 2, 3, 4], "s": ["x", "y", "café", None]})
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -3044,7 +3030,7 @@ class TestMergeRowrangeInsert:
         lib.write("sym", target)
         lt = lib._dev_tools.library_tool()
         assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 2  # 1 row slice x 2 column slices
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         expected = pd.DataFrame({"a": [1, 2, 3], "b": [1.0, 2.0, 30.0], "c": [10, 20, 300]})
         assert_frame_equal(lib.read("sym").data, expected)
         # One insert segment is appended per column slice; do_nothing leaves the matched rows untouched.
@@ -3066,7 +3052,7 @@ class TestMergeRowrangeUpdateAndInsert:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+            lib.merge("sym", source, strategy=self.strategy, on=["a"])
         stats = qs.get_query_stats()
         # update one segment in place and append one segment for insertion
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
@@ -3085,7 +3071,7 @@ class TestMergeRowrangeUpdateAndInsert:
         source = pd.DataFrame({"a": [1, 2], "b": [10.0, 20.0]})
         lib.write("sym", target)
         lt = lib._dev_tools.library_tool()
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a"])
         expected = pd.DataFrame({"a": [1, 2, 3], "b": [10.0, 20.0, 3.0]})
         assert_frame_equal(lib.read("sym").data, expected)
         # The update rewrites the single row slice (one new data key); nothing is inserted.
@@ -3097,7 +3083,7 @@ class TestMergeRowrangeUpdateAndInsert:
         source = pd.DataFrame({"a": [1, 3], "b": ["x", "q"], "c": [10.0, 30.0]})
         # (a=1, b="x") matches row 0 and updates c; (a=3, b="q") is unmatched and appended.
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=self.strategy, on=["a", "b"])
+        lib.merge("sym", source, strategy=self.strategy, on=["a", "b"])
         expected = pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "q"], "c": [10.0, 2.0, 30.0]})
         assert_frame_equal(lib.read("sym").data, expected)
 
@@ -3108,7 +3094,7 @@ class TestMergeRowrangeUpdateAndInsert:
         source = pd.DataFrame({"a": [1, 1], "b": [10.0, 11.0]})
         lib.write("sym", target)
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=["a"])
+            lib.merge("sym", source, strategy=self.strategy, on=["a"])
 
 
 @pytest.mark.parametrize(
@@ -3133,7 +3119,7 @@ class TestMergeInsertRowSlicingRowRange:
         expected_data_key_writes = 4 if strategy.matched == MergeAction.UPDATE else 3
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
         if strategy.matched == MergeAction.UPDATE:
@@ -3242,7 +3228,7 @@ class TestMergeInsertRowSlicingRowRange:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
         expected = pd.DataFrame({"a": expected_a, "b": expected_b})
@@ -3267,7 +3253,7 @@ class TestMergeInsertRowSlicingRowRange:
         expected_data_key_writes = 6 if strategy.matched == MergeAction.UPDATE else 2
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
         if strategy.matched == MergeAction.UPDATE:
@@ -3327,7 +3313,7 @@ class TestMergeInsertRowSlicingRowRange:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected = pd.DataFrame(
@@ -3347,7 +3333,7 @@ class TestMergeInsertRowSlicingRowRange:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected = pd.DataFrame({"a": [10, 20, 30, 40, 50], "b": [10.0, 20.0, 30.0, 40.0, 50.0]})
@@ -3381,7 +3367,7 @@ class TestMergeInsertRowSlicingRowRange:
         expected_data_key_writes = 9 if strategy.matched == MergeAction.UPDATE else 6
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == expected_data_key_writes
         if strategy.matched == MergeAction.UPDATE:
@@ -3430,7 +3416,7 @@ class TestMergeInsertRowSlicingRowRange:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected = pd.DataFrame({"a": [1, 7, 7, 7, 7, 7, 8], "b": ["a", "A", "B", "C", "D", "E", "F"]})
@@ -3464,7 +3450,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
         expected = pd.DataFrame(
@@ -3567,7 +3553,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 3
         expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
@@ -3636,7 +3622,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected = pd.DataFrame({"b": expected_b, "s": expected_s}, index=expected_index)
@@ -3660,7 +3646,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 3
         expected = pd.DataFrame(
@@ -3709,7 +3695,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+            lib.merge("sym", source, strategy=strategy, on=["a"])
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 4
         expected = pd.DataFrame(
@@ -3752,7 +3738,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected_index = pd.DatetimeIndex(
@@ -3807,7 +3793,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 6
         if strategy.matched == MergeAction.UPDATE:
@@ -3856,7 +3842,7 @@ class TestMergeDatetimeInsertRowSlicing:
         lib.write("sym", target)
         qs.reset_stats()
         with qs.query_stats():
-            lib.merge_experimental("sym", source, strategy=strategy)
+            lib.merge("sym", source, strategy=strategy)
         stats = qs.get_query_stats()
         assert query_stats_operation_count(stats, "Memory_PutObject", "TABLE_DATA") == 2
         expected = pd.DataFrame(
@@ -3969,7 +3955,7 @@ class TestMergeMultiindexUpdate:
 
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="E_DUPLICATE_COLUMN") as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
         assert '"my_duplicate"' in str(exc_info.value)
 
     @pytest.mark.parametrize(
@@ -4050,7 +4036,7 @@ class TestMergeMultiindexUpdate:
 
         lib.write("sym", target)
         with pytest.raises(UserInputException) as exc_info:
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
         assert "not contain the datetime index column" in str(exc_info.value)
 
     def test_unnamed_datetime_index_on_contains_column_named_index_not_in_dataframe(self, lmdb_library):
@@ -4072,7 +4058,7 @@ class TestMergeMultiindexUpdate:
 
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="E_COLUMN_NOT_FOUND"):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
 
     @pytest.mark.parametrize(
         "index_column_names, data_column_names, on",
@@ -4160,7 +4146,7 @@ class TestMergeMultiindexUpdate:
 
         lib.write("sym", target)
         with pytest.raises(UserInputException, match="E_DUPLICATE_COLUMN"):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
 
     def test_default_on_rowrange_raises(self, lmdb_library):
         index_names = ["idx", "a", "b"]
@@ -4172,7 +4158,7 @@ class TestMergeMultiindexUpdate:
         source = pd.DataFrame({"c": [1000, 2000], "d": [-1000.0, -2000.0]}, index=source_idx)
         lmdb_library.write("sym", target)
         with pytest.raises(UserInputException):
-            lmdb_library.merge_experimental("sym", source, strategy=self.strategy)
+            lmdb_library.merge("sym", source, strategy=self.strategy)
 
     ####################################################################################################################
     # Happy paths
@@ -4384,7 +4370,7 @@ class TestMergeMultiindexUpdate:
         source = pd.DataFrame({c: [99.0] for c in data_names}, index=src_idx)
         lib.write("sym", target)
         with pytest.raises(TypeError):
-            lib.merge_experimental("sym", source, strategy=self.strategy, on=on)
+            lib.merge("sym", source, strategy=self.strategy, on=on)
 
 
 @pytest.mark.parametrize(
@@ -4454,7 +4440,7 @@ def test_merge_insert_with_repeated_boundary_timestamps(lmdb_library, target_seg
     lt = lib._dev_tools.library_tool()
     assert len(lt.find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == len(target_segments)
 
-    lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), on=["a"])
+    lib.merge("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), on=["a"])
     assert_frame_equal(lib.read("sym").data, expected)
 
 
@@ -4467,7 +4453,7 @@ def test_merge_insert_into_back_shared_middle_group(lmdb_library):
     assert len(lib._dev_tools.library_tool().find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
 
     source = pd.DataFrame({"a": [1000, 1001, 1002]}, index=pd.DatetimeIndex([15, 25, 35]))
-    lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), on=["a"])
+    lib.merge("sym", source, strategy=MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT), on=["a"])
 
     expected = pd.DataFrame(
         {"a": [0, 1000, 1, 2, 1001, 3, 4, 1002, 5, 6, 7]},
@@ -4485,7 +4471,7 @@ def test_merge_insert_only_into_chain_with_shared_boundaries(lmdb_library):
     assert len(lib._dev_tools.library_tool().find_keys_for_symbol(KeyType.TABLE_DATA, "sym")) == 4
 
     source = pd.DataFrame({"a": [1000]}, index=pd.DatetimeIndex([25]))
-    lib.merge_experimental("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), on=["a"])
+    lib.merge("sym", source, strategy=MergeStrategy(MergeAction.DO_NOTHING, MergeAction.INSERT), on=["a"])
 
     expected = pd.DataFrame(
         {"a": [0, 1, 2, 1000, 3, 4, 5, 6, 7]},
@@ -4549,7 +4535,7 @@ class TestMergeMultiindexInsert:
         expected = pd.DataFrame({"c": expected_c, "d": expected_d}, index=expected_idx)
 
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=strategy, on=None)
+        lib.merge("sym", source, strategy=strategy, on=None)
         assert_frame_equal(lib.read("sym").data, expected)
 
     @pytest.mark.parametrize(
@@ -4577,7 +4563,7 @@ class TestMergeMultiindexInsert:
             expected = pd.DataFrame({"a": [1, 2, 3, 9], "b": [1.0, 20.0, 3.0, 90.0]}, index=expected_idx)
 
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        lib.merge("sym", source, strategy=strategy, on=["a"])
         assert_frame_equal(lib.read("sym").data, expected)
 
     @pytest.mark.parametrize(
@@ -4599,7 +4585,7 @@ class TestMergeMultiindexInsert:
 
         lib.write("sym", target)
         with pytest.raises(UserInputException):
-            lib.merge_experimental("sym", source, strategy=strategy, on=None)
+            lib.merge("sym", source, strategy=strategy, on=None)
 
     @pytest.mark.parametrize(
         "is_datetime",
@@ -4639,7 +4625,7 @@ class TestMergeMultiindexInsert:
         expected = pd.DataFrame({"c": expected_c}, index=expected_idx)
 
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+        lib.merge("sym", source, strategy=strategy, on=["a"])
         assert_frame_equal(lib.read("sym").data, expected)
 
     def test_string_secondary_level_insert(self, lmdb_library):
@@ -4661,7 +4647,7 @@ class TestMergeMultiindexInsert:
         expected = pd.DataFrame({"a": [1, 2, 3, 4]}, index=expected_idx)
 
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=strategy, on=None)
+        lib.merge("sym", source, strategy=strategy, on=None)
         assert_frame_equal(lib.read("sym").data, expected)
 
     def test_datetime_insert_across_row_slices(self, lmdb_library_factory):
@@ -4697,7 +4683,7 @@ class TestMergeMultiindexInsert:
         expected = pd.DataFrame({"a": [0, 100, 1, 101, 2]}, index=expected_idx)
 
         lib.write("sym", target)
-        lib.merge_experimental("sym", source, strategy=strategy, on=None)
+        lib.merge("sym", source, strategy=strategy, on=None)
         assert_frame_equal(lib.read("sym").data, expected)
 
     @pytest.mark.parametrize(
@@ -4722,7 +4708,7 @@ class TestMergeMultiindexInsert:
             on = ["s"]
 
         sym = f"nonexistent_{is_datetime}"
-        lib.merge_experimental(sym, source, strategy=strategy, upsert=True, on=on)
+        lib.merge(sym, source, strategy=strategy, upsert=True, on=on)
         assert_frame_equal(lib.read(sym).data, source)
 
 
@@ -4757,7 +4743,7 @@ def test_match_on_float_nan(lmdb_library, match_na, target, source, expected_mat
     lib = lmdb_library
     strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
     lib.write("sym", target)
-    lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+    lib.merge("sym", source, strategy=strategy, on=["a"], match_na=match_na)
     expected = expected_match_na_true if match_na else expected_match_na_false
     assert_frame_equal(lib.read("sym").data, expected)
     lt = lib._dev_tools.library_tool()
@@ -4803,7 +4789,7 @@ def test_match_on_string_none_nan(
     lib = lmdb_version_store_v1
     strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
     lib.write("sym", target)
-    lib.merge_experimental("sym", source, strategy=strategy, on=on, match_na=match_na)
+    lib.merge("sym", source, strategy=strategy, on=on, match_na=match_na)
     expected = expected_match_na_true if match_na else expected_match_na_false
     assert_frame_equal(lib.read("sym").data, expected)
 
@@ -4835,9 +4821,9 @@ def test_multiple_source_rows_match_via_missing(lmdb_library, match_na, target, 
     lib.write("sym", target)
     if match_na:
         with pytest.raises(UserInputException, match="Multiple source rows match the same target row"):
-            lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+            lib.merge("sym", source, strategy=strategy, on=["a"], match_na=match_na)
     else:
-        lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+        lib.merge("sym", source, strategy=strategy, on=["a"], match_na=match_na)
         assert_frame_equal(lib.read("sym").data, target)
 
 
@@ -4876,7 +4862,7 @@ def test_match_on_datetime_nat(lmdb_library, match_na, target, source, expected_
     lib = lmdb_library
     strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.DO_NOTHING)
     lib.write("sym", target)
-    lib.merge_experimental("sym", source, strategy=strategy, on=["a"], match_na=match_na)
+    lib.merge("sym", source, strategy=strategy, on=["a"], match_na=match_na)
     expected = expected_match_na_true if match_na else expected_match_na_false
     assert_frame_equal(lib.read("sym").data, expected)
 
@@ -4914,5 +4900,5 @@ def test_unmatched_nan_source_rows_inserted_default(lmdb_library, target, source
     lib = lmdb_library
     strategy = MergeStrategy(MergeAction.UPDATE, MergeAction.INSERT)
     lib.write("sym", target)
-    lib.merge_experimental("sym", source, strategy=strategy, on=["a"])
+    lib.merge("sym", source, strategy=strategy, on=["a"])
     assert_frame_equal(lib.read("sym").data, expected)


### PR DESCRIPTION
#### Reference Issues/PRs
<!--Example: Fixes #1234. See also #3456.-->
Monday issue: 12901030250

The merge/merge-update API is now stable. Rename the public Library.merge_experimental / NativeVersionStore.merge_experimental to merge, and drop the 'under development / not subject to semver' framing from the docstrings and the merge notebook (keeping the dynamic-schema limitation). Updates the unit, hypothesis, stress and compat tests, the ASV benchmark, and ArcticDB_merge.ipynb.

#### What does this implement or fix?

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
