### PR TITLE
Correctly combine arrow string format metadata

### DIFF
--- a/cpp/arcticdb/processing/schema_combine.cpp
+++ b/cpp/arcticdb/processing/schema_combine.cpp
@@ -668,7 +668,8 @@ void on_column_metadata_one_sided(
                 column
         );
     }
-    // TODO (monday ref 12841500984): Add a similar check for string format
+    // We explicitly allow has_string_format() to be combined with a missing column_meta.
+    // It will just inherit the value already specified in metadata.
 }
 
 // The leading dimension of an ndarray is the row count, thus has to be combined when combining norm metadata.
@@ -736,6 +737,10 @@ NormalizationMetadata accumulate_arrow_and_arrow_norm(
                     );
                     // Present in both, so drop anything they disagree on, such as the timezone.
                     res_columns[column_name].clear_timezone();
+                }
+                if (other_column->has_string_format()) {
+                    // Always override string format with the last.
+                    res_columns[column_name].set_string_format(other_column->string_format());
                 }
             }
     );

--- a/cpp/arcticdb/processing/schema_combine.cpp
+++ b/cpp/arcticdb/processing/schema_combine.cpp
@@ -739,8 +739,17 @@ NormalizationMetadata accumulate_arrow_and_arrow_norm(
                     res_columns[column_name].clear_timezone();
                 }
                 if (other_column->has_string_format()) {
-                    // Always override string format with the last.
-                    res_columns[column_name].set_string_format(other_column->string_format());
+                    if (res_columns[column_name].has_string_format()) {
+                        if (res_columns[column_name].string_format() != other_column->string_format()) {
+                            // If we are mixing different string formats we always use large_string
+                            res_columns[column_name].set_string_format(
+                                    proto::descriptors::ArrowStringFormat::LARGE_STRING
+                            );
+                        }
+                    } else {
+                        // If only other has_string_format we inherit it.
+                        res_columns[column_name].set_string_format(other_column->string_format());
+                    }
                 }
             }
     );

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -785,7 +785,8 @@ def test_append_mix_strings_and_large_strings(in_memory_version_store_arrow, fir
     lib.append(sym, append_table)
 
     received = lib.read(sym).data
-    expected = pa.table({"col": pa.array(["a", "bb", "ccc", "dddd"], second_type)})
+    # Mismatched formats always resolve to large_string, regardless of which side is small/large.
+    expected = pa.table({"col": pa.array(["a", "bb", "ccc", "dddd"], pa.large_string())})
     assert expected.equals(received)
 
 
@@ -1878,11 +1879,12 @@ class TestStringFormatRoundtrip:
         assert received.schema.field(0).type == pa.timestamp("ns")
         assert received.schema.field(1).type == pa.string()
         assert received.schema.field(2).type == pa.large_string()
-        assert received.schema.field(3).type == pa.dictionary(pa.int32(), pa.large_string())
-        assert received.schema.field(4).type == pa.string()
+        # Mismatched formats always resolve to large_string, regardless of which side is small/large/dict.
+        assert received.schema.field(3).type == pa.large_string()
+        assert received.schema.field(4).type == pa.large_string()
         assert received.schema.field(5).type == pa.large_string()
-        assert received.schema.field(6).type == pa.dictionary(pa.int32(), pa.large_string())
-        assert received.schema.field(7).type == pa.string()
+        assert received.schema.field(6).type == pa.large_string()
+        assert received.schema.field(7).type == pa.large_string()
         assert received.schema.field(8).type == pa.large_string()
         assert received.schema.field(9).type == pa.dictionary(pa.int32(), pa.large_string())
         expected_values = write_values + modify_values
@@ -1892,11 +1894,11 @@ class TestStringFormatRoundtrip:
             ),
             "small_to_small": pa.array(expected_values, pa.string()),
             "small_to_large": pa.array(expected_values, pa.large_string()),
-            "small_to_dict": pa.compute.dictionary_encode(pa.array(expected_values, pa.large_string())),
-            "large_to_small": pa.array(expected_values, pa.string()),
+            "small_to_dict": pa.array(expected_values, pa.large_string()),
+            "large_to_small": pa.array(expected_values, pa.large_string()),
             "large_to_large": pa.array(expected_values, pa.large_string()),
-            "large_to_dict": pa.compute.dictionary_encode(pa.array(expected_values, pa.large_string())),
-            "dict_to_small": pa.array(expected_values, pa.string()),
+            "large_to_dict": pa.array(expected_values, pa.large_string()),
+            "dict_to_small": pa.array(expected_values, pa.large_string()),
             "dict_to_large": pa.array(expected_values, pa.large_string()),
             "dict_to_dict": pa.compute.dictionary_encode(pa.array(expected_values, pa.large_string())),
         }
@@ -2168,11 +2170,12 @@ class TestStringFormatRoundtrip:
         received = lib.batch_read([sym])[sym].data if batch else lib.read(sym).data
         assert received.schema.field(0).type == pa.string()
         assert received.schema.field(1).type == pa.large_string()
