### PR TITLE
Stop archiving the core objects on the wheel path, and make compile time measurable

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -171,9 +171,23 @@ jobs:
         # When the MSVC version is update custom-triplets/x64-windows-static-msvc.cmake must also be updated with the correct toolsed version.
       - name: Install Required MSVC
         if: matrix.os == 'windows'
+        shell: pwsh  # the job default is bash; this step needs PowerShell for the toolset check
+        # ~2 min of every Windows compile job. The install is only needed while the image ships a toolset other
+        # than the pinned one, so check first - this becomes a no-op once the image and the pin agree.
         run: |
-          choco install -y -f visualstudio2022buildtools --version=117.11.4 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/390666095_1317821361/channel"
-          choco install -y ninja
+          $toolsets = "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
+          $have = (Test-Path $toolsets) -and @(Get-ChildItem $toolsets -Directory -ErrorAction SilentlyContinue |
+                  Where-Object { $_.Name -like '14.41*' }).Count -gt 0
+          if ($have) {
+            Write-Output "MSVC 14.41 build tools already present, skipping the install"
+          } else {
+            choco install -y -f visualstudio2022buildtools --version=117.11.4 --params "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --installChannelUri https://aka.ms/vs/17/release/390666095_1317821361/channel"
+          }
+          if (Get-Command ninja -ErrorAction SilentlyContinue) {
+            Write-Output "ninja already present, skipping the install"
+          } else {
+            choco install -y ninja
+          }
 
       - name: Enable Windows compiler commands
         if: matrix.os == 'windows'
