### PR TITLE
Name azurite test containers with a random uuid, not a truncated time-based one

### DIFF
--- a/python/arcticdb/storage_fixtures/azure.py
+++ b/python/arcticdb/storage_fixtures/azure.py
@@ -38,6 +38,13 @@ if TYPE_CHECKING:
     from azure.storage.blob import ContainerClient
 
 
+def new_container_name() -> str:
+    # uuid4 in full, not a truncated uuid1: the first 8 characters of a uuid1 are its time_low field, and
+    # xdist workers are separate processes with no shared uniqueness counter, so two of them creating a fixture
+    # within one clock tick (~15.6ms on Windows) get the same name and the second create_container() gets a 409.
+    return f"container{uuid.uuid4().hex}"
+
+
 class AzureContainer(StorageFixture):
     _FIELD_REGEX = {
         ArcticUriFields.HOST: re.compile("[/;](BlobEndpoint=https?://)([^;:/]+)"),
@@ -86,7 +93,7 @@ class AzureContainer(StorageFixture):
             self.arctic_uri = self.factory.get_arctic_uri()
             self.client = ContainerClient.from_connection_string(self.arctic_uri, self.container, **self._get_policy())
         else:
-            self.container = f"container{str(uuid.uuid1())[:8]}"
+            self.container = new_container_name()
             self._set_uri_and_client_azurite(f"AccountName={factory.account_name};AccountKey={factory.account_key}")
             # __exit__() assumes this object owns the container, so always create and bail if exists:
             self.client.create_container()

--- a/python/tests/unit/arcticdb/test_storage_fixture_naming.py
+++ b/python/tests/unit/arcticdb/test_storage_fixture_naming.py
@@ -1,0 +1,26 @@
+"""
+Copyright 2026 Man Group Operations Limited
+
+Use of this software is governed by the Business Source License 1.1 included in the file LICENSE.txt.
+
+As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
+"""
+
+import re
+import uuid
+from unittest import mock
+
+from arcticdb.storage_fixtures.azure import new_container_name
+
+
+def test_container_name_is_not_derived_from_the_clock():
+    # xdist workers are separate processes, so a clock-derived name collides whenever two of them create a
+    # fixture within the same tick and azurite rejects the second with "container already exists".
+    with mock.patch.object(uuid, "uuid1", return_value=uuid.UUID(int=0)):
+        names = {new_container_name() for _ in range(100)}
+    assert len(names) == 100
+
+
+def test_container_name_is_a_valid_azure_container_name():
+    # 3-63 characters, lowercase letters, digits and hyphens, starting with a letter or digit.
+    assert re.fullmatch(r"[a-z0-9][a-z0-9-]{2,62}", new_container_name())


### PR DESCRIPTION
### The failure

Master run 33619888557, job `3.11 Windows / integration-inferstr`: **4 failed, 145 errors**, every one of them

```
azure.core.exceptions.ResourceExistsError: The specified container already exists.   (HTTP 409)
```

raised from `AzureContainer.__init__` → `create_container()`. The first error is at **0%** of the run, with no azurite test passing before it.

### Why

`python/arcticdb/storage_fixtures/azure.py` named the container:

```python
self.container = f"container{str(uuid.uuid1())[:8]}"
```

Those 8 characters are not random — they are the uuid's `time_low` field, the low 32 bits of a 100 ns counter:

```
uuid1: 3c09951c-a6ce-11f1-bd0b-00155d6a4f54  ->  prefix 3c09951c == time_low 3c09951c
```

`uuid1` keeps values unique *within a process* (`_last_timestamp`), but xdist workers are separate processes with no shared counter. Two workers creating a fixture inside the same clock tick therefore get byte-identical names, and the second `create_container()` gets a 409.

Windows is where it bites: `time.time_ns()` there has ~15.6 ms granularity on Python 3.11, against nanoseconds on Linux. It is timing-dependent, which is why it is rare — the previous 22 Windows integration jobs across four master runs have zero occurrences. The job that failed took **4976 s against 2851 s** for the same job on the previous commit, and runner speed is exactly what decides whether workers line up in the same tick.

### The change

`uuid4().hex` — 4 billion random values instead of a clock-derived one. The name generation moves into `new_container_name()` so it can be tested.