-        assert received.schema.field(2).type == pa.dictionary(pa.int32(), pa.large_string())
-        assert received.schema.field(3).type == pa.string()
+        # Mismatched formats always resolve to large_string, regardless of which side is small/large/dict.
+        assert received.schema.field(2).type == pa.large_string()
+        assert received.schema.field(3).type == pa.large_string()
         assert received.schema.field(4).type == pa.large_string()
-        assert received.schema.field(5).type == pa.dictionary(pa.int32(), pa.large_string())
-        assert received.schema.field(6).type == pa.string()
+        assert received.schema.field(5).type == pa.large_string()
+        assert received.schema.field(6).type == pa.large_string()
         assert received.schema.field(7).type == pa.large_string()
         assert received.schema.field(8).type == pa.dictionary(pa.int32(), pa.large_string())
         assert received.schema.field(9).type == pa.string()
@@ -2289,11 +2292,12 @@ def test_symbol_concat_arrow_string_types(in_memory_version_store_arrow):
     received = lib.batch_read_and_join([sym_0, sym_1], QueryBuilder().concat()).data
     assert received.schema.field(0).type == pa.string()
     assert received.schema.field(1).type == pa.large_string()
-    assert received.schema.field(2).type == pa.dictionary(pa.int32(), pa.large_string())
-    assert received.schema.field(3).type == pa.string()
+    # Mismatched formats always resolve to large_string, regardless of which side is small/large/dict.
+    assert received.schema.field(2).type == pa.large_string()
+    assert received.schema.field(3).type == pa.large_string()
     assert received.schema.field(4).type == pa.large_string()
-    assert received.schema.field(5).type == pa.dictionary(pa.int32(), pa.large_string())
-    assert received.schema.field(6).type == pa.string()
+    assert received.schema.field(5).type == pa.large_string()
+    assert received.schema.field(6).type == pa.large_string()
     assert received.schema.field(7).type == pa.large_string()
     assert received.schema.field(8).type == pa.dictionary(pa.int32(), pa.large_string())
     assert received.schema.field(9).type == pa.string()

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -2248,10 +2248,6 @@ def test_roundtrip_string_types_batch(in_memory_version_store_arrow):
     assert received_1.schema.field(2).type == pa.dictionary(pa.int32(), pa.large_string())
 
 
-@pytest.mark.xfail(
-    reason="Monday 12841500984: Not worth making work on this branch as will need re-coding after #3326 is merged",
-    strict=True,
-)
 def test_symbol_concat_arrow_string_types(in_memory_version_store_arrow):
     lib = in_memory_version_store_arrow
     sym_0 = "test_symbol_concat_arrow_string_types_0"
@@ -2293,11 +2289,11 @@ def test_symbol_concat_arrow_string_types(in_memory_version_store_arrow):
     received = lib.batch_read_and_join([sym_0, sym_1], QueryBuilder().concat()).data
     assert received.schema.field(0).type == pa.string()
     assert received.schema.field(1).type == pa.large_string()
-    assert received.schema.field(2).type == pa.large_string()
-    assert received.schema.field(3).type == pa.large_string()
+    assert received.schema.field(2).type == pa.dictionary(pa.int32(), pa.large_string())
+    assert received.schema.field(3).type == pa.string()
     assert received.schema.field(4).type == pa.large_string()
-    assert received.schema.field(5).type == pa.large_string()
-    assert received.schema.field(6).type == pa.large_string()
+    assert received.schema.field(5).type == pa.dictionary(pa.int32(), pa.large_string())
+    assert received.schema.field(6).type == pa.string()
     assert received.schema.field(7).type == pa.large_string()
     assert received.schema.field(8).type == pa.dictionary(pa.int32(), pa.large_string())
     assert received.schema.field(9).type == pa.string()


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes monday ref [12841500984](https://man312219.monday.com/boards/7852509418/pulses/12841500984)

#### What does this implement or fix?
Allows combining arrow string format metadata.

Whenever combining two different string formats the result will be `large_string`.

Examples:
```
small_string, large_string -> large_string
large_string, categorical -> large_string
small_string, categorical -> large_string
```

#### Any other comments?

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [ ] Have you updated the relevant docstrings, documentation and copyright notice?
 - [ ] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
 - [ ] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
 - [ ] Are API changes highlighted in the PR description?
 - [ ] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes?
</details>

<!--
Thanks for contributing a Pull Request to ArcticDB! Please ensure you have taken a look at:
 - ArcticDB's Code of Conduct: https://github.com/man-group/ArcticDB/blob/master/CODE_OF_CONDUCT.md
 - ArcticDB's Contribution Licensing: https://github.com/man-group/ArcticDB/blob/master/docs/mkdocs/docs/technical/contributing.md#contribution-licensing
-->
