### PR TITLE
Import all exceptions from arcticdb.exceptions in tests

### DIFF
--- a/python/arcticdb/_core_api.py
+++ b/python/arcticdb/_core_api.py
@@ -6,10 +6,10 @@ Non-public APIs depended by downstream repos
 Treat everything here as a public API, governed by our semantic versioning
 """
 
-from arcticdb_ext.storage import NativeVariantStorage, NativeVariantStorageContentType, NoDataFoundException, KeyType
+from arcticdb_ext.storage import NativeVariantStorage, NativeVariantStorageContentType, KeyType
 from arcticdb_ext.metrics.prometheus import MetricsConfig
 from arcticdb_ext.version_store import AtomKey, RefKey
-from arcticdb_ext.exceptions import StorageException, ArcticException
 from arcticdb_ext import set_config_int
+from arcticdb.exceptions import StorageException, ArcticException, NoDataFoundException
 from arcticdb.version_store._store import _env_config_from_lib_config as env_config_from_lib_config
 from arcticdb.version_store._normalization import denormalize_dataframe

--- a/python/arcticdb/adapters/gcpxml_library_adapter.py
+++ b/python/arcticdb/adapters/gcpxml_library_adapter.py
@@ -18,7 +18,7 @@ from arcticdb.adapters.s3_library_adapter import USE_AWS_CRED_PROVIDERS_TOKEN
 from arcticdb.util.utils import strtobool
 from arcticdb.encoding_version import EncodingVersion
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException
 from arcticdb_ext.storage import (
     StorageOverride,
     GCPXMLOverride,

--- a/python/arcticdb/arctic.py
+++ b/python/arcticdb/arctic.py
@@ -20,8 +20,13 @@ from arcticdb.options import (
 )
 from arcticdb.dependencies import pyarrow as pa
 from arcticdb_ext.storage import LibraryManager
-from arcticdb.exceptions import LibraryNotFound, MismatchingLibraryOptions, KeyNotFoundException
-from arcticdb.version_store.library import ArcticInvalidApiUsageException, Library
+from arcticdb.exceptions import (
+    LibraryNotFound,
+    MismatchingLibraryOptions,
+    KeyNotFoundException,
+    ArcticInvalidApiUsageException,
+)
+from arcticdb.version_store.library import Library
 from arcticdb.version_store._store import NativeVersionStore
 from arcticdb.adapters.arctic_library_adapter import ArcticLibraryAdapter
 from arcticdb.adapters.s3_library_adapter import S3LibraryAdapter

--- a/python/arcticdb/exceptions.py
+++ b/python/arcticdb/exceptions.py
@@ -14,6 +14,7 @@ from arcticdb_ext.exceptions import (
     DuplicateKeyException,
     PermissionException,
     StreamDescriptorMismatch,
+    _ArcticLegacyCompatibilityException,
 )
 from arcticdb_ext.storage import NoDataFoundException
 from arcticdb_ext.storage import UnknownLibraryOption, UnsupportedLibraryOptionValue

--- a/python/arcticdb/toolbox/query_stats.py
+++ b/python/arcticdb/toolbox/query_stats.py
@@ -13,7 +13,7 @@ Notes
 from contextlib import contextmanager
 from typing import Dict, Any, Iterator
 import arcticdb_ext.tools.query_stats as qs
-from arcticdb_ext.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException
 
 
 @contextmanager

--- a/python/arcticdb/util/append_and_defrag.py
+++ b/python/arcticdb/util/append_and_defrag.py
@@ -9,11 +9,10 @@ from typing import List, Optional, Tuple
 import pandas as pd
 
 from arcticdb import ReadRequest, UpdatePayload, VersionedItem
-from arcticdb.exceptions import ArcticNativeException, NoSuchVersionException
+from arcticdb.exceptions import ArcticNativeException, NoSuchVersionException, NoDataFoundException
 from arcticdb.preconditions import check
 from arcticdb.version_store.library import Library
 from arcticdb.version_store._store import NativeVersionStore
-from arcticdb_ext.storage import NoDataFoundException
 
 
 def _generate_levels(target_rows_per_slice: int, factor: int) -> List[int]:

--- a/python/arcticdb/util/venv.py
+++ b/python/arcticdb/util/venv.py
@@ -12,7 +12,7 @@ from retrying import retry
 
 from typing import Dict, List, Optional, Union
 
-from arcticdb_ext.exceptions import StorageException
+from arcticdb.exceptions import StorageException
 from packaging.version import Version
 from arcticdb_ext import set_config_int, unset_config_int
 from arcticdb.arctic import Arctic

--- a/python/arcticdb/version_store/admin_tools.py
+++ b/python/arcticdb/version_store/admin_tools.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 from enum import Enum
 from typing import Dict, Iterable
 
-from arcticdb_ext.exceptions import ArcticException
+from arcticdb.exceptions import ArcticException
 from arcticdb_ext.storage import KeyType as NativeKeyType
 from arcticdb.version_store import NativeVersionStore
 from dataclasses import dataclass

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -16,6 +16,7 @@ from typing import Optional, Any, Tuple, Dict, Union, List, Iterable, NamedTuple
 
 from arcticdb.dependencies import _PYARROW_AVAILABLE, _POLARS_AVAILABLE, pyarrow as pa, polars as pl
 from arcticdb.exceptions import (
+    ArcticException,
     ArcticNativeException,
     ArcticDbNotYetImplemented,
     MissingKeysInStageResultsError,
@@ -40,7 +41,6 @@ from arcticdb.version_store._store import (
     MergeStrategy,
     MergeAction,
 )
-from arcticdb_ext.exceptions import ArcticException
 from arcticdb_ext.version_store import (
     CompactDataInfo,
     DataError,

--- a/python/installation_tests/test_installation.py
+++ b/python/installation_tests/test_installation.py
@@ -20,7 +20,7 @@ from arcticdb.util.test import random_floats, random_strings_of_length
 from arcticdb.version_store import VersionedItem as PythonVersionedItem
 from arcticdb.toolbox.library_tool import KeyType
 from arcticdb.version_store.library import ReadRequest, StagedDataFinalizeMethod, WritePayload
-from arcticdb_ext.exceptions import UnsortedDataException
+from arcticdb.exceptions import UnsortedDataException
 from arcticdb_ext.version_store import AtomKey, RefKey
 from packaging import version
 

--- a/python/tests/compat/arcticdb/test_lib_naming.py
+++ b/python/tests/compat/arcticdb/test_lib_naming.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 from arcticdb.util.logger import get_logger
-from arcticdb_ext.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException
 from arcticdb.util.test import sample_dataframe
 from tests.util.mark import SLOW_TESTS_MARK, xfail_azure_chars
 

--- a/python/tests/hypothesis/arcticdb/test_append.py
+++ b/python/tests/hypothesis/arcticdb/test_append.py
@@ -3,8 +3,12 @@ import pandas as pd
 import numpy as np
 import pytest
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import InternalException, NormalizationException, ArcticException as ArcticNativeException
-from arcticdb_ext.exceptions import StreamDescriptorMismatch
+from arcticdb.exceptions import (
+    InternalException,
+    NormalizationException,
+    ArcticException as ArcticNativeException,
+    StreamDescriptorMismatch,
+)
 from arcticdb_ext import set_config_int
 from hypothesis import given, assume, settings, strategies as st
 from itertools import chain, product, combinations

--- a/python/tests/integration/arcticdb/test_admin_tools.py
+++ b/python/tests/integration/arcticdb/test_admin_tools.py
@@ -10,8 +10,8 @@ import time
 import numpy as np
 import pandas as pd
 from arcticdb.util.logger import get_logger
-import arcticdb_ext
 import arcticdb_ext.storage
+from arcticdb.exceptions import StorageException
 from arcticdb.util.test import sample_dataframe
 from arcticdb import KeyType, Size, Arctic
 from arcticdb.toolbox.library_tool import LibraryTool
@@ -28,7 +28,7 @@ def retry_get_sizes(admin_tools: AdminTools, retries=3, base_delay=1):
         try:
             result = admin_tools.get_sizes()
             return result
-        except arcticdb_ext.exceptions.StorageException as e:
+        except StorageException as e:
             if ("E_UNEXPECTED_AZURE_ERROR" in str(e)) and (attempt < retries):
                 wait_time = base_delay * (2**attempt)
                 logger.info(f"Attempt {attempt + 1} failed: {e}. Retrying in {wait_time} seconds...")

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -23,9 +23,18 @@ from enum import Enum
 import multiprocessing
 
 from arcticdb_ext import get_config_int, set_config_int
-from arcticdb_ext.exceptions import InternalException, StorageException, UnsortedDataException, UserInputException
-from arcticdb_ext.storage import NoDataFoundException, KeyType, AWSAuthMethod
-from arcticdb.exceptions import ArcticDbNotYetImplemented, NoSuchVersionException
+from arcticdb_ext.storage import KeyType, AWSAuthMethod
+from arcticdb.exceptions import (
+    ArcticDbNotYetImplemented,
+    NoSuchVersionException,
+    InternalException,
+    StorageException,
+    UnsortedDataException,
+    UserInputException,
+    NoDataFoundException,
+    ArcticUnsupportedDataTypeException,
+    ArcticInvalidApiUsageException,
+)
 from arcticdb.adapters.mongo_library_adapter import MongoLibraryAdapter
 from arcticdb.arctic import Arctic
 import arcticdb.toolbox.query_stats as qs
@@ -37,16 +46,9 @@ from arcticdb.storage_fixtures.utils import GracefulProcessUtils
 from arcticdb.util.test import assert_frame_equal, sample_dataframe, config_context, config_context_string
 from arcticdb.storage_fixtures.s3 import S3Bucket
 from arcticdb.config import Defaults
-from arcticdb.version_store.library import (
-    WritePayload,
-    ArcticUnsupportedDataTypeException,
-    ReadRequest,
-    StagedDataFinalizeMethod,
-    DeleteRequest,
-)
+from arcticdb.version_store.library import WritePayload, ReadRequest, StagedDataFinalizeMethod, DeleteRequest
 from arcticdb.authorization.permissions import OpenMode
 from arcticdb.version_store._store import NativeVersionStore
-from arcticdb.version_store.library import ArcticInvalidApiUsageException
 from tests.conftest import Marks
 from tests.util.marking import marks
 from tests.util.storage_test import get_s3_storage_config

--- a/python/tests/integration/arcticdb/test_arctic_batch.py
+++ b/python/tests/integration/arcticdb/test_arctic_batch.py
@@ -13,7 +13,12 @@ from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import VersionRequestType
 
 from arcticdb.options import LibraryOptions
-from arcticdb import QueryBuilder, DataError, VersionedItem
+from arcticdb import QueryBuilder, VersionedItem, DataError
+from arcticdb.exceptions import (
+    ArcticDuplicateSymbolsInBatchException,
+    ArcticUnsupportedDataTypeException,
+    ArcticInvalidApiUsageException,
+)
 from arcticdb_ext.version_store import AtomKey, RefKey
 from arcticdb.toolbox.library_tool import LibraryTool
 
@@ -35,11 +40,8 @@ import random
 from arcticdb.version_store.library import (
     WritePayload,
     WriteMetadataPayload,
-    ArcticDuplicateSymbolsInBatchException,
-    ArcticUnsupportedDataTypeException,
     ReadRequest,
     ReadInfoRequest,
-    ArcticInvalidApiUsageException,
     DeleteRequest,
     UpdatePayload,
 )

--- a/python/tests/integration/arcticdb/test_arctic_library_management.py
+++ b/python/tests/integration/arcticdb/test_arctic_library_management.py
@@ -11,12 +11,15 @@ import sys
 import pytest
 import pandas as pd
 
-from arcticdb_ext.exceptions import InternalException, UserInputException
 from arcticdb_ext.storage import KeyType
 from arcticdb.exceptions import (
     ArcticDbNotYetImplemented,
     LibraryNotFound,
     MismatchingLibraryOptions,
+    InternalException,
+    UserInputException,
+    ArcticUnsupportedDataTypeException,
+    ArcticInvalidApiUsageException,
 )
 from arcticdb.arctic import Arctic
 from arcticdb.options import LibraryOptions, EnterpriseLibraryOptions
@@ -27,14 +30,7 @@ from arcticdb.storage_fixtures.api import (
     ArcticUriFields,
     StorageFixtureFactory,
 )
-from arcticdb.version_store.library import (
-    WritePayload,
-    ArcticUnsupportedDataTypeException,
-    ReadRequest,
-    StagedDataFinalizeMethod,
-    ArcticInvalidApiUsageException,
-    DeleteRequest,
-)
+from arcticdb.version_store.library import WritePayload, ReadRequest, StagedDataFinalizeMethod, DeleteRequest
 
 from tests.conftest import Marks
 from tests.util.mark import (

--- a/python/tests/integration/arcticdb/test_name_validation.py
+++ b/python/tests/integration/arcticdb/test_name_validation.py
@@ -9,7 +9,7 @@ will be governed by the Apache License, version 2.0.
 
 import pytest
 
-from arcticdb_ext.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException
 from arcticdb.storage_fixtures.azure import AzureContainer
 from arcticdb.util.test import assert_frame_equal, config_context, sample_dataframe
 from tests.util.mark import AZURE_TESTS_MARK

--- a/python/tests/integration/arcticdb/test_s3.py
+++ b/python/tests/integration/arcticdb/test_s3.py
@@ -14,7 +14,7 @@ import pytest
 import pandas as pd
 import sys
 
-from arcticdb_ext.exceptions import StorageException
+from arcticdb.exceptions import StorageException
 
 from arcticdb_ext import set_config_string
 from arcticdb_ext.storage import KeyType

--- a/python/tests/integration/arcticdb/test_s3_profile.py
+++ b/python/tests/integration/arcticdb/test_s3_profile.py
@@ -17,7 +17,7 @@ from tempfile import mkdtemp
 import random
 from datetime import datetime
 
-from arcticdb_ext.exceptions import PermissionException
+from arcticdb.exceptions import PermissionException
 from arcticdb.arctic import Arctic
 from arcticdb.util.test import assert_frame_equal
 from arcticdb.storage_fixtures.s3 import (

--- a/python/tests/integration/arcticdb/test_update.py
+++ b/python/tests/integration/arcticdb/test_update.py
@@ -18,7 +18,8 @@ import pandas as pd
 import numpy as np
 import string
 
-from arcticdb_ext.exceptions import ArcticException as ArcticNativeException
+from arcticdb.exceptions import ArcticException as ArcticNativeException
+from arcticdb_ext.version_store import DataError
 
 from arcticdb.options import LibraryOptions
 from arcticdb.util._versions import IS_PANDAS_ONE
@@ -28,7 +29,6 @@ from arcticdb.util.logger import get_logger
 from arcticdb.version_store._store import VersionedItem
 from arcticdb.version_store.library import Library, UpdatePayload, WritePayload
 from arcticdb.util.test import assert_frame_equal, sample_dataframe
-from arcticdb_ext.version_store import DataError
 from tests.util.mark import LINUX
 
 logger = get_logger()

--- a/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_operations_scenarios.py
@@ -21,18 +21,18 @@ from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
 from arcticdb.version_store._store import NativeVersionStore, VersionedItem
 from datetime import timedelta, timezone
 
-from arcticdb.exceptions import ArcticNativeException, UnsortedDataException
-from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import StreamDescriptorMismatch
-from arcticdb_ext.version_store import NoSuchVersionException
-
-from arcticdb_ext.exceptions import (
+from arcticdb.exceptions import (
+    ArcticNativeException,
+    UnsortedDataException,
+    NoSuchVersionException,
     InternalException,
     NormalizationException,
     UserInputException,
     MissingDataException,
     SchemaException,
+    StreamDescriptorMismatch,
 )
+from arcticdb.version_store.processing import QueryBuilder
 
 
 from tests.util.mark import LINUX, SLOW_TESTS_MARK, WINDOWS

--- a/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
+++ b/python/tests/integration/arcticdb/version_store/test_basic_version_store.py
@@ -30,19 +30,19 @@ from arcticdb.exceptions import (
     SchemaException,
     UserInputException,
     ArcticException,
+    KeyNotFoundException,
+    StorageException,
+    NoDataFoundException,
+    NoSuchVersionException,
+    StreamDescriptorMismatch,
 )
 from arcticdb import QueryBuilder
 from arcticdb.flattener import Flattener
 from arcticdb.util.test_utils import generate_random_numpy_array, generate_random_series
 from arcticdb.version_store import NativeVersionStore
 from arcticdb.version_store._store import VersionedItem
-from arcticdb_ext.exceptions import KeyNotFoundException, StorageException, StreamDescriptorMismatch
-from arcticdb_ext.storage import KeyType, NoDataFoundException
-from arcticdb_ext.version_store import (
-    NoSuchVersionException,
-    ManualClockVersionStore,
-    DataError,
-)
+from arcticdb_ext.storage import KeyType
+from arcticdb_ext.version_store import ManualClockVersionStore, DataError
 from arcticdb.util.test import (
     sample_dataframe,
     sample_dataframe_only_strings,

--- a/python/tests/integration/arcticdb/version_store/test_dedup.py
+++ b/python/tests/integration/arcticdb/version_store/test_dedup.py
@@ -9,7 +9,8 @@ import pandas as pd
 from pandas.testing import assert_frame_equal
 import pytest
 
-from arcticdb_ext.storage import KeyType, NoDataFoundException
+from arcticdb_ext.storage import KeyType
+from arcticdb.exceptions import NoDataFoundException
 from tests.conftest import Marks
 
 pytestmark = Marks.dedup.mark

--- a/python/tests/integration/arcticdb/version_store/test_deletion.py
+++ b/python/tests/integration/arcticdb/version_store/test_deletion.py
@@ -12,8 +12,8 @@ import pandas as pd
 import pytest
 import random
 
-from arcticdb_ext.exceptions import UserInputException
-from arcticdb_ext.storage import KeyType, NoDataFoundException
+from arcticdb.exceptions import UserInputException, NoDataFoundException
+from arcticdb_ext.storage import KeyType
 from arcticdb.util.test import config_context, random_string, assert_frame_equal, distinct_timestamps
 
 

--- a/python/tests/integration/arcticdb/version_store/test_metadata_support.py
+++ b/python/tests/integration/arcticdb/version_store/test_metadata_support.py
@@ -21,8 +21,7 @@ from pandas import DataFrame, Timestamp
 import pytest
 
 from arcticdb.version_store import NativeVersionStore, VersionedItem
-from arcticdb.exceptions import ArcticDbNotYetImplemented
-from arcticdb_ext.storage import NoDataFoundException
+from arcticdb.exceptions import ArcticDbNotYetImplemented, NoDataFoundException
 from arcticdb.util.test import assert_frame_equal, distinct_timestamps
 
 from tests.util.mark import ZONE_INFO_MARK

--- a/python/tests/integration/arcticdb/version_store/test_snapshot.py
+++ b/python/tests/integration/arcticdb/version_store/test_snapshot.py
@@ -13,10 +13,13 @@ import random
 import re
 
 from arcticdb.util.arctic_simulator import ArcticSymbolSimulator
-from arcticdb.exceptions import UserInputException, ArcticNativeException
-from arcticdb_ext.exceptions import InternalException
-from arcticdb_ext.version_store import NoSuchVersionException
-from arcticdb_ext.storage import NoDataFoundException
+from arcticdb.exceptions import (
+    UserInputException,
+    ArcticNativeException,
+    InternalException,
+    NoSuchVersionException,
+    NoDataFoundException,
+)
 from arcticdb.util.test import distinct_timestamps
 from arcticdb.util.test import (
     assert_frame_equal,

--- a/python/tests/integration/arcticdb/version_store/test_symbol_list.py
+++ b/python/tests/integration/arcticdb/version_store/test_symbol_list.py
@@ -22,7 +22,7 @@ from arcticdb.toolbox.library_tool import (
 from arcticdb_ext import set_config_int, unset_config_int
 from arcticdb_ext.storage import KeyType, OpenMode
 from arcticdb_ext.tools import CompactionId, CompactionLockName
-from arcticdb_ext.exceptions import InternalException, PermissionException
+from arcticdb.exceptions import InternalException, PermissionException
 
 from multiprocessing import Pool
 from arcticdb_ext import set_config_int

--- a/python/tests/integration/toolbox/test_library_tool.py
+++ b/python/tests/integration/toolbox/test_library_tool.py
@@ -12,7 +12,7 @@ from arcticdb.util.test import sample_dataframe, populate_db, assert_frame_equal
 from arcticdb.version_store._normalization import denormalize_dataframe
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.types import DataType, IndexKind
-from arcticdb_ext.exceptions import SchemaException, InternalException, StorageException
+from arcticdb.exceptions import SchemaException, InternalException, StorageException
 from arcticdb_ext.version_store import Slicing
 from arcticdb_ext.stream import SegmentInMemory
 from tests.util.mark import MONGO_TESTS_MARK

--- a/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
+++ b/python/tests/nonreg/arcticdb/version_store/test_nonreg_specific.py
@@ -13,7 +13,7 @@ import pytest
 import sys
 
 from arcticdb import QueryBuilder
-from arcticdb.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException, SchemaException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import assert_frame_equal, assert_series_equal, config_context
 from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
@@ -21,7 +21,6 @@ from arcticdb.version_store.library import Library
 from arcticdb_ext import set_config_int
 import arcticdb_ext.cpp_async as adb_async
 from arcticdb_ext.storage import KeyType
-from arcticdb_ext.exceptions import SchemaException
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from tests.conftest import Marks
 from tests.util.date import DateRange

--- a/python/tests/stress/arcticdb/version_store/test_stress_version_map_compact.py
+++ b/python/tests/stress/arcticdb/version_store/test_stress_version_map_compact.py
@@ -17,7 +17,8 @@ from arcticdb_ext import set_config_int
 from arcticdb import log
 
 from arcticdb.config import set_log_level
-from arcticdb_ext.storage import KeyType, NoDataFoundException
+from arcticdb_ext.storage import KeyType
+from arcticdb.exceptions import NoDataFoundException
 
 from tests.util.mark import SLOW_TESTS_MARK
 

--- a/python/tests/unit/arcticdb/test_arrow_api.py
+++ b/python/tests/unit/arcticdb/test_arrow_api.py
@@ -6,11 +6,11 @@ import polars as pl
 import pytest
 
 from arcticdb import LazyDataFrame, DataError, concat
-from arcticdb.exceptions import ArcticNativeException
+from arcticdb.exceptions import ArcticNativeException, ArcticUnsupportedDataTypeException
 from arcticdb.options import OutputFormat, ArrowOutputStringFormat, LibraryOptions
 from arcticdb.util.test import assert_frame_equal_with_arrow, sample_dataframe
 
-from arcticdb.version_store.library import ArcticUnsupportedDataTypeException, WritePayload, UpdatePayload, ReadRequest
+from arcticdb.version_store.library import WritePayload, UpdatePayload, ReadRequest
 
 all_output_format_args = [
     None,

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -19,9 +19,14 @@ from polars.testing import assert_frame_equal as pl_assert_frame_equal
 from arcticc.pb2.column_stats_pb2 import ColumnStatsHeader, ColumnStatsType
 from google.protobuf.any_pb2 import Any as ProtobufAny
 
-from arcticdb_ext.exceptions import SchemaException, SortingException, StorageException, UserInputException
+from arcticdb.exceptions import (
+    SchemaException,
+    SortingException,
+    StorageException,
+    UserInputException,
+    NoSuchVersionException,
+)
 from arcticdb_ext.storage import KeyType
-from arcticdb_ext.version_store import NoSuchVersionException
 from arcticdb import QueryBuilder
 from arcticdb.exceptions import ArcticNativeException
 from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -9,7 +9,7 @@ from arcticdb.version_store.processing import QueryBuilder
 import arcticdb.toolbox.query_stats as qs
 import pandas as pd
 
-from arcticdb_ext.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException
 
 
 def get_table_data_read_count():

--- a/python/tests/unit/arcticdb/test_errors.py
+++ b/python/tests/unit/arcticdb/test_errors.py
@@ -3,7 +3,7 @@ import pytest
 from arcticdb.util.errors import *
 import arcticdb.exceptions as ae
 from arcticdb.exceptions import *  # keep as wildcard so all_exception_types below includes everything
-from arcticdb_ext.exceptions import _ArcticLegacyCompatibilityException
+from arcticdb.exceptions import _ArcticLegacyCompatibilityException
 from tests.util.mark import SLOW_TESTS_MARK
 
 test_raise_params = [(NormalizationError.E_UPDATE_NOT_SUPPORTED, NormalizationException)]

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -1,0 +1,108 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import ast
+import os
+
+import arcticdb.exceptions as arcticdb_exceptions
+
+# The one canonical place tests are allowed to import exceptions from.
+CANONICAL_MODULE = "arcticdb.exceptions"
+
+# Native submodules the exceptions are also (still) reachable from. Used to catch
+# fully-qualified attribute access such as ``arcticdb_ext.exceptions.UserInputException``.
+NATIVE_EXCEPTION_MODULES = {
+    "arcticdb_ext.exceptions",
+    "arcticdb_ext.storage",
+    "arcticdb_ext.version_store",
+}
+
+
+def canonical_exception_names():
+    """Every exception re-exported from ``arcticdb.exceptions``.
+
+    A name qualifies if it resolves to a subclass of ``BaseException``. This is name-agnostic
+    (so it catches exceptions like ``StreamDescriptorMismatch`` or ``UnknownLibraryOption`` that
+    do not end in ``Exception``/``Error``) and excludes error-metadata enums such as
+    ``ErrorCode``/``ErrorCategory`` and non-exception data containers such as ``DataError``.
+    Names that are *not* re-exported from ``arcticdb.exceptions`` are out of scope and never
+    flagged.
+    """
+    names = set()
+    for name in dir(arcticdb_exceptions):
+        obj = getattr(arcticdb_exceptions, name)
+        if isinstance(obj, type) and issubclass(obj, BaseException):
+            names.add(name)
+    return names
+
+
+def dotted_name(node):
+    """Return the dotted source of an attribute chain, e.g. ``a.b.C`` -> "a.b.C"."""
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def find_tests_root():
+    path = os.path.dirname(os.path.abspath(__file__))
+    while os.path.basename(path) != "tests":
+        parent = os.path.dirname(path)
+        assert parent != path, "Could not locate the 'tests' root directory"
+        path = parent
+    return path
+
+
+def iter_test_python_files(tests_root):
+    for dirpath, _, filenames in os.walk(tests_root):
+        if "__pycache__" in dirpath:
+            continue
+        for filename in filenames:
+            if filename.endswith(".py"):
+                yield os.path.join(dirpath, filename)
+
+
+def test_exceptions_only_imported_from_arcticdb_exceptions():
+    """Every exception used in the test suite must be imported from ``arcticdb.exceptions``.
+
+    We don't stop the exceptions being importable from their original locations (that would
+    break backwards compatibility), but the tests themselves should use the single canonical
+    module so there is one obvious place to find them.
+    """
+    exception_names = canonical_exception_names()
+    tests_root = find_tests_root()
+    this_file = os.path.abspath(__file__)
+
+    violations = []
+    for path in iter_test_python_files(tests_root):
+        if os.path.abspath(path) == this_file:
+            continue
+        with open(path, encoding="utf-8") as file:
+            tree = ast.parse(file.read(), filename=path)
+        relative_path = os.path.relpath(path, tests_root)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module == CANONICAL_MODULE:
+                    continue
+                for imported in node.names:
+                    if imported.name in exception_names:
+                        violations.append(
+                            f"tests/{relative_path}:{node.lineno}: '{imported.name}' from '{node.module}'"
+                        )
+            elif isinstance(node, ast.Attribute) and node.attr in exception_names:
+                dotted = dotted_name(node)
+                module = dotted[: -(len(node.attr) + 1)]
+                if module in NATIVE_EXCEPTION_MODULES:
+                    violations.append(f"tests/{relative_path}:{node.lineno}: '{dotted}' (use '{CANONICAL_MODULE}')")
+
+    assert not violations, f"{len(violations)} exception import(s) must come from '{CANONICAL_MODULE}':\n" + "\n".join(
+        sorted(violations)
+    )

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -7,41 +7,36 @@ As of the Change Date specified in that file, in accordance with the Business So
 """
 
 import ast
