### PR TITLE
Windows: stop console log writes landing inside LMDB files (fixes long-standing CI flakes)

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -791,11 +791,10 @@ jobs:
           ARCTICDB_LMDBSTORAGE_WARNIFOPENED_STR: all
           ARCTICDB_PYTEST_INFER_STRING: ${{ matrix.infer_string_id == '-inferstr' && '1' || '0' }}
           # Extra flags for mdb_env_open (see LMDBStorage.ExtraFlags in docs/mkdocs/docs/runtime_config.md).
-          # Skipping the fsync per commit makes the Windows unit jobs ~3x faster, but neither variant is safe
-          # there: MDB_NOSYNC|MDB_NOMETASYNC gave sporadic MDB_MAP_RESIZED, and MDB_WRITEMAP|MDB_NOSYNC makes
-          # Windows allocate the whole map_size per library, filling the disk and silently losing pages.
-          # Kept at 0 until that is understood; details in docs/claude/plans/gpetrov/ci_lmdb_extra_flags/.
-          ARCTICDB_LMDBStorage_ExtraFlags_int: '0'
+          # MDB_NOSYNC | MDB_NOMETASYNC (0x50000): skip the fsync per LMDB commit; the Windows unit jobs are ~3x
+          # faster and durability is irrelevant on CI. Not MDB_WRITEMAP, which makes Windows allocate the whole
+          # map_size per library on disk. See docs/claude/plans/gpetrov/ci_win_console_sink/.
+          ARCTICDB_LMDBStorage_ExtraFlags_int: ${{ matrix.os == 'windows' && '327680' || '0' }}
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -499,6 +499,7 @@ set(arcticdb_srcs
         entity/type_utils.cpp
         entity/types_proto.cpp
         log/log.cpp
+        log/console_sink.cpp
         pipeline/column_mapping.cpp
         pipeline/column_name_resolution.cpp
         pipeline/column_stats.cpp

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -263,6 +263,7 @@ set(arcticdb_srcs
         entity/field_collection_proto.hpp
         entity/python_bindings_common.hpp
         log/log.hpp
+        log/console_sink.hpp
         log/trace.hpp
         pipeline/column_mapping.hpp
         pipeline/column_name_resolution.hpp

--- a/cpp/arcticdb/log/console_sink.cpp
+++ b/cpp/arcticdb/log/console_sink.cpp
@@ -1,0 +1,74 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <arcticdb/log/console_sink.hpp>
+
+#include <cstdio>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <io.h>
+#endif
+
+namespace arcticdb::log {
+
+#ifdef _WIN32
+namespace {
+
+using GetOsfHandleFn = intptr_t(__cdecl*)(int);
+
+// _get_osfhandle from the process-shared CRT, resolved once: GetModuleHandle/GetProcAddress take the loader lock,
+// which would serialise logging threads if done per line. nullptr when no shared CRT is loaded at that point (a
+// static-CRT executable such as the C++ test binary), where nothing else can dup2 our fds anyway and fwrite is
+// correct.
+GetOsfHandleFn shared_crt_get_osfhandle() {
+    static const GetOsfHandleFn fn = [] {
+        HMODULE ucrt = ::GetModuleHandleW(L"ucrtbase.dll");
+        return ucrt == nullptr ? nullptr : reinterpret_cast<GetOsfHandleFn>(::GetProcAddress(ucrt, "_get_osfhandle"));
+    }();
+    return fn;
+}
+
+bool write_via_shared_crt(int fd, const char* data, size_t size) {
+    auto get_osfhandle = shared_crt_get_osfhandle();
+    if (get_osfhandle == nullptr)
+        return false;
+    // Looked up per write: the fd's handle changes when something dup2s over it, which is the whole point
+    auto handle = reinterpret_cast<HANDLE>(get_osfhandle(fd));
+    if (handle == INVALID_HANDLE_VALUE || handle == nullptr)
+        return false;
+    while (size > 0) {
+        DWORD written = 0;
+        if (!::WriteFile(handle, data, static_cast<DWORD>(size), &written, nullptr) || written == 0)
+            return false;
+        data += written;
+        size -= written;
+    }
+    return true;
+}
+
+} // namespace
+#endif
+
+void write_to_console(FILE* file, const char* data, size_t size) {
+#ifdef _WIN32
+    std::fflush(file);
+    if (write_via_shared_crt(::_fileno(file), data, size))
+        return;
+#endif
+    std::fwrite(data, 1, size, file);
+    std::fflush(file);
+}
+
+} // namespace arcticdb::log

--- a/cpp/arcticdb/log/console_sink.hpp
+++ b/cpp/arcticdb/log/console_sink.hpp
@@ -17,10 +17,16 @@
 
 namespace arcticdb::log {
 
-/// Console sink that writes through the C stdio FILE* on every call. spdlog's stdout/stderr sinks cache the Win32
-/// HANDLE of fd 1/2 at construction and WriteFile to it; once something dup2()s over that fd (pytest capture) the
-/// cached handle is closed and its value is recycled by the next CreateFile (e.g. LMDB's data.mdb), so log lines end
-/// up written into that file. fwrite() resolves the handle from the fd on each write, so it follows redirections.
+/// Writes to the stdio stream so that output follows fd redirections (dup2) done after the sink was created.
+/// On Windows, if a process-shared CRT (ucrtbase.dll, the one Python uses) is loaded, the fd's current handle is
+/// looked up there on every write; arcticdb_ext links the CRT statically so its own fd table does not see redirections
+/// made through Python's CRT. Otherwise, or on other platforms, this is fwrite + fflush.
+void write_to_console(FILE* file, const char* data, size_t size);
+
+/// Console sink that goes through write_to_console(). spdlog's stdout/stderr sinks cache the Win32 HANDLE of fd 1/2
+/// at construction and WriteFile to it; once something dup2()s over that fd (pytest capture) the cached handle is
+/// closed and its value is recycled by the next CreateFile (e.g. LMDB's data.mdb), so log lines end up written into
+/// that file. The same happens to a static CRT's own fd table when another CRT in the process does the dup2.
 template<typename Mutex>
 class ConsoleSink final : public spdlog::sinks::base_sink<Mutex> {
   public:
@@ -30,8 +36,7 @@ class ConsoleSink final : public spdlog::sinks::base_sink<Mutex> {
     void sink_it_(const spdlog::details::log_msg& msg) override {
         spdlog::memory_buf_t formatted;
         this->formatter_->format(msg, formatted);
-        std::fwrite(formatted.data(), 1, formatted.size(), file_);
-        std::fflush(file_);
+        write_to_console(file_, formatted.data(), formatted.size());
     }
 
     void flush_() override { std::fflush(file_); }

--- a/cpp/arcticdb/log/console_sink.hpp
+++ b/cpp/arcticdb/log/console_sink.hpp
@@ -1,0 +1,49 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#pragma once
+
+#include <spdlog/sinks/base_sink.h>
+#include <spdlog/sinks/sink.h>
+
+#include <cstdio>
+#include <memory>
+#include <mutex>
+
+namespace arcticdb::log {
+
+/// Console sink that writes through the C stdio FILE* on every call. spdlog's stdout/stderr sinks cache the Win32
+/// HANDLE of fd 1/2 at construction and WriteFile to it; once something dup2()s over that fd (pytest capture) the
+/// cached handle is closed and its value is recycled by the next CreateFile (e.g. LMDB's data.mdb), so log lines end
+/// up written into that file. fwrite() resolves the handle from the fd on each write, so it follows redirections.
+template<typename Mutex>
+class ConsoleSink final : public spdlog::sinks::base_sink<Mutex> {
+  public:
+    explicit ConsoleSink(FILE* file) : file_(file) {}
+
+  protected:
+    void sink_it_(const spdlog::details::log_msg& msg) override {
+        spdlog::memory_buf_t formatted;
+        this->formatter_->format(msg, formatted);
+        std::fwrite(formatted.data(), 1, formatted.size(), file_);
+        std::fflush(file_);
+    }
+
+    void flush_() override { std::fflush(file_); }
+
+  private:
+    FILE* file_;
+};
+
+using ConsoleSinkMt = ConsoleSink<std::mutex>;
+
+/// Console sink for stdout/stderr. Colour output is only honoured off Windows, where spdlog's ANSI colour sink also
+/// writes via fwrite; the Windows colour sink has the same cached-HANDLE problem as the plain one.
+std::shared_ptr<spdlog::sinks::sink> make_console_sink(bool std_err, bool color);
+
+} // namespace arcticdb::log

--- a/cpp/arcticdb/log/log.cpp
+++ b/cpp/arcticdb/log/log.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <arcticdb/log/log.hpp>
+#include <arcticdb/log/console_sink.hpp>
 #include <arcticdb/util/preprocess.hpp>
 #include <arcticdb/util/pb_util.hpp>
 #include <spdlog/sinks/stdout_sinks.h>
@@ -32,11 +33,24 @@ std::shared_ptr<Loggers> loggers_instance_;
 std::once_flag loggers_init_flag_;
 } // namespace
 
+std::shared_ptr<spdlog::sinks::sink> make_console_sink(bool std_err, bool color) {
+#ifndef _WIN32
+    if (color) {
+        if (std_err)
+            return std::make_shared<spdlog::sinks::stderr_color_sink_mt>();
+        return std::make_shared<spdlog::sinks::stdout_color_sink_mt>();
+    }
+#else
+    (void)color;
+#endif
+    return std::make_shared<ConsoleSinkMt>(std_err ? stderr : stdout);
+}
+
 struct Loggers::Impl {
     std::mutex config_mutex_;
     std::unordered_map<std::string, spdlog::sink_ptr> sink_by_id_;
     std::unique_ptr<spdlog::logger> unconfigured_ =
-            std::make_unique<spdlog::logger>("arcticdb", std::make_shared<spdlog::sinks::stderr_sink_mt>());
+            std::make_unique<spdlog::logger>("arcticdb", make_console_sink(true, false));
     std::unique_ptr<spdlog::logger> root_;
     std::unique_ptr<spdlog::logger> storage_;
     std::unique_ptr<spdlog::logger> inmem_;
@@ -190,19 +204,9 @@ bool Loggers::configure(const arcticdb::proto::logger::LoggersConfig& conf, bool
     for (auto&& [sink_id, sink_conf] : conf.sink_by_id()) {
         switch (sink_conf.sink_case()) {
         case SinkConf::kConsole:
-            if (sink_conf.console().has_color()) {
-                if (sink_conf.console().std_err()) {
-                    impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stderr_color_sink_mt>());
-                } else {
-                    impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stdout_color_sink_mt>());
-                }
-            } else {
-                if (sink_conf.console().std_err()) {
-                    impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stderr_sink_mt>());
-                } else {
-                    impl_->sink_by_id_.try_emplace(sink_id, std::make_shared<spdlog::sinks::stdout_sink_mt>());
-                }
-            }
+            impl_->sink_by_id_.try_emplace(
+                    sink_id, make_console_sink(sink_conf.console().std_err(), sink_conf.console().has_color())
+            );
             break;
         case SinkConf::kFile:
             impl_->sink_by_id_.try_emplace(

--- a/cpp/arcticdb/log/test/test_log.cpp
+++ b/cpp/arcticdb/log/test/test_log.cpp
@@ -45,3 +45,58 @@ TEST(TestLog, TestFormatBytes) {
     auto s = arcticdb::format_bytes(12345678);
     ASSERT_EQ(s, "12.35MB");
 }
+
+#ifdef _WIN32
+#include <io.h>
+#define ARCTICDB_DUP _dup
+#define ARCTICDB_DUP2 _dup2
+#define ARCTICDB_CLOSE _close
+#else
+#include <unistd.h>
+#define ARCTICDB_DUP dup
+#define ARCTICDB_DUP2 dup2
+#define ARCTICDB_CLOSE close
+#endif
+
+#include <arcticdb/log/console_sink.hpp>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+// Regression test: a console sink created before fd 2 is redirected (as pytest's capture does) must write to the
+// redirected target, not to whatever the original stderr handle was. With spdlog's stderr_sink_mt on Windows the line
+// went to the cached HANDLE, whose value had by then been reused by another file.
+TEST(TestLog, ConsoleSinkFollowsStderrRedirection) {
+    auto sink = arcticdb::log::make_console_sink(true, false);
+    spdlog::logger logger("redirect_test", sink);
+    logger.set_pattern("%v");
+
+    const auto capture_path = std::filesystem::temp_directory_path() / "arcticdb_test_log_stderr_capture.txt";
+    std::filesystem::remove(capture_path);
+
+    int saved_stderr = ARCTICDB_DUP(2);
+    ASSERT_GE(saved_stderr, 0);
+    std::fflush(stderr);
+    {
+        FILE* capture = std::fopen(capture_path.string().c_str(), "w");
+        ASSERT_NE(capture, nullptr);
+#ifdef _WIN32
+        ASSERT_EQ(ARCTICDB_DUP2(_fileno(capture), 2), 0);
+#else
+        ASSERT_EQ(ARCTICDB_DUP2(fileno(capture), 2), 2);
+#endif
+        std::fclose(capture);
+    }
+    logger.warn("captured-line-42");
+    logger.flush();
+    std::fflush(stderr);
+    ARCTICDB_DUP2(saved_stderr, 2);
+    ARCTICDB_CLOSE(saved_stderr);
+
+    std::ifstream in(capture_path);
+    std::stringstream contents;
+    contents << in.rdbuf();
+    in.close();
+    std::filesystem::remove(capture_path);
+    ASSERT_NE(contents.str().find("captured-line-42"), std::string::npos) << "got: " << contents.str();
+}

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -166,7 +166,8 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
   for every LMDB env opened by the process (`lmdb_extra_env_flags()` in `lmdb_storage.cpp`). Opt-in, default 0.
   Skipping the fsync per commit makes the Windows CI unit jobs ~3x faster. `MDB_WRITEMAP` makes Windows allocate the
   full `map_size` per library on disk, so it is not usable on the CI runners. The `MDB_MAP_RESIZED`/`MDB_BAD_TXN`
-  flakes seen with `MDB_NOSYNC` (and rarely on master) were log lines being written into `data.mdb` on Windows; see
+  flakes seen with `MDB_NOSYNC` (and rarely on master) were log lines being written into `data.mdb` on Windows
+  (static CRT fd table vs pytest's `dup2` through Python's CRT); see
   `cpp/arcticdb/log/console_sink.hpp` and `docs/claude/plans/gpetrov/ci_win_console_sink/branch-work-log.md`.
 - `LMDBStorage.WarnIfOpened`: see `warn_if_lmdb_already_open()`.
 

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -164,7 +164,7 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
 
 - `LMDBStorage.ExtraFlags` (env `ARCTICDB_LMDBStorage_ExtraFlags_int`): extra `MDB_*` flags passed to `mdb_env_open`
   for every LMDB env opened by the process (`lmdb_extra_env_flags()` in `lmdb_storage.cpp`). Opt-in, default 0.
-  Skipping the fsync per commit makes the Windows CI unit jobs ~3x faster. `MDB_WRITEMAP` makes Windows allocate the
+  CI sets `MDB_NOSYNC | MDB_NOMETASYNC` on Windows test jobs (~3x faster unit jobs). `MDB_WRITEMAP` makes Windows allocate the
   full `map_size` per library on disk, so it is not usable on the CI runners. The `MDB_MAP_RESIZED`/`MDB_BAD_TXN`
   flakes seen with `MDB_NOSYNC` (and rarely on master) were log lines being written into `data.mdb` on Windows
   (static CRT fd table vs pytest's `dup2` through Python's CRT); see

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -164,10 +164,10 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
 
 - `LMDBStorage.ExtraFlags` (env `ARCTICDB_LMDBStorage_ExtraFlags_int`): extra `MDB_*` flags passed to `mdb_env_open`
   for every LMDB env opened by the process (`lmdb_extra_env_flags()` in `lmdb_storage.cpp`). Opt-in, default 0.
-  Skipping the fsync per commit makes the Windows CI unit jobs ~3x faster but is not enabled: `MDB_NOSYNC` gave
-  sporadic `MDB_MAP_RESIZED` on Windows (cause unknown), and `MDB_WRITEMAP` makes Windows allocate the full
-  `map_size` per library on disk, which filled the runner disk and silently lost pages. See
-  `docs/claude/plans/gpetrov/ci_lmdb_extra_flags/branch-work-log.md`.
+  Skipping the fsync per commit makes the Windows CI unit jobs ~3x faster. `MDB_WRITEMAP` makes Windows allocate the
+  full `map_size` per library on disk, so it is not usable on the CI runners. The `MDB_MAP_RESIZED`/`MDB_BAD_TXN`
+  flakes seen with `MDB_NOSYNC` (and rarely on master) were log lines being written into `data.mdb` on Windows; see
+  `cpp/arcticdb/log/console_sink.hpp` and `docs/claude/plans/gpetrov/ci_win_console_sink/branch-work-log.md`.
 - `LMDBStorage.WarnIfOpened`: see `warn_if_lmdb_already_open()`.
 
 ### Limitations

--- a/docs/claude/plans/gpetrov/ci_win_console_sink/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_win_console_sink/branch-work-log.md
@@ -1,0 +1,36 @@
+# Branch work log: gpetrov/ci_win_console_sink
+
+Stacked on `gpetrov/ci_lmdb_extra_flags`. Fixes a real Windows bug and, because of it, turns the LMDB knob on.
+
+## The bug
+
+spdlog's `stderr_sink_mt`, ArcticDB's default sink, caches `_get_osfhandle(_fileno(stderr))` when it is built and
+writes with `WriteFile(handle_, ...)`. pytest capture `dup2`s a temp file over fd 2, the CRT closes the original
+HANDLE, Windows recycles that handle value for the next `CreateFileW` - which in these tests is LMDB's `data.mdb` -
+and every later log line is written into the database at its current file offset, i.e. over the meta pages.
+
+Windows-only and, in practice, test-only. It explains the roughly 1-in-50 `MDB_CORRUPTED` / `MDB_PAGE_NOTFOUND`
+flakes seen on master for months, and why `MDB_NOSYNC` made them far more frequent: commits get ~20x faster, so
+more log lines land between syncs.
+
+## The fix, in two steps
+
+1. `ConsoleSink` writes through `fwrite(stderr)` + `fflush` instead of a cached handle. Not enough on its own:
+   with it, 20 of 56 Windows jobs still failed and the meta page still held `arcticdb | ... DB v7.0.0 release`.
+2. `arcticdb_ext` is built `/MT` (`x64-windows-static-msvc`), so it has its own CRT fd table. pytest's `os.dup2`
+   goes through Python's `ucrtbase.dll`: it closes the OS handle behind *that* fd 2, while our CRT's fd 2 still
+   names the recycled handle. `write_to_console()` therefore resolves the fd through the shared CRT's
+   `_get_osfhandle` when `ucrtbase.dll` is loaded, and falls back to fwrite when it is not (a static-CRT
+   executable, where nothing can dup2 our fds anyway). The lookup is cached in a function-local static, since
+   `GetModuleHandle`/`GetProcAddress` take the loader lock; the *handle* is still resolved per write, which is
+   the entire point.
+
+## Tests and result
+
+- `TestLog.ConsoleSinkFollowsStderrRedirection` dup2s a file over fd 2 after the sink exists and asserts the line
+  lands there.
+- `python/tests/unit/arcticdb/test_log_capture.py` asserts a C++ log line reaches pytest's `capfd`. Fails on
+  Windows before the fix, passes on Linux either way.
+- Run 33206552356: 0 of 54 Windows jobs with LMDB errors, against 20 of 56 before; the capfd test passed 108/108
+  on Windows. `ARCTICDB_LMDBStorage_ExtraFlags_int=327680` is enabled for Windows test jobs on the strength of
+  that, taking Windows `unit` from 40-107 min to 10-11.

--- a/python/tests/unit/arcticdb/test_log_capture.py
+++ b/python/tests/unit/arcticdb/test_log_capture.py
@@ -1,0 +1,20 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+from arcticdb_ext.log import log, LogLevel, LoggerId
+
+
+def test_cpp_log_lines_follow_fd_capture(capfd):
+    # pytest's capfd dup2()s a temp file over fd 2 through Python's CRT. On Windows arcticdb_ext has its own static
+    # CRT, so its fd 2 still pointed at the original stderr handle, which Python's CRT had closed and Windows had reused
+    # for the next opened file (LMDB's data.mdb) - log lines were written into the database. The log line must land
+    # in the capture.
+    marker = "arcticdb-log-capture-marker-7e1c"
+    log(LoggerId.ROOT, LogLevel.ERROR, marker)
+    err = capfd.readouterr().err
+    assert marker in err


### PR DESCRIPTION
Stacked on #3358. **Fixes a real Windows bug**, and on the strength of that turns the LMDB knob from the previous PR on for Windows test jobs.

### The bug

spdlog's `stderr_sink_mt` — ArcticDB's default sink — caches `_get_osfhandle(_fileno(stderr))` at construction on Windows and writes with `WriteFile(handle_, ...)`. pytest capture `dup2`s a temp file over fd 2, the CRT closes the original `HANDLE`, Windows recycles that handle value for the next `CreateFileW` — which in these tests is LMDB's `data.mdb` — and **every later log line is written into the database** at its current file offset, i.e. over the meta pages.

Windows-only and, in practice, test-only. It explains the ~1-in-50 `MDB_CORRUPTED` / `MDB_PAGE_NOTFOUND` flakes seen on master for months (`MDB_CORRUPTED` on run 30895908105, `MDB_BAD_TXN` on 30527747377 and 30466219731), and why `MDB_NOSYNC` made them far more frequent: commits get ~20× faster, so more log lines land between syncs.

The evidence is direct — the diagnostics added in the previous PR dumped ASCII log text (`arcticdb | ... V1 ... deprecated`) sitting inside LMDB's meta pages, both in memory and on disk.

### The fix, in two steps

1. `ConsoleSink` writes through `fwrite(stderr)` + `fflush` rather than a cached handle. **Not sufficient alone** — 20 of 56 Windows jobs still failed, and the meta page still held `arcticdb | ... DB v7.0.0 release`.
2. `arcticdb_ext` is built `/MT` (`x64-windows-static-msvc`), so it has its **own CRT fd table**. pytest's `os.dup2` goes through Python's `ucrtbase.dll`: it closes the OS handle behind *that* fd 2, while our CRT's fd 2 still names the recycled handle. So `write_to_console()` resolves the fd through the shared CRT's `_get_osfhandle` when `ucrtbase.dll` is loaded, falling back to `fwrite` when it is not (a static-CRT executable, where nothing can `dup2` our fds anyway).

The `GetModuleHandle`/`GetProcAddress` lookup is cached in a function-local static, since it takes the loader lock and would serialise logging threads. The **handle** is still resolved per write — that is the entire point of the fix.

### Tests

- `TestLog.ConsoleSinkFollowsStderrRedirection` — `dup2`s a file over fd 2 after the sink exists, asserts the line lands there.
- `python/tests/unit/arcticdb/test_log_capture.py` — asserts a C++ log line reaches pytest's `capfd`. Fails on Windows before the fix, passes on Linux either way.

### Result

Run 33206552356: **0 of 54** Windows jobs with LMDB errors, against 20 of 56 before; the capfd test passed 108/108 on Windows. With that established, `ARCTICDB_LMDBStorage_ExtraFlags_int=327680` (`MDB_NOSYNC|MDB_NOMETASYNC`) is enabled for Windows test jobs, taking Windows `unit` from 40–107 min to **10–11**.

### Reviewer notes

- Non-Windows behaviour is unchanged; the shared-CRT path is `#ifdef`ed to Windows.
- ANSI colour sinks stay off on Windows only, as before.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
