### PR TITLE
fix(python): honour fail_on_missing_custom_normalizer when unpickling the normalizer

### DIFF
--- a/python/arcticdb/version_store/_custom_normalizers.py
+++ b/python/arcticdb/version_store/_custom_normalizers.py
@@ -107,15 +107,22 @@ class CompositeCustomNormalizer(CustomNormalizer):
         return n.denormalize(item, norm_meta)
 
     def __setstate__(self, state):
+        # __setstate__ may be called on an instance built by object.__new__, which has not run
+        # __init__, so these have to be established here rather than assumed to already exist.
+        self._normalizers = []
+        self._normalizer_by_typename = {}
         self._fail_on_missing_type = state["fail_on_missing"]
         for cls in state["class_names"]:
             try:
                 normalizer = _fq_class_name_to_type(cls)()
-                self._normalizer_by_typename[cls] = normalizer
-                self._normalizers.append(normalizer)
             except ImportError:
-                if not self._fail_on_missing_type:
-                    continue
+                log.warning("Could not import custom normalizer type {}".format(cls))
+                if self._fail_on_missing_type:
+                    raise
+                continue
+
+            self._normalizer_by_typename[cls] = normalizer
+            self._normalizers.append(normalizer)
 
     def __getstate__(self):
         return {"class_names": list(self._normalizer_by_typename.keys()), "fail_on_missing": self._fail_on_missing_type}

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock
 import numpy as np
 import pandas as pd
 import dateutil as du
+import pickle
 import pytest
 import pytz
 from arcticdb_ext.types import IndexKind
@@ -551,6 +552,34 @@ def test_serialize_custom_normalizer():
     df, norm_meta = cloned_normalizer.normalize(dt)
     denormed = cloned_normalizer.denormalize(df, norm_meta)
     assert_array_equal(dt.custom_values, denormed.custom_values)
+
+
+def test_pickle_roundtrip_custom_normalizer():
+    # __setstate__ must work on an instance built by object.__new__, which is what pickle does.
+    clear_registered_normalizers()
+    register_normalizer(TestCustomNormalizer())
+    normalizer = get_custom_normalizer(fail_on_missing=True)
+
+    cloned_normalizer = pickle.loads(pickle.dumps(normalizer))
+
+    assert_equal(len(normalizer._normalizers), len(cloned_normalizer._normalizers))
+    assert_equal(normalizer._normalizers[0].__class__, cloned_normalizer._normalizers[0].__class__)
+    assert_equal(normalizer._fail_on_missing_type, cloned_normalizer._fail_on_missing_type)
+
+
+@pytest.mark.parametrize("fail_on_missing", [True, False])
+def test_deserialize_custom_normalizer_missing_type(fail_on_missing):
+    # A worker process that cannot import the normalizer must honour fail_on_missing, otherwise the
+    # custom type silently falls through to being pickled on write.
+    state = {"class_names": ["arcticdb_no_such_module.SomeNormalizer"], "fail_on_missing": fail_on_missing}
+    normalizer = CompositeCustomNormalizer([], False)
+
+    if fail_on_missing:
+        with pytest.raises(ImportError):
+            normalizer.__setstate__(state)
+    else:
+        normalizer.__setstate__(state)
+        assert_equal(normalizer._normalizers, [])
 
 
 def test_force_pickle_on_norm_failure():


### PR DESCRIPTION
### Reference Issues/PRs
None open. Related: #2995, which fixed the `ConfigsMap` half of this same `NativeVersionStore` pickle path.

### What does this implement or fix?

`CompositeCustomNormalizer.__setstate__` has two defects.

**1. It assumes `__init__` has run.** `pickle` builds the instance with `object.__new__` and never calls `__init__`, so `_normalizers` and `_normalizer_by_typename` do not exist:

```python
>>> pickle.loads(pickle.dumps(get_custom_normalizer(fail_on_missing=True)))
AttributeError: 'CompositeCustomNormalizer' object has no attribute '_normalizer_by_typename'
```

Both current callers work around this by hand-constructing `CompositeCustomNormalizer([], False)` before calling `__setstate__` (`_store.py:534`, and `test_serialize_custom_normalizer`).

**2. `fail_on_missing_custom_normalizer` has no effect.**

```python
except ImportError:
    if not self._fail_on_missing_type:
        continue
```

False continues; True falls out of the `if`, off the end of the handler, and continues anyway. Both branches swallow the error. `denormalize()` on the same class *does* raise when the flag is set, so the intent is unambiguous.

### Why it matters

On the spawn/forkserver path, `NativeVersionStore.__getstate__` ships normalizer *class names* to the worker. If the worker cannot import one, it is dropped silently even with `fail_on_missing_custom_normalizer` set. `normalize()` then returns `None` for that type, and `_store.py:609` falls through to the `pickle_on_failure` branch, so the custom object is written as a **pickled blob instead of a normalised frame** with no error raised. That is the exact outcome the flag exists to prevent.

Reproduced against released 6.23.0, with the normalizer's module made unimportable:

```
worker _fail_on_missing_type : True   <- flag survived the round trip
worker _normalizers          : []     <- normalizer silently dropped
worker normalize(Thing)      : None   <- falls through to pickle-on-write
```

### What does this PR do?

Initialises both containers in `__setstate__`, and re-raises the `ImportError` when the flag is set, logging the missing type either way.

### Any other comments?

Behaviour only changes for users who set `fail_on_missing_custom_normalizer=True` *and* have an unimportable normalizer type, who currently get silent pickling instead of the error they asked for. The `False` path is unchanged.

Three tests added to `test_normalization.py`: a `pickle` round trip, and both flag values against a missing type. Against unpatched 6.23.0 the round trip and the `True` case fail; the existing `test_serialize_custom_normalizer` passes before and after.

### Checklist
<details>
  <summary>Checklist for code changes...</summary>

- [x] Have you updated the relevant docstrings, documentation and copyright notice?
- [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
- [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
- [ ] Are API changes highlighted in the PR description?
- [ ] Is the PR labelled as enhancement or bug if it can be added to our release notes?
</details>