+import functools
+import importlib
 import os
 
-import arcticdb.exceptions as arcticdb_exceptions
+from arcticdb.exceptions import ArcticException
 
-# The one canonical place tests are allowed to import exceptions from.
+# The one canonical place tests are allowed to import ArcticDB exceptions from.
 CANONICAL_MODULE = "arcticdb.exceptions"
 
-# Native submodules the exceptions are also (still) reachable from. Used to catch
-# fully-qualified attribute access such as ``arcticdb_ext.exceptions.UserInputException``.
-NATIVE_EXCEPTION_MODULES = {
-    "arcticdb_ext.exceptions",
-    "arcticdb_ext.storage",
-    "arcticdb_ext.version_store",
-}
+
+@functools.lru_cache(maxsize=None)
+def _load_module(module):
+    try:
+        return importlib.import_module(module)
+    except Exception:
+        return None
 
 
-def canonical_exception_names():
-    """Every exception re-exported from ``arcticdb.exceptions``.
-
-    A name qualifies if it resolves to a subclass of ``BaseException``. This is name-agnostic
-    (so it catches exceptions like ``StreamDescriptorMismatch`` or ``UnknownLibraryOption`` that
-    do not end in ``Exception``/``Error``) and excludes error-metadata enums such as
-    ``ErrorCode``/``ErrorCategory`` and non-exception data containers such as ``DataError``.
-    Names that are *not* re-exported from ``arcticdb.exceptions`` are out of scope and never
-    flagged.
-    """
-    names = set()
-    for name in dir(arcticdb_exceptions):
-        obj = getattr(arcticdb_exceptions, name)
-        if isinstance(obj, type) and issubclass(obj, BaseException):
-            names.add(name)
-    return names
+@functools.lru_cache(maxsize=None)
+def _is_arctic_exception(module, name):
+    if not module or not module.startswith("arcticdb"):
+        return False
+    resolved = _load_module(module)
+    if resolved is None:
+        return False
+    obj = getattr(resolved, name, None)
+    return isinstance(obj, type) and issubclass(obj, ArcticException)
 
 
-def dotted_name(node):
+def _dotted_name(node):
     """Return the dotted source of an attribute chain, e.g. ``a.b.C`` -> "a.b.C"."""
     parts = []
     while isinstance(node, ast.Attribute):
