### PR TITLE
Add an LMDBStorage.ExtraFlags knob and LMDB corruption diagnostics

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -794,7 +794,7 @@ jobs:
           # Skipping the fsync per commit makes the Windows unit jobs ~3x faster, but neither variant is safe
           # there: MDB_NOSYNC|MDB_NOMETASYNC gave sporadic MDB_MAP_RESIZED, and MDB_WRITEMAP|MDB_NOSYNC makes
           # Windows allocate the whole map_size per library, filling the disk and silently losing pages.
-          # Kept at 0 until that is understood; details in docs/claude/plans/gpetrov/ci_lmdb_nosync/.
+          # Kept at 0 until that is understood; details in docs/claude/plans/gpetrov/ci_lmdb_extra_flags/.
           ARCTICDB_LMDBStorage_ExtraFlags_int: '0'
 
       - name: Collect crash dumps (Windows)

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -790,11 +790,12 @@ jobs:
           ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: 0
           ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR: all
           ARCTICDB_PYTEST_INFER_STRING: ${{ matrix.infer_string_id == '-inferstr' && '1' || '0' }}
-          # MDB_WRITEMAP | MDB_NOSYNC (0x90000): write pages through the memory map and skip the fsync per
-          # LMDB commit, which dominates the small-write-heavy tests on NTFS. Test data is throwaway so
-          # durability is irrelevant. WRITEMAP rather than plain NOSYNC because Windows does not guarantee
-          # coherence between WriteFile and a mapped view, which showed up as sporadic MDB_MAP_RESIZED.
-          ARCTICDB_LMDBStorage_ExtraFlags_int: ${{ matrix.os == 'windows' && '589824' || '0' }}
+          # Extra flags for mdb_env_open (see LMDBStorage.ExtraFlags in docs/mkdocs/docs/runtime_config.md).
+          # Skipping the fsync per commit makes the Windows unit jobs ~3x faster, but neither variant is safe
+          # there: MDB_NOSYNC|MDB_NOMETASYNC gave sporadic MDB_MAP_RESIZED, and MDB_WRITEMAP|MDB_NOSYNC makes
+          # Windows allocate the whole map_size per library, filling the disk and silently losing pages.
+          # Kept at 0 until that is understood; details in docs/claude/plans/gpetrov/ci_lmdb_nosync/.
+          ARCTICDB_LMDBStorage_ExtraFlags_int: '0'
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -790,6 +790,11 @@ jobs:
           ARCTICDB_WARN_ON_WRITING_EMPTY_DATAFRAME: 0
           ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR: all
           ARCTICDB_PYTEST_INFER_STRING: ${{ matrix.infer_string_id == '-inferstr' && '1' || '0' }}
+          # MDB_WRITEMAP | MDB_NOSYNC (0x90000): write pages through the memory map and skip the fsync per
+          # LMDB commit, which dominates the small-write-heavy tests on NTFS. Test data is throwaway so
+          # durability is irrelevant. WRITEMAP rather than plain NOSYNC because Windows does not guarantee
+          # coherence between WriteFile and a mapped view, which showed up as sporadic MDB_MAP_RESIZED.
+          ARCTICDB_LMDBStorage_ExtraFlags_int: ${{ matrix.os == 'windows' && '589824' || '0' }}
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1126,6 +1126,7 @@ if(${TEST})
             processing/test/test_unsorted_aggregation.cpp
             processing/test/test_merge_update.cpp
             storage/test/test_lmdb_cve.cpp
+            storage/test/test_lmdb_flags.cpp
             processing/test/test_structure_by_time_slice.cpp
             storage/test/test_local_storages.cpp
             storage/test/test_memory_storage.cpp

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -10,7 +10,12 @@
 #include <arcticdb/storage/lmdb/lmdb_client_impl.hpp>
 #include <arcticdb/storage/mock/lmdb_mock_client.hpp>
 
+#include <cstring>
 #include <filesystem>
+#include <vector>
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/constants.hpp>
@@ -36,10 +41,20 @@ struct LmdbKeepalive {
         transaction_(std::move(transaction)) {}
 };
 
