### PR TITLE
fix(python): will_item_be_pickled raises UnboundLocalError instead of returning True

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -3633,6 +3633,7 @@ class NativeVersionStore:
             recursively normalized, it is considered `pickled` as well.
         """
         result = False
+        norm_meta = None
         try:
             _udm, _item, norm_meta = self._try_normalize(
                 symbol="",
@@ -3644,9 +3645,11 @@ class NativeVersionStore:
             )
         except Exception:
             # This will also log the exception inside composite normalizer's normalize
+            # An item that cannot be normalized is pickled by `write`, so the answer is
+            # True and there is no norm_meta to inspect below.
             result = True
 
-        result |= norm_meta.WhichOneof("input_type") == "msg_pack_frame"
+        result |= norm_meta is not None and norm_meta.WhichOneof("input_type") == "msg_pack_frame"
         log_warning_message = get_config_int("VersionStore.WillItemBePickledWarningMsg") != 0 and log.is_active(
             _LogLevel.WARN
         )

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -665,6 +665,24 @@ def test_will_item_be_pickled(lmdb_version_store, sym):
 
 
 @pytest.mark.parametrize(
+    "item",
+    [
+        pytest.param(type("Unnormalizable", (object,), {})(), id="custom_object"),
+        pytest.param(lambda x: x, id="lambda"),
+    ],
+)
+def test_will_item_be_pickled_when_normalization_raises(lmdb_version_store, item):
+    """An item that cannot be normalized must report True, not raise.
+
+    `_try_normalize` is called with `pickle_on_failure=False`, so it raises for
+    anything msgpack cannot handle. `norm_meta` was only bound inside the `try`,
+    and the following line dereferenced it unconditionally, so the API raised
+    `UnboundLocalError` in precisely the case where the answer is True.
+    """
+    assert lmdb_version_store.will_item_be_pickled(item) is True
+
+
+@pytest.mark.parametrize(
     "data",
     [
         {"a": {"b": {"c": {"d": np.arange(24)}}}},


### PR DESCRIPTION
### Summary

`will_item_be_pickled` raises `UnboundLocalError` instead of returning `True`, for exactly the class of item it exists to identify.

`norm_meta` is bound only inside the `try`, and the line after the `except` dereferences it unconditionally:

```python
result = False
try:
    _udm, _item, norm_meta = self._try_normalize(..., pickle_on_failure=False, ...)
except Exception:
    result = True

result |= norm_meta.WhichOneof("input_type") == "msg_pack_frame"
```

`_try_normalize` is called with `pickle_on_failure=False`, so it raises for anything msgpack cannot handle. `norm_meta` is then never assigned and the next line raises. The docstring promises a `bool`.

### Reproduction

Against released 6.23.0:

```python
lib = Arctic("lmdb:///tmp/x").get_library("t", create_if_missing=True)._nvs

lib.will_item_be_pickled(pd.DataFrame({"a": [1, 2]}))   # False
lib.will_item_be_pickled({1, 2, 3})                     # True
lib.will_item_be_pickled(SomeClass())                   # UnboundLocalError
lib.will_item_be_pickled(lambda x: x)                   # UnboundLocalError
```

A `set` is handled correctly because msgpack normalizes it. A plain user-defined object — arguably the most likely thing someone calls this API about — raises.

### Why the tests didn't catch it

`test_will_item_be_pickled`, `test_will_item_be_pickled_recursive_normalizer` and `test_will_item_pickled_msgpack` all pass items that normalize successfully, so the `except` branch never runs.

### The change

Initialise `norm_meta = None` and guard the dereference. One line changed, one added.

Behaviour for every currently-covered input is unchanged — DataFrame `False`, ndarray `False`, dict `True`, set `True` — and an unnormalizable item now returns `True` instead of raising. I verified each of those against 6.23.0 rather than reasoning about it.

Adds a parametrised regression test over a custom object and a lambda, which fails on `master` with `UnboundLocalError`.

### Notes

- The CLA sign-off line is in the commit message per clause 7.
- I can't set labels as an outside contributor, so the `patch`/`minor`/`major` check will stay red until someone applies one. This is a `patch` by my reading.