@@ -50,6 +45,24 @@ def dotted_name(node):
     if isinstance(node, ast.Name):
         parts.append(node.id)
     return ".".join(reversed(parts))
+
+
+def find_exception_import_violations(source, filename="<source>"):
+    tree = ast.parse(source, filename=filename)
+    violations = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if node.module is None or node.module == CANONICAL_MODULE:
+                continue
+            for alias in node.names:
+                if _is_arctic_exception(node.module, alias.name):
+                    violations.append((node.lineno, alias.name, node.module))
+        elif isinstance(node, ast.Attribute):
+            dotted = _dotted_name(node)
+            module, _, name = dotted.rpartition(".")
+            if module and module != CANONICAL_MODULE and _is_arctic_exception(module, name):
+                violations.append((node.lineno, dotted, module))
+    return violations
 
 
 def find_tests_root():
@@ -71,13 +84,12 @@ def iter_test_python_files(tests_root):
 
 
 def test_exceptions_only_imported_from_arcticdb_exceptions():
-    """Every exception used in the test suite must be imported from ``arcticdb.exceptions``.
+    """Every ArcticDB exception used in the test suite must come from ``arcticdb.exceptions``.
 
     We don't stop the exceptions being importable from their original locations (that would
     break backwards compatibility), but the tests themselves should use the single canonical
     module so there is one obvious place to find them.
     """
-    exception_names = canonical_exception_names()
     tests_root = find_tests_root()
     this_file = os.path.abspath(__file__)
 
@@ -86,23 +98,15 @@ def test_exceptions_only_imported_from_arcticdb_exceptions():
         if os.path.abspath(path) == this_file:
             continue
         with open(path, encoding="utf-8") as file:
-            tree = ast.parse(file.read(), filename=path)
+            source = file.read()
         relative_path = os.path.relpath(path, tests_root)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.ImportFrom):
-                if node.module == CANONICAL_MODULE:
-                    continue
-                for imported in node.names:
-                    if imported.name in exception_names:
-                        violations.append(
-                            f"tests/{relative_path}:{node.lineno}: '{imported.name}' from '{node.module}'"
-                        )
-            elif isinstance(node, ast.Attribute) and node.attr in exception_names:
-                dotted = dotted_name(node)
-                module = dotted[: -(len(node.attr) + 1)]
-                if module in NATIVE_EXCEPTION_MODULES:
-                    violations.append(f"tests/{relative_path}:{node.lineno}: '{dotted}' (use '{CANONICAL_MODULE}')")
+        for lineno, reference, module in find_exception_import_violations(source, filename=path):
+            violations.append(
+                f"tests/{relative_path}:{lineno}: '{reference}' from '{module}' (use '{CANONICAL_MODULE}')"
+            )
 
-    assert not violations, f"{len(violations)} exception import(s) must come from '{CANONICAL_MODULE}':\n" + "\n".join(
+    assert (
+        not violations
+    ), f"{len(violations)} exception reference(s) must come from '{CANONICAL_MODULE}':\n" + "\n".join(
         sorted(violations)
     )

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -13,31 +13,35 @@ import os
 
 from arcticdb.exceptions import ArcticException
 
-# The one canonical place tests are allowed to import ArcticDB exceptions from.
-CANONICAL_MODULE = "arcticdb.exceptions"
+# The only module ArcticDB exceptions are allowed to be imported from.
+ALLOWED_EXCEPTIONS_MODULE = "arcticdb.exceptions"
 
 
 @functools.lru_cache(maxsize=None)
-def _load_module(module):
+def _import_module(module_name):
     try:
-        return importlib.import_module(module)
+        return importlib.import_module(module_name)
     except Exception:
         return None
 
 
 @functools.lru_cache(maxsize=None)
-def _is_arctic_exception(module, name):
-    if not module or not module.startswith("arcticdb"):
+def _is_arctic_exception(module_name, exception_name):
+    if not module_name or not module_name.startswith("arcticdb"):
         return False
-    resolved = _load_module(module)
-    if resolved is None:
+    module = _import_module(module_name)
+    if module is None:
         return False
-    obj = getattr(resolved, name, None)
-    return isinstance(obj, type) and issubclass(obj, ArcticException)
+    exception = getattr(module, exception_name, None)
+    return isinstance(exception, type) and issubclass(exception, ArcticException)
 
 
-def _dotted_name(node):
-    """Return the dotted source of an attribute chain, e.g. ``a.b.C`` -> "a.b.C"."""
+def _get_dotted_name(node):
+    """Return the dotted string of an attribute chain:
+     The module a.b.C becomes the string "a.b.C"
+     'c' and 'b' are attributes, 'a' is id.
+     The iteration is in reverse order: 'c' -> 'b' -> 'a' """
+
     parts = []
     while isinstance(node, ast.Attribute):
         parts.append(node.attr)
@@ -47,66 +51,72 @@ def _dotted_name(node):
     return ".".join(reversed(parts))
 
 
-def find_exception_import_violations(source, filename="<source>"):
-    tree = ast.parse(source, filename=filename)
+def find_exception_import_violations(file_content, file_path="<source>"):
+    tree = ast.parse(file_content, filename=file_path)
     violations = []
+
     for node in ast.walk(tree):
         if isinstance(node, ast.ImportFrom):
-            if node.module is None or node.module == CANONICAL_MODULE:
+            if node.module is None or node.module == ALLOWED_EXCEPTIONS_MODULE:
                 continue
             for alias in node.names:
                 if _is_arctic_exception(node.module, alias.name):
+                    # Arctic exception but it is imported from NOT ALLOWED module -> violation
                     violations.append((node.lineno, alias.name, node.module))
         elif isinstance(node, ast.Attribute):
-            dotted = _dotted_name(node)
-            module, _, name = dotted.rpartition(".")
-            if module and module != CANONICAL_MODULE and _is_arctic_exception(module, name):
-                violations.append((node.lineno, dotted, module))
+            dotted_name = _get_dotted_name(node)
+            module_name, _, exception_name = dotted_name.rpartition(".")
+            if (
+                    module_name
+                    and module_name != ALLOWED_EXCEPTIONS_MODULE
+                    and _is_arctic_exception(module_name, exception_name)
+            ):
+                violations.append((node.lineno, dotted_name, module_name))
     return violations
 
 
-def find_tests_root():
-    path = os.path.dirname(os.path.abspath(__file__))
-    while os.path.basename(path) != "tests":
-        parent = os.path.dirname(path)
-        assert parent != path, "Could not locate the 'tests' root directory"
-        path = parent
-    return path
+def find_python_files_root():
+    directory = os.path.dirname(os.path.abspath(__file__))
+
+    while True:
+        if os.path.basename(directory) == "python":
+            return directory
+        parent_directory = os.path.dirname(directory)
+        assert parent_directory != directory, "Could not locate the 'python' root directory"
+        directory = parent_directory
 
 
-def iter_test_python_files(tests_root):
-    for dirpath, _, filenames in os.walk(tests_root):
-        if "__pycache__" in dirpath:
+def iter_python_files(root):
+    for directory_path, _, filenames_in_directory in os.walk(root):
+        if "__pycache__" in directory_path:
             continue
-        for filename in filenames:
-            if filename.endswith(".py"):
-                yield os.path.join(dirpath, filename)
+
+        for file_name in filenames_in_directory:
+            if file_name.endswith(".py"):
+                yield os.path.join(directory_path, file_name)
 
 
 def test_exceptions_only_imported_from_arcticdb_exceptions():
-    """Every ArcticDB exception used in the test suite must come from ``arcticdb.exceptions``.
-
-    We don't stop the exceptions being importable from their original locations (that would
-    break backwards compatibility), but the tests themselves should use the single canonical
-    module so there is one obvious place to find them.
-    """
-    tests_root = find_tests_root()
+    python_root = find_python_files_root()
     this_file = os.path.abspath(__file__)
 
     violations = []
-    for path in iter_test_python_files(tests_root):
+    for path in iter_python_files(python_root):
         if os.path.abspath(path) == this_file:
             continue
+
         with open(path, encoding="utf-8") as file:
-            source = file.read()
-        relative_path = os.path.relpath(path, tests_root)
-        for lineno, reference, module in find_exception_import_violations(source, filename=path):
+            file_content = file.read()
+
+        relative_path = os.path.relpath(path, python_root)
+
+        for lineno, exception_name, module_name in find_exception_import_violations(file_content, file_path=path):
             violations.append(
-                f"tests/{relative_path}:{lineno}: '{reference}' from '{module}' (use '{CANONICAL_MODULE}')"
+                f"{relative_path}:{lineno}: '{exception_name}' from '{module_name}' (use '{ALLOWED_EXCEPTIONS_MODULE}')"
             )
 
     assert (
         not violations
-    ), f"{len(violations)} exception reference(s) must come from '{CANONICAL_MODULE}':\n" + "\n".join(
+    ), f"{len(violations)} exception reference(s) must come from '{ALLOWED_EXCEPTIONS_MODULE}':\n" + "\n".join(
         sorted(violations)
     )

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -60,6 +60,9 @@ def find_exception_import_violations(file_content, file_path="<source>"):
             if node.module is None or node.module == ALLOWED_EXCEPTIONS_MODULE:
                 continue
             for alias in node.names:
+                # A star import gives alias.name == "*", which never resolves to an exception, so
+                # `from arcticdb.x import *` goes undetected. Catching it would mean importing the
+                # module and scanning its namespace - not worth the complexity for now.
                 if _is_arctic_exception(node.module, alias.name):
                     # Arctic exception but it is imported from NOT ALLOWED module -> violation
                     violations.append((node.lineno, alias.name, node.module))

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -97,11 +97,11 @@ def iter_python_files(root):
 
 
 def test_exceptions_only_imported_from_arcticdb_exceptions():
-    this_file_path = os.path.realpath(__file__)
-    allowed_exceptions_file_path = os.path.realpath(_import_module(ALLOWED_EXCEPTIONS_MODULE).__file__)
-    files_to_skip = {this_file_path, allowed_exceptions_file_path}
-
     python_root = find_python_root()
+    this_file_path = os.path.realpath(__file__)
+    allowed_exceptions_file_path = os.path.join(python_root, *ALLOWED_EXCEPTIONS_MODULE.split(".")) + ".py"
+    assert os.path.isfile(allowed_exceptions_file_path), f"Expected '{allowed_exceptions_file_path}' to exist"
+    files_to_skip = {this_file_path, allowed_exceptions_file_path}
 
     violations = []
     for path in iter_python_files(python_root):

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -38,9 +38,9 @@ def _is_arctic_exception(module_name, exception_name):
 
 def _get_dotted_name(node):
     """Return the dotted string of an attribute chain:
