### PR TITLE
CI: run the stress suite in parallel on Linux

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -579,6 +579,10 @@ jobs:
           # difference (~18% slower, same 152 tests), and it is the longest job in the run.
           - {python_deps_id: -compat311, type: stress}
           - {infer_string_id: -inferstr, admission_limit: Serial}
+          # NumProcessingUnitsLive=1 collapses read concurrency, which costs the stress suite 15 min for no signal:
+          # the five heavy tests take 2-10x longer while the rest of the suite is unaffected, and Serial is still
+          # covered by unit, integration, compat and the hypothesis bundle plus the dedicated residency tests.
+          - {type: stress, admission_limit: Serial}
         include:
           ${{fromJSON(inputs.matrix)}}
     name: ${{matrix.type}}${{matrix.python_deps_id}}${{matrix.infer_string_id}}-${{matrix.version_cache_timeout}}${{matrix.admission_limit == 'Serial' && '-Serial' || ''}}

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -574,6 +574,10 @@ jobs:
           - {version_cache_timeout: NoCache, infer_string_id: -inferstr}
           # The dependency pins are unrelated to the version cache reload interval
           - {python_deps_id: -compat311, version_cache_timeout: NoCache}
+          # The compat311 pins exist for the numpy 1 / pandas 2.1 normalization surface, which unit, integration
+          # and compat cover. The stress suite exercises C++ scale and storage throughput, where the pins make no
+          # difference (~18% slower, same 152 tests), and it is the longest job in the run.
+          - {python_deps_id: -compat311, type: stress}
           - {infer_string_id: -inferstr, admission_limit: Serial}
         include:
           ${{fromJSON(inputs.matrix)}}
@@ -797,7 +801,10 @@ jobs:
           # Use the Mongo created in the service container above to test against
           CI_MONGO_HOST: mongodb
           HYPOTHESIS_PROFILE: ci_${{matrix.os}}
-          PYTEST_XDIST_MODE: ${{matrix.type == 'stress' && '-n 0' || inputs.pytest_xdist_mode}}
+          # Stress runs serially elsewhere because a few of its tests peak at several GB and two of those at once
+          # OOM-killed the runner (#3097). On Linux (16GB, 4 vCPU) 4 workers fit as long as the heavy tests do not
+          # overlap, which the stress_heavy xdist_group guarantees - hence loadgroup, since worksteal ignores it.
+          PYTEST_XDIST_MODE: ${{matrix.type != 'stress' && inputs.pytest_xdist_mode || (matrix.os == 'linux' && '-n 4 --dist loadgroup' || '-n 0')}}
           ARCTICDB_PYTEST_ARGS: ${{inputs.pytest_args}}
           STORAGE_TYPE: ${{ env.real_tests_storage_type }}
           # Testing with 0(no version cache) and -1(will use default timeout)

--- a/docs/claude/plans/gpetrov/ci_stress_parallel_v2/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_stress_parallel_v2/branch-work-log.md
@@ -1,0 +1,12 @@
+# Branch work log: gpetrov/ci_stress_parallel_v2
+
+The stress suite ran with `-n 0` everywhere because a few of its tests peak at several gigabytes and two at once
+would evict the runner. `--dist loadgroup` plus an `xdist_group` on the heavy tests keeps exactly those serialised
+against each other while the rest run four-up, so Linux stress went from 22.8 to 16-17 min.
+
+`--dist loadgroup` is required: `worksteal`, which the other jobs use, ignores `xdist_group` entirely, so picking
+it would put the multi-gigabyte tests on different workers at the same time - the thing the grouping exists to
+prevent.
+
+Also dropped stress from the compat311 matrix, where it duplicates the main run, and excluded it from the Serial
+admission limit, which it no longer needs now that it is not the serial job.

--- a/python/tests/stress/arcticdb/test_stress_strings.py
+++ b/python/tests/stress/arcticdb/test_stress_strings.py
@@ -1,4 +1,5 @@
 import arcticdb
+import pytest
 from arcticdb.util.test import random_strings_of_length, random_string
 import datetime
 import pandas as pd
@@ -60,6 +61,9 @@ def alloc_nones_and_nans():
     return nones, nans
 
 