@@ -542,7 +556,7 @@ jobs:
           # On Windows, exclusions like "!**/*.ext" are prefixed with a drive letter (D:\) of the current working dir
           # before matching. This breaks since we moved the build_dir to C:. Work around by templating exclusions:
           path: ${{matrix.build_dir}}/*-build
-            ${{env._exclusion}}${{inputs.job_type == 'build-python-wheels' && 'nofile' || matrix.symbols}}
+            ${{env._exclusion}}${{(inputs.job_type == 'build-python-wheels' && github.event_name != 'pull_request') && 'nofile' || matrix.symbols}}
             ${{env._exclusion}}${{join(matrix.do_not_archive, env._exclusion)}}
 
     outputs:

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -333,6 +333,13 @@ jobs:
           rm -f cpp/out/${ARCTIC_CMAKE_PRESET}-build/test_unit_arcticdb.json
           find cpp/out/${ARCTIC_CMAKE_PRESET}-build/arcticdb/CMakeFiles -name "*test_unit*.o" -delete 2>/dev/null || true
 
+      # Hit rate is the first thing to look at when a compile job is slow; without this it is only ever
+      # visible inside the manylinux wheel build (setup.py prints it there).
+      - name: Show sccache stats
+        if: inputs.job_type != 'build-python-wheels' && always()
+        run: sccache --show-stats
+        continue-on-error: true
+
       # We don't do anything with the benchmarks automatically yet, but check that they at least compile and run.
       - name: Compile C++ Benchmarks
         if: inputs.job_type == 'cpp-tests' && env.ARCTICDB_USE_SANITIZER == ''

--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -921,18 +921,23 @@ target_include_directories(arcticdb_core_static PUBLIC
 
 target_link_libraries(arcticdb_core_static PUBLIC ${arcticdb_core_libraries})
 
-# The objects of arcticdb_core_static without the archive step, carrying the same usage requirements. The generator
-# expressions are evaluated after the whole project is configured, so they also pick up what the top level
-# CMakeLists.txt adds to arcticdb_core_static.
-add_library(arcticdb_core_objects INTERFACE)
-target_sources(arcticdb_core_objects INTERFACE $<TARGET_OBJECTS:arcticdb_core_object>)
+# The usage requirements of arcticdb_core_static without its sources, for intermediate targets that must compile
+# against the core but must not carry a second copy of its objects. The generator expressions are evaluated after
+# the whole project is configured, so they also pick up what the top level CMakeLists.txt adds.
+add_library(arcticdb_core_usage INTERFACE)
 target_include_directories(
-        arcticdb_core_objects INTERFACE $<TARGET_PROPERTY:arcticdb_core_static,INTERFACE_INCLUDE_DIRECTORIES>
+        arcticdb_core_usage INTERFACE $<TARGET_PROPERTY:arcticdb_core_static,INTERFACE_INCLUDE_DIRECTORIES>
 )
 target_compile_definitions(
-        arcticdb_core_objects INTERFACE $<TARGET_PROPERTY:arcticdb_core_static,INTERFACE_COMPILE_DEFINITIONS>
+        arcticdb_core_usage INTERFACE $<TARGET_PROPERTY:arcticdb_core_static,INTERFACE_COMPILE_DEFINITIONS>
 )
-target_link_libraries(arcticdb_core_objects INTERFACE ${arcticdb_core_libraries})
+target_link_libraries(arcticdb_core_usage INTERFACE ${arcticdb_core_libraries})
+
+# The same, plus the objects themselves. INTERFACE sources propagate into the consumer, so link this from the
+# final binary only - linking it from a static library would archive the objects into that library instead.
+add_library(arcticdb_core_objects INTERFACE)
+target_link_libraries(arcticdb_core_objects INTERFACE arcticdb_core_usage)
+target_sources(arcticdb_core_objects INTERFACE $<TARGET_OBJECTS:arcticdb_core_object>)
 
 add_library(arcticdb_core SHARED $<TARGET_OBJECTS:arcticdb_core_object>)
 
@@ -961,7 +966,9 @@ set(arcticdb_python_headers
     python/adapt_read_dataframe.hpp
 )
 set_pdb_name_per_translation_unit(${arcticdb_python_srcs})
-add_library(arcticdb_python STATIC ${arcticdb_python_srcs} ${arcticdb_python_headers})
+# OBJECT, not STATIC: arcticdb_ext is its only consumer, so archiving its objects (plus the core objects it
+# links) only to read them straight back cost 260s of every Windows compile job. See arcticdb_core_objects.
+add_library(arcticdb_python OBJECT ${arcticdb_python_srcs} ${arcticdb_python_headers})
 if(${ARCTICDB_USE_PCH})
     message(STATUS "Using precompiled headers for target arcticdb_python")
     target_precompile_headers(
@@ -982,7 +989,7 @@ endif()
 # subdirectory.
 target_link_libraries(arcticdb_python
         PUBLIC
-        arcticdb_core_objects
+        arcticdb_core_usage
         ${AWSSDK_LINK_LIBRARIES}
         )
 
@@ -1035,7 +1042,8 @@ endif()
 
 target_link_libraries(arcticdb_ext
         PRIVATE
-        arcticdb_python)
+        arcticdb_python
+        arcticdb_core_objects)
 
 if (WIN32)
     target_link_options(arcticdb_ext

--- a/docs/claude/plans/gpetrov/ci_build_speedups/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_build_speedups/branch-work-log.md
@@ -1,0 +1,87 @@
+# Branch work log: gpetrov/ci_build_speedups
+
+Sits on top of the whole CI stack (`ci_stress_nightly_only` + `build_core_objects` + `ci_publish_and_critical_path`).
+Where that stack attacked test jobs, this attacks compile, which now gates everything: every test job starts within
+0.0 min of its own compile finishing, so there is no runner queueing left to hide behind.
+
+## The framing that matters: warm is not cold
+
+Reference run 33316030365 is a **100% sccache-hit run** (`Compile requests 197 / Cache hits 197`), so its 250
+compile job-min contain almost no compilation. Run 33179259321, with genuinely new C++, missed independently in all
+six Linux jobs (27.9-38.1% hit) and each `Build wheel` took 34-39 min instead of 4-5. Different problem, different
+fixes. What follows targets the warm run, which is what sets today's 40 min wall.
+
+Warm budget inside the slowest compile job (Windows wheel 3.12, 860 s): vcpkg restore 262 s, cmake configure 276 s,
+**ninja compile 113 s**, **link 378 s**. Compiling ArcticDB is 13% of it; linking is 44%.
+
+## What is here
+
+- **sccache stats on every platform.** `setup.py` only printed them when `AUDITWHEEL_PLAT` was set, i.e. only
+  inside the manylinux container, so Windows - the critical path - was entirely unmeasured. Plus a step after the
+  C++ compiles. This is first because it is what makes everything else measurable.
+- **Nothing archived on the wheel path.** See below.
+- **Windows fixed costs**: skip the ~2 min build-tools install when the image already has the pinned 14.41 toolset,
+  and stop shipping 868 MB of per-TU PDBs on pull requests (kept on master and the nightly).
+
+## The archive bug this fixes
+
+`45ba80f7d` ("Link arcticdb_ext against the core objects") was supposed to remove a ~1 GB archive step from the
+wheel path. It did not. `arcticdb_python` is a STATIC library, and INTERFACE sources propagate into the consumer,
+so `target_link_libraries(arcticdb_python PUBLIC arcticdb_core_objects)` archived all 157 core objects into
+`arcticdb_python.lib` instead - measured at **260 s** of the 378 s link in the reference run, against ~23 s for the
+same step on Linux, which has thin archives (`ARCTICDB_THIN_ARCHIVES=ON`; `lib.exe` has no equivalent).
+
+Fixed by splitting the INTERFACE target in two:
+
+- `arcticdb_core_usage` - include dirs, compile definitions and link libraries, **no sources**. For intermediate
+  targets that must compile against the core without carrying a copy of it.
+- `arcticdb_core_objects` - the above plus `$<TARGET_OBJECTS:arcticdb_core_object>`. Link from the final binary
+  only; linking it from a static library is exactly what caused the bug.
+
+and making `arcticdb_python` an OBJECT library. Verified locally on the generated link line: **167 object files,
+167 distinct, no arcticdb archive**, 157 from the core and 8 from the bindings.
+
+### Measured on CI (run 33331318539, dispatch on this branch, against baseline 33316030365)
+
+`arcticdb_python.lib` no longer appears in the Windows ninja output at all; the only static archives left are
+third-party (`lmdb.lib`, `arcticdb_proto.lib`, 0-1 s each).
+
+| Windows 3.12 | before | after |
+|---|---:|---:|
+| `arcticdb_python.lib` archive | 260s | gone |
+| `arcticdb_ext.pyd` link | 118s | 59s |
+| ninja phase | 491s | 203s |
+| `Build wheel` step | 860s | 460s |
+
+Across all six Windows compile jobs: **16.0 -> 12.2 min mean**, i.e. ~3.8 min per job and ~23 job-min, and 3.8 min
+off the front of every Windows test chain. Linux and macOS are unchanged within noise, as expected - Linux already
+had thin archives.
+
+The risk worth recording: handing `arcticdb_ext.pyd` 165 loose objects instead of one library was expected to make
+*its* link slower and possibly eat the saving. It did the opposite, 118 s -> 59 s; the linker had been re-reading
+members out of the archive.
+
+Windows sccache stats, visible for the first time thanks to the change above: `Compile requests 192 / Cache hits
+183 / Cache misses 0 / hit rate 100.00 %`. So Windows is as warm as Linux and the Linux-only picture held.
+
+The MSVC toolset check behaved as predicted: it logged the check, found no 14.41, and installed (108 s). No saving
+today - it is correctness for when the image and the pin agree, nothing more.
+
+## Deliberately not here
+
+- **Release-only vcpkg triplets** (~2 min wall, ~25 job-min; Windows restores 3.6 GB of debug dependency libs it
+  never opens). `VCPKG_BUILD_TYPE` is part of the ABI hash, so a new triplet name invalidates the whole NuGet
+  binary cache and the first run rebuilds all ~135 packages from source. Worth doing, but it would swamp the
+  measurements here, so it goes in its own run.
+- **macOS `-j1`** (`RAM/5000` in `cpp/CMake/CpuCount.cmake` single-threads a 3-core runner) and Linux `-j3`->`-j4`.
+  Job-minutes only - macOS is not on the critical path - and both need a peak-RSS measurement first.
+- **Build-once-per-OS for the core.** Real (113 of 157 core TUs transitively include pybind11 or `Python.h`,
+  through ~7 shallow leak points such as `column.hpp:30` and `native_tensor.hpp:20`) but a job-minutes play, not a
+  wall play: the six compile jobs all start in the same second and miss independently, so deduplication only helps
+  the next run. Capturing it within one run needs a build-once job feeding six link-only jobs, which serialises,
+  and at zero queueing that trades wall for cost.
+- **Precompiled headers.** Measured, same flags and machine: ~3 s/TU, ~6% overall - loading the 487 MB `.gch` eats
+  most of the parse saving. And `cpp/CMake/pdb_generation.cmake:35` makes PCH a `FATAL_ERROR` alongside per-TU
+  PDBs, so Windows cannot have both it and sccache.
+- **Unity builds / splitting a monster TU.** All 165 core+bindings TUs timed; the worst is ~60 s
+  (`version_core.cpp`) and the tail is flat, not spiky. Nothing to target.

--- a/setup.py
+++ b/setup.py
@@ -302,7 +302,7 @@ class CMakeBuild(build_ext):
             _log_and_run(cmake, "--build", candidates[0], *jobs, "--target", "install_" + ext.name)
         finally:
             launcher = os.getenv("CMAKE_CXX_COMPILER_LAUNCHER", "")
-            if "sccache" in launcher and "AUDITWHEEL_PLAT" in os.environ:
+            if "sccache" in launcher:
                 subprocess.run([launcher, "--show-stats"])
 
         assert os.path.exists(dest), f"No output at {dest}, but we didn't get a bad return code from CMake?"


### PR DESCRIPTION
Stacked on #3364, which it corrects. Attacks **compile**, which now gates everything: with the test-job work in #3358–#3363 done, every test job starts within 0.0 min of its own compile finishing, so there is no queueing left to hide behind.

### First, the framing that changes how to read any compile timing

Run 33316030365 is a **100% sccache-hit run** (`Compile requests 197 / Cache hits 197`), so its 250 compile job-min contain almost no compilation. Inside its slowest compile job (Windows wheel 3.12, 860s):

| phase | time | share |
|---|---:|---:|
| vcpkg restore | 262s | 30% |
| cmake configure | 276s | 32% |
| ninja compile | 113s | 13% |
| **link** | **378s** | **44%** |

Compiling ArcticDB is 13% of a warm compile job. **Linking is 44%**, and that is what this PR removes.

### The bug in #3364

That PR was meant to stop a ~1 GB archive being built and read straight back. It didn't. `arcticdb_python` is a STATIC library, and **INTERFACE sources propagate into the consumer**, so `target_link_libraries(arcticdb_python PUBLIC arcticdb_core_objects)` archived all 157 core objects into `arcticdb_python.lib` instead — measured at 260s of that 378s link. The cost moved; it did not go away. (Linux barely noticed: `ARCTICDB_THIN_ARCHIVES=ON` makes the same step ~23s. `lib.exe` has no thin archives.)

Fixed by splitting the INTERFACE target in two:

- **`arcticdb_core_usage`** — include dirs, compile definitions, link libraries. **No sources.** For intermediate targets that must compile against the core without carrying a copy of it.
- **`arcticdb_core_objects`** — the above, plus `$<TARGET_OBJECTS:arcticdb_core_object>`. Link from the final binary only; linking it from a static library is precisely what caused the bug.

and making `arcticdb_python` an OBJECT library. `arcticdb_ext` links both object sets directly. `arcticdb_core_static` is untouched and still built for the C++ test binaries.

### Measured (run 33331318539 on this branch, against baseline 33316030365)

`arcticdb_python.lib` no longer appears in the Windows ninja output at all — the only archives left are third-party.

| Windows 3.12 | before | after |
|---|---:|---:|
| `arcticdb_python.lib` archive | 260s | **gone** |
| `arcticdb_ext.pyd` link | 118s | **59s** |
| ninja phase | 491s | **203s** |
| `Build wheel` | 860s | **460s** |

**All six Windows compile jobs: 16.0 → 12.2 min mean** — ~3.8 min each, ~23 job-min, and 3.8 min off the front of every Windows test chain. Linux and macOS unchanged within noise.

Worth recording because it cut the other way from the prediction: handing `arcticdb_ext.pyd` 165 loose objects instead of one library was expected to slow *its* link and possibly eat the saving. It halved it instead, 118s → 59s — the linker had been re-reading members out of the archive.

Verified locally before dispatch: the generated link line is 167 object files, **167 distinct**, no arcticdb archive; the extension builds and `from arcticdb import Arctic` works.

### Also here

- **sccache stats on every platform.** `setup.py` only printed them when `AUDITWHEEL_PLAT` was set, i.e. only inside the manylinux container — so Windows, the critical path, was completely unmeasured, and so were all three C++ test compiles. First result: Windows is `192 requests / 183 hits / 0 misses / 100.00%`, confirming the Linux-only picture held. This is cheap and it is what makes every other compile change measurable.
- **Skip the MSVC build-tools install when the image already has the pinned 14.41 toolset.** ~2 min of every Windows compile job. Honest expectation: this saves nothing today, because the pin exists precisely because the image ships something else — it logged the check, found no 14.41, and installed. It is correctness for when the two agree, not a win.
- **Drop the per-TU PDBs on pull requests.** Wheel jobs deliberately keep symbols and the scheme produces 868 MB of them; `Archive build metadata` is ~1.1 min on the critical path. Kept on master and the nightly, where the symbols are worth having. Not exercised by the dispatch run above, which is not a pull request — it will be exercised by this PR's own run.

### Investigated and rejected (evidence in the branch work log)

- **Precompiled headers** — measured, same flags and machine: ~3s/TU, ~6% overall; loading the 487 MB `.gch` eats most of the parse saving. And `cpp/CMake/pdb_generation.cmake:35` makes PCH a `FATAL_ERROR` alongside per-TU PDBs, so Windows cannot have both it and sccache.
- **A long-pole TU / unity build** — all 165 core+bindings TUs timed; worst is ~60s (`version_core.cpp`) and the tail is flat, not spiky.
- **vcpkg building from source** — not happening; zero `Building <port>` lines, all six logs report `Restored 135–137 package(s)` from NuGet. The cost is restore *volume*, addressed separately.
- **Build-once-per-OS for the core** — real (113 of 157 core TUs transitively include pybind11 or `Python.h`, through ~7 shallow leak points such as `column.hpp:30` and `native_tensor.hpp:20`) but a job-minutes play, not a wall play: the six compile jobs start in the same second and miss independently, so deduplication only helps the *next* run. Capturing it within one run needs a build-once job feeding six link-only jobs, which serialises — and at zero queueing that trades wall for cost.

### Note on the verification run

33331318539 is a `workflow_dispatch`, so it takes the master path (stress included, benchmarks at the full 20× count). Its 43 min wall is **not** comparable to the 40 min PR-path figure; the per-step compile timings above are. One test failed, `3.11 Linux / unit-inferstr-DefaultCache` on a dedup-size assertion (`1070 <= 905`) — unrelated to linking, since the same objects are linked either way, but I have not proven it is a pre-existing flake.
