### PR TITLE
fix(python): is_server_type raises UnboundLocalError when the server is unreachable

### DIFF
--- a/python/arcticdb/storage_fixtures/s3.py
+++ b/python/arcticdb/storage_fixtures/s3.py
@@ -899,10 +899,14 @@ def is_server_type(url: str, server_type: str):
     /whoami url is added to Moto* objects to identify GCP or S3"""
     try:
         response = requests.get(url, verify=False)
-        if response.status_code == 200 and server_type in response.text:
-            return True
     except Exception as e:
+        # Without returning here, the diagnostic logging below raises UnboundLocalError on
+        # `response` and hides the connection error it was meant to report.
         logger.error(f"Error during server type check: {e}")
+        return False
+
+    if response.status_code == 200 and server_type in response.text:
+        return True
     logger.error(f"Was not of expected type: status code {response.status_code}, text: {response.text}")
     return False
 
@@ -915,7 +919,7 @@ def create_bucket(s3_client, bucket_name, max_retries=15):
         except botocore.exceptions.EndpointConnectionError as e:
             if i >= max_retries - 1:
                 raise
-            logger.warning(f"S3 create bucket failed. Retry {1}/{max_retries}")
+            logger.warning(f"S3 create bucket failed. Retry {i + 1}/{max_retries}")
             time.sleep(1)
         except Exception as e:
             logger.error(f"create_bucket - Error: {e.response['Error']['Message']}")
@@ -971,15 +975,6 @@ class MotoS3StorageFixtureFactory(BaseS3StorageFixtureFactory):
         # and not using the fixtures
         # so this guarantees a unique bucket name
         return f"test-{bucket_type}-bucket-{self.unique_id}-{self._bucket_id}"
-
-    def is_server_type(url: str, server_type: str):
-        try:
-            response = requests.get(url, verify=False)
-            if response.status_code == 200 and server_type in response.text:
-                return True
-        except Exception:
-            pass
-        return False
 
     def _start_server(self, seed=2):
         port = self.port = get_ephemeral_port(seed)


### PR DESCRIPTION
### Reference Issues/PRs
None open.

### What does this implement or fix?

`is_server_type` swallows the exception and then falls through into a log line that dereferences the variable the `try` failed to bind:

```python
try:
    response = requests.get(url, verify=False)
    if response.status_code == 200 and server_type in response.text:
        return True
except Exception as e:
    logger.error(f"Error during server type check: {e}")
logger.error(f"Was not of expected type: status code {response.status_code}, text: {response.text}")
return False
```

When `requests.get` raises, which is the normal case when Moto has not come up, `response` is unbound. Against released 6.23.0 with nothing listening:

```
log: Error during server type check: ... [Errno 111] Connection refused
RAISED UnboundLocalError: local variable 'response' referenced before assignment
```

Both callers are assertions:

```python
assert is_server_type(self.endpoint + "/whoami", "S3"), "The server has not identified as S3"
```

so a fixture that fails to start surfaces as `UnboundLocalError` from inside `_start_server` rather than the assertion message, and the connection error that was correctly logged one line earlier is buried.

### What does this PR do?

Moves the success check out of the `try` so the handler returns `False` directly. Verified on the patched function: connection refused returns `False` and logs the connection error, a matching server returns `True`, a non-matching one returns `False` and logs the status and body.

Two smaller things in the same file, happy to split them out if you would rather:

- **Removes `MotoS3StorageFixtureFactory.is_server_type`.** It is an older copy of the same function, declared in the class body with no `self`. The call site in `_start_server` is unqualified, so it resolves to the module-level function; a class body is not an enclosing scope for methods, making the class-body copy unreachable. It also predates the logging, which is where the bug was introduced.
- **Fixes the retry counter in `create_bucket`,** which interpolates the literal `{1}` and so always logs `Retry 1/15` no matter which attempt failed.

### Any other comments?

One more thing I did not touch, since it is a real behaviour change rather than a fix: `create_bucket`'s final handler is `except Exception as e` but the body reads `e.response['Error']['Message']`, which raises `AttributeError` for any non-botocore exception. And once retries are exhausted on that path the function returns `None` without having created the bucket, so the failure only shows up later as a confusing `NoSuchBucket`. Glad to send that separately if you want it.

### Checklist
<details>
  <summary>Checklist for code changes...</summary>

- [x] Have you updated the relevant docstrings, documentation and copyright notice?
- [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
- [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
- [ ] Are API changes highlighted in the PR description?
- [ ] Is the PR labelled as enhancement or bug if it can be added to our release notes?
</details>