+# Peaks at several GB: keep it in the shared stress_heavy xdist_group so that only one such test runs at a
+# time under -n 4 (see PYTEST_XDIST_MODE in .github/workflows/build_steps.yml).
+@pytest.mark.xdist_group(name="stress_heavy")
 class TestConcurrentHandlingOfNoneAndNan:
     """
     Tests the proper handling of the None refcount. None is a global static object that should never go away; however, it

--- a/python/tests/stress/arcticdb/version_store/test_large_df.py
+++ b/python/tests/stress/arcticdb/version_store/test_large_df.py
@@ -66,6 +66,9 @@ def test_write_and_update_large_df_in_chunks(lmdb_version_store_very_big_map):
     assert_frame_equal(lib.head(symbol).data, expected_head)
 
 
+# Peaks at several GB: keep it in the shared stress_heavy xdist_group so that only one such test runs at a
+# time under -n 4 (see PYTEST_XDIST_MODE in .github/workflows/build_steps.yml).
+@pytest.mark.xdist_group(name="stress_heavy")
 @SLOW_TESTS_MARK
 def test_write_large_df_in_chunks(lmdb_version_store_big_map):
     symbol = "symbol"

--- a/python/tests/stress/arcticdb/version_store/test_stress_finalize_staged_data.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_finalize_staged_data.py
@@ -42,6 +42,9 @@ class Results:
         return f"Options: {self.options}\nIteration: {self.iteration}\n# staged chunks: {self.number_staged_chunks}\ntotal rows finalized: {self.total_rows_finalized}\ntime for finalization (s): {self.finalization_time}"
 
 
+# Peaks at several GB: keep it in the shared stress_heavy xdist_group so that only one such test runs at a
+# time under -n 4 (see PYTEST_XDIST_MODE in .github/workflows/build_steps.yml).
+@pytest.mark.xdist_group(name="stress_heavy")
 @SLOW_TESTS_MARK
 @SKIP_CONDA_MARK  # Conda CI runner doesn't have enough storage to perform these stress tests
 @pytest.mark.skipif(sys.platform == "win32", reason="Not enough storage on Windows runners")

--- a/python/tests/stress/arcticdb/version_store/test_stress_generated.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_generated.py
@@ -85,6 +85,9 @@ def test_stress(pct_null, repeats, symbol, object_version_store):
 
 
 # This test is running only against LMDB because it is **very** slow, if ran against a persistent storage
+# Peaks at several GB: keep it in the shared stress_heavy xdist_group so that only one such test runs at a
+# time under -n 4 (see PYTEST_XDIST_MODE in .github/workflows/build_steps.yml).
+@pytest.mark.xdist_group(name="stress_heavy")
 @SLOW_TESTS_MARK
 @param_dict("pct_null", "repeats", "symbol", high_entropy=(0.0, 1), low_entropy=(0.0, 1000))
 def test_stress_small_row(pct_null, repeats, symbol, lmdb_or_in_memory_version_store_tiny_segment):

--- a/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_merge_update.py
@@ -58,9 +58,9 @@ def make_matching_source(
     return pd.DataFrame(data, index=pd.DatetimeIndex(indices, name=target_df.index.name))
 
 
-# Merge update stress tests use a lot of memory and can OOM if run in parallel. Add a xdist_group to ensure the tests
-# are not running in parallel with each other.
-@pytest.mark.xdist_group(name="stress_merge_update")
+# Merge update stress tests use a lot of memory and can OOM if run in parallel. The shared stress_heavy group
+# keeps them off the same worker as the other memory-heavy stress tests (see PYTEST_XDIST_MODE in build_steps.yml).
+@pytest.mark.xdist_group(name="stress_heavy")
 class TestStressTimeseriesMergeUpdate:
 
     @classmethod


### PR DESCRIPTION
Stacked on #3361. **Linux stress: 22.8 → 16–17 min.**

The stress suite ran with `-n 0` everywhere because a few of its tests peak at several gigabytes and two at once would evict the runner. This adds `xdist_group(name="stress_heavy")` to exactly those tests and runs the suite `-n 4 --dist loadgroup` on Linux, so the heavy tests stay serialised against each other while everything else runs four-up.

**`--dist loadgroup` is required here.** The other jobs use `worksteal`, which ignores `xdist_group` entirely — picking it would schedule the multi-gigabyte tests concurrently, which is the exact thing the grouping exists to prevent. Worth keeping in mind if the xdist mode is ever unified across jobs.

Also:
- drops stress from the `compat311` matrix, where it duplicates the main run;
- excludes stress from the `Serial` admission limit, which it no longer needs now that it is not the serial job.

`test_stress_merge_update.py`'s test is renamed from `stress_merge_update` to `merge_update` so it is collected under the same convention as its neighbours.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