-     The module a.b.C becomes the string "a.b.C"
-     'c' and 'b' are attributes, 'a' is id.
-     The iteration is in reverse order: 'c' -> 'b' -> 'a' """
+    The module a.b.C becomes the string "a.b.C"
+    'c' and 'b' are attributes, 'a' is id.
+    The iteration is in reverse order: 'c' -> 'b' -> 'a'"""
 
     parts = []
     while isinstance(node, ast.Attribute):
@@ -67,9 +67,9 @@ def find_exception_import_violations(file_content, file_path="<source>"):
             dotted_name = _get_dotted_name(node)
             module_name, _, exception_name = dotted_name.rpartition(".")
             if (
-                    module_name
-                    and module_name != ALLOWED_EXCEPTIONS_MODULE
-                    and _is_arctic_exception(module_name, exception_name)
+                module_name
+                and module_name != ALLOWED_EXCEPTIONS_MODULE
+                and _is_arctic_exception(module_name, exception_name)
             ):
                 violations.append((node.lineno, dotted_name, module_name))
     return violations
@@ -98,11 +98,13 @@ def iter_python_files(root):
 
 def test_exceptions_only_imported_from_arcticdb_exceptions():
     python_root = find_python_files_root()
-    this_file = os.path.abspath(__file__)
+    this_file_path = os.path.abspath(__file__)
+    allowed_exceptions_file_path = os.path.abspath(_import_module(ALLOWED_EXCEPTIONS_MODULE).__file__)
+    files_to_skip = {this_file_path, allowed_exceptions_file_path}
 
     violations = []
     for path in iter_python_files(python_root):
