### PR TITLE
Fix the pytest-data publish job, and report the critical path in the run summary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -553,6 +553,22 @@ jobs:
       - run: echo Dummy job to simplify PR merge checks configuration
       # FUTURE: add some test stats/reporting
 
+  # Wall time is the longest chain of jobs, not the sum of the work, so this reports which chain it was. It runs
+  # even when the build failed, since a run that fails slowly is worth seeing too.
+  critical_path:
+    needs: [cpp-test-linux, cpp-test-windows, cpp-test-macos, build-python-wheels-linux, build-python-wheels-windows, build-python-wheels-macos]
+    if: always() && !cancelled()
+    runs-on: ubuntu-22.04
+    permissions: {actions: read}
+    steps:
+      # checkout v3 has no sparse-checkout inputs, and the repo is small enough that a full checkout is cheap
+      - uses: actions/checkout@v3.3.0
+      - name: Report what set the wall-clock time
+        env:
+          GH_TOKEN: ${{github.token}}
+        run: python3 build_tooling/ci_critical_path.py >> $GITHUB_STEP_SUMMARY
+        continue-on-error: true
+
   publish:
     needs: [common_config, can_merge]
     if: |

--- a/.github/workflows/publish_pytest_data.yml
+++ b/.github/workflows/publish_pytest_data.yml
@@ -26,22 +26,18 @@ jobs:
           # get the current date and time in UTC
           echo "GITHUB_RUN_STARTED_AT=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_ENV
 
-      - name: Gather pytest xmls from run ${{ github.run_id }}
-        id: gather-pytest-xmls
-        uses: actions/download-artifact@v8
-        with:
-            pattern: "*pytest-*"
-            run-id: ${{ github.run_id }}
-            github-token: ${{github.token}}  
-            path: ${{ env.ARTEFACT_PATH }}
-
       - name: Checkout
         uses: actions/checkout@v3.3.0
 
       - name: Install requirements
         run: |
           apt update
-          apt install -y git
+          apt install -y git curl
+          # gh, for the artifact downloads in process_pytest_artifacts.py
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list
+          apt update
+          apt install -y gh
           python3 -m pip install arcticdb[Testing] click "pandas<3" pytz
 
       - name: Setup softlink for SSL
@@ -58,7 +54,10 @@ jobs:
           aws_access_key: "${{ secrets.AWS_S3_ACCESS_KEY }}"
           aws_secret_key: "${{ secrets.AWS_S3_SECRET_KEY }}"
 
-      - name: Process pytest xmls
+      # The script fetches this run's artifacts itself, several at a time. actions/download-artifact walks them one
+      # at a time, which took ~20 min for the ~100 small artifacts a run produces - longer than the tests themselves.
+      - name: Gather and process pytest xmls from run ${{ github.run_id }}
+        env:
+          GH_TOKEN: ${{github.token}}
         run: |
-          ls -R ${{ env.ARTEFACT_PATH }}
-          python3 build_tooling/process_pytest_artifacts.py --download-dir ${{ env.ARTEFACT_PATH }} --use-github-actions
+          python3 build_tooling/process_pytest_artifacts.py --download-dir ${{ env.ARTEFACT_PATH }} --use-github-actions --max-workers 16

