### PR TITLE
CI: exclude test paths from Windows Defender to speed up Windows pytest jobs

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -637,6 +637,18 @@ jobs:
           disk-root: "D:"  # This is also the checkout directory. Total size 12GB.
         continue-on-error: true
 
+      # Real-time scanning of the thousands of small LMDB/temp files the tests create makes
+      # Windows test jobs 5-10x slower per test than Linux.
+      - name: Exclude test paths from Windows Defender
+        if: matrix.os == 'windows'
+        shell: pwsh
+        run: |
+          Add-MpPreference -ExclusionPath "$env:GITHUB_WORKSPACE", "$env:RUNNER_TEMP", "$env:TEMP", "$env:LOCALAPPDATA\Temp", "C:\hostedtoolcache", "C:\tmp", "D:\tmp"
+          Add-MpPreference -ExclusionProcess "python.exe", "pytest.exe", "node.exe", "azurite.exe"
+          Set-MpPreference -DisableRealtimeMonitoring $true
+          Get-MpPreference | Select-Object DisableRealtimeMonitoring, ExclusionPath, ExclusionProcess
+        continue-on-error: true
+
       # GitHub runner image does not come with npm
       - name: Install npm (Linux and macOS)
         if: matrix.os == 'linux' || matrix.os == 'macos'

--- a/docs/claude/plans/gpetrov/ci_speedup/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_speedup/branch-work-log.md
@@ -1,0 +1,14 @@
+# Branch work log: gpetrov/ci_speedup
+
+## Baseline (PR run 32735025613, 2026-08-24)
+- 241 jobs, 4h12m wall-clock, ~2190 job-minutes.
+- C++ compile is already fast (sccache 100% hit on Linux; 7-15 min wheel builds).
+- Critical path is Windows pytest jobs: 50-107 min each, 1375 Windows test job-minutes vs 512 Linux.
+- Same 19,490 `unit` tests: 36 CPU-min on Linux, 171-387 CPU-min on Windows (5-10x per test).
+
+## 2026-08-28
+- Added a Windows Defender exclusion / realtime-monitoring-off step before the Python tests
+  (`build_steps.yml`, python_tests job). Experiment 1: measure Windows unit/integration job times
+  against the baseline above.
+- Next candidates: shard Windows unit/integration with pytest-split (already installed, unused);
+  reduce `ci_windows` hypothesis max_examples; trim Windows Python matrix on PRs.


### PR DESCRIPTION
## What

Adds a step to the Windows Python test jobs that excludes the workspace/temp paths from Windows Defender and disables real-time monitoring for the job (`continue-on-error`, 4s). The checkout and `RUNNER_TEMP` live on `D:\`, which the runner image does not exclude.

No product code changes.

## Why

Windows pytest jobs are the critical path of every PR build. Profiling showed the same 19,490 `unit` tests take 36 CPU-min on Linux but 171–387 CPU-min on Windows, with real-time scanning of the thousands of small LMDB/temp files the tests create as the first suspect.

## Measured (run [33155035842](https://github.com/man-group/ArcticDB/actions/runs/33155035842) vs baseline run [32735025613](https://github.com/man-group/ArcticDB/actions/runs/32735025613), 22 paired Windows `unit`/`integration`/`stress` jobs)

| | baseline | this PR |
|---|---|---|
| Longest Windows test job (critical path) | 107 min | **71 min** |
| Total Windows test job-minutes | 1336 | 1200 (−10%) |
| Median Windows test job | 58 min | 56 min |
| `unit` per-test CPU sum, cp313 | 387 min | **172 min** |
| `unit` per-test CPU sum, cp39 | 171 min | 144 min |

It removes the pathological outliers and most of the run-to-run variance; the typical job is unchanged, so Windows is still ~4–5× slower per test than Linux. That remaining gap is being investigated separately (LMDB fsync-per-commit on NTFS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xc7BAuEGNex1VAkEKyehA