### PR TITLE
Guard ConfigsMap against concurrent access

### DIFF
--- a/cpp/arcticdb/util/configs_map.hpp
+++ b/cpp/arcticdb/util/configs_map.hpp
@@ -11,14 +11,44 @@
 #include <boost/algorithm/string.hpp>
 #include <arcticdb/entity/protobufs.hpp>
 
+#include <mutex>
+#include <shared_mutex>
 #include <unordered_map>
 #include <memory>
 #include <optional>
+#include <utility>
+#include <vector>
 
 namespace arcticdb {
 
 using namespace arcticdb::proto::config;
 
+/*
+ * A process-global singleton that is read from hot paths on many threads while
+ * other threads mutate it. VersionMap::has_cached_entry, for example, reads
+ * VersionMap.ReloadInterval on every version-map access, so any background
+ * thread touching a version map is a continuous reader; set_int/unset_int (via
+ * the set_config_int/unset_config_int bindings) are the writers.
+ *
+ * The maps must therefore be guarded. Unsynchronised, an insert that rehashes
+ * relinks every bucket and an erase frees a node, either of which leaves a
+ * concurrent find() walking a dangling pointer -- a segfault inside
+ * std::unordered_map::find, not an incorrect config value.
+ *
+ * A shared_mutex suits the access pattern: reads vastly outnumber writes. The
+ * uncontended shared lock measures at roughly +33ns on a ~195ns accessor
+ * (gcc 11, -O2, aarch64; 20M single-threaded get_int calls), i.e. about 17% of
+ * a call that is already dominated by the boost::to_upper_copy allocation and
+ * the hash lookup. That is immaterial next to the work has_cached_entry guards
+ * -- a version-map entry lookup, and a storage round trip whenever the cache
+ * misses -- so the cost is paid where it cannot be measured. Keys are
+ * upper-cased outside the critical section to keep the hold time short.
+ *
+ * If that overhead ever does matter, the alternative is copy-on-write behind an
+ * atomic<shared_ptr<const map>>: lock-free for readers, whole-map copy for the
+ * rare writer. It was not chosen here because it is materially harder to review
+ * for a path where the measured cost is already in the noise.
+ */
 class ConfigsMap {
   public:
     static void init();
@@ -29,26 +59,47 @@ class ConfigsMap {
 
 #define HANDLE_TYPE(LABEL, TYPE)                                                                                       \
     void set_##LABEL(const std::string& label, TYPE val) {                                                             \
-        map_of_##LABEL[boost::to_upper_copy<std::string>(label)] = val;                                                \
+        auto key = boost::to_upper_copy<std::string>(label);                                                           \
+        std::unique_lock lock(mutex_);                                                                                 \
+        map_of_##LABEL[std::move(key)] = std::move(val);                                                               \
     }                                                                                                                  \
                                                                                                                        \
     TYPE get_##LABEL(const std::string& label, TYPE default_val) const {                                               \
-        auto it = map_of_##LABEL.find(boost::to_upper_copy<std::string>(label));                                       \
+        const auto key = boost::to_upper_copy<std::string>(label);                                                     \
+        std::shared_lock lock(mutex_);                                                                                 \
+        auto it = map_of_##LABEL.find(key);                                                                            \
         return it == map_of_##LABEL.cend() ? default_val : it->second;                                                 \
     }                                                                                                                  \
                                                                                                                        \
     std::optional<TYPE> get_##LABEL(const std::string& label) const {                                                  \
-        auto it = map_of_##LABEL.find(boost::to_upper_copy<std::string>(label));                                       \
+        const auto key = boost::to_upper_copy<std::string>(label);                                                     \
+        std::shared_lock lock(mutex_);                                                                                 \
+        auto it = map_of_##LABEL.find(key);                                                                            \
         return it == map_of_##LABEL.cend() ? std::nullopt : std::make_optional(it->second);                            \
     }                                                                                                                  \
                                                                                                                        \
-    void unset_##LABEL(const std::string& label) { map_of_##LABEL.erase(boost::to_upper_copy<std::string>(label)); }   \
+    void unset_##LABEL(const std::string& label) {                                                                     \
+        const auto key = boost::to_upper_copy<std::string>(label);                                                     \
+        std::unique_lock lock(mutex_);                                                                                 \
+        map_of_##LABEL.erase(key);                                                                                     \
+    }                                                                                                                  \
                                                                                                                        \
-    const std::unordered_map<std::string, TYPE>& get_all_##LABEL() const { return map_of_##LABEL; }                    \
+    /* Returns a copy: handing out a reference would let the caller read the    */                                     \
+    /* map while another thread mutates it, reintroducing the race.             */                                     \
+    std::unordered_map<std::string, TYPE> get_all_##LABEL() const {                                                    \
+        std::shared_lock lock(mutex_);                                                                                 \
+        return map_of_##LABEL;                                                                                         \
+    }                                                                                                                  \
                                                                                                                        \
     void set_all_##LABEL(const std::unordered_map<std::string, TYPE>& entries) {                                       \