-static void raise_lmdb_exception(const ::lmdb::error& e, const std::string& object_name) {
+static void raise_lmdb_exception(const ::lmdb::error& e, const std::string& object_name, ::lmdb::env* env = nullptr) {
     auto error_code = e.code();
 
     auto error_message_suffix = fmt::format("LMDBError#{}: {} for object {}", error_code, e.what(), object_name);
+    if (env != nullptr && is_lmdb_corruption_error(error_code)) {
+        std::string diagnostics;
+        try {
+            diagnostics = lmdb_env_diagnostics(*env).to_string();
+        } catch (const std::exception& diag_ex) {
+            diagnostics = fmt::format("diagnostics unavailable: {}", diag_ex.what());
+        }
+        log::storage().error("LMDB corruption-type error {}: {}", error_message_suffix, diagnostics);
+        error_message_suffix += fmt::format(" | {}", diagnostics);
+    }
 
     if (error_code == MDB_NOTFOUND) {
         throw KeyNotFoundException(fmt::format("Key Not Found Error: {}", error_message_suffix));
@@ -90,7 +105,7 @@ void LmdbStorage::do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn) {
     } catch (const ::lmdb::key_exist_error& e) {
         throw DuplicateKeyException(fmt::format("Key already exists: {}: {}", key_seg.variant_key(), e.what()));
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex, k);
+        raise_lmdb_exception(ex, k, env_ptr());
     }
 }
 
@@ -160,7 +175,7 @@ KeySegmentPair LmdbStorage::do_read(VariantKey&& variant_key, ReadKeyOpts) {
         ARCTICDB_DEBUG(log::storage(), "Failed to find segment for key {}", variant_key_view(variant_key));
         throw KeyNotFoundException(variant_key);
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex, stored_key);
+        raise_lmdb_exception(ex, stored_key, env_ptr());
     }
     return KeySegmentPair{};
 }
@@ -196,7 +211,7 @@ void LmdbStorage::do_read(VariantKey&& key, const ReadVisitor& visitor, storage:
         ARCTICDB_DEBUG(log::storage(), "Failed to find segment for key {}", variant_key_view(key));
         failed_read.emplace(key);
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex, stored_key);
+        raise_lmdb_exception(ex, stored_key, env_ptr());
     }
 
     if (failed_read)
@@ -217,7 +232,7 @@ bool LmdbStorage::do_key_exists(const VariantKey& key) {
     } catch ([[maybe_unused]] const ::lmdb::not_found_error& ex) {
         ARCTICDB_DEBUG(log::storage(), "Caught lmdb not found error: {}", ex.what());
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex, stored_key);
+        raise_lmdb_exception(ex, stored_key, env_ptr());
     }
     return false;
 }
@@ -250,10 +265,10 @@ boost::container::small_vector<VariantKey, 1> LmdbStorage::do_remove_internal(
                     failed_deletes.emplace_back(key);
                 }
             } catch (const ::lmdb::error& ex) {
-                raise_lmdb_exception(ex, stored_key);
+                raise_lmdb_exception(ex, stored_key, env_ptr());
             }
         } catch (const ::lmdb::error& ex) {
-            raise_lmdb_exception(ex, db_name);
+            raise_lmdb_exception(ex, db_name, env_ptr());
         }
     }
     return failed_deletes;
@@ -303,7 +318,7 @@ bool LmdbStorage::do_fast_delete() {
         try {
             ::lmdb::dbi_drop(dtxn, dbi);
         } catch (const ::lmdb::error& ex) {
-            raise_lmdb_exception(ex, db_name);
+            raise_lmdb_exception(ex, db_name, env_ptr());
         }
     });
 
@@ -328,7 +343,7 @@ bool LmdbStorage::do_iterate_type_until_match(
             }
         }
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex, type_db);
+        raise_lmdb_exception(ex, type_db, env_ptr());
     }
     return false;
 }
@@ -405,6 +420,141 @@ T or_else(T val, T or_else_val, T def = T()) {
 }
 } // namespace
 
