### PR TITLE
CI: run the stress suite on master and the nightly, not on pull requests

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -509,13 +509,18 @@ jobs:
         # There are so few nonreg and enduser tests, run them in the hypothesis runner: a job of its own costs
         # ~2.5 min of runner setup for ~6s of tests, and one less job per matrix entry means less runner contention.
         run: |
+          # The stress suite has caught nothing in 90 days: 1 failure in 2465 jobs across 176 master runs, and that
+          # one was "the runner has received a shutdown signal". It is the second most expensive type in the run, so
+          # pull requests skip it and master, the nightly and manual dispatches still run it in full.
+          drop_stress=''
+          if [ "${{github.event_name}}" = 'pull_request' ]; then drop_stress='s/"stress",// ; s/,"stress"//'; fi
           if [ ${{inputs.python3}} -gt 8 ]
           then
             find python/tests/* -maxdepth 0 -type d -not \( -name "__pycache__" -o -name "util" -o -name "nonreg" -o -name "scripts" -o -name "sanitizers" -o -name "enduser" \) -exec basename {} \; | tr '\n' ',' |
-              sed 's/^/test_dirs=["/ ; s/,$/"]/ ; s/,/","/g ; s/"hypothesis"/"{hypothesis,nonreg,scripts,sanitizers,enduser}"/' | tee -a $GITHUB_ENV
+              sed 's/^/test_dirs=["/ ; s/,$/"]/ ; s/,/","/g ; s/"hypothesis"/"{hypothesis,nonreg,scripts,sanitizers,enduser}"/' | sed "$drop_stress" | tee -a $GITHUB_ENV
           else
             find python/tests/* -maxdepth 0 -type d -not \( -name "__pycache__" -o -name "util" -o -name "nonreg" -o -name "scripts" -o -name "compat" -o -name "sanitizers" -o -name "enduser" \) -exec basename {} \; | tr '\n' ',' |
-              sed 's/^/test_dirs=["/ ; s/,$/"]/ ; s/,/","/g ; s/"hypothesis"/"{hypothesis,nonreg,scripts,sanitizers,enduser}"/' | tee -a $GITHUB_ENV
+              sed 's/^/test_dirs=["/ ; s/,$/"]/ ; s/,/","/g ; s/"hypothesis"/"{hypothesis,nonreg,scripts,sanitizers,enduser}"/' | sed "$drop_stress" | tee -a $GITHUB_ENV
           fi
 
       # ========================= Common =========================

--- a/docs/claude/plans/gpetrov/ci_stress_nightly_only/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_stress_nightly_only/branch-work-log.md
@@ -1,0 +1,19 @@
+# Branch work log: gpetrov/ci_stress_nightly_only
+
+Runs the stress suite on master pushes and the nightly, not on pull requests.
+
+This trades coverage for time, so here is the evidence. Over 90 days and 176 master runs of `build.yml`
+(`ci_job_failure_stats.py`, job-level conclusions from the Actions API):
+
+| job type | failed jobs |
+|---|---:|
+| unit | 63 |
+| compile | 47 |
+| integration | 46 |
+| **stress** (2,465 jobs) | **1** |
+
+The single stress failure was a runner shutdown, not a test. So the suite has not caught a regression on master
+in three months while costing a job slot on every pull request; master and the nightly keep it.
+
+The reviewer's call is whether "one failure in 2,465, and that one infrastructural" is enough to move a suite off
+the pull-request path. Everything else in the stack stands on its own if this one is rejected.


### PR DESCRIPTION
Stacked on #3362, and deliberately **last and alone** — it is the only change in the stack that reduces coverage, so it should live or die on its own evidence rather than ride in behind six performance PRs. Nothing else in the stack depends on it.

### The change

Run the stress suite on master pushes and the nightly, not on pull requests.

### The evidence

Over 90 days and 176 master runs of `build.yml`, job-level conclusions from the Actions API:

| job type | failed jobs |
|---|---:|
| unit | 63 |
| compile | 47 |
| integration | 46 |
| **stress** (2,465 jobs) | **1** |

And that single stress failure was a **runner shutdown**, not a test.

So the suite has not caught a regression on master in three months, while costing a job slot on every pull request. Master and the nightly still run it, so a regression is caught before a release — just not before a merge.

### The call for the reviewer

Whether "one failure in 2,465, and that one infrastructural" is enough to move a suite off the pull-request path. Reasonable people can say no; if so, drop this PR and the other seven still stand.

The numbers came from a reusable script (job-level failure rates by suite over an arbitrary window) which I kept local rather than adding to the repo — happy to contribute it if it would be useful to others.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
