### PR TITLE
Conda builds: give the binaries an RPATH into the environment they were built against

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -165,6 +165,21 @@ ENDIF()
 
 set(CMAKE_INSTALL_RPATH "\\$ORIGIN/lib")
 
+# conda-forge's compiler activation puts -Wl,-rpath,$PREFIX/lib in LDFLAGS; building in-tree does not go
+# through it, so arcticdb_ext and the test binaries would resolve libstdc++, libssl and libcrypto through the
+# system paths rather than the environment they were compiled against. Skipped under conda-build, which has the
+# activation and where CONDA_PREFIX is the build-tools prefix - relocation only rewrites RPATHs inside $PREFIX,
+# so that path would ship as a dangling absolute RPATH.
+if(ARCTICDB_USING_CONDA AND CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT DEFINED ENV{CONDA_BUILD})
+    if(NOT DEFINED ENV{CONDA_PREFIX})
+        message(FATAL_ERROR "ARCTICDB_USING_CONDA is set but no conda environment is active. Activate the "
+                "environment before configuring, or the built objects will load the host's libstdc++ and "
+                "OpenSSL and fail at import with missing GLIBCXX/OPENSSL symbol versions.")
+    endif()
+    list(APPEND CMAKE_BUILD_RPATH "$ENV{CONDA_PREFIX}/lib")
+    list(APPEND CMAKE_INSTALL_RPATH "$ENV{CONDA_PREFIX}/lib")
+endif()
+
 if (NOT MSVC)
     if(NOT ${ARCTICDB_USING_CONDA})
         # Compilers on conda-forge are relatively strict.


### PR DESCRIPTION
Every `linux_64` and `linux_aarch64` job in **Build with conda** fails before running a test, on this branch and on unrelated ones alike (e.g. `skip_dedup`, run 33501093712). The last green conda run on master is 2026-08-06.

### What is actually wrong

Three symptoms, one cause:

```
ImportError: /usr/lib/x86_64-linux-gnu/libssl.so.3: version `OPENSSL_3.3.0' not found
  (required by .../envs/arcticdb/lib/python3.13/lib-dynload/_ssl...so)

test_unit_arcticdb: /usr/lib/x86_64-linux-gnu/libcrypto.so.3: version `OPENSSL_3.4.0' not found
  (required by .../envs/arcticdb/lib/libs2n.so.1)

ImportError: /usr/lib/aarch64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.31' not found
  (required by python/arcticdb_ext.cpython-313-...so)
```

`arcticdb_ext` and the C++ test binaries have no RPATH into the conda environment, so `libstdc++`, `libssl` and `libcrypto` resolve through the runner's system paths — where the image ships OpenSSL 3.0 and an older libstdc++. That was harmless until conda-forge's python, `libs2n` and gcc started needing symbols the host copies do not export.

Python's own `_ssl.so` resolves correctly on its own — `ldd` in the job confirms both libraries coming from the environment via its `RPATH $ORIGIN/../..`. It only fails inside pytest because `arcticdb_ext`, imported a few frames earlier, has already loaded the *system* `libssl.so.3` under that soname, and the loader reuses whatever is loaded first.

### The change

conda-forge's compiler activation normally supplies `-Wl,-rpath,$PREFIX/lib` through `LDFLAGS`. This build does not go through that activation, so CMake sets the same thing when `ARCTICDB_USING_CONDA` is on and the host is Linux. No workflow changes; the vcpkg builds, macOS and Windows are untouched.

Two details, both from review:

- **Skipped under conda-build.** Feedstock builds do go through the compiler activation, and there `CONDA_PREFIX` is the *build-tools* prefix. `setup.py` installs the extension through the `install_arcticdb_ext` target, so `CMAKE_INSTALL_RPATH` reaches the packaged object, and conda-build's relocation only rewrites RPATH entries pointing inside `$PREFIX` — a build-prefix path would ship as a dangling absolute RPATH. So the block is skipped when `CONDA_BUILD` is set.
- **Not a silent no-op.** Configuring with `ARCTICDB_USING_CONDA` on Linux and no environment active is a `FATAL_ERROR` naming the symptom, rather than quietly building objects that fail later with unrelated-looking loader errors.

### What was tried first, and why it is not the answer

- **`LD_LIBRARY_PATH=$CONDA_PREFIX/lib`** — no effect. It is consulted *after* the `DT_RPATH` of whichever object loads the library first, so it cannot displace a copy already bound.
- **`LD_PRELOAD` of the environment's `libssl`/`libcrypto`** — fixed the import (the unit suite reached **18,438 passed**) but leaked into every fixture subprocess: moto died at startup with the `GLIBCXX` error above, producing 107 collection errors. Patching one library at a time in the environment is whack-a-mole; the binaries should simply know where their own libraries live.

Verification is the conda workflow on this PR: `linux_64` and `linux_aarch64`, both C++ and Python jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CZcBJvhzAUYjejNcXyBWYq