+        std::vector<std::pair<std::string, TYPE>> upper;                                                               \
+        upper.reserve(entries.size());                                                                                 \
         for (const auto& [k, v] : entries) {                                                                           \
-            map_of_##LABEL[boost::to_upper_copy<std::string>(k)] = v;                                                  \
+            upper.emplace_back(boost::to_upper_copy<std::string>(k), v);                                               \
+        }                                                                                                              \
+        std::unique_lock lock(mutex_);                                                                                 \
+        for (auto& [k, v] : upper) {                                                                                   \
+            map_of_##LABEL[std::move(k)] = std::move(v);                                                               \
         }                                                                                                              \
     }
 
@@ -59,6 +110,8 @@ class ConfigsMap {
 #undef HANDLE_TYPE
 
   private:
+    /* Guards all three maps. mutable so the const getters can take a shared lock. */
+    mutable std::shared_mutex mutex_;
     std::unordered_map<std::string, int64_t> map_of_int;
     std::unordered_map<std::string, std::string> map_of_string;
     std::unordered_map<std::string, double> map_of_double;


### PR DESCRIPTION
**Draft** — opened for review of the approach; see the caveats at the bottom before merging.

`ConfigsMap` is a process-global singleton whose three `unordered_map`s carry **no synchronisation**, while being read from hot paths on many threads. Concurrent `find()` against `operator[]` or `erase()` on the same `std::unordered_map` is undefined behaviour: an insert that rehashes relinks every bucket, an erase frees a node, and either leaves a reader walking a dangling pointer.

## How it was found

Intermittent `worker 'gwN' crashed` pytest failures in arcticdb-enterprise. Not flaky tests, and not OOM — a genuine segfault. The chain:

```
writer   main thread, set_config_int / unset_config_int
         (a test helper toggling VersionMap.ReloadInterval around each comparison)
reader   LibraryReplicator background threads
         -> VersionMap::check_reload -> has_cached_entry   (version_map.hpp:738)
         -> ConfigsMap::get_int("VersionMap.ReloadInterval")
```

`has_cached_entry` reads that key on **every version-map access**, so any background thread touching a version map is a continuous reader.

Worth noting for anyone who meets this in the wild: the Python traceback names the wrong code. The faulting thread is pure C++ with no Python frame, so `faulthandler` cannot show it and prints the main thread's incidental position instead.

## Reproduction

A standalone program compiled against this header — four reader threads calling `get_int` the way `has_cached_entry` does, one writer cycling `set_int`/`unset_int`:

| Header | Runs | Outcome |
|---|---|---|
| Unsynchronised | 5 | **5 × SIGSEGV** within 10s |
| With this change | 6 | 0 crashes, ~120M racing reads |

gdb on the unpatched build lands exactly where you would expect:

```
#9  arcticdb::ConfigsMap::get_int (label="VersionMap.ReloadInterval") at configs_map.hpp:56
#8  std::unordered_map::find
#5  _M_find_before_node  __k="VERSIONMAP.RELOADINTERVAL"
#2  std::operator==  __rhs=<error: Cannot access memory at address 0xc0aae92381cad1f3>
#0  memcmp ()  → SIGSEGV
```

The search key is intact; the key it is compared *against* is a freed node.

## Cost

A `shared_mutex` suits the pattern — reads vastly outnumber writes. Measured at **+33ns on a ~195ns accessor** (gcc 11, `-O2`, aarch64; 20M single-threaded `get_int` calls), about 17% of a call already dominated by the `boost::to_upper_copy` allocation and the hash lookup.

I want to be straight that 17% is not nothing. It is immaterial *here* because of what it guards — a version-map entry lookup, and a storage round trip whenever the cache misses — so it lands where it cannot be measured. Keys are upper-cased outside the critical section to keep hold times short.

If that overhead ever does matter, the alternative is copy-on-write behind an `atomic<shared_ptr<const map>>`: lock-free for readers, whole-map copy for the rare writer. Not chosen here because it is materially harder to review for a path where the measured cost is already in the noise. Happy to switch if you would rather.

## `get_all_*` now returns by value

Handing out a reference into a live map let the caller read it while another thread mutated it — the same race one level up. It has no C++ callers, and the pybind binding already copied into a dict, so this is not an API change in practice.

## Scope

Production generally sets config once at startup and then only reads, so real-world exposure is low — this mainly bites test helpers and any runtime-tuning or feature-flag path that mutates config while workers run. It is undefined behaviour either way, and all three maps are affected, not just `int`.

## Caveats for the reviewer

- **Not built or run in this repo's CI yet** — the reproduction and benchmark were built against this header out-of-tree on aarch64. The header is used widely, so a full build is the real check.
- **Benchmark is aarch64**; x86-64 figures will differ in magnitude, though the failure mode does not.
- I am not the owner of this code and may be missing intent behind the unsynchronised design — if there is a reason these maps were deliberately lock-free, say so and I will rework it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Rk2fNrpZUBf3pq6JYUjgU