--- a/build_tooling/ci_critical_path.py
+++ b/build_tooling/ci_critical_path.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Summarise what set the wall-clock time of a CI run.
+
+Wall time is not the sum of the work: with runners to spare it is the longest *chain* of jobs. This prints, as
+GitHub-flavoured markdown, when the run became merge-ready, which jobs ended last, and a gantt of the tail, so the
+next thing worth optimising is obvious from the run page.
+
+    python3 build_tooling/ci_critical_path.py                      # the current run, in Actions
+    python3 build_tooling/ci_critical_path.py --run-id 33304573296 # any run, locally
+
+In a workflow, append it to the step summary:
+
+    python3 build_tooling/ci_critical_path.py >> $GITHUB_STEP_SUMMARY
+"""
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+
+GATE_JOBS = ("can_merge",)  # jobs that mark "the run has said what a developer needs to know"
+
+
+def gh_api(path):
+    out = subprocess.run(["gh", "api", path, "--paginate"], capture_output=True, text=True)
+    if out.returncode != 0:
+        print(f"could not read {path}: {out.stderr.strip()[:200]}", file=sys.stderr)
+        return []
+    decoder, text, results, idx = json.JSONDecoder(), out.stdout.strip(), [], 0
+    while idx < len(text):
+        obj, idx = decoder.raw_decode(text, idx)
+        results.append(obj)
+        while idx < len(text) and text[idx] in " \n\r\t":
+            idx += 1
+    return results
+
+
+def parse(ts):
+    return dt.datetime.fromisoformat(ts.replace("Z", "+00:00")) if ts else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "man-group/ArcticDB"))
+    ap.add_argument("--run-id", default=os.environ.get("GITHUB_RUN_ID"))
+    ap.add_argument("--top", type=int, default=10, help="how many jobs to show")
+    args = ap.parse_args()
+    if not args.run_id:
+        sys.exit("no run id: pass --run-id or set GITHUB_RUN_ID")
+
+    run = next(iter(gh_api(f"/repos/{args.repo}/actions/runs/{args.run_id}")), None)
+    if not run:
+        sys.exit("could not read the run")
+    started = parse(run.get("run_started_at") or run["created_at"])
+
+    jobs = []
+    for page in gh_api(f"/repos/{args.repo}/actions/runs/{args.run_id}/jobs?per_page=100"):
+        jobs.extend(page.get("jobs", []))
+    done = [
+        (
+            (parse(j["completed_at"]) - started).total_seconds() / 60,
+            (parse(j["started_at"]) - started).total_seconds() / 60,
+            j["name"].split(" (")[0],
+            j["conclusion"],
+        )
+        for j in jobs
+        if j.get("started_at") and j.get("completed_at") and j.get("conclusion") != "skipped"
+    ]
+    if not done:
+        sys.exit("no completed jobs yet")
+    done.sort(reverse=True)
+
+    end = done[0][0]
+    gate = [row for row in done if any(g in row[2] for g in GATE_JOBS)]
+    print("## Critical path\n")
+    if gate:
+        print(f"**Merge-ready after {gate[0][0]:.0f} min**, run ends at {end:.0f} min "
+              f"(the difference is post-processing nobody waits for).\n")
+    else:
+        print(f"**Run ends at {end:.0f} min.**\n")
+
+    print("| ends | starts | duration | job |")
+    print("|-----:|-------:|---------:|-----|")
+    for ends, starts, name, conclusion in done[: args.top]:
+        mark = "" if conclusion == "success" else f" ({conclusion})"
+        print(f"| {ends:.0f}m | {starts:.0f}m | **{ends - starts:.0f}m** | {name}{mark} |")
+
+    tail = [row for row in done[: args.top] if row[0] > end - 25]
+    if tail:
+        print("\n```mermaid\ngantt")
+        print("    title The last jobs to finish (minutes from run start)")
+        print("    dateFormat X\n    axisFormat %M")
+        for ends, starts, name, _ in reversed(tail):
+            label = "".join(" " if c in ":,{}#;" else c for c in name)[:44].strip()
+            print(f"    {label} :{int(starts * 60)}, {int(ends * 60)}")
+        print("```")
+
+    longest = done[0]
+    contenders = [row for row in done if row[2] != longest[2]]
+    if contenders:
+        print(f"\nWithout `{longest[2]}` the run would end at {contenders[0][0]:.0f} min "
+              f"({longest[0] - contenders[0][0]:.0f} min sooner), and `{contenders[0][2]}` would set it instead.")
+    print(f"\n{len(done)} jobs, {sum(row[0] - row[1] for row in done):.0f} job-minutes.")
+
+
+if __name__ == "__main__":
+    main()

--- a/build_tooling/process_pytest_artifacts.py
+++ b/build_tooling/process_pytest_artifacts.py
@@ -118,26 +118,34 @@ def create_run_from_github_actions():
             f"GITHUB_RUN_ID: {run_id}, GITHUB_REF_NAME: {branch}, GITHUB_SHA: {commit_hash}"
         )
 
+    repo = os.environ.get("GITHUB_REPOSITORY", "man-group/ArcticDB")
     run_dict = {
         "id": run_id,
         "head_branch": branch,
         "run_started_at": start_time,
         "head_commit": {"id": commit_hash},
+        "artifacts_url": f"/repos/{repo}/actions/runs/{run_id}/artifacts",
     }
 
     return Run(run_dict)
 
 
 def get_artifacts_for_run(artifact_download_url):
-    """Get artifacts for a specific workflow run"""
+    """Get every artifact of a workflow run.
+
+    Paginated: a run of the full matrix uploads more than the 100 artifacts one page holds, and the rest were
+    being dropped silently.
+    """
+    separator = "&" if "?" in artifact_download_url else "?"
     cmd = [
         "gh",
         "api",
+        "--paginate",
         "-H",
         "Accept: application/vnd.github+json",
         "-H",
         "X-GitHub-Api-Version: 2022-11-28",
-        f"{artifact_download_url}",
+        f"{artifact_download_url}{separator}per_page=100",
     ]
 
     try:
@@ -145,13 +153,17 @@ def get_artifacts_for_run(artifact_download_url):
     except subprocess.CalledProcessError as e:
         print(f"Error running command: {' '.join(cmd)}")
         print(f"Return code: {e.returncode}")
-        print(f"Error output: {e.stderr.decode('utf-8')}")
+        print(f"Error output: {e.stderr}")
         raise
 
-    data = json.loads(output.stdout)
-    artifacts = data.get("artifacts", [])
+    # --paginate concatenates one JSON object per page
+    decoder, text, artifacts, idx = json.JSONDecoder(), output.stdout.strip(), [], 0
+    while idx < len(text):
+        page, idx = decoder.raw_decode(text, idx)
+        artifacts.extend(page.get("artifacts", []))
+        while idx < len(text) and text[idx] in " \n\r\t":
+            idx += 1
 
-    # print(f"Found {len(artifacts)} artifacts for run {artifact_download_url}")
     return artifacts
 
 
@@ -456,7 +468,7 @@ def download_pytest_xmls_in_parallel(runs, download_dir, max_workers) -> List[st
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         future_to_run = {}
         for run in runs:
-            future = executor.submit(process_workflow_run, run, download_dir)
+            future = executor.submit(process_workflow_run, run, download_dir, 4)
             future_to_run[future] = run
 
         runs_to_remove = []
@@ -472,26 +484,36 @@ def download_pytest_xmls_in_parallel(runs, download_dir, max_workers) -> List[st
         return runs_to_remove
 
 
-def process_workflow_run(run: Run, download_dir: Path) -> Dict[str, Path]:
-    """Process a single workflow run - get artifacts and download them"""
+def process_workflow_run(
+    run: Run, download_dir: Path, artifact_workers: int = 8, check_status: bool = True
+) -> Dict[str, Path]:
+    """Process a single workflow run - get artifacts and download them.
 