+bool is_lmdb_corruption_error(int error_code) {
+    switch (error_code) {
+    case MDB_PAGE_NOTFOUND:
+    case MDB_CORRUPTED:
+    case MDB_PANIC:
+    case MDB_INVALID:
+    case MDB_MAP_RESIZED:
+    case MDB_BAD_TXN:
+        return true;
+    default:
+        return false;
+    }
+}
+
+namespace {
+
+// Byte offsets within a meta page (64-bit build): 16-byte MDB_page header, then MDB_meta
+constexpr size_t META_MAGIC = 16;
+constexpr size_t META_VERSION = 20;
+constexpr size_t META_MAPSIZE = 32;
+constexpr size_t META_DBS =
+        40; // MDB_db[2], 48 bytes each: pad(4) flags(2) depth(2) branch(8) leaf(8) overflow(8) entries(8) root(8)
+constexpr size_t META_DB_SIZE = 48;
+constexpr size_t META_LAST_PG = META_DBS + 2 * META_DB_SIZE;
+constexpr size_t META_TXNID = META_LAST_PG + 8;
+constexpr size_t META_BYTES = META_TXNID + 8;
+
+template<typename T>
+T read_le(const std::vector<uint8_t>& buf, size_t offset) {
+    T out{};
+    std::memcpy(&out, buf.data() + offset, sizeof(T));
+    return out;
+}
+
+LmdbEnvDiagnostics::Meta parse_meta(const std::vector<uint8_t>& page) {
+    LmdbEnvDiagnostics::Meta meta;
+    if (page.size() < META_BYTES)
+        return meta;
+    meta.magic = read_le<uint32_t>(page, META_MAGIC);
+    meta.version = read_le<uint32_t>(page, META_VERSION);
+    meta.mapsize = read_le<uint64_t>(page, META_MAPSIZE);
+    meta.psize = read_le<uint32_t>(page, META_DBS);
+    meta.free_root = read_le<uint64_t>(page, META_DBS + META_DB_SIZE - 8);
+    meta.main_root = read_le<uint64_t>(page, META_DBS + 2 * META_DB_SIZE - 8);
+    meta.last_pg = read_le<uint64_t>(page, META_LAST_PG);
+    meta.txnid = read_le<uint64_t>(page, META_TXNID);
+    return meta;
+}
+
+// Reads the data file through the file handle, not the map
+std::vector<uint8_t> read_file_bytes(mdb_filehandle_t fd, size_t count) {
+    std::vector<uint8_t> buf(count);
+#ifdef _WIN32
+    OVERLAPPED ov{};
+    DWORD got = 0;
+    if (!ReadFile(fd, buf.data(), static_cast<DWORD>(count), &got, &ov)) {
+        throw std::runtime_error(fmt::format("ReadFile failed with error {}", GetLastError()));
+    }
+    buf.resize(got);
+#else
+    const auto got = ::pread(fd, buf.data(), count, 0);
+    if (got < 0) {
+        throw std::runtime_error(fmt::format("pread failed with errno {}", errno));
+    }
+    buf.resize(static_cast<size_t>(got));
+#endif
+    return buf;
+}
+
+} // namespace
+
+LmdbEnvDiagnostics lmdb_env_diagnostics(::lmdb::env& env) {
+    LmdbEnvDiagnostics out;
+    MDB_envinfo info{};
+    MDB_stat stat{};
+    ::lmdb::env_info(env.handle(), &info);
+    ::lmdb::env_stat(env.handle(), &stat);
+    ::lmdb::env_get_flags(env.handle(), &out.flags);
+    out.mapsize = info.me_mapsize;
+    out.last_pgno = info.me_last_pgno;
+    out.last_txnid = info.me_last_txnid;
+    out.max_readers = info.me_maxreaders;
+    out.num_readers = info.me_numreaders;
+    out.psize = stat.ms_psize;
+    try {
+        mdb_filehandle_t fd;
+        ::lmdb::env_get_fd(env.handle(), &fd);
+        const auto bytes = read_file_bytes(fd, 2 * static_cast<size_t>(stat.ms_psize));
+        for (size_t i = 0; i < 2; ++i) {
+            const auto begin = i * stat.ms_psize;
+            if (bytes.size() >= begin + META_BYTES) {
+                out.file_metas[i] =
+                        parse_meta(std::vector<uint8_t>(bytes.begin() + begin, bytes.begin() + begin + META_BYTES));
+            } else {
+                out.file_read_error = fmt::format("short read: {} bytes", bytes.size());
+            }
+        }
+    } catch (const std::exception& ex) {
+        out.file_read_error = ex.what();
+    }
+    return out;
+}
+
+std::string LmdbEnvDiagnostics::to_string() const {
+    auto meta_str = [](const Meta& m) {
+        return fmt::format(
+                "{{magic={:#x} version={} mapsize={} psize={} free_root={} main_root={} last_pg={} txnid={}}}",
+                m.magic,
+                m.version,
+                m.mapsize,
+                m.psize,
+                static_cast<int64_t>(m.free_root),
+                static_cast<int64_t>(m.main_root),
+                m.last_pg,
+                m.txnid
+        );
+    };
+    return fmt::format(
+            "lmdb env: flags={:#x} mapsize={} maxpg={} last_pgno={} last_txnid={} psize={} readers={}/{}; file "
+            "meta0={} "
+            "meta1={}{}",
+            flags,
+            mapsize,
+            psize ? mapsize / psize : 0,
+            last_pgno,
+            last_txnid,
+            psize,
+            num_readers,
+            max_readers,
+            meta_str(file_metas[0]),
+            meta_str(file_metas[1]),
+            file_read_error.empty() ? "" : fmt::format(" (file read error: {})", file_read_error)
+    );
+}
+
 unsigned int lmdb_extra_env_flags() {
     return static_cast<unsigned int>(ConfigsMap::instance()->get_int("LMDBStorage.ExtraFlags", 0));
 }
