### PR TITLE
Build the release presets against release-only vcpkg triplets

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -154,11 +154,11 @@
         "VCPKG_TARGET_TRIPLET": "arm64-osx-15"
       }
     },
-    { "name": "windows-cl-release",       "inherits": "windows-cl-debug",       "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" }},
+    { "name": "windows-cl-release",       "inherits": "windows-cl-debug",       "cacheVariables": { "CMAKE_BUILD_TYPE": "Release", "VCPKG_TARGET_TRIPLET": "x64-windows-static-msvc-release" }},
     { "name": "windows-cl-conda-release", "inherits": "windows-cl-conda-debug", "cacheVariables": { "CMAKE_BUILD_TYPE": "Release" } },
-    { "name": "linux-release",            "inherits": "linux-debug",            "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } },
+    { "name": "linux-release",            "inherits": "linux-debug",            "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo", "VCPKG_OVERLAY_TRIPLETS": "custom-triplets", "VCPKG_TARGET_TRIPLET": "x64-linux-release" } },
     { "name": "linux-conda-release",      "inherits": "linux-conda-debug",      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } },
-    { "name": "macos-release",            "inherits": "macos-debug",            "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } },
+    { "name": "macos-release",            "inherits": "macos-debug",            "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo", "VCPKG_TARGET_TRIPLET": "arm64-osx-15-release" } },
     { "name": "macos-conda-release",      "inherits": "macos-conda-debug",      "cacheVariables": { "CMAKE_BUILD_TYPE": "RelWithDebInfo" } }
   ],
   "buildPresets": [

--- a/cpp/custom-triplets/arm64-osx-15-release.cmake
+++ b/cpp/custom-triplets/arm64-osx-15-release.cmake
@@ -1,0 +1,28 @@
+# Overlay triplet for macOS arm64.
+#
+# Identical to the stock vcpkg triplets/arm64-osx.cmake, but pins
+# VCPKG_OSX_DEPLOYMENT_TARGET so every dependency (folly, fmt, spdlog, ...) is
+# compiled with -mmacosx-version-min=15.0, matching CMAKE_OSX_DEPLOYMENT_TARGET
+# in the macos-* presets.
+#
+# Why this matters: the wheel is built on the macos-26 runner with Xcode 26's
+# libc++. If a dependency is compiled at the host's default deployment target,
+# libc++'s availability gating lets it emit a *strong* reference to newer dylib
+# symbols (e.g. std::__1::__hash_memory) that do not exist in the macOS 15 system
+# libc++. arcticdb_ext then links fine on macos-26 but fails to dlopen at runtime
+# on macOS 15 with "Symbol not found: __ZNSt3__113__hash_memoryEPKvm".
+# Building the deps at 15.0 makes libc++ take the back-deployable path instead.
+#
+# Keeping the target in the triplet (rather than only in the MACOSX_DEPLOYMENT_TARGET
+# env var) also folds it into vcpkg's ABI hash, so the binary cache cannot serve
+# stale dependencies that were built against a newer target.
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+
+set(VCPKG_CMAKE_SYSTEM_NAME Darwin)
+set(VCPKG_OSX_ARCHITECTURES arm64)
+set(VCPKG_OSX_DEPLOYMENT_TARGET "15.0")
+
+# Release-only: CI never opens the debug dependency libraries, and they are more than half of vcpkg_installed.
+set(VCPKG_BUILD_TYPE release)

--- a/cpp/custom-triplets/x64-linux-release.cmake
+++ b/cpp/custom-triplets/x64-linux-release.cmake
@@ -1,0 +1,7 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+
+# Release-only: CI never opens the debug dependency libraries, and they are more than half of vcpkg_installed.
+set(VCPKG_BUILD_TYPE release)

--- a/cpp/custom-triplets/x64-windows-static-msvc-release.cmake
+++ b/cpp/custom-triplets/x64-windows-static-msvc-release.cmake
@@ -1,0 +1,6 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_PLATFORM_TOOLSET_VERSION 14.41)
+# Release-only: CI never opens the debug dependency libraries, and they are more than half of vcpkg_installed.
+set(VCPKG_BUILD_TYPE release)


### PR DESCRIPTION
Stacked on #3366. **Do not merge on the strength of its own CI run** — see the warning below.

### The waste

Every release build restores debug dependency libraries it never opens. Measured from the `Disk usage` step of run 33316030365:

| | debug/lib | total `vcpkg_installed` | debug share | NuGet restore |
|---|---:|---:|---:|---|
| Windows | 3617 MB | 6949 MB | **52%** | `Restored 135 package(s) in 3.9 min` |
| Linux (wheel) | 2134 MB | 3297 MB | **65%** | `Restored 136 package(s) in 1.6 min` |
| macOS | 1565 MB | 2197 MB | **71%** | `Restored 137 package(s) in 1.7 min` |

That restore is paid in all 21 compile jobs of every run, and roughly half to two-thirds of what it moves is never opened. Estimated saving ~2 min wall, ~25 job-min.

### The change

Three new `-release` triplets that set `VCPKG_BUILD_TYPE release`, wired into the `*-release` presets only — six changed lines in `CMakePresets.json`.

Deliberately *new* triplets rather than a flag on the existing ones: `windows-cl-debug` links `/MTd` and genuinely needs debug-CRT dependencies, so local debug work is unaffected.

### ⚠️ The first run on these triplets is expected to be slow

`VCPKG_BUILD_TYPE` is part of vcpkg's ABI hash, so these are new binary-cache keys. Every one of the ~135 ports misses and **builds from source**, where today all six logs report a clean `Restored 135–137 package(s)` from NuGet. The feed is `readwrite`, so that run populates it and later runs restore normally.

So this PR's own CI tells you almost nothing about the benefit, and a lot about the cost. **The number to judge it on is the run *after* the cache is populated**, compared against the table above: `Restored N package(s)` time, and `vcpkg_installed` size in the `Disk usage` step.

The other thing this first run is genuinely useful for is finding any port that does not build release-only. That is the real risk here, and it is better discovered now than after someone adopts the idea.

### Verification run

Dispatched on this branch as 33363016374 before opening the PR, precisely so the expensive cold build happens once, out of band.
