### PR TITLE
Link arcticdb_ext against the core objects instead of the static archive

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -921,6 +921,19 @@ target_include_directories(arcticdb_core_static PUBLIC
 
 target_link_libraries(arcticdb_core_static PUBLIC ${arcticdb_core_libraries})
 
+# The objects of arcticdb_core_static without the archive step, carrying the same usage requirements. The generator
+# expressions are evaluated after the whole project is configured, so they also pick up what the top level
+# CMakeLists.txt adds to arcticdb_core_static.
+add_library(arcticdb_core_objects INTERFACE)
+target_sources(arcticdb_core_objects INTERFACE $<TARGET_OBJECTS:arcticdb_core_object>)
+target_include_directories(
+        arcticdb_core_objects INTERFACE $<TARGET_PROPERTY:arcticdb_core_static,INTERFACE_INCLUDE_DIRECTORIES>
+)
+target_compile_definitions(
+        arcticdb_core_objects INTERFACE $<TARGET_PROPERTY:arcticdb_core_static,INTERFACE_COMPILE_DEFINITIONS>
+)
+target_link_libraries(arcticdb_core_objects INTERFACE ${arcticdb_core_libraries})
+
 add_library(arcticdb_core SHARED $<TARGET_OBJECTS:arcticdb_core_object>)
 
 target_link_libraries(arcticdb_core PRIVATE
@@ -961,9 +974,15 @@ if(${ARCTICDB_USE_PCH})
     )
 endif()
 
+# arcticdb_core_objects rather than arcticdb_core_static: for the wheel build arcticdb_ext is the only consumer,
+# so archiving ~1GB of objects and reading them straight back is pure overhead. On Windows creating that archive
+# alone took 112-385s of every compile job, and arcticdb_ext pulls in nearly all of its members anyway (see the
+# ARCTICDB_THIN_ARCHIVES comment above, which does the same thing for GNU ar; lib.exe has no thin archives).
+# arcticdb_core_static is still built for the test binaries and for projects that consume this one as a
+# subdirectory.
 target_link_libraries(arcticdb_python
         PUBLIC
-        arcticdb_core_static
+        arcticdb_core_objects
         ${AWSSDK_LINK_LIBRARIES}
         )
 

--- a/docs/claude/plans/gpetrov/build_core_objects/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/build_core_objects/branch-work-log.md
@@ -1,0 +1,8 @@
+# Branch work log: gpetrov/build_core_objects
+
+Independent of the CI stack; branched straight off master.
+
+`arcticdb_ext` linked `arcticdb_core_static`, so the archive was built and then largely re-read at link time. It
+now consumes `$<TARGET_OBJECTS:arcticdb_core_object>` through an INTERFACE target that forwards the usage
+requirements off `arcticdb_core_static` with `$<TARGET_PROPERTY:...>`, which keeps include dirs, compile
+definitions and link libraries identical while skipping the archive step.


### PR DESCRIPTION
Independent of the CI stack — branched straight off master, touches nothing else.

`arcticdb_ext` linked `arcticdb_core_static`, so the archive was built and then largely re-read at link time. It now consumes `$<TARGET_OBJECTS:arcticdb_core_object>` through an INTERFACE target that forwards the usage requirements off `arcticdb_core_static` via `$<TARGET_PROPERTY:...>`, keeping include directories, compile definitions and link libraries identical while skipping the archive step.

20 lines of CMake. `arcticdb_core_static` itself is unchanged and still used by the C++ test binaries.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
