### PR TITLE
Cut three stalls out of the integration suite (IPv4 fixtures, mongo timeouts, Azure keep-alive)

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -795,6 +795,9 @@ jobs:
           # faster and durability is irrelevant on CI. Not MDB_WRITEMAP, which makes Windows allocate the whole
           # map_size per library on disk. See docs/claude/plans/gpetrov/ci_win_console_sink/.
           ARCTICDB_LMDBStorage_ExtraFlags_int: ${{ matrix.os == 'windows' && '327680' || '0' }}
+          # The Azure C++ SDK pools connections; reusing one azurite has already closed (node closes idle
+          # connections after 5s) blocks the next request for seconds, or ~2 minutes when several are in flight.
+          ARCTICDB_AzureStorage_HttpKeepAlive_int: '0'
 
       - name: Collect crash dumps (Windows)
         if: matrix.os == 'windows' && failure()

--- a/cpp/arcticdb/storage/azure/azure_client_impl.cpp
+++ b/cpp/arcticdb/storage/azure/azure_client_impl.cpp
@@ -49,6 +49,7 @@
 #include <azure/storage/blobs.hpp>
 
 #include <arcticdb/storage/azure/azure_client_impl.hpp>
+#include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/storage/azure/azure_client_interface.hpp>
 #include <arcticdb/storage/object_store_utils.hpp>
 #include <arcticdb/util/error_code.hpp>
