### PR TITLE
fix(python): pickling warning says "metadata" when data is being pickled

### DIFF
--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -1397,8 +1397,11 @@ class MsgPackNormalizer(Normalizer):
     Fall back plan for the time being to store arbitrary data
     """
 
-    def __init__(self, cfg=None):
+    def __init__(self, cfg=None, pickled_subject="data"):
         self.strict_mode = cfg.strict_mode if cfg is not None else False
+        # What this instance serialises. Only used so the pickling log message names the
+        # right thing: this class is the fallback for user data as well as for metadata.
+        self._pickled_subject = pickled_subject
 
     def normalize(self, obj, **kwargs):
         disallow_pickle = kwargs.get("disallow_pickle", None)
@@ -1451,7 +1454,7 @@ class MsgPackNormalizer(Normalizer):
         if disallow_pickle:
             raise TypeError("Normalizing data by pickling has been disabled.")
         else:
-            return ExtType(MsgPackSerialization.PY_PICKLE_3, packb(Pickler.write(obj)))
+            return ExtType(MsgPackSerialization.PY_PICKLE_3, packb(Pickler.write(obj, self._pickled_subject)))
 
     def _ext_hook(self, code, data):
         if code == MsgPackSerialization.PD_TIMESTAMP:
@@ -1506,8 +1509,8 @@ class Pickler(object):
         return pd.read_pickle(io.BytesIO(data))
 
     @staticmethod
-    def write(obj):
-        log.log(get_pickled_metadata_loglevel(), f"Pickling metadata - may not be readable by other clients")
+    def write(obj, subject="data"):
+        log.log(get_pickled_metadata_loglevel(), f"Pickling {subject} - may not be readable by other clients")
         return pickle.dumps(obj, protocol=PICKLE_PROTOCOL)
 
 
@@ -1743,7 +1746,7 @@ _WARN_RECURSIVE_METASTRUCT = 8 << 20  # 8MB
 def _init_msgpack_metadata():
     cfg = VersionStoreConfig.MsgPack()
     cfg.max_blob_size = _MAX_USER_DEFINED_META
-    return MsgPackNormalizer(cfg)
+    return MsgPackNormalizer(cfg, pickled_subject="metadata")
 
 
 _msgpack_metadata = _init_msgpack_metadata()

--- a/python/tests/unit/arcticdb/version_store/test_normalization.py
+++ b/python/tests/unit/arcticdb/version_store/test_normalization.py
@@ -232,6 +232,25 @@ def test_warns_on_large_meta(log):
     assert "User defined metadata is above warning size" in log.warn.call_args[0][0]
 
 
+class _Unserializable:
+    """Something msgpack cannot handle, so it falls through to the pickler."""
+
+
+@patch("arcticdb.version_store._normalization.log")
+def test_pickling_metadata_says_metadata(log):
+    normalize_metadata({"a": _Unserializable()})
+    assert "Pickling metadata" in log.log.call_args[0][1]
+
+
+@patch("arcticdb.version_store._normalization.log")
+def test_pickling_data_does_not_say_metadata(log):
+    # The same MsgPackNormalizer is the fallback for user data, where the message
+    # previously still claimed metadata was being pickled.
+    MsgPackNormalizer().normalize(_Unserializable())
+    assert "Pickling data" in log.log.call_args[0][1]
+    assert "metadata" not in log.log.call_args[0][1]
+
+
 def test_fails_humongous_meta():
     with pytest.raises(ArcticDbNotYetImplemented):
         from arcticdb.version_store._normalization import _MAX_USER_DEFINED_META as MAX


### PR DESCRIPTION
### Reference Issues/PRs
Closes #2336.

### What does this implement or fix?

`Pickler.write` hardcodes "metadata" in its message:

```python
@staticmethod
def write(obj):
    log.log(get_pickled_metadata_loglevel(), f"Pickling metadata - may not be readable by other clients")
```

but its only caller is `MsgPackNormalizer._custom_pack`, and that class is the fallback normalizer for **user data** as well as the serializer for metadata. So pickling data reports that metadata was pickled.

Reproduced on 6.23.0, passing no metadata argument at all:

```
A) write_pickle(DATA), no metadata passed : Pickling metadata - may not be readable by other clients
B) write(df) with unserializable metadata : Pickling metadata - may not be readable by other clients
```

### The change

`MsgPackNormalizer` gains a `pickled_subject`, defaulting to `"data"`. `_init_msgpack_metadata`, which builds the single module-level instance `normalize_metadata` uses, sets it to `"metadata"`. `Pickler.write` names it.

After:

```
A) write_pickle(DATA), no metadata passed : Pickling data - may not be readable by other clients
B) write(df) with unserializable metadata : Pickling metadata - may not be readable by other clients
```

The metadata wording is unchanged, so anyone grepping logs for it still finds the metadata case.

### Tests

Two added beside `test_warns_on_large_meta`, which already patches the same logger, so the pattern matches what is there:

```
                                             master   this branch
test_pickling_metadata_says_metadata          PASS       PASS
test_pickling_data_does_not_say_metadata      FAIL       PASS
```

The metadata one passes either way on purpose, it is there to pin that the existing wording did not regress.

### Note on verification

I do not have a working C++ toolchain, so I could not run the repo's suite directly. I verified by applying the identical four edits to the installed 6.23.0 wheel and running the two tests' logic against it, which is the before/after shown above. The change is pure Python and touches no bindings.

### Checklist
<details>
  <summary>Checklist for code changes...</summary>

- [x] Have you updated the relevant docstrings, documentation and copyright notice?
- [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)?
- [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)?
- [ ] Are API changes highlighted in the PR description?
- [ ] Is the PR labelled as enhancement or bug if it can be added to our release notes?
</details>