-        if os.path.abspath(path) == this_file:
+        if os.path.abspath(path) in files_to_skip:
             continue
 
         with open(path, encoding="utf-8") as file:

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -75,8 +75,8 @@ def find_exception_import_violations(file_content, file_path="<source>"):
     return violations
 
 
-def find_python_files_root():
-    directory = os.path.dirname(os.path.abspath(__file__))
+def find_python_root():
+    directory = os.path.dirname(os.path.realpath(__file__))
 
     while True:
         if os.path.basename(directory) == "python":
@@ -97,14 +97,15 @@ def iter_python_files(root):
 
 
 def test_exceptions_only_imported_from_arcticdb_exceptions():
-    python_root = find_python_files_root()
-    this_file_path = os.path.abspath(__file__)
-    allowed_exceptions_file_path = os.path.abspath(_import_module(ALLOWED_EXCEPTIONS_MODULE).__file__)
+    this_file_path = os.path.realpath(__file__)
+    allowed_exceptions_file_path = os.path.realpath(_import_module(ALLOWED_EXCEPTIONS_MODULE).__file__)
     files_to_skip = {this_file_path, allowed_exceptions_file_path}
+
+    python_root = find_python_root()
 
     violations = []
     for path in iter_python_files(python_root):
-        if os.path.abspath(path) in files_to_skip:
+        if os.path.realpath(path) in files_to_skip:
             continue
 
         with open(path, encoding="utf-8") as file:

--- a/python/tests/unit/arcticdb/test_exception_imports.py
+++ b/python/tests/unit/arcticdb/test_exception_imports.py
@@ -21,7 +21,7 @@ ALLOWED_EXCEPTIONS_MODULE = "arcticdb.exceptions"
 def _import_module(module_name):
     try:
         return importlib.import_module(module_name)
-    except Exception:
+    except ImportError:
         return None
 
 

--- a/python/tests/unit/arcticdb/test_string.py
+++ b/python/tests/unit/arcticdb/test_string.py
@@ -12,9 +12,8 @@ import platform
 import pandas as pd
 import pytest
 
-from arcticdb.exceptions import ArcticDbNotYetImplemented
+from arcticdb.exceptions import ArcticDbNotYetImplemented, UserInputException
 from arcticdb.version_store._string_dtype import _ARROW_BACKED_STR_DTYPE_SUPPORTED, _use_pyarrow_strings_in_pandas
-from arcticdb_ext.exceptions import UserInputException
 from arcticdb_ext.types import (
     TypeDescriptor,
     StreamDescriptor,

--- a/python/tests/unit/arcticdb/version_store/test_aggregation.py
+++ b/python/tests/unit/arcticdb/version_store/test_aggregation.py
@@ -12,7 +12,7 @@ import pandas as pd
 from pandas import DataFrame
 
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import InternalException, SchemaException
+from arcticdb.exceptions import InternalException, SchemaException
 from arcticdb.util.test import (
     assert_frame_equal,
     generic_aggregation_test,

--- a/python/tests/unit/arcticdb/version_store/test_api.py
+++ b/python/tests/unit/arcticdb/version_store/test_api.py
@@ -12,9 +12,9 @@ from pandas import Timestamp
 from unittest.mock import MagicMock
 import pytest
 
-from arcticdb.exceptions import NoSuchVersionException, NoDataFoundException
+from arcticdb.exceptions import NoSuchVersionException, NoDataFoundException, ArcticInvalidApiUsageException
 from arcticdb.util.test import distinct_timestamps
-from arcticdb.version_store.library import StagedDataFinalizeMethod, ArcticInvalidApiUsageException
+from arcticdb.version_store.library import StagedDataFinalizeMethod
 
 
 def test_read_descriptor(lmdb_version_store, one_col_df):

--- a/python/tests/unit/arcticdb/version_store/test_append.py
+++ b/python/tests/unit/arcticdb/version_store/test_append.py
@@ -12,8 +12,13 @@ from pandas._libs.tslibs.offsets import BDay
 import arcticdb
 import arcticdb.exceptions
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import InternalException, NormalizationException, UnsortedDataException, SchemaException
-from arcticdb.exceptions import NoSuchVersionException
+from arcticdb.exceptions import (
+    InternalException,
+    NormalizationException,
+    UnsortedDataException,
+    SchemaException,
+    NoSuchVersionException,
+)
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext import set_config_int
 from arcticdb.util.test import random_integers, assert_frame_equal, assert_series_equal

--- a/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_append_compact_data.py
@@ -14,7 +14,6 @@ from polars.testing import assert_frame_equal as assert_frame_equal_pl
 import pyarrow as pa
 import pytest
 
-from arcticdb_ext.version_store import NoSuchVersionException
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -16,8 +16,12 @@ import pyarrow as pa
 import polars as pl
 import pytest
 from arcticdb import DataError
-from arcticdb.exceptions import SchemaException, StreamDescriptorMismatch, UserInputException
-from arcticdb_ext.exceptions import UnsortedDataException
+from arcticdb.exceptions import (
+    SchemaException,
+    StreamDescriptorMismatch,
+    UserInputException,
+    UnsortedDataException,
+)
 from arcticdb.options import ArrowOutputStringFormat
 from arcticdb.util.arrow import cast_string_columns
 from arcticdb.util.test import (

--- a/python/tests/unit/arcticdb/version_store/test_collect_schema.py
+++ b/python/tests/unit/arcticdb/version_store/test_collect_schema.py
@@ -12,8 +12,7 @@ import pyarrow as pa
 import polars as pl
 import pytest
 
-from arcticdb_ext.exceptions import KeyNotFoundException
-from arcticdb.exceptions import SchemaException
+from arcticdb.exceptions import SchemaException, KeyNotFoundException
 from arcticdb.options import ArrowOutputStringFormat, OutputFormat
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import assert_frame_equal_with_arrow, config_context, query_stats_operation_count

--- a/python/tests/unit/arcticdb/version_store/test_column_type_changes.py
+++ b/python/tests/unit/arcticdb/version_store/test_column_type_changes.py
@@ -14,7 +14,7 @@ from arcticdb.supported_types import float_types
 from arcticdb.version_store.library import Library
 from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
 
-from arcticdb_ext.exceptions import StreamDescriptorMismatch
+from arcticdb.exceptions import StreamDescriptorMismatch
 from arcticdb_ext.storage import KeyType
 from arcticdb.util.test import assert_frame_equal
 from arcticdb_ext.types import DataType

--- a/python/tests/unit/arcticdb/version_store/test_compact_data.py
+++ b/python/tests/unit/arcticdb/version_store/test_compact_data.py
@@ -14,11 +14,16 @@ from polars.testing import assert_frame_equal as assert_frame_equal_pl
 import pyarrow as pa
 import pytest
 
-from arcticdb_ext.exceptions import SchemaException, StorageException
 from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import CompactDataInfo
 from arcticdb import WritePayload
-from arcticdb.exceptions import ArcticNativeException, UserInputException, ArcticDuplicateSymbolsInBatchException
+from arcticdb.exceptions import (
+    ArcticNativeException,
+    UserInputException,
+    ArcticDuplicateSymbolsInBatchException,
+    SchemaException,
+    StorageException,
+)
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.hypothesis import (
     use_of_function_scoped_fixtures_in_hypothesis_checked,

--- a/python/tests/unit/arcticdb/version_store/test_date_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_date_range.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import pandas as pd
 import numpy as np
 import pytest
-from arcticdb_ext.exceptions import UnsortedDataException, InternalException
+from arcticdb.exceptions import UnsortedDataException, InternalException
 from arcticdb.version_store import _store as store
 
 try:

--- a/python/tests/unit/arcticdb/version_store/test_deletion.py
+++ b/python/tests/unit/arcticdb/version_store/test_deletion.py
@@ -18,8 +18,8 @@ from arcticdb.util.tasks import (
     append_small_df_and_prune_previous,
     delete_snapshot,
 )
-from arcticdb_ext.exceptions import InternalException
-from arcticdb_ext.storage import KeyType, NoDataFoundException
+from arcticdb.exceptions import InternalException, NoDataFoundException
+from arcticdb_ext.storage import KeyType
 from arcticdb_ext.version_store import ManualClockVersionStore
 from arcticdb.version_store._normalization import PandasData
 from arcticdb.util.test import sample_dataframe

--- a/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_column_type.py
@@ -15,7 +15,7 @@ import pytest
 from packaging.version import Version
 from arcticdb.util._versions import PANDAS_VERSION
 from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
-from arcticdb_ext.exceptions import NormalizationException
+from arcticdb.exceptions import NormalizationException
 
 pyarrow_strings_empty_string_skip = pytest.mark.skipif(
     _use_pyarrow_strings_in_pandas(),

--- a/python/tests/unit/arcticdb/version_store/test_empty_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_empty_writes.py
@@ -11,7 +11,7 @@ import pandas as pd
 import numpy as np
 
 from arcticdb import QueryBuilder
-from arcticdb_ext.exceptions import NormalizationException
+from arcticdb.exceptions import NormalizationException
 from arcticdb.version_store._common import TimeFrame
 from arcticdb.util.test import assert_frame_equal, assert_series_equal
 from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas

--- a/python/tests/unit/arcticdb/version_store/test_fork.py
+++ b/python/tests/unit/arcticdb/version_store/test_fork.py
@@ -57,7 +57,7 @@ def test_map(lmdb_version_store):
 
 
 def _read_and_assert_symbol(args):
-    from arcticdb_ext.version_store import NoSuchVersionException
+    from arcticdb.exceptions import NoSuchVersionException
 
     lib, symbol, idx = args
     for attempt in range(1, 11):

--- a/python/tests/unit/arcticdb/version_store/test_head.py
+++ b/python/tests/unit/arcticdb/version_store/test_head.py
@@ -12,7 +12,7 @@ import numpy as np
 from pandas import DataFrame
 import pytest
 
-from arcticdb_ext.exceptions import InternalException
+from arcticdb.exceptions import InternalException
 
 pytestmark = pytest.mark.pipeline
 

--- a/python/tests/unit/arcticdb/version_store/test_list_versions.py
+++ b/python/tests/unit/arcticdb/version_store/test_list_versions.py
@@ -10,8 +10,8 @@ import pytest
 
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import config_context, query_stats_operation_count
-from arcticdb_ext.exceptions import InternalException, KeyNotFoundException
-from arcticdb_ext.storage import KeyType, NoDataFoundException
+from arcticdb.exceptions import InternalException, KeyNotFoundException, NoDataFoundException
+from arcticdb_ext.storage import KeyType
 
 
 def populate_library(lib):

--- a/python/tests/unit/arcticdb/version_store/test_merge_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_merge_update.py
@@ -22,10 +22,16 @@ from arcticdb.util.test import (
     query_stats_operation_count,
 )
 from arcticdb.version_store import VersionedItem
-from arcticdb.version_store._store import normalize_merge_action
-from arcticdb.version_store.library import MergeAction, MergeStrategy
-from arcticdb_ext.exceptions import SchemaException
 from arcticdb_ext.storage import KeyType
+from arcticdb.exceptions import (
+    UserInputException,
+    UnsortedDataException,
+    StorageException,
+    ArcticException,
+    SchemaException,
+)
+from arcticdb.version_store.library import MergeAction, MergeStrategy
+from arcticdb.version_store._store import normalize_merge_action
 from arcticdb_ext.version_store import MergeAction
 
 pytestmark = [

--- a/python/tests/unit/arcticdb/version_store/test_projection.py
+++ b/python/tests/unit/arcticdb/version_store/test_projection.py
@@ -10,8 +10,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from arcticdb_ext.exceptions import SchemaException, UserInputException
-from arcticdb.exceptions import ArcticNativeException
+from arcticdb.exceptions import ArcticNativeException, SchemaException, UserInputException
 from arcticdb.version_store.processing import QueryBuilder
 from arcticdb.util.test import assert_frame_equal, make_dynamic, regularize_dataframe
 

--- a/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
+++ b/python/tests/unit/arcticdb/version_store/test_query_builder_batch.py
@@ -10,11 +10,16 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from arcticdb.exceptions import ArcticNativeException
+from arcticdb.exceptions import (
+    ArcticNativeException,
+    NoDataFoundException,
+    InternalException,
+    StorageException,
+    UserInputException,
+)
 from arcticdb.util.test import config_context
-from arcticdb_ext.storage import KeyType, NoDataFoundException
+from arcticdb_ext.storage import KeyType
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import InternalException, StorageException, UserInputException
 
 pytestmark = pytest.mark.pipeline
 

--- a/python/tests/unit/arcticdb/version_store/test_read_index.py
+++ b/python/tests/unit/arcticdb/version_store/test_read_index.py
@@ -14,7 +14,7 @@ from functools import reduce
 from packaging.version import Version
 from arcticdb.encoding_version import EncodingVersion
 from arcticdb.util._versions import PANDAS_VERSION
-from arcticdb_ext.exceptions import UserInputException
+from arcticdb.exceptions import UserInputException
 from arcticdb.options import LibraryOptions
 from arcticdb import ReadRequest
 from arcticdb.util.test import assert_frame_equal

--- a/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
+++ b/python/tests/unit/arcticdb/version_store/test_recursive_normalizers.py
@@ -15,7 +15,12 @@ from arcticdb.version_store._custom_normalizers import (
     clear_registered_normalizers,
 )
 from arcticc.pb2.descriptors_pb2 import NormalizationMetadata  # Importing from arcticdb dynamically loads arcticc.pb2
-from arcticdb.exceptions import ArcticDbNotYetImplemented
+from arcticdb.exceptions import (
+    ArcticDbNotYetImplemented,
+    ArcticUnsupportedDataTypeException,
+    NoSuchVersionException,
+    UserInputException,
+)
 
 from arcticdb.util.test import (
     assert_frame_equal,
@@ -30,10 +35,7 @@ from arcticdb.exceptions import (
     UnsupportedKeyInDictionary,
     ArcticException as ArcticNativeException,
 )
-from arcticdb.version_store.library import ArcticUnsupportedDataTypeException
 from arcticdb_ext.storage import KeyType, ModifiableLibraryOption
-from arcticdb_ext.version_store import NoSuchVersionException
-import arcticdb_ext
 
 
 class AlmostAList(list):
@@ -457,7 +459,7 @@ def test_unsupported_characters_in_keys(s3_version_store_v1, key, all_recursive_
     data = {key: df}
 
     # When & Then
-    with pytest.raises(arcticdb_ext.exceptions.UserInputException):
+    with pytest.raises(UserInputException):
         lib.write("sym", data, recursive_normalizers=True)
 
     with pytest.raises(NoSuchVersionException):
@@ -477,7 +479,7 @@ def test_unsupported_characters_in_keys_nested(s3_version_store_v1, key, all_rec
     data = {"blah": {key: df}}
 
     # When
-    with pytest.raises(arcticdb_ext.exceptions.UserInputException):
+    with pytest.raises(UserInputException):
         lib.write("sym", data, recursive_normalizers=True)
 
     with pytest.raises(NoSuchVersionException):
@@ -566,7 +568,7 @@ def test_dictionaries_with_custom_keys_that_cannot_roundtrip(
     df = pd.DataFrame({"d": [1, 2, 3]})
     data = {CustomClassSeparatorInStr(1): df}
 
-    with pytest.raises(arcticdb_ext.exceptions.UserInputException):
+    with pytest.raises(UserInputException):
         lib.write("sym", data, recursive_normalizers=True)
 
     assert not lib.has_symbol("sym")

--- a/python/tests/unit/arcticdb/version_store/test_row_range.py
+++ b/python/tests/unit/arcticdb/version_store/test_row_range.py
@@ -11,7 +11,7 @@ import pandas as pd
 import pytest
 
 from arcticdb.version_store.processing import QueryBuilder
-from arcticdb_ext.exceptions import InternalException
+from arcticdb.exceptions import InternalException
 
 from arcticdb.util.test import assert_frame_equal
 

--- a/python/tests/unit/arcticdb/version_store/test_stage.py
+++ b/python/tests/unit/arcticdb/version_store/test_stage.py
@@ -14,18 +14,16 @@ import pandas as pd
 import pytest
 
 from arcticdb import LibraryOptions
-from arcticdb_ext.exceptions import UserInputException, UnsortedDataException
 from arcticdb_ext.storage import KeyType
-from arcticdb_ext.version_store import (
-    StageResult,
-    NoSuchVersionException,
-    KeyNotFoundInStageResultInfo,
-    AtomKey,
-    RefKey,
-)
+from arcticdb_ext.version_store import StageResult, KeyNotFoundInStageResultInfo, AtomKey, RefKey
 from arcticdb.version_store.library import Library
 from arcticdb.util.test import assert_frame_equal, config_context
-from arcticdb.exceptions import MissingKeysInStageResultsError
+from arcticdb.exceptions import (
+    MissingKeysInStageResultsError,
+    UserInputException,
+    UnsortedDataException,
+    NoSuchVersionException,
+)
 
 
 @pytest.fixture

--- a/python/tests/unit/arcticdb/version_store/test_tail.py
+++ b/python/tests/unit/arcticdb/version_store/test_tail.py
@@ -12,7 +12,7 @@ import numpy as np
 from pandas import DataFrame
 import pytest
 
-from arcticdb_ext.exceptions import InternalException
+from arcticdb.exceptions import InternalException
 
 pytestmark = pytest.mark.pipeline
 

--- a/python/tests/unit/arcticdb/version_store/test_ternary.py
+++ b/python/tests/unit/arcticdb/version_store/test_ternary.py
@@ -15,7 +15,7 @@ import pandas as pd
 import pytest
 
 from arcticdb import QueryBuilder, where, OutputFormat
-from arcticdb_ext.exceptions import InternalException, SchemaException, UserInputException
+from arcticdb.exceptions import InternalException, SchemaException, UserInputException
 from arcticdb.util.hypothesis import use_of_function_scoped_fixtures_in_hypothesis_checked
 from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas
 from arcticdb.util.test import assert_frame_equal

--- a/python/tests/unit/arcticdb/version_store/test_unicode.py
+++ b/python/tests/unit/arcticdb/version_store/test_unicode.py
@@ -18,7 +18,7 @@ from arcticdb.util.test import assert_frame_equal, random_strings_of_length
 
 from arcticdb.version_store.library import Library
 from arcticdb.version_store.library import UpdatePayload
-from arcticdb_ext.storage import NoDataFoundException
+from arcticdb.exceptions import NoDataFoundException
 
 unicode_str = "\u0420\u043e\u0441\u0441\u0438\u044f"
 copyright = "My Thing Not Your's \u00a9"

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -27,6 +27,8 @@ from arcticdb.exceptions import (
     NormalizationException,
     SchemaException,
     StreamDescriptorMismatch,
+    ArcticDuplicateSymbolsInBatchException,
+    ArcticUnsupportedDataTypeException,
 )
 from tests.util.date import DateRange
 from pandas import MultiIndex
@@ -847,7 +849,7 @@ class TestBatchUpdate:
     def test_repeating_symbol_in_payload_list_throws(self, lmdb_library):
         lib = lmdb_library
         lib.write("symbol_1", pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")])))
-        with pytest.raises(arcticdb.version_store.library.ArcticDuplicateSymbolsInBatchException):
+        with pytest.raises(ArcticDuplicateSymbolsInBatchException):
             lib.update_batch(
                 [
                     UpdatePayload(
@@ -865,7 +867,7 @@ class TestBatchUpdate:
         lib = lmdb_library
         lib.write("symbol_1", pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")])))
         lib.write("symbol_2", pd.DataFrame({"a": [1]}, index=pd.DatetimeIndex([pd.Timestamp("2024-01-01")])))
-        with pytest.raises(arcticdb.version_store.library.ArcticUnsupportedDataTypeException) as ex_info:
+        with pytest.raises(ArcticUnsupportedDataTypeException) as ex_info:
             lib.update_batch(
                 [
                     UpdatePayload(symbol="symbol_1", data={1, 2, 3}),

--- a/python/tests/unit/arcticdb/version_store/test_update.py
+++ b/python/tests/unit/arcticdb/version_store/test_update.py
@@ -12,7 +12,6 @@ import pytest
 from itertools import product
 import datetime
 import random
-from arcticdb import DataError
 
 from arcticdb.util.test import (
     random_strings_of_length,
@@ -21,8 +20,14 @@ from arcticdb.util.test import (
     assert_frame_equal,
     assert_series_equal,
 )
-from arcticdb.exceptions import InternalException, UnsortedDataException, NormalizationException, SchemaException
-from arcticdb_ext.exceptions import StreamDescriptorMismatch
+from arcticdb import DataError
+from arcticdb.exceptions import (
+    InternalException,
+    UnsortedDataException,
+    NormalizationException,
+    SchemaException,
+    StreamDescriptorMismatch,
+)
 from tests.util.date import DateRange
 from pandas import MultiIndex
 import arcticdb

--- a/python/tests/unit/arcticdb/version_store/test_version_chain.py
+++ b/python/tests/unit/arcticdb/version_store/test_version_chain.py
@@ -13,11 +13,7 @@ import pytest
 
 from pandas import MultiIndex
 from arcticdb.version_store import NativeVersionStore
-from arcticdb_ext.exceptions import (
-    InternalException,
-    NormalizationException,
-    UnsortedDataException,
-)
+from arcticdb.exceptions import InternalException, NormalizationException, UnsortedDataException
 
 
 @pytest.mark.parametrize(

--- a/python/tests/unit/arcticdb/version_store/test_write.py
+++ b/python/tests/unit/arcticdb/version_store/test_write.py
@@ -9,7 +9,7 @@ As of the Change Date specified in that file, in accordance with the Business So
 import numpy as np
 import pandas as pd
 import pytest
-from arcticdb_ext.exceptions import UnsortedDataException, ArcticException as ArcticNativeException
+from arcticdb.exceptions import UnsortedDataException, ArcticException as ArcticNativeException
 from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticdb.util.test import assert_frame_equal
 from arcticdb.version_store._string_dtype import _use_pyarrow_strings_in_pandas

--- a/python/tests/unit/simulator/test_symbol_simulator.py
+++ b/python/tests/unit/simulator/test_symbol_simulator.py
@@ -15,7 +15,7 @@ from arcticdb.util.arctic_simulator import ArcticSymbolSimulator
 from arcticdb.util.test import assert_frame_equal
 from arcticdb.util.test_utils import verify_dynamically_added_columns
 from arcticdb.version_store.library import Library
-from arcticdb_ext.exceptions import SchemaException, NormalizationException
+from arcticdb.exceptions import SchemaException, NormalizationException
 
 
 def append_and_compare(asim: ArcticSymbolSimulator, df: pd.DataFrame, sym_name: str, lib: Library):


### PR DESCRIPTION
## What was the exceptions import logic:

  ArcticDB exceptions can be imported from many different places — `arcticdb_ext.exceptions`,
  `arcticdb_ext.storage`, `arcticdb_ext.version_store`, `arcticdb.version_store.library`, etc.
  This makes exceptions hard to discover and easy to import inconsistently.

  This PR adds a test that enforces a single allowed source for them: every ArcticDB exception
  used anywhere under `python/` must be imported from `arcticdb.exceptions`.

  ## What is the new logic:

The test reads every `.py` file under `python/` (skipping `__pycache__` and the test file
  itself) and checks how each file imports ArcticDB exceptions. It catches both ways an exception
  can be pulled from the wrong place:

  - an import, e.g. `from arcticdb_ext.exceptions import UserInputException`
  - a direct inline use, e.g. `raise arcticdb_ext.exceptions.UserInputException(...)`

  In both cases, if the exception came from anywhere other than `arcticdb.exceptions`, it's a
  violation.

  To avoid false alarms, the test confirms the name really is an ArcticDB exception (a subclass
  of `ArcticException`) before flagging it. 