@@ -471,7 +621,7 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
             lmdb_instance_->dbi_by_key_type_.emplace(std::move(db_name), std::make_unique<::lmdb::dbi>(std::move(dbi)));
         });
     } catch (const ::lmdb::error& ex) {
-        raise_lmdb_exception(ex, "dbi creation");
+        raise_lmdb_exception(ex, "dbi creation", env_ptr());
     }
 
     txn.commit();

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -405,6 +405,10 @@ T or_else(T val, T or_else_val, T def = T()) {
 }
 } // namespace
 
+unsigned int lmdb_extra_env_flags() {
+    return static_cast<unsigned int>(ConfigsMap::instance()->get_int("LMDBStorage.ExtraFlags", 0));
+}
+
 LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const Config& conf) :
     Storage(library_path, mode) {
     if (conf.use_mock_storage_for_testing()) {
@@ -456,7 +460,7 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
     env().set_mapsize(mapsize);
     env().set_max_dbs(or_else(static_cast<unsigned int>(conf.max_dbs()), 1024U));
     env().set_max_readers(or_else(conf.max_readers(), 1024U));
-    env().open(lib_dir_.generic_string().c_str(), MDB_NOTLS);
+    env().open(lib_dir_.generic_string().c_str(), MDB_NOTLS | lmdb_extra_env_flags());
 
     auto txn = ::lmdb::txn::begin(env());
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -23,6 +23,12 @@ struct LmdbInstance {
     std::unordered_map<std::string, std::unique_ptr<::lmdb::dbi>> dbi_by_key_type_;
 };
 
+/// Extra flags passed to mdb_env_open for every LMDB env, from LMDBStorage.ExtraFlags in ConfigsMap
+/// (env var ARCTICDB_LMDBStorage_ExtraFlags_int). Lets a process opt into e.g. MDB_WRITEMAP | MDB_NOSYNC without
+/// changing library configs, e.g. to avoid an fsync per commit on CI where durability is irrelevant. Passed at open
+/// rather than mdb_env_set_flags because MDB_WRITEMAP can only be set at open.
+unsigned int lmdb_extra_env_flags();
+
 class LmdbStorage final : public Storage {
   public:
     using Config = arcticdb::proto::lmdb_storage::Config;

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -12,7 +12,10 @@
 #include <arcticdb/util/pb_util.hpp>
 #include <arcticdb/storage/lmdb/lmdb_client_interface.hpp>
 #include <arcticdb/storage/lmdb/lmdb.hpp>
+#include <array>
+#include <cstdint>
 #include <filesystem>
+#include <string>
 
 namespace fs = std::filesystem;
 
@@ -29,6 +32,38 @@ struct LmdbInstance {
 /// rather than mdb_env_set_flags because MDB_WRITEMAP can only be set at open.
 unsigned int lmdb_extra_env_flags();
 
+/// What LMDB believes about an env (mdb_env_info/stat) next to the two meta pages read straight from data.mdb with
+/// pread/ReadFile, bypassing the memory map. Attached to corruption-type errors so a failure in CI records whether
+/// the mapped view and the file disagree.
+struct LmdbEnvDiagnostics {
+    struct Meta {
+        uint32_t magic = 0;
+        uint32_t version = 0;
+        uint64_t mapsize = 0;
+        uint32_t psize = 0;
+        uint64_t free_root = 0;
+        uint64_t main_root = 0;
+        uint64_t last_pg = 0;
+        uint64_t txnid = 0;
+    };
+    unsigned int flags = 0;
+    size_t mapsize = 0;
+    size_t last_pgno = 0;
+    size_t last_txnid = 0;
+    unsigned int psize = 0;
+    unsigned int max_readers = 0;
+    unsigned int num_readers = 0;
+    std::array<Meta, 2> file_metas{};
+    std::string file_read_error;
+
+    std::string to_string() const;
+};
+
+/// True for LMDB error codes that indicate the env contents are not what LMDB expects
+bool is_lmdb_corruption_error(int error_code);
+
+LmdbEnvDiagnostics lmdb_env_diagnostics(::lmdb::env& env);
+
 class LmdbStorage final : public Storage {
   public:
     using Config = arcticdb::proto::lmdb_storage::Config;
@@ -40,7 +75,11 @@ class LmdbStorage final : public Storage {
 
     std::string name() const final;
 
+    LmdbEnvDiagnostics diagnostics() { return lmdb_env_diagnostics(env()); }
+
   private:
+    ::lmdb::env* env_ptr() { return lmdb_instance_ ? &lmdb_instance_->env_ : nullptr; }
+
     void do_write(KeySegmentPair& key_seg) final;
 
     void do_write_if_none(KeySegmentPair& kv [[maybe_unused]]) final {

--- a/cpp/arcticdb/storage/test/test_lmdb_flags.cpp
+++ b/cpp/arcticdb/storage/test/test_lmdb_flags.cpp
@@ -61,3 +61,58 @@ TEST(LmdbFlags, StorageOpensAndWritesWithExtraFlags) {
 }
 
 } // namespace
+
+namespace {
+
+TEST(LmdbDiagnostics, FileMetaPagesAgreeWithEnvInfo) {
+    const auto db_path = std::filesystem::temp_directory_path() / "arcticdb_test_lmdb_diagnostics";
+    std::filesystem::remove_all(db_path);
+    std::filesystem::create_directories(db_path);
+
+    LmdbStorage::Config cfg;
+    cfg.set_path(db_path.generic_string());
+    cfg.set_map_size(128ULL * (1ULL << 20));
+    cfg.set_recreate_if_exists(true);
+    as::LibraryPath library_path{"a", "b"};
+    {
+        LmdbStorage lmdb_storage(library_path, as::OpenMode::WRITE, cfg);
+        for (int i = 0; i < 3; ++i) {
+            ac::entity::AtomKey k =
+                    ac::entity::atom_key_builder().gen_id(i).build<ac::entity::KeyType::TABLE_DATA>(ac::NumericId{999});
+            auto segment_in_memory = ac::get_test_frame<ac::stream::TimeseriesIndex>("symbol", {}, 10, 0).segment_;
+            auto codec_opts = ac::proto::encoding::VariantCodec();
+            auto segment = ac::encode_dispatch(std::move(segment_in_memory), codec_opts, ac::EncodingVersion::V2);
+            as::KeySegmentPair kv(k, std::move(segment));
+            lmdb_storage.write(std::move(kv));
+        }
+
+        const auto d = lmdb_storage.diagnostics();
+        ASSERT_TRUE(d.file_read_error.empty()) << d.file_read_error;
+        ASSERT_EQ(d.psize, 4096U);
+        ASSERT_EQ(d.mapsize, 128ULL * (1ULL << 20));
+        for (const auto& m : d.file_metas) {
+            ASSERT_EQ(m.magic, 0xBEEFC0DEU);
+            ASSERT_EQ(m.psize, d.psize);
+            ASSERT_EQ(m.mapsize, d.mapsize);
+        }
+        // The newer of the two meta pages on disk is the one LMDB is using
+        const auto& newest = d.file_metas[0].txnid > d.file_metas[1].txnid ? d.file_metas[0] : d.file_metas[1];
+        ASSERT_EQ(newest.txnid, d.last_txnid);
+        ASSERT_EQ(newest.last_pg, d.last_pgno);
+        ASSERT_GT(d.last_txnid, 0U);
+
+        const auto text = d.to_string();
+        ASSERT_NE(text.find("last_txnid="), std::string::npos) << text;
+    }
+    std::filesystem::remove_all(db_path);
+}
+
+TEST(LmdbDiagnostics, CorruptionErrorCodes) {
+    ASSERT_TRUE(as::lmdb::is_lmdb_corruption_error(MDB_MAP_RESIZED));
+    ASSERT_TRUE(as::lmdb::is_lmdb_corruption_error(MDB_PAGE_NOTFOUND));
+    ASSERT_TRUE(as::lmdb::is_lmdb_corruption_error(MDB_BAD_TXN));
+    ASSERT_FALSE(as::lmdb::is_lmdb_corruption_error(MDB_NOTFOUND));
+    ASSERT_FALSE(as::lmdb::is_lmdb_corruption_error(MDB_MAP_FULL));
+}
+
+} // namespace

--- a/cpp/arcticdb/storage/test/test_lmdb_flags.cpp
+++ b/cpp/arcticdb/storage/test/test_lmdb_flags.cpp
@@ -1,0 +1,63 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/codec/codec.hpp>
+#include <arcticdb/entity/atom_key.hpp>
+#include <arcticdb/storage/lmdb/lmdb_storage.hpp>
+#include <arcticdb/stream/test/stream_test_common.hpp>
+#include <arcticdb/util/configs_map.hpp>
+
+#include <filesystem>
+
+namespace {
+
+namespace ac = arcticdb;
+namespace as = arcticdb::storage;
+using LmdbStorage = as::lmdb::LmdbStorage;
+
+// MDB_WRITEMAP can only be given to mdb_env_open, so it is the interesting case for this hook
+constexpr int64_t WRITEMAP_NOSYNC = MDB_WRITEMAP | MDB_NOSYNC;
+
+TEST(LmdbFlags, DefaultsToNoExtraFlags) { ASSERT_EQ(as::lmdb::lmdb_extra_env_flags(), 0U); }
+
+TEST(LmdbFlags, ExtraFlagsComeFromConfigsMap) {
+    ac::ScopedConfig extra("LMDBStorage.ExtraFlags", WRITEMAP_NOSYNC);
+    ASSERT_EQ(as::lmdb::lmdb_extra_env_flags(), static_cast<unsigned int>(WRITEMAP_NOSYNC));
+}
+
+TEST(LmdbFlags, StorageOpensAndWritesWithExtraFlags) {
+    ac::ScopedConfig extra("LMDBStorage.ExtraFlags", WRITEMAP_NOSYNC);
+    const auto db_path = std::filesystem::temp_directory_path() / "arcticdb_test_lmdb_flags";
+    std::filesystem::remove_all(db_path);
+    std::filesystem::create_directories(db_path);
+
+    LmdbStorage::Config cfg;
+    cfg.set_path(db_path.generic_string());
+    cfg.set_map_size(128ULL * (1ULL << 20));
+    cfg.set_recreate_if_exists(true);
+    as::LibraryPath library_path{"a", "b"};
+    {
+        // Scoped so the env is closed before remove_all: Windows refuses to delete open files
+        LmdbStorage lmdb_storage(library_path, as::OpenMode::WRITE, cfg);
+
+        ac::entity::AtomKey k =
+                ac::entity::atom_key_builder().gen_id(1).build<ac::entity::KeyType::TABLE_DATA>(ac::NumericId{999});
+        auto segment_in_memory = ac::get_test_frame<ac::stream::TimeseriesIndex>("symbol", {}, 10, 0).segment_;
+        auto codec_opts = ac::proto::encoding::VariantCodec();
+        auto segment = ac::encode_dispatch(std::move(segment_in_memory), codec_opts, ac::EncodingVersion::V2);
+        as::KeySegmentPair kv(k, std::move(segment));
+        lmdb_storage.write(std::move(kv));
+        ASSERT_TRUE(lmdb_storage.key_exists(k));
+    }
+
+    std::filesystem::remove_all(db_path);
+}
+
+} // namespace

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -160,6 +160,14 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
 | `cpp/arcticdb/storage/lmdb/lmdb_storage.cpp` | LMDB storage implementation |
 | `cpp/third_party/lmdbxx/` | LMDB C++ wrapper |
 
+### Runtime configuration
+
+- `LMDBStorage.ExtraFlags` (env `ARCTICDB_LMDBStorage_ExtraFlags_int`): extra `MDB_*` flags passed to `mdb_env_open`
+  for every LMDB env opened by the process (`lmdb_extra_env_flags()` in `lmdb_storage.cpp`). CI sets
+  `MDB_WRITEMAP | MDB_NOSYNC` (0x90000) on Windows test jobs to skip the fsync per commit. Plain `MDB_NOSYNC` gave
+  sporadic `MDB_MAP_RESIZED` on Windows (WriteFile vs mapped-view coherence is not guaranteed there). Default 0.
+- `LMDBStorage.WarnIfOpened`: see `warn_if_lmdb_already_open()`.
+
 ### Limitations
 
 - **Single process**: LMDB doesn't support multiple processes writing simultaneously

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -167,7 +167,7 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
   Skipping the fsync per commit makes the Windows CI unit jobs ~3x faster but is not enabled: `MDB_NOSYNC` gave
   sporadic `MDB_MAP_RESIZED` on Windows (cause unknown), and `MDB_WRITEMAP` makes Windows allocate the full
   `map_size` per library on disk, which filled the runner disk and silently lost pages. See
-  `docs/claude/plans/gpetrov/ci_lmdb_nosync/branch-work-log.md`.
+  `docs/claude/plans/gpetrov/ci_lmdb_extra_flags/branch-work-log.md`.
 - `LMDBStorage.WarnIfOpened`: see `warn_if_lmdb_already_open()`.
 
 ### Limitations

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -163,9 +163,11 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
 ### Runtime configuration
 
 - `LMDBStorage.ExtraFlags` (env `ARCTICDB_LMDBStorage_ExtraFlags_int`): extra `MDB_*` flags passed to `mdb_env_open`
-  for every LMDB env opened by the process (`lmdb_extra_env_flags()` in `lmdb_storage.cpp`). CI sets
-  `MDB_WRITEMAP | MDB_NOSYNC` (0x90000) on Windows test jobs to skip the fsync per commit. Plain `MDB_NOSYNC` gave
-  sporadic `MDB_MAP_RESIZED` on Windows (WriteFile vs mapped-view coherence is not guaranteed there). Default 0.
+  for every LMDB env opened by the process (`lmdb_extra_env_flags()` in `lmdb_storage.cpp`). Opt-in, default 0.
+  Skipping the fsync per commit makes the Windows CI unit jobs ~3x faster but is not enabled: `MDB_NOSYNC` gave
+  sporadic `MDB_MAP_RESIZED` on Windows (cause unknown), and `MDB_WRITEMAP` makes Windows allocate the full
+  `map_size` per library on disk, which filled the runner disk and silently lost pages. See
+  `docs/claude/plans/gpetrov/ci_lmdb_nosync/branch-work-log.md`.
 - `LMDBStorage.WarnIfOpened`: see `warn_if_lmdb_already_open()`.
 
 ### Limitations

--- a/docs/claude/plans/gpetrov/ci_lmdb_extra_flags/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_lmdb_extra_flags/branch-work-log.md
@@ -1,0 +1,28 @@
+# Branch work log: gpetrov/ci_lmdb_extra_flags
+
+First of a stack of CI-time PRs. Adds the LMDB knob and the diagnostics the investigation needed; the CI value
+stays 0 here and is turned on in `gpetrov/ci_win_console_sink`, which fixes what made it unsafe.
+
+## Why
+
+Windows `unit` jobs took 144-172 CPU-min against 36 on Linux, and every slow test was a small-write-heavy LMDB
+workload. The env was opened with only `MDB_NOTLS`, so every commit fsyncs, and `FlushFileBuffers` on NTFS costs
+about a millisecond.
+
+## What is here
+
+- `LMDBStorage.ExtraFlags` (`ConfigsMap`, env `ARCTICDB_LMDBStorage_ExtraFlags_int`), ORed into the flags passed
+  to `mdb_env_open`. Opt-in, default 0, so nothing changes unless it is set. gtests in
+  `cpp/arcticdb/storage/test/test_lmdb_flags.cpp`.
+- `LmdbEnvDiagnostics`: on `MDB_MAP_RESIZED`/`PAGE_NOTFOUND`/`CORRUPTED`/`BAD_TXN`/`PANIC`/`INVALID` the raised
+  message and the storage log carry `mdb_env_info`/`mdb_stat` plus both meta pages read straight from `data.mdb`
+  with pread/ReadFile, bypassing the map. That is what told apart "map and file disagree" from "both garbage",
+  and it is what found the root cause: ASCII log text sitting inside LMDB's meta pages.
+
+## Measurements
+
+- Windows `3.9 unit` with `327680` (`MDB_NOSYNC|MDB_NOMETASYNC`): 51 -> 17 min, per-test CPU sum 171 -> 34.5 min
+  against Linux's 36, `test_realistic` 684 -> 20 s against Linux's 25 s. All 20,174 tests passed.
+- `MDB_WRITEMAP` is not usable on Windows runners: a writable mapping makes Windows back the whole `map_size`
+  (2 GiB per library, and the fixture asks for 100 GB), which filled C: to 100% and lost pages silently.
+- Linux is indifferent to the flags: `test_realistic` is 28 s either way, since fsync on ext4 is cheap.

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -114,6 +114,17 @@ Values:
 * 0: Use WinHTTP
 * 1: Use WinINet
 
+### LMDBStorage.ExtraFlags
+
+Extra LMDB environment flags (a bitwise OR of `MDB_*` values from `lmdb.h`) passed to `mdb_env_open` for every LMDB
+library opened by the process, on top of the flags in the library's storage config.
+
+Intended for throwaway data such as test suites, where `MDB_WRITEMAP | MDB_NOSYNC` (`0x90000`, i.e. `589824`) writes
+through the memory map and skips the fsync on every commit. Do not use those flags for data you need to survive a
+crash or power loss.
+
+Default: 0 (no extra flags).
+
 ### VersionStore.NumCPUThreads and VersionStore.NumIOThreads
 
 ArcticDB uses two threadpools in order to manage computational resources:

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -119,9 +119,12 @@ Values:
 Extra LMDB environment flags (a bitwise OR of `MDB_*` values from `lmdb.h`) passed to `mdb_env_open` for every LMDB
 library opened by the process, on top of the flags in the library's storage config.
 
-Intended for throwaway data such as test suites, where `MDB_WRITEMAP | MDB_NOSYNC` (`0x90000`, i.e. `589824`) writes
-through the memory map and skips the fsync on every commit. Do not use those flags for data you need to survive a
-crash or power loss.
+Intended for throwaway data, e.g. `MDB_NOSYNC | MDB_NOMETASYNC` (`0x50000`, i.e. `327680`) skips the fsync on every
+commit. Do not use those flags for data you need to survive a crash or power loss.
+
+On Windows, `MDB_WRITEMAP` makes the OS allocate the whole `map_size` of every library on disk (LMDB otherwise extends
+the file lazily there), and with `MDB_NOSYNC` a full disk is not reported and pages are lost silently. Neither
+variant is currently used by ArcticDB's own CI on Windows.
 
 Default: 0 (no extra flags).
 


### PR DESCRIPTION
First of a stack that takes the `build.yml` run from ~100 min wall / ~4,900 job-min to **40 min / 1,686 job-min**, verified green end to end. This PR adds the LMDB knob and the diagnostics that found the root cause; the CI value stays **0** here, and is turned on in the next PR, which fixes what made it unsafe.

### Why

Windows `unit` jobs burned 144–172 CPU-min against 36 on Linux, and every slow test was a small-write-heavy LMDB workload. The env was opened with only `MDB_NOTLS`, so every commit fsyncs, and `FlushFileBuffers` on NTFS costs about a millisecond.

### What is here

- **`LMDBStorage.ExtraFlags`** (`ConfigsMap`, env `ARCTICDB_LMDBStorage_ExtraFlags_int`), ORed into the flags passed to `mdb_env_open`. Opt-in, **default 0**, so nothing changes for users or for CI in this PR.
- **`LmdbEnvDiagnostics`** — on `MDB_MAP_RESIZED`/`PAGE_NOTFOUND`/`CORRUPTED`/`BAD_TXN`/`PANIC`/`INVALID`, the raised message and the storage log now carry `mdb_env_info`/`mdb_stat` plus both meta pages read straight from `data.mdb` via pread/ReadFile, bypassing the map. This is what distinguishes "map and file disagree" from "both garbage", and it is what found the root cause behind the long-standing Windows flakes.

### Tests

`cpp/arcticdb/storage/test/test_lmdb_flags.cpp` — `LmdbFlags.*` and `LmdbDiagnostics.*`, passing locally on a debug build.

### Measured (with the flag set, which happens in the next PR)

`3.9 Windows / unit` 51 → 17 min; per-test CPU sum 171 → 34.5 min against Linux's 36; `test_realistic` 684 s → 20 s against Linux's 25 s; all 20,174 tests passed. Linux is indifferent — fsync on ext4 is cheap.

### Reviewer notes

- No behaviour change without the env var, and no API change.
- `MDB_WRITEMAP` is documented as **not** usable on Windows runners: a writable mapping makes Windows back the whole `map_size` (2 GiB per library, and one fixture asks for 100 GB), which filled `C:` to 100% and lost pages silently.
- `LmdbStorage::diagnostics()` is public so tooling can call it.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
