### PR TITLE
Remove three fixed costs from the test jobs: a 20s sleep, a needless disk cleanup, and redundant re-reads

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -615,16 +615,6 @@ jobs:
           tool-cache: false
           large-packages: false # Time-consuming but doesn't save that much space (4GB)
           docker-images: false  # We're using docker images we don't want to clear
-      - name: Free Disk Space (Container)
-        if: matrix.os == 'linux' && matrix.container
-        run: |          
-          rm -rf /mnt/usr/local/lib/android 
-          rm -rf /mnt/usr/share/dotnet
-          rm -rf /mnt/usr/local/share/boost
-          rm -rf /mnt/opt/ghc
-          rm -rf /mnt/opt/hostedtoolcache/CodeQL
-          rm -rf /mnt/usr/local/lib/node_modules
-
       - name: Disk Space After Clean Up
         if: matrix.os == 'linux'
         run: |

--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -852,6 +852,7 @@ jobs:
           name: pytest-${{env.distinguishing_name}}
           path: |
             ${{runner.temp}}/*test*
+            ${{runner.temp}}/faulthandler
         continue-on-error: true
 
   # This job installs the SAME freshly-built wheel on an different runner and verifies it

--- a/build_tooling/parallel_test.sh
+++ b/build_tooling/parallel_test.sh
@@ -35,6 +35,19 @@ export PYTHONFAULTHANDLER=1
 export ARCTICDB_FAULTHANDLER_TIMEOUT=3300
 export ARCTICDB_FAULTHANDLER_DIR="$TEST_OUTPUT_DIR/faulthandler"
 
+# A step timeout SIGKILLs the whole step: no junit XML (it is only written at session end), no --durations, and
+# print_faulthandler_crashes below never runs - two hours of runner time that tell us nothing. This has happened
+# on slow Windows runners, where the same suite takes 46 min or 123 min depending on which VM SKU it lands on.
+# Send SIGINT a little before that instead, which makes pytest and xdist shut down, write the report and print
+# the slowest tests. --kill-after covers the case where the SIGINT itself is not enough.
+session_timeout=${PYTEST_SESSION_TIMEOUT:-100m}
+timeout_cmd=""
+if command -v timeout >/dev/null 2>&1; then
+    timeout_cmd="timeout --signal=INT --kill-after=5m $session_timeout"
+else
+    echo "No timeout(1) available; the session will run until the CI step limit kills it"
+fi
+
 print_faulthandler_crashes() {
     if [ -d "$ARCTICDB_FAULTHANDLER_DIR" ] && ls "$ARCTICDB_FAULTHANDLER_DIR"/crash_*.log 1>/dev/null 2>&1; then
         echo ""
@@ -54,7 +67,8 @@ set +e
 
 if [ -z "$ARCTICDB_PYTEST_ARGS" ]; then
     echo "Executing tests with no additional arguments"
-    $catch python -u -m pytest --timeout=3600 --timeout_method=thread $PYTEST_XDIST_MODE -v \
+    $timeout_cmd $catch python -u -m pytest --timeout=3600 --timeout_method=thread $PYTEST_XDIST_MODE -v \
+        --durations=50 \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \
@@ -67,7 +81,8 @@ else
     echo "Executing tests with additional pytest argiments:"
     echo "from user: $ARCTICDB_PYTEST_ARGS"
     echo "from automation: $PYTEST_ADD_TO_COMMAND_LINE"
-    $catch python -u -m pytest --timeout=3600 --timeout_method=thread $PYTEST_XDIST_MODE -v \
+    $timeout_cmd $catch python -u -m pytest --timeout=3600 --timeout_method=thread $PYTEST_XDIST_MODE -v \
+        --durations=50 \
         --log-file="$TEST_OUTPUT_DIR/pytest-logger.$group.log" \
         --junitxml="$TEST_OUTPUT_DIR/pytest.$group.xml" \
         --basetemp="$PARALLEL_TEST_ROOT/temp-pytest-output" \

--- a/docs/claude/plans/gpetrov/ci_port_and_disk/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_port_and_disk/branch-work-log.md
@@ -96,3 +96,62 @@ writes, prunes, snapshots and deletes to line up. Left at 100.
 
 A caution on measuring this locally: the first "after" reading was 70s rather than 46.5s because another process
 was busy on the same machine. Both halves of an A/B here have to be taken on an idle box.
+
+## The dedup flake, and the dead feature behind it
+
+`test_string_dedup_basic` failed in four separate runs over two days and four times in 25 failed master runs over
+60 days, always as `assert <with_dedup> <= <without_dedup>` with margins from 0.5% to 18%.
+
+`getsize()` keeps ids, not references. With Arrow-backed strings (every observed failure was an `-inferstr` job)
+each loop iteration materialises a temporary that is freed before the next, so its id is reused and the function
+sums a handful of arbitrary objects rather than 4000. Measuring **the same frame** five times running returns
+1582, 888, 888, 888, 888 - a 78% swing with no change in data. The assertion was reporting the sign of allocator
+noise.
+
+Replaced with a count of distinct string objects, holding the values alive so ids stay distinct, guarded on
+object dtype. 40 repeats under `-inferstr` show no variance.
+
+### `optimise_string_memory` has been a no-op since 2024-07-02
+
+The counts come out exactly equal under object dtype because the feature does nothing. Verified directly:
+
+- `DecodePathData::set_optimize_for_memory()` (`decode_path_data.hpp:45`), the switch read at
+  `python_strings.cpp:194` to choose global deduplication, **has no callers anywhere in the repo**.
+- `ReadOptions::optimise_string_memory_` (`read_options.hpp:32`) is written from Python and **never read** in C++;
+  there is no getter.
+- `7df641fba` "Release GIL on read" (2024-07-02) dropped the wiring: before it `read_frame.cpp` had the
+  `unique_string_map_` machinery, after it there are zero references.
+
+So a documented `read()` kwarg has silently done nothing for two years - users get one Python string object per
+row where they asked for one per distinct value. Recorded as `test_string_dedup_shares_string_objects`,
+`xfail(strict=True)`, which flips to a pass when the wiring returns.
+
+Anyone restoring it should first fix what looks like a refcount bug in the now-unreachable `assign_strings_shared`
+(`python_strings.cpp:135-183`): `get_allocated_strings` pre-populates `allocated` for strings an earlier column
+created, and the main loop then skips those offsets without `inc_ref` while `write_strings_to_destination` still
+stores `count` more pointers. That is a code reading of dead code, not a runtime observation.
+
+## Windows jobs that hit the 120-minute step limit
+
+Two `3.11 Windows / unit` jobs burned the full step limit. Neither hung: 20,209 of 20,212 tests had completed,
+the last one passed 13 seconds before the kill, and summed per-worker gaps show the workers ~99% busy throughout.
+
+The cause is the runner. The same job takes **46 min or 123 min** depending on which Windows VM it lands on, and
+the discriminator is the temp disk size reported by the `Disk usage` step:
+
+| D: size | duration |
+|---|---|
+| 220G | 123 min, 123 min (both timed out) |
+| 150G | 46 min |
+
+Both report `cores: 4, RAM: 16378MB` and the same runner image. The slowdown is uniform across unrelated test
+families (`test_realistic` 405s -> 1190s, `recursive_normalizers` 433s -> 1063s), so it is not a test regression.
+It affects roughly 5% of Windows `unit` jobs, and it is the same effect behind the Windows *compile* jobs that
+occasionally take 2-3x their usual time - `Install Required MSVC`, which only downloads and installs, doubles too.
+
+Three diagnostic gaps this exposed, all now fixed:
+- A step timeout SIGKILLs the step, so no junit XML, no `--durations`, no crash dumps. Now SIGINT at 100m first.
+- `--durations` was not enabled, so "everything is uniformly slower" was invisible in the log.
+- `ARCTICDB_FAULTHANDLER_DIR` is `$TEST_OUTPUT_DIR/faulthandler` but the artifact glob was `$TEST_OUTPUT_DIR/*test*`,
+  so the watchdog's output could never reach CI. (The watchdog itself behaved correctly here: it is a per-test
+  budget of 3300s and the slowest test was 1190s. Wrong tool for an aggregate overrun.)

--- a/docs/claude/plans/gpetrov/ci_port_and_disk/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_port_and_disk/branch-work-log.md
@@ -1,0 +1,65 @@
+# Branch work log: gpetrov/ci_port_and_disk
+
+Sits on the test-job stack (`gpetrov/ci_stress_nightly_only`). Two changes found while looking for what sets the
+wall now that Windows and compile are fixed: the run's critical path is the Linux `integration` job (27.1 min) and
+the merged `{hypothesis,...}` job (29.3 min), both of which start promptly and simply run long.
+
+## The 20 second sleep
+
+`get_ephemeral_port` held the probed socket open for 20s (30 under conda) on the **success** path, as a way of
+letting a second caller racing for the same number discover the collision. Every moto S3, GCP, azurite and mongod
+startup paid it.
+
+Evidence it dominates, from the junit XML of `3.9 Linux / integration-DefaultCache` in run 33316030365 - the
+duration histogram has nothing at all in the 19-20.5s band and a cluster immediately above it:
+
+```
+  15-19 s   n=  4    1.08 min
+19-20.5 s   n=  0    0.00 min   <- nothing
+20.5-23 s   n= 33   12.00 min
+```
+
+55 tests at >=20s, **18.3 of the job's 81.6 CPU-min**. `test_read_path_with_dot`, which writes one symbol and reads
+it back, took 21.7s. The Linux `unit` job spends ~8.3 CPU-min the same way, a quarter of that suite. On macOS the
+same test takes 92s and 21 such tests are 57% of the job.
+
+Replaced with a disjoint block of 100 ports per (seed, xdist worker), walked from a pid-derived offset. A
+collision inside a run is now impossible by construction rather than unlikely, and jobs are on separate runners.
+The bind was only ever a probe - the caller binds for real afterwards, so the race the sleep was guarding against
+existed either way - and the retries in `MotoS3StorageFixtureFactory._safe_enter` and `start_with_retry` still
+cover something outside the run taking the port in between.
+
+Verified locally: 15 calls across 5 seeds in 0.001s, all distinct; distinct across simulated `gw0`-`gw3`;
+`tests/integration/arcticdb/test_s3.py` goes from not finishing within 120s to **10.4s**.
+
+## The disk cleanup nobody needed
+
+`Free Disk Space (Container)` deleted ~20 GB from every containerised Linux test job. From the job log:
+
+```
+14:19:07  overlay 146G  65G  82G  45% /   <- before the cleanup
+14:20:53  overlay 146G  45G 101G  31% /   <- after 105s of rm -rf
+14:44:59  overlay 146G  46G 100G  32% /   <- after the whole test run
+```
+
+82 GB free before it ran; the entire job consumed 1 GB. Same picture on `unit` and `stress`. It cost 48-105s on
+each of 44 Linux test jobs, ~66 job-min per run. Removed from the test job; the compile jobs keep their own.
+
+The `Free Disk Space (Base Runner)` variant beside it was skipped on all 44 jobs, so it is left alone.
+
+## Not done here
+
+- **Shard the integration suite 2x** (~-8.7 wall min, +46 job-min). Only worth it *after* the port fix: session
+  factories start once per worker per job, so a second shard duplicates ~40 startups, which used to mean +14
+  CPU-min of new sleep.
+- **Run the slowest tests first.** ~1.2 min of tail on integration - at 14:43:21 the run is at 99% with the
+  `test_compact_data` variants left, and three workers idle from 14:44:22 to 14:44:58. `pytest-split` is already
+  installed by the workflow and never used. `--dist worksteal` cannot fix this: it rebalances queues but cannot
+  split a single 60s test.
+- **The hypothesis job's real pathology**, which is separate work: 96% of that job is `test_stateful`, and 96% of
+  *that* is the nine `@invariant()` methods, whose per-step cost grows ~4x across the run because several iterate
+  every version or snapshot and do real storage reads. Cost is quadratic in `stateful_step_count`, which is set to
+  100 against hypothesis's default of 50. Gating the four heaviest with `@precondition` is the fix.
+- Also measured, for the record: `sanitizers` and `enduser` are **100% skipped** in that job (0.00s, 41 skips), and
+  `compat311` is not inherently slower - across four runs of the same variant the non-stateful part is flat at
+  20.6-24.5 CPU-min and all the variance is the hypothesis seed.

--- a/docs/claude/plans/gpetrov/ci_port_and_disk/branch-work-log.md
+++ b/docs/claude/plans/gpetrov/ci_port_and_disk/branch-work-log.md
@@ -56,10 +56,43 @@ The `Free Disk Space (Base Runner)` variant beside it was skipped on all 44 jobs
   `test_compact_data` variants left, and three workers idle from 14:44:22 to 14:44:58. `pytest-split` is already
   installed by the workflow and never used. `--dist worksteal` cannot fix this: it rebalances queues but cannot
   split a single 60s test.
-- **The hypothesis job's real pathology**, which is separate work: 96% of that job is `test_stateful`, and 96% of
-  *that* is the nine `@invariant()` methods, whose per-step cost grows ~4x across the run because several iterate
-  every version or snapshot and do real storage reads. Cost is quadratic in `stateful_step_count`, which is set to
-  100 against hypothesis's default of 50. Gating the four heaviest with `@precondition` is the fix.
+- **Restricting `test_stateful` to fewer matrix variants** (~-5 wall min, ~-190 job-min) - a real coverage cut, so
+  it should be argued on its own rather than folded in here.
 - Also measured, for the record: `sanitizers` and `enduser` are **100% skipped** in that job (0.00s, 41 skips), and
   `compat311` is not inherently slower - across four runs of the same variant the non-stateful part is flat at
   20.6-24.5 CPU-min and all the variance is the hypothesis seed.
+
+## The stateful hypothesis test (added after the first two changes)
+
+96% of the merged `{hypothesis,...}` job is `test_stateful`, and 96% of *that* was the nine `@invariant()` methods
+rather than the code under test. `test_list_versions_all_and_read` dominated: `read_metadata` + `read` +
+`assert_frame_equal` for every version of every symbol, after every step. Since a step changes one symbol, at step
+50 with ~40 live versions 39 of those 40 reads re-proved what the previous step had already proved. Measured
+per-step invariant cost grew 37ms (step 10) -> 147ms (step 90).
+
+The rules now mark the `(symbol, version)` pairs they change and the invariant reads back only those. The full
+`list_versions()` comparison still runs every step, so the deleted flags, snapshot sets and the "failed to find
+these" check are unchanged - only the redundant re-reads go.
+
+The subtle case, and the reason this needs a guard rather than eyeballing: `delete_snapshot` changes no version's
+data, but un-pinning can make a tombstoned version deletable, which changes whether it reads back at all. So it
+has to mark every version the snapshot held.
+
+Two guards against a gap in the marking silently un-testing a version:
+- `teardown()` reads everything back once per example, so a gap still fails - one example later rather than one
+  step later. It returns early if an exception is already propagating, so it cannot mask a rule's own failure.
+- `test_dirty_versions_cover_every_model_change` fingerprints the model around each rule and asserts every change
+  was marked. Verified to bite: deleting the `delete_snapshot` marking fails it with the pinned version.
+
+Measured locally, 8 examples of one shard on an otherwise idle machine: **171.4s -> 57.2s (3.0x)**.
+
+### Why `stateful_step_count` was left at 100
+
+Cost per example is quadratic in it and hypothesis's own default is 50, so halving it looked like a free 4x. It
+is not: measured on top of the change above, 57.2s -> 46.5s, only **1.23x**, because scoping the reads had already
+removed most of the quadratic term. Paying for 19% by halving the length of the operation sequences explored is a
+bad trade in a test whose whole purpose is to find version-map and snapshot interactions that need a sequence of
+writes, prunes, snapshots and deletes to line up. Left at 100.
+
+A caution on measuring this locally: the first "after" reading was 70s rather than 46.5s because another process
+was busy on the same machine. Both halves of an A/B here have to be taken on an idle box.

--- a/python/arcticdb/storage_fixtures/utils.py
+++ b/python/arcticdb/storage_fixtures/utils.py
@@ -14,6 +14,8 @@ import platform
 import sys
 import requests
 import signal
+import itertools
+import re
 import socketserver
 import time
 import warnings
@@ -21,8 +23,6 @@ from typing import Union, Any
 from contextlib import AbstractContextManager
 from dataclasses import dataclass, field
 import trustme
-
-from arcticdb.util.marks import ARCTICDB_USING_CONDA
 
 _WINDOWS = platform.system() == "Windows"
 _MACOS = sys.platform.lower().startswith("darwin")
@@ -34,23 +34,44 @@ import logging
 logger = logging.getLogger("Utils")
 
 
+_PORT_RANGE_START = 10000
+_PORT_BLOCK_SIZE = 100
+_MAX_XDIST_WORKERS = 16
+_SEED_BLOCKS = 32
+_port_call_counter = itertools.count()
+
+
+def _xdist_worker_index():
+    """0 for gw0, 1 for gw1, ... and 0 when not running under xdist."""
+    match = re.fullmatch(r"gw(\d+)", os.getenv("PYTEST_XDIST_WORKER", ""))
+    return int(match.group(1)) % _MAX_XDIST_WORKERS if match else 0
+
+
 def get_ephemeral_port(seed=0):
-    # Some OS has a tendency to reuse a port number that has just been closed, so if we use the trick from
-    # https://stackoverflow.com/a/61685162/ and multiple test runners call this function at roughly the same time, they
-    # may get the same port! Below more sophisticated implementation uses the PID to avoid that:
-    pid = os.getpid()
-    port = (pid // 1000 + pid) % 1000 + seed * 1000 + 10000  # Crude hash
-    while port < 65535:
+    """A probably-free port, distinct from every other port this test run hands out.
+
+    Two callers used to be able to pick the same number, so this held the socket open for 20s to give the loser a
+    chance to notice. That sleep ran on every moto, azurite and mongod startup and cost ~22% of the integration
+    suite. Instead, give each (seed, xdist worker) a disjoint block and walk it, which makes a collision within a
+    run impossible by construction rather than merely unlikely. The bind is still only a probe - the caller binds
+    for real afterwards - so callers keep their existing retries for the case where something outside this run
+    takes the port in between.
+    """
+    block_start = (
+        _PORT_RANGE_START + ((seed % _SEED_BLOCKS) * _MAX_XDIST_WORKERS + _xdist_worker_index()) * _PORT_BLOCK_SIZE
+    )
+    # Offset by the pid so two independent runs on one machine do not start at the same end of the block
+    first = (os.getpid() + next(_port_call_counter)) % _PORT_BLOCK_SIZE
+    for probe in range(_PORT_BLOCK_SIZE):
+        port = block_start + (first + probe) % _PORT_BLOCK_SIZE
         try:
             with socketserver.TCPServer(("localhost", port), None):
-                time.sleep(
-                    30 if ARCTICDB_USING_CONDA else 20
-                )  # Hold the port open for a while to improve the chance of collision detection
-                return port
+                pass
         except OSError as e:
             print(repr(e), file=sys.stderr)
-            port += 1000
-    raise Exception(f"Cannot find a free port for PID {pid}")
+            continue
+        return port
+    raise Exception(f"Cannot find a free port in {block_start}-{block_start + _PORT_BLOCK_SIZE} for seed {seed}")
 
 
 ProcessUnion = Union[multiprocessing.Process, subprocess.Popen]

--- a/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
+++ b/python/tests/hypothesis/arcticdb/test_hypothesis_version_store.py
@@ -14,6 +14,7 @@ from itertools import zip_longest
 import attr
 import os
 import pytest
+import sys
 
 from hypothesis import strategies as st, assume, stateful, settings, HealthCheck
 from hypothesis.stateful import RuleBasedStateMachine, Bundle, rule, invariant, run_state_machine_as_test
@@ -95,6 +96,10 @@ class VersionStoreComparison(RuleBasedStateMachine):
         self._versions = defaultdict(list)
         self._visible_snapshots = {}
         self._snapshot_tombstones = set()
+        # (symbol, version) pairs whose model state a rule has changed since they were last read back. Reading a
+        # version that no rule has touched can only re-prove what the previous step already proved, and doing it
+        # for every version on every step made the cost quadratic in stateful_step_count.
+        self._dirty = set()
 
         self._lib.version_store.clear()
         self._lib.version_store.flush_version_map()
@@ -103,9 +108,10 @@ class VersionStoreComparison(RuleBasedStateMachine):
 
     def _prune_previous_versions(self, sym):
         vers = self._versions[sym]
-        for value in vers:
+        for ver_num, value in enumerate(vers):
             if value.state == State.NORMAL:
                 value.state = State.TOMBSTONED  # Delayed deletes
+                self._dirty.add((sym, ver_num))
 
     def _get_latest_undeleted_version(self, sym) -> Tuple[Optional[int], Optional[Version]]:
         vers = self._versions[sym]
@@ -140,6 +146,7 @@ class VersionStoreComparison(RuleBasedStateMachine):
         assert created.symbol == sym
         assert created.version == len(vers)
         vers.append(Version(data, meta))
+        self._dirty.add((sym, len(vers) - 1))
 
     @rule(
         target=symbols,
@@ -162,6 +169,22 @@ class VersionStoreComparison(RuleBasedStateMachine):
     @invariant()
     def test_list_versions_all_and_read(self):
         """lib.list_versions() with args"""
+        self._check_list_versions(read_versions=self._dirty)
+        self._dirty = set()
+
+    def teardown(self):
+        """Read every version back once per example.
+
+        The invariant above only re-reads what the rules marked dirty, so a gap in that marking would silently
+        stop checking a version. Reading everything at the end of the example still catches it, one example later
+        than a full per-step read would.
+        """
+        if sys.exc_info()[0] is not None:
+            return  # a rule already failed; do not mask its traceback with a second failure here
+        self._check_list_versions(read_versions=None)
+
+    def _check_list_versions(self, read_versions):
+        """Compare list_versions() against the model, reading back `read_versions` (None means all of them)."""
         expected_vers = {}
         for sym, versions in self._versions.items():
             for ver_num, ver in enumerate(versions):
@@ -174,6 +197,9 @@ class VersionStoreComparison(RuleBasedStateMachine):
             expected = expected_vers.pop(sym_ver)
             assert actual["deleted"] is (expected.state == State.TOMBSTONED)
             assert set(actual["snapshots"]) == expected.active_snap_names()
+
+            if read_versions is not None and sym_ver not in read_versions:
+                continue  # nothing has touched it since it last read back correctly
 
             actual_meta = self._lib.read_metadata(*sym_ver)
             assert (actual_meta.symbol, actual_meta.version) == sym_ver
@@ -247,6 +273,7 @@ class VersionStoreComparison(RuleBasedStateMachine):
             vers = self._versions[sym]
             snap.sym_vers[sym] = len(vers) - 1
             vers[-1].snaps.add(snap)
+            self._dirty.add((sym, len(vers) - 1))
 
         self._visible_snapshots[name] = snap
         return name
@@ -257,6 +284,8 @@ class VersionStoreComparison(RuleBasedStateMachine):
         assume(snap)
         snap.state = State.TOMBSTONED  # Delayed deletes
         self._snapshot_tombstones.add(snap)
+        # Un-pinning can make a tombstoned version deletable, which changes whether it reads back
+        self._dirty.update(snap.sym_vers.items())
         self._lib.delete_snapshot(name)
 
     @invariant()
@@ -302,12 +331,45 @@ def test_stateful(lib_type, shard, request):
             max_examples=examples,
             deadline=None,
             stateful_step_count=100,
-            # data_too_large: with stateful_step_count=100 a single example is large, so hypothesis routinely
+            # data_too_large: a single example is large, so hypothesis routinely
             # overruns while generating; the ratio of overruns to valid examples is what trips the check, and it
             # trips more readily now the examples are split across shards.
             suppress_health_check=[HealthCheck.filter_too_much, HealthCheck.data_too_large],
         ),
     )
+
+
+def test_dirty_versions_cover_every_model_change(lmdb_version_store_delayed_deletes_v1):
+    """Every model change must be marked dirty, or the invariant silently stops re-reading that version."""
+    VersionStoreComparison._lib = lmdb_version_store_delayed_deletes_v1
+    state = VersionStoreComparison()
+
+    def fingerprint():
+        return {
+            (sym, i): (ver.state, frozenset(ver.active_snap_names()), ver.can_delete(), ver.metadata)
+            for sym, vers in state._versions.items()
+            for i, ver in enumerate(vers)
+        }
+
+    steps = [
+        lambda: state.write_new_symbol(sym="a", write_mode=WriteMode.DATA),
+        lambda: state.write_new_version_to_symbol(sym="a", prune=False, write_mode=WriteMode.BOTH),
+        lambda: state.snapshot(name="s0", with_meta=True),
+        lambda: state.write_new_version_to_symbol(sym="a", prune=True, write_mode=WriteMode.DATA),
+        lambda: state.write_new_symbol(sym="b", write_mode=WriteMode.META),
+        lambda: state.snapshot(name="s1", with_meta=False),
+        lambda: state.delete_snapshot(name="s0"),
+        lambda: state.delete_symbol(sym="b"),
+        lambda: state.delete_snapshot(name="s1"),
+    ]
+    for i, step in enumerate(steps):
+        before = fingerprint()
+        state._dirty.clear()
+        step()
+        after = fingerprint()
+        changed = {k for k in set(before) | set(after) if before.get(k) != after.get(k)}
+        missed = changed - state._dirty
+        assert not missed, f"step {i} changed {sorted(missed)} without marking them dirty"
 
 
 def test_single(lmdb_version_store_delayed_deletes_v1):

--- a/python/tests/unit/arcticdb/test_storage_fixture_ports.py
+++ b/python/tests/unit/arcticdb/test_storage_fixture_ports.py
@@ -1,0 +1,18 @@
+"""Port allocation for the test storage fixtures (moto, azurite, mongod)."""
+
+import time
+
+from arcticdb.storage_fixtures.utils import get_ephemeral_port
+
+
+def test_get_ephemeral_port_returns_promptly():
+    # This used to hold the socket open for 20s on every call to detect collisions, which cost ~22% of the
+    # integration suite and ~25% of the unit suite across every moto, azurite and mongod startup.
+    start = time.monotonic()
+    get_ephemeral_port()
+    assert time.monotonic() - start < 5
+
+
+def test_get_ephemeral_port_does_not_repeat():
+    ports = [get_ephemeral_port(seed) for seed in (1, 2, 7, 10, 20) for _ in range(3)]
+    assert len(set(ports)) == len(ports), f"duplicate ports handed out: {sorted(ports)}"

--- a/python/tests/unit/arcticdb/version_store/test_string_dedup.py
+++ b/python/tests/unit/arcticdb/version_store/test_string_dedup.py
@@ -43,6 +43,24 @@ def getsize(df):
     return size
 
 
+def distinct_string_objects(df):
+    """How many distinct Python string objects the frame holds - what deduplication is supposed to reduce.
+
+    getsize() cannot be used to compare two frames. It keeps only ids, not references, so when the strings are
+    Arrow-backed each iteration materialises a temporary that is freed before the next one and its id is reused:
+    it then sums a handful of arbitrary objects rather than all of them. Measuring the same frame repeatedly that
+    way returned 1582, 888, 888, 888, 888 - the number tracks allocator state, not the data. Holding the values
+    alive keeps the ids distinct and makes the count deterministic.
+    """
+    values = [val for col in df.columns for val in df.loc[:, col]]
+    return len({id(val) for val in values})
+
+
+def has_python_string_objects(df):
+    """False when strings are Arrow-backed, where there are no per-row Python objects to deduplicate."""
+    return all(df[col].dtype == object for col in df.columns)
+
+
 # Use tiny segment to prove deduplication across segments
 def test_string_dedup_basic(lmdb_version_store_tiny_segment):
     lib = lmdb_version_store_tiny_segment
@@ -53,7 +71,25 @@ def test_string_dedup_basic(lmdb_version_store_tiny_segment):
     read_df_without_dedup = lib.read(symbol, optimise_string_memory=False).data
     assert np.array_equal(original_df, read_df_with_dedup)
     assert np.array_equal(original_df, read_df_without_dedup)
-    assert getsize(read_df_with_dedup) <= getsize(read_df_without_dedup)
+    if has_python_string_objects(read_df_with_dedup):
+        assert distinct_string_objects(read_df_with_dedup) <= distinct_string_objects(read_df_without_dedup)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="optimise_string_memory has been a no-op since 7df641fba (Release GIL on read, 2024-07-02): the read "
+    "path stopped passing it through, DecodePathData::set_optimize_for_memory() now has no callers, and "
+    "ReadOptions::optimise_string_memory_ is written but never read. Flip to a pass when the wiring is restored.",
+)
+def test_string_dedup_shares_string_objects(lmdb_version_store_tiny_segment):
+    """With deduplication on, equal strings should be one Python object, not one per row."""
+    lib = lmdb_version_store_tiny_segment
+    symbol = "test_string_dedup_shares_string_objects"
+    unique_strings = random_ascii_strings(100, 10)
+    original_df = generate_dataframe(["col1", "col2", "col3", "col4"], 1000, unique_strings)
+    lib.write(symbol, original_df, dynamic_strings=True)
+    read_df_with_dedup = lib.read(symbol, optimise_string_memory=True).data
+    assert distinct_string_objects(read_df_with_dedup) <= len(unique_strings)
 
 
 # Test that dedup still works when writing fixed-width strings and appending dynamic strings, and vice-versa
@@ -110,7 +146,8 @@ def test_string_dedup_nans(lmdb_version_store_tiny_segment):
             except TypeError as e:
                 print("Differ at {}: '{}' vs '{}'\n{}".format(idx, original_val, read_val, e))
                 assert False
-    assert getsize(read_df_with_dedup) <= getsize(read_df_without_dedup)
+    if has_python_string_objects(read_df_with_dedup):
+        assert distinct_string_objects(read_df_with_dedup) <= distinct_string_objects(read_df_without_dedup)
 
 
 @pytest.mark.skip("Used for profiling")


### PR DESCRIPTION
Stacked on #3363. Two changes to the jobs that now set the run's wall clock, found by profiling the junit XML rather than guessing.

## 1. Every test server start slept 20 seconds

`get_ephemeral_port` held the probed socket open for 20s (30 under conda) on the **success** path, so that a second caller racing for the same number would fail to bind and notice. Every moto S3, GCP, azurite and mongod startup paid it.

The junit durations for `3.9 Linux / integration-DefaultCache` make it unmissable — the histogram has **nothing at all** between 19s and 20.5s, with a cluster immediately above:

| bucket | tests | CPU-min |
|---|---:|---:|
| 15–19 s | 4 | 1.08 |
| **19–20.5 s** | **0** | **0.00** |
| 20.5–23 s | 33 | 12.00 |

**55 tests at ≥20s — 18.3 of that job's 81.6 CPU-min, 22%.** `test_read_path_with_dot` writes one symbol and reads it back: 21.7s. And it is not confined to integration — the Linux `unit` job spends ~8.3 CPU-min the same way, **a quarter of that suite**. On macOS the same test takes 92s, and 21 such tests are 57% of the job.

**The fix:** give each `(seed, xdist worker)` a disjoint block of 100 ports and walk it from a pid-derived offset. A collision within a run becomes impossible by construction rather than merely unlikely, and separate jobs are on separate runners.

Worth being clear that **no safety is lost**: the bind was only ever a probe, and the caller binds for real afterwards — so the race the sleep was meant to catch existed either way, and the sleep only widened the window for detecting two *simultaneous probers*. The retries in `MotoS3StorageFixtureFactory._safe_enter` and `start_with_retry` still cover anything outside the run taking the port in between.

**Verified locally:** 15 calls across 5 seeds in 0.001s, all distinct; distinct across simulated `gw0`–`gw3`; and `tests/integration/arcticdb/test_s3.py` goes from **not finishing inside 120s to 10.4s**.

New test `python/tests/unit/arcticdb/test_storage_fixture_ports.py` asserts the call returns promptly and does not repeat — it fails against the old implementation (which needed ~320s for its 16 calls) and passes in 0.03s now.

## 2. A disk cleanup that freed space nothing needed

`Free Disk Space (Container)` deleted ~20 GB from every containerised Linux test job. From the job log:

```
14:19:07  overlay 146G  65G  82G  45% /   <- before the cleanup
14:20:53  overlay 146G  45G 101G  31% /   <- after 105s of rm -rf
14:44:59  overlay 146G  46G 100G  32% /   <- after the entire test run
```

**82 GB were already free, and the whole job consumed 1 GB.** Same picture on `unit` and on `stress`, the most disk-hungry suite. It cost 48–105s on each of the 44 Linux test jobs — ~66 job-min per run, and 1.5–3.0 min on whichever job is the critical path.

The compile jobs, which genuinely do fill the disk, keep their own cleanup. The `Free Disk Space (Base Runner)` variant beside this one was skipped on all 44 jobs, so it is left untouched.

## Expected effect

| | wall (per job) | job-min |
|---|---:|---:|
| port fix, Linux integration | −4.5 min | ~−100 |
| port fix, unit / compat / hypothesis, all three OSes | — | large, not yet quantified |
| disk cleanup | −1.5 to −3.0 min | ~−66 |

Estimates from the measured CPU-min at the job's observed 87% parallel efficiency, not from a CI run — this PR's own run is the measurement.

## Deliberately not here

- **Sharding integration 2×** (~−8.7 wall min, +46 job-min) — only worth doing *after* this, since session factories start once per worker per job and a second shard used to duplicate ~40 startups, i.e. +14 CPU-min of fresh sleep.
- **Slowest-tests-first ordering** — ~1.2 min of tail on integration, where three of four workers idle for the last 36s while one runs a 60s `test_compact_data`. `--dist worksteal` cannot help: it rebalances queues but cannot split a single test.
- **Restricting `test_stateful` to fewer matrix variants** (~−5 wall min, ~−190 job-min) — a real coverage cut, so it deserves its own argument rather than being folded in here.


## 3. The stateful hypothesis test re-read everything, every step

96% of the merged `{hypothesis,…}` job is `test_stateful`, and 96% of *that* was the nine `@invariant()` methods rather than the code under test. `test_list_versions_all_and_read` dominated: `read_metadata` + `read` + `assert_frame_equal` for **every version of every symbol, after every step**. A step changes one symbol, so at step 50 with ~40 live versions, 39 of those 40 reads re-proved what the previous step had already proved. Measured per-step invariant cost grew from 37 ms at step 10 to 147 ms at step 90.

The rules now mark the `(symbol, version)` pairs they change, and the invariant reads back only those. **The full `list_versions()` comparison still runs every step** — the deleted flags, the snapshot sets, and the "list_versions() failed to find these" check are all unchanged. Only the redundant re-reads go.

The subtle case, and the reason this needs a guard rather than careful eyeballing: `delete_snapshot` changes no version's *data*, but un-pinning can make a tombstoned version deletable, which changes whether it reads back at all. So it has to mark every version that snapshot held.

**Two guards**, because a gap in the marking would silently stop testing a version:

- `teardown()` reads everything back once per example, so a gap still fails the test — one example later rather than one step later. It returns early if an exception is already propagating, so it cannot mask a rule's own traceback with its own failure.
- `test_dirty_versions_cover_every_model_change` fingerprints the model around each rule and asserts every change was marked. Verified to bite: deleting the `delete_snapshot` marking makes it fail with `('a', 1)`, the version that snapshot had pinned.

**Measured locally, 8 examples of one shard on an idle machine: 171.4s → 57.2s (3.0×).**

### Why `stateful_step_count` is left at 100

Worth recording, because it looks like an obvious win and isn't. Cost per example is quadratic in it and hypothesis's own default is 50, so halving it should be ~4×. Measured on top of the change above: **57.2s → 46.5s, only 1.23×** — scoping the reads had already removed most of the quadratic term. Paying 19% by halving the length of the operation sequences explored is a bad trade in a test whose entire purpose is finding version-map and snapshot interactions that need a sequence of writes, prunes, snapshots and deletes to line up. Left at 100.