-    if run.run_conclusion and run.run_conclusion.lower() == "cancelled":
-        # print(f"Skipping run {run.run_id} - cancelled")
-        return {run.run_id: None}
+    check_status is off when we are publishing the run we are part of: such a run is in progress by definition,
+    since this job is one of its jobs.
+    """
 
-    # Only process completed runs
-    if run.run_status and run.run_status.lower() != "completed":
-        # print(f"Skipping run {run.run_id} - not completed")
-        return {run.run_id: None}
+    if check_status:
+        if run.run_conclusion and run.run_conclusion.lower() == "cancelled":
+            # print(f"Skipping run {run.run_id} - cancelled")
+            return {run.run_id: None}
+
+        # Only process completed runs
+        if run.run_status and run.run_status.lower() != "completed":
+            # print(f"Skipping run {run.run_id} - not completed")
+            return {run.run_id: None}
 
     print(f"Processing run {run.run_id}: ({run.run_status}/{run.run_conclusion}) {run.timestamp}")
 
-    downloaded_zips = []
     artifacts = get_artifacts_for_run(run.artifacts_url)
-    for artifact in artifacts:
-        zip_path = download_artifact(run, artifact, download_dir)
-        if zip_path:
-            downloaded_zips.append(zip_path)
+    # A run has ~100 pytest artifacts of a few tens of KB each, so this is latency bound, not bandwidth bound:
+    # downloading them one at a time takes ~20 minutes against well under one in parallel.
+    with ThreadPoolExecutor(max_workers=artifact_workers) as executor:
+        downloaded_zips = [
+            zip_path
+            for zip_path in executor.map(lambda a: download_artifact(run, a, download_dir), artifacts)
+            if zip_path
+        ]
 
     downloaded_files = []
     for zip_path in downloaded_zips:
@@ -569,7 +591,7 @@ def save_csv_files_to_lib(run_ids, csv_files):
 
 
 @click.command()
-@click.option("--max-workers", type=int, default=5)
+@click.option("--max-workers", type=int, default=16)
 @click.option("--download-dir", type=str, default="gh_artifacts")
 @click.option(
     "--max-pages",
@@ -594,6 +616,15 @@ def main(max_workers, download_dir, max_pages, use_github_actions):
         except Exception as e:
             print(f"Error creating Run object from GitHub Actions environment: {e}")
             raise
+
+        if not any(download_dir.glob("**/*.xml")):
+            # Nothing has been downloaded for us, so fetch this run's artifacts ourselves. actions/download-artifact
+            # walks them one at a time, which costs ~20 minutes for ~100 small artifacts.
+            print(f"Downloading artifacts for run {run_obj.run_id} with {max_workers} workers...")
+            start_time = time.time()
+            download_dir.mkdir(parents=True, exist_ok=True)
+            process_workflow_run(run_obj, download_dir, max_workers, check_status=False)
+            print(f"Time taken: {time.time() - start_time:.2f} seconds")
     else:
         # Get workflow runs
         print("Fetching workflow runs...")

--- a/docs/claude/plans/gpetrov/ci_publish_and_critical_path/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_publish_and_critical_path/branch-work-log.md
@@ -1,0 +1,21 @@
+# Branch work log: gpetrov/ci_publish_and_critical_path
+
+Independent of the CI stack; branched straight off master. Tooling only - no test or production code.
+
+## The publish job was slow and silently lossy
+
+It took 21 minutes and processed 29 of 113 artifacts, so most test timings never reached the database - which
+defeats the point of keeping the history. Two bugs: the artifact list was fetched without pagination, so only the
+first page existed as far as the job was concerned, and the downloads were serial. Now paginated and pulled
+through a thread pool. A third bug appeared once it worked: the job publishes the run it is part of, and that run
+is not `completed` while it is still running, so the status check rejected it. 21 min -> 1 min, all 113
+artifacts, verified locally by simulating the Actions environment (92 XML files in 21.7 s).
+
+## Where the time actually goes
+
+Wall time is not the sum of the work - with runners to spare it is the longest chain of jobs - and that was not
+visible from the run page. `build_tooling/ci_critical_path.py` appends to `$GITHUB_STEP_SUMMARY`: when the run
+became merge-ready, the last jobs to finish, a gantt of the tail, and "without X the run would end at Y". It also
+runs standalone against any run id, which is how the numbers in this stack were measured.
+
+The job is `continue-on-error`, so a reporting failure can never fail a build.


### PR DESCRIPTION
Independent of the CI stack — branched straight off master. **Tooling only**, no test or production code.

### The publish job was slow *and* silently lossy

It took **21 minutes** and processed **29 of 113 artifacts**, so most test timings never reached the database — which defeats the point of keeping the history at all.

Two bugs: the artifact list was fetched without pagination, so only the first page existed as far as the job was concerned; and the downloads ran serially. Now paginated and pulled through a thread pool.

A third surfaced once the first two were fixed: the job publishes the run it is *part of*, and that run is not `completed` while it is still running, so the status check rejected it.

**21 min → 1 min, all 113 artifacts.** Verified locally by simulating the Actions environment (92 XML files in 21.7 s) and then on CI.

### Where the time actually goes

Wall time is not the sum of the work — with runners to spare it is the longest *chain* of jobs — and that was not visible from the run page. `build_tooling/ci_critical_path.py` appends to `$GITHUB_STEP_SUMMARY`: when the run became merge-ready, the last jobs to finish, a mermaid gantt of the tail, and "without X the run would end at Y".

It also runs standalone against any run id (`--run-id`), which is how the numbers throughout this stack were measured.

The job is `continue-on-error`, so a reporting failure can never fail a build.

---

**Stack** (each targets the one above; #3364 and #3365 are independent of it):

| | PR | |
|---|---|---|
| 1 | #3358 | LMDB `ExtraFlags` knob + corruption diagnostics |
| 2 | #3359 | Windows console-sink fix, enables the knob |
| 3 | #3360 | Integration-suite stalls (IPv4, mongo, Azure) |
| 4 | #3361 | Defender, hypothesis sharding, matrix trims |
| 5 | #3362 | Stress suite in parallel on Linux |
| 6 | #3363 | Stress off pull requests |
| — | #3364 | `arcticdb_ext` links core objects (off master) |
| — | #3365 | Publish job + critical-path summary (off master) |

Together, verified green end to end: **~100 min wall / ~4,900 job-min → 40 min / 1,686 job-min** (run 33316030365, 122 jobs, all passing).