@@ -111,6 +112,9 @@ Azure::Storage::Blobs::BlobClientOptions RealAzureClient::get_client_options(con
     // On Linux, use libcurl with CA cert configuration
     ARCTICDB_RUNTIME_DEBUG(log::storage(), "Using libcurl transport");
     Azure::Core::Http::CurlTransportOptions curl_transport_options;
+    // Reusing a pooled connection that the server has already closed makes the next request hang for ~2 minutes
+    // before it is retried. Azurite (node) closes idle connections after 5s, so tests hit this regularly.
+    curl_transport_options.HttpKeepAlive = ConfigsMap::instance()->get_int("AzureStorage.HttpKeepAlive", 1) != 0;
     if (!conf.ca_cert_path().empty()) {
         curl_transport_options.CAInfo = conf.ca_cert_path();
     }

--- a/docs/claude/cpp/STORAGE_BACKENDS.md
+++ b/docs/claude/cpp/STORAGE_BACKENDS.md
@@ -171,6 +171,15 @@ lib = ac.create_library("mylib", library_options=LibraryOptions(
   `cpp/arcticdb/log/console_sink.hpp` and `docs/claude/plans/gpetrov/ci_win_console_sink/branch-work-log.md`.
 - `LMDBStorage.WarnIfOpened`: see `warn_if_lmdb_already_open()`.
 
+### Azure runtime configuration
+
+- `AzureStorage.HttpKeepAlive` (env `ARCTICDB_AzureStorage_HttpKeepAlive_int`, default 1): passed to
+  `CurlTransportOptions::HttpKeepAlive` on Linux/macOS. The Azure C++ SDK (azure-core-cpp 1.12.0) pools connections
+  and reusing one the server has already closed blocks the request for seconds before it is retried — ~2 minutes when
+  several batch deletes are in flight. Azurite closes idle connections after 5s, so CI test jobs set this to 0. Real
+  Azure keeps connections alive much longer, so the default is unchanged. Regression test:
+  `test_keep_alive_disabled_avoids_stale_connection_stall`.
+
 ### Limitations
 
 - **Single process**: LMDB doesn't support multiple processes writing simultaneously

--- a/docs/claude/plans/gpetrov/ci_fixture_speedups/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_fixture_speedups/branch-work-log.md
@@ -1,0 +1,31 @@
+# Branch work log: gpetrov/ci_fixture_speedups
+
+Three unrelated stalls found while chasing the integration jobs, which were 45-47 min and the critical path once
+Windows was fixed.
+
+## localhost resolves to ::1 first
+
+On Windows the moto, GCP and azurite fixtures bind IPv4 only, so every connection through the name wastes about
+2 s failing over: 100 connects take 205 s via `localhost` and 0.5 s via `127.0.0.1`. The fixtures now use the
+literal and the test CA covers it.
+
+This needs the moto change in the same commit. moto keys one Flask app, and one set of buckets, per value
+returned by `get_backend_for_host`, so once the S3 and IAM endpoints stopped agreeing on a host string they got
+separate backends and every bucket created through one was invisible to the other (`NoSuchBucket`).
+
+## test_mongo_retryable_network_error, ~1,000 s in every run
+
+The test kills mongod and runs six operations, each waiting the default 120 s `SelectionTimeoutMs` per backoff
+attempt; teardown then spent 72 s sending `shutdown` to a server that was already dead. Scoped the timeouts to
+the test and skipped the shutdown when the process has exited. Not runnable locally (no mongod); verified on CI.
+
+## Six azurite tests, ~123 s or ~186 s each, but under 1 s alone
+
+Debug-level timing of the `Submitting/Submitted DeleteBlob batch` pairs showed 967 batch deletes in a run, 966
+instant and exactly one taking 122.4 s. It is not azurite: 60 concurrent batch deletes driven from Python peak at
+0.06 s. It is the Azure C++ SDK's curl pool reusing a connection azurite (node, 5 s `keepAliveTimeout`) has
+already closed. Deterministic repro: write, idle 6 s, write with prune - 5-6 s instead of 0.08 s.
+
+Added `AzureStorage.HttpKeepAlive` (default 1, so unchanged for users) wired to
+`CurlTransportOptions::HttpKeepAlive`. With it off the local xdist repro goes from "1 of 967 batches takes 122.4 s"
+to "1002 batches, slowest 0.0 s". CI test jobs set it to 0. Worth reporting upstream to azure-sdk-for-cpp.

--- a/docs/mkdocs/docs/runtime_config.md
+++ b/docs/mkdocs/docs/runtime_config.md
@@ -123,10 +123,20 @@ Intended for throwaway data, e.g. `MDB_NOSYNC | MDB_NOMETASYNC` (`0x50000`, i.e.
 commit. Do not use those flags for data you need to survive a crash or power loss.
 
 On Windows, `MDB_WRITEMAP` makes the OS allocate the whole `map_size` of every library on disk (LMDB otherwise extends
-the file lazily there), and with `MDB_NOSYNC` a full disk is not reported and pages are lost silently. Neither
-variant is currently used by ArcticDB's own CI on Windows.
+the file lazily there), and with `MDB_NOSYNC` a full disk is not reported and pages are lost silently, so avoid
+`MDB_WRITEMAP` there. ArcticDB's own CI uses `MDB_NOSYNC | MDB_NOMETASYNC` on its Windows test jobs.
 
 Default: 0 (no extra flags).
+
+### AzureStorage.HttpKeepAlive
+
+Whether the Azure client reuses pooled HTTP connections (`1`, the default) or opens a new connection per request
+(`0`). Only applies to the libcurl transport, i.e. Linux and macOS.
+
+The Azure SDK blocks for several seconds when it reuses a pooled connection the server has already closed, so set
+this to `0` against servers that close idle connections quickly — notably Azurite, which closes them after 5
+seconds. Leave it at the default against real Azure Blob Storage, where connection reuse avoids a TLS handshake per
+request.
 
 ### VersionStore.NumCPUThreads and VersionStore.NumIOThreads
 

--- a/python/arcticdb/storage_fixtures/azure.py
+++ b/python/arcticdb/storage_fixtures/azure.py
@@ -166,7 +166,9 @@ class AzureContainer(StorageFixture):
 
 
 class AzuriteStorageFixtureFactory(StorageFixtureFactory):
-    host = "localhost"
+    # An IPv4 literal, not "localhost": azurite binds IPv4 only and on Windows "localhost" resolves to ::1 first,
+    # so every connection wastes ~2s failing over.
+    host = "127.0.0.1"
 
     # Per https://learn.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string#configure-a-connection-string-for-azurite
     account_name = "devstoreaccount1"

--- a/python/arcticdb/storage_fixtures/mongo.py
+++ b/python/arcticdb/storage_fixtures/mongo.py
@@ -135,7 +135,8 @@ class ManagedMongoDBServer(StorageFixtureFactory):
         self._client = get_mongo_client(self.mongo_uri)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self._client:
+        # Skip the shutdown command if the test already killed the server: pymongo would wait for server selection
+        if self._client and self._p.poll() is None:
             with handle_cleanup_exception(self):
                 self._client["admin"].command({"shutdown": 1, "force": True, "timeoutSecs": 1})
 

--- a/python/arcticdb/storage_fixtures/mongo.py
+++ b/python/arcticdb/storage_fixtures/mongo.py
@@ -123,9 +123,10 @@ class ManagedMongoDBServer(StorageFixtureFactory):
 
     def _safe_enter(self):
         cmd = [self._executable, "--port", str(self._port), "--dbpath", self._data_dir]
-        self.mongo_uri = f"mongodb://localhost:{self._port}"
+        # IPv4 literal, not "localhost": on Windows the name resolves to ::1 first and mongod binds IPv4 only
+        self.mongo_uri = f"mongodb://127.0.0.1:{self._port}"
         self._p = GracefulProcessUtils.start_with_retry(
-            url=f"http://localhost:{self._port}",
+            url=f"http://127.0.0.1:{self._port}",
             service_name="mongod",
             num_retries=2,
             timeout=240,

--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -726,13 +726,15 @@ class HostDispatcherApplication(DomainDispatcherApplication):
         return match.group(1) if match else None
 
     def get_backend_for_host(self, host):
-        """The stand-alone server needs a way to distinguish between S3 and IAM. We use the host for that"""
+        """Maps a request's host to the moto app instance that serves it."""
         if host is None:
             return None
-        if "s3" in host or host == "localhost":
+        # Both the S3 and the IAM endpoint map here, so they share one moto app instance and therefore one set of
+        # data: /moto-api/reset is posted to the IAM endpoint and must reset the S3 backend. Fixtures address the
+        # server by IPv4 literal, never by name, because on Windows "localhost" resolves to ::1 first and the
+        # server binds IPv4 only, so every connection wastes ~2s failing over.
+        if "s3" in host or host in ("localhost", "127.0.0.1"):
             return "s3"
-        elif host == "127.0.0.1":
-            return "iam"
         elif host == "moto_api":
             return "moto_api"
         else:
@@ -926,7 +928,8 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
     default_key = Key(id="awd", secret="awd", user_name="dummy")
     _RO_POLICY: str
     _RW_POLICY: str
-    host = "localhost"
+    # An IPv4 literal, not "localhost": see get_backend_for_host
+    host = "127.0.0.1"
     region = "us-east-1"
     port: int
     endpoint: str
@@ -985,7 +988,7 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         port = self.port = get_ephemeral_port(seed)
         self.endpoint = f"{self.http_protocol}://{self.host}:{port}"
         self.working_dir = mkdtemp(suffix="MotoS3StorageFixtureFactory")
-        self._iam_endpoint = f"{self.http_protocol}://localhost:{port}"
+        self._iam_endpoint = f"{self.http_protocol}://{self.host}:{port}"
 
         self.ssl = (
             self.http_protocol == "https"
@@ -1138,7 +1141,7 @@ class MotoGcpS3StorageFixtureFactory(MotoS3StorageFixtureFactory):
         port = self.port = get_ephemeral_port(seed)
         self.endpoint = f"{self.http_protocol}://{self.host}:{port}"
         self.working_dir = mkdtemp(suffix="MotoGcpS3StorageFixtureFactory")
-        self._iam_endpoint = f"{self.http_protocol}://localhost:{port}"
+        self._iam_endpoint = f"{self.http_protocol}://{self.host}:{port}"
 
         self.ssl = (
             self.http_protocol == "https"

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -173,7 +173,8 @@ def get_ca_cert_for_testing(working_dir):
     cert_file = os.path.join(working_dir, "cert.pem")
     client_cert_file = os.path.join(working_dir, "client.pem")
     ca = trustme.CA()
-    server_cert = ca.issue_cert("localhost")
+    # 127.0.0.1 as well as the name: fixtures connect by IPv4 literal to avoid the ~2s ::1 fallback on Windows
+    server_cert = ca.issue_cert("localhost", "127.0.0.1")
     server_cert.private_key_pem.write_to_path(key_file)
     server_cert.cert_chain_pems[0].write_to_path(cert_file)
     ca.cert_pem.write_to_path(client_cert_file)

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -34,7 +34,13 @@ from arcticdb import QueryBuilder
 from arcticdb.storage_fixtures.api import StorageFixture, ArcticUriFields, StorageFixtureFactory
 from arcticdb.storage_fixtures.mongo import MongoDatabase
 from arcticdb.storage_fixtures.utils import GracefulProcessUtils
-from arcticdb.util.test import assert_frame_equal, sample_dataframe, config_context, config_context_string
+from arcticdb.util.test import (
+    assert_frame_equal,
+    sample_dataframe,
+    config_context,
+    config_context_multi,
+    config_context_string,
+)
 from arcticdb.storage_fixtures.s3 import S3Bucket
 from arcticdb.config import Defaults
 from arcticdb.version_store.library import (
@@ -1694,7 +1700,12 @@ def test_backing_store(lmdb_version_store_v1, s3_version_store_v1):
 @SLOW_TESTS_MARK
 @MONGO_TESTS_MARK
 def test_mongo_retryable_network_error(mongo_server_fn_scope, sym):
-    with config_context("VersionMap.MaxReadRefTrials", 0):
+    # The server is killed below, so every operation waits for server selection on each retry. The defaults
+    # (120s selection timeout, backoff up to 2s) make this test take ~15 minutes; the error path is the same
+    # with short timeouts. Both settings are read when the Arctic instance creates the mongo client.
+    with config_context_multi(
+        {"VersionMap.MaxReadRefTrials": 0, "MongoClient.SelectionTimeoutMs": 500, "MongoClient.RetryWaitMaxMs": 200}
+    ):
         ac = Arctic(mongo_server_fn_scope.mongo_uri)
         lib = ac.get_library("test", create_if_missing=True)
         lt = lib._nvs.library_tool()

--- a/python/tests/integration/arcticdb/test_azure_transport.py
+++ b/python/tests/integration/arcticdb/test_azure_transport.py
@@ -6,6 +6,7 @@
 
 import os
 import platform
+import time
 import pytest
 import ssl
 import uuid
@@ -14,7 +15,7 @@ import pandas as pd
 from arcticdb.storage_fixtures.azure import AzureContainer
 from arcticdb.arctic import Arctic
 from arcticc.pb2.azure_storage_pb2 import Config as AzureConfig
-from arcticdb.util.test import assert_frame_equal
+from arcticdb.util.test import assert_frame_equal, config_context
 from arcticdb.scripts.update_storage import run
 from tests.util.mark import AZURE_TESTS_MARK, SSL_TESTS_MARK, SSL_TEST_SUPPORTED
 from tests.scripts.test_update_storage import create_library_config
@@ -181,3 +182,25 @@ def test_azurite_ssl_verification(azurite_ssl_storage, monkeypatch, client_cert_
         lib.write("sym", pd.DataFrame())
     finally:
         ac.delete_library(lib_name)
+
+
+@AZURE_TESTS_MARK
+@pytest.mark.skipif(platform.system() == "Windows", reason="WinHTTP transport, no curl connection pool")
+def test_keep_alive_disabled_avoids_stale_connection_stall(azurite_storage: AzureContainer):
+    """AzureStorage.HttpKeepAlive=0 must reach the curl transport.
+
+    The Azure C++ SDK pools connections; reusing one the server has already closed makes the next request block for
+    seconds (minutes when several are in flight) before it is retried. Azurite closes idle connections after 5s, so
+    going idle and then writing reproduces it. With keep-alive off there is no pooled connection to go stale.
+    """
+    with config_context("AzureStorage.HttpKeepAlive", 0):
+        lib = Arctic(azurite_storage.arctic_uri).create_library("test_keep_alive")
+        df = pd.DataFrame({"column": [1, 2, 3, 4]}, index=pd.date_range("1/1/2018", periods=4))
+        lib.write("symbol", df)
+        time.sleep(6)  # longer than azurite's 5s keepAliveTimeout
+
+        start = time.time()
+        lib.write("symbol", df, prune_previous_versions=True)
+        elapsed = time.time() - start
+
+    assert elapsed < 2, f"write after an idle period took {elapsed:.1f}s, stale pooled connection was reused"


### PR DESCRIPTION
Stacked on #3359. Three unrelated stalls found while chasing the integration jobs, which were 45–47 min and the critical path once Windows was fixed. **16–18 min after this.**

### 1. `localhost` resolves to `::1` first

On Windows the moto, GCP and azurite fixtures bind IPv4 only, so every connection through the name wastes ~2 s failing over: **100 connects take 205 s via `localhost` and 0.5 s via `127.0.0.1`.** The fixtures now use the literal, and the test CA covers it.

The moto change has to be in the same commit: moto keys one Flask app, and one set of buckets, per value returned by `get_backend_for_host`. Once the S3 and IAM endpoints stopped agreeing on a host string they got separate backends, and every bucket created through one was invisible to the other (`NoSuchBucket`). Splitting these two would put a commit on master where the S3 tests 404.

### 2. `test_mongo_retryable_network_error`, ~1,000 s in every run

The test kills mongod and runs six operations, each waiting the default 120 s `SelectionTimeoutMs` per backoff attempt; teardown then spent 72 s sending `shutdown` to a server that was already dead. The timeouts are now scoped to the test, and the shutdown is skipped when the process has already exited.

Not runnable locally (no mongod); verified on CI.

### 3. Six azurite tests, ~123 s or ~186 s each — but under 1 s alone

Debug timing of the `Submitting/Submitted DeleteBlob batch` pairs showed 967 batch deletes in a run: 966 instant, **exactly one taking 122.4 s**.

It is not azurite — 60 concurrent batch deletes driven from Python peak at 0.06 s. It is the Azure C++ SDK's curl pool reusing a connection azurite (node, 5 s `keepAliveTimeout`) has already closed. Deterministic repro: write, idle 6 s, write with prune → 5–6 s instead of 0.08 s.

So this adds **`AzureStorage.HttpKeepAlive`** (default `1` — unchanged for users) wired to `CurlTransportOptions::HttpKeepAlive`. With it off, the local xdist repro goes from "1 of 967 batches takes 122.4 s" to "1002 batches, slowest 0.0 s". CI test jobs set it to 0.

Worth reporting upstream to azure-sdk-for-cpp.

### Reviewer notes

- The only production-code change is the new Azure config knob, and its default preserves today's behaviour.
- Everything else is test fixtures.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
