### PR TITLE
Raise consistent exceptions with duplicate symbols in batch modification method

### DIFF
--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -795,6 +795,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         std::vector<arcticdb::proto::descriptors::UserDefinedMetadata>&& user_meta_protos
 ) {
     py::gil_scoped_release release_gil;
+    check_for_duplicated_symbols(stream_ids, "write_metadata");
     auto stream_update_info_futures =
             batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -1331,7 +1332,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
 ) {
     ARCTICDB_RUNTIME_DEBUG(log::version(), "Command: batch_compact_data");
     py::gil_scoped_release release_gil;
-    check_for_duplicated_symbols(stream_ids, "batch_compact_data");
+    check_for_duplicated_symbols(stream_ids, "compact_data");
     auto update_info_futs =
             batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);
     internal::check<ErrorCode::E_ASSERTION_FAILURE>(
@@ -1930,6 +1931,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         bool prune_previous_versions, bool validate_index, bool throw_on_error
 ) {
     py::gil_scoped_release release_gil;
+    check_for_duplicated_symbols(stream_ids, "write");
 
     auto update_info_futs = batch_get_next_version_id_and_optionally_latest_undeleted_version_async(
             store(), version_map(), stream_ids, write_options_.de_duplication
@@ -2026,6 +2028,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         const AppendOptions& append_options, bool throw_on_error
 ) {
     py::gil_scoped_release release_gil;
+    check_for_duplicated_symbols(stream_ids, "append");
 
     auto stream_update_info_futures =
             batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);
@@ -2062,6 +2065,7 @@ std::vector<std::variant<VersionedItem, DataError>> LocalVersionedEngine::batch_
         const std::vector<UpdateQuery>& update_queries, bool prune_previous_versions, bool upsert
 ) {
     py::gil_scoped_release release_gil;
+    check_for_duplicated_symbols(stream_ids, "update");
 
     auto stream_update_info_futures =
             batch_get_next_version_id_and_optionally_latest_undeleted_version_async(store(), version_map(), stream_ids);

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -6,6 +6,7 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
+import collections
 import copy
 from dataclasses import dataclass
 import datetime
@@ -554,10 +555,15 @@ class NativeVersionStore:
         return backing_store
 
     @staticmethod
-    def _raise_if_duplicate_symbols_in_batch(batch):
-        symbols = {(p if isinstance(p, str) else p.symbol) for p in batch}
-        if len(symbols) < len(batch):
-            raise ArcticDuplicateSymbolsInBatchException
+    def _raise_if_duplicate_symbols_in_batch(symbols: List[str]):
+        symbol_counts = collections.defaultdict(int)
+        for sym in symbols:
+            symbol_counts[sym] += 1
+        duplicated_symbols = [sym for sym, count in symbol_counts.items() if count > 1]
+        if len(duplicated_symbols):
+            raise ArcticDuplicateSymbolsInBatchException(
+                f"Batch modification method received duplicate symbols {duplicated_symbols}"
+            )
 
     def _try_normalize(
         self,
@@ -1249,6 +1255,7 @@ class NativeVersionStore:
         upsert: bool = False,
         index_column_vector: Optional[List[bool]] = None,
     ):
+        self._raise_if_duplicate_symbols_in_batch(symbols)
         update_queries = [_PythonVersionStoreUpdateQuery() for _ in range(len(symbols))]
         for i in range(len(data_vector)):
             data_vector[i] = self._apply_date_range_to_update_query(
@@ -1935,6 +1942,7 @@ class NativeVersionStore:
         index_column_vector: Optional[List[bool]] = None,
         **kwargs,
     ) -> List[VersionedItem]:
+        self._raise_if_duplicate_symbols_in_batch(symbols)
         proto_cfg = self._lib_cfg.lib_desc.version.write_options
         prune_previous_version = resolve_defaults(
             "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_version
@@ -1965,6 +1973,7 @@ class NativeVersionStore:
     def _batch_write_metadata_to_versioned_items(
         self, symbols: List[str], metadata_vector: List[Any], prune_previous_version, throw_on_error
     ):
+        self._raise_if_duplicate_symbols_in_batch(symbols)
         proto_cfg = self._lib_cfg.lib_desc.version.write_options
         prune_previous_version = resolve_defaults(
             "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_version
@@ -2106,6 +2115,7 @@ class NativeVersionStore:
         compact_data,
         **kwargs,
     ):
+        self._raise_if_duplicate_symbols_in_batch(symbols)
         proto_cfg = self._lib_cfg.lib_desc.version.write_options
         prune_previous_version = resolve_defaults(
             "prune_previous_version", proto_cfg, global_default=False, existing_value=prune_previous_version
@@ -2175,7 +2185,7 @@ class NativeVersionStore:
             i-th entry corresponds to i-th element of `symbols`.
         """
         self._validate_kwargs("batch_restore_version", self._valid_read_kwargs, kwargs)
-
+        self._raise_if_duplicate_symbols_in_batch(symbols)
         _check_batch_kwargs(NativeVersionStore.batch_restore_version, NativeVersionStore.restore_version, kwargs)
         version_queries = self._get_version_queries(len(symbols), as_ofs, **kwargs)
         read_options, _ = self._get_read_options_and_output_format(**kwargs)

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1298,7 +1298,6 @@ class Library:
         >>> items[0].symbol, items[1].symbol
         ('symbol_1', 'symbol_2')
         """
-        self._nvs._raise_if_duplicate_symbols_in_batch(payloads)
         self._raise_if_unsupported_type_in_write_batch(payloads)
 
         throw_on_error = False
@@ -1347,7 +1346,6 @@ class Library:
         write: For more detailed documentation.
         write_pickle: For information on the implications of providing data that needs to be pickled.
         """
-        self._nvs._raise_if_duplicate_symbols_in_batch(payloads)
 
         return self._nvs._batch_write_internal(
             [p.symbol for p in payloads],
@@ -1519,7 +1517,6 @@ class Library:
             If data that is not of NormalizableType appears in any of the payloads.
         """
 
-        self._nvs._raise_if_duplicate_symbols_in_batch(append_payloads)
         self._raise_if_unsupported_type_in_write_batch(append_payloads)
         throw_on_error = False
 
@@ -1727,7 +1724,6 @@ class Library:
         2024-01-02        11
         """
 
-        self._nvs._raise_if_duplicate_symbols_in_batch(update_payloads)
         self._raise_if_unsupported_type_in_write_batch(update_payloads)
 
         batch_update_result = self._nvs._batch_update_internal(
@@ -2653,7 +2649,6 @@ class Library:
         {'the': 'metadata_2'}
         """
 
-        self._nvs._raise_if_duplicate_symbols_in_batch(write_metadata_payloads)
         throw_on_error = False
         return self._nvs._batch_write_metadata_to_versioned_items(
             [p.symbol for p in write_metadata_payloads],

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -41,6 +41,7 @@ from arcticdb.version_store.library import (
     ReadInfoRequest,
     ArcticInvalidApiUsageException,
     DeleteRequest,
+    UpdatePayload,
 )
 from tests.conftest import Marks
 from tests.util.marking import marks
@@ -311,33 +312,28 @@ def test_write_object_in_batch_without_pickle_mode_many_symbols(arctic_library):
     assert "(and more)... 10 data in total have bad types." in message
 
 
-@pytest.mark.storage
-def test_write_batch_duplicate_symbols(arctic_library):
-    """Should throw and not write if duplicate symbols are provided."""
-    lib = arctic_library
-    with pytest.raises(ArcticDuplicateSymbolsInBatchException):
-        lib.write_batch(
-            [
-                WritePayload("symbol_1", pd.DataFrame()),
-                WritePayload("symbol_1", pd.DataFrame(), metadata="great_metadata"),
-            ]
-        )
-
-    assert not lib.list_symbols()
-
-
-@pytest.mark.storage
-def test_write_pickle_batch_duplicate_symbols(arctic_library):
-    """Should throw and not write if duplicate symbols are provided."""
-    lib = arctic_library
-    with pytest.raises(ArcticDuplicateSymbolsInBatchException):
-        lib.write_pickle_batch(
-            [
-                WritePayload("symbol_1", pd.DataFrame()),
-                WritePayload("symbol_1", pd.DataFrame(), metadata="great_metadata"),
-            ]
-        )
-
+# Equivalent V1 API test in test_basic_version_store.py
+@pytest.mark.parametrize(
+    "method",
+    ["write_batch", "write_pickle_batch", "append_batch", "update_batch", "write_metadata_batch", "compact_data_batch"],
+)
+def test_duplicate_symbols_in_modification_methods(in_memory_library, method):
+    lib = in_memory_library
+    syms = ["sym1", "sym2", "sym1", "sym2", "sym3"]
+    if method == "update_batch":
+        payloads = [UpdatePayload(sym, pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)])) for sym in syms]
+    elif method == "write_metadata_batch":
+        payloads = [WriteMetadataPayload(sym, "metadata") for sym in syms]
+    elif method == "compact_data_batch":
+        payloads = syms
+    else:  # write_batch/write_pickle_batch/append_batch
+        payloads = [WritePayload(sym, pd.DataFrame({"col": [0]})) for sym in syms]
+    with pytest.raises(ArcticDuplicateSymbolsInBatchException) as e:
+        getattr(lib, method)(payloads)
+    msg = str(e.value)
+    assert "sym1" in msg
+    assert "sym2" in msg
+    assert "sym3" not in msg
     assert not lib.list_symbols()
 
 
@@ -1700,9 +1696,7 @@ def test_compact_data_batch_prune_previous(lmdb_library, prune_previous_versions
 
 
 # These compact_data_batch tests have equivalents in test_compact_data.py for the V1 API. This tests the V1 vs V2 API
-# differences, namely:
-# * DataError objects returned when one symbol fails, rather than the whole method raising
-# * Exception raised on duplicated symbol names
+# differences, namely DataError objects returned when one symbol fails, rather than the whole method raising
 def test_compact_data_batch_one_symbol_doesnt_exist(lmdb_library):
     lib = lmdb_library
     num_symbols = 3
@@ -1741,10 +1735,3 @@ def test_compact_data_batch_one_symbol_recursively_normalized(lmdb_library):
     assert res[2].version_request_data is None
     assert res[2].error_code == ErrorCode.E_OPERATION_NOT_SUPPORTED_WITH_RECURSIVE_NORMALIZED_DATA
     assert res[2].error_category == ErrorCategory.SCHEMA
-
-
-def test_compact_data_batch_duplicated_symbols(lmdb_library):
-    lib = lmdb_library
-    syms = ["duplicated_sym", "unique_sym", "duplicated_sym"]
-    with pytest.raises(ArcticDuplicateSymbolsInBatchException):
-        lib.compact_data_batch(syms)

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -25,6 +25,7 @@ from pytz import timezone
 
 from arcticdb.exceptions import (
     ArcticDbNotYetImplemented,
+    ArcticDuplicateSymbolsInBatchException,
     InternalException,
     SchemaException,
     UserInputException,
@@ -2719,7 +2720,7 @@ def test_batch_restore_version_mixed_as_ofs(lmdb_version_store):
     assert latest["s3"].metadata == "s3-1"
 
 
-@pytest.mark.parametrize("bad_thing", ("symbol", "as_of", "duplicate"))
+@pytest.mark.parametrize("bad_thing", ("symbol", "as_of"))
 def test_batch_restore_version_bad_input_noop(lmdb_version_store, bad_thing):
     """Leave everything alone if anything in the batch is bad."""
     lib = lmdb_version_store
@@ -2755,14 +2756,6 @@ def test_batch_restore_version_bad_input_noop(lmdb_version_store, bad_thing):
             NoSuchVersionException, match=r"E_NO_SUCH_VERSION Could not find.*restore_version.*missing versions \[s3\]"
         ):
             lib.batch_restore_version(syms, as_ofs)
-    elif bad_thing == "duplicate":
-        restore_syms = ["s1", "s1", "s2"]
-        as_ofs = [1, second_ts, first_ts]
-        with pytest.raises(
-            UserInputException,
-            match=r"E_INVALID_USER_ARGUMENT Duplicate symbols in restore_version.*more than once \[s1\]",
-        ):
-            lib.batch_restore_version(restore_syms, as_ofs)
     else:
         raise RuntimeError(f"Unexpected bad_thing={bad_thing}")
 
@@ -3566,3 +3559,28 @@ def test_read_specific_version_reloads_when_new_versions_written(basic_store_fac
         result = lib_b.read(symbol, as_of=-6)
         assert result.version == 0
         assert_equal(result.data, dataframes[0])
+
+
+# Equivalent V2 API test in test_arctic_batch.py
+@pytest.mark.parametrize(
+    "method",
+    ["batch_write", "batch_append", "batch_write_metadata", "batch_compact_data", "batch_restore_version"],
+)
+def test_duplicate_symbols_in_modification_methods(in_memory_version_store, method):
+    lib = in_memory_version_store
+    syms = ["sym1", "sym2", "sym1", "sym2", "sym3"]
+    if method == "batch_write_metadata":
+        args = [["metadata"] * len(syms)]
+    elif method == "batch_compact_data":
+        args = []
+    elif method == "batch_restore_version":
+        args = [[0] * len(syms)]
+    else:  # batch_write/batch_append
+        args = [[pd.DataFrame({"col": [0]})] * len(syms)]
+    with pytest.raises(ArcticDuplicateSymbolsInBatchException) as e:
+        getattr(lib, method)(syms, *args)
+    msg = str(e.value)
+    assert "sym1" in msg
+    assert "sym2" in msg
+    assert "sym3" not in msg
+    assert not lib.list_symbols()

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -902,14 +902,6 @@ def test_batch_compact_data_one_symbol_recursively_normalized(lmdb_version_store
     assert "recursive" in str(e.value) and syms[2] in str(e.value)
 
 
-def test_batch_compact_data_duplicated_symbols(lmdb_version_store_v1):
-    lib = lmdb_version_store_v1
-    syms = ["duplicated_sym", "unique_sym", "duplicated_sym"]
-    lib.batch_write(syms[:2], 2 * [pd.DataFrame({"col": [0]}, index=[pd.Timestamp(0)])])
-    with pytest.raises(ArcticDuplicateSymbolsInBatchException):
-        lib.batch_compact_data(syms)
-
-
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(


### PR DESCRIPTION
⚠️ API break of V1 (`NativeVersionStore`) API
On duplicate symbol names, `batch_restore_version` previously raised a `UserInputException`. Now it raises an `ArcticDuplicateSymbolsInBatchException`.

#### Reference Issues/PRs
[12701526171](https://man312219.monday.com/boards/7852509418/pulses/12701526171)

#### What does this implement or fix?
Previously, batch modification methods on the V1 API did not gracefully handle duplicated symbol names (e.g. `batch_write/batch_append/batch_write_metadata` raised `E_NON_INCREASING_INDEX_VERSION` when the second occurrence of a symbol tried to write it's index key).
Now all batch modification methods on the V1 API use `_raise_if_duplicate_symbols_in_batch` (as the V2 API does).
Also improved the exception message to contain the duplicated symbol names, and added test coverage for V2 API methods that previously lacked it.