### PR TITLE
Allow deleting staged data by StageResult

### DIFF
--- a/cpp/arcticdb/stream/incompletes.cpp
+++ b/cpp/arcticdb/stream/incompletes.cpp
@@ -24,6 +24,7 @@
 #include <arcticdb/pipeline/write_frame.hpp>
 #include <arcticdb/pipeline/read_query.hpp>
 #include <iterator>
+#include <ranges>
 
 namespace arcticdb {
 
@@ -622,6 +623,14 @@ std::vector<VariantKey> read_incomplete_keys_for_symbol(
             [](const AppendMapEntry& entry) { return entry.slice_and_key_.key(); }
     );
     return slice_and_key;
+}
+
+void delete_incomplete_keys_for_stage_results(
+        const std::shared_ptr<Store>& store, const std::vector<StageResult>& stage_results
+) {
+    auto keys_to_delete_view = stage_results | std::views::transform(&StageResult::staged_segments) | std::views::join;
+    std::vector<VariantKey> keys_to_delete(keys_to_delete_view.begin(), keys_to_delete_view.end());
+    store->remove_keys(keys_to_delete, storage::RemoveOpts{.ignores_missing_key_ = true}).get();
 }
 
 std::optional<int64_t> latest_incomplete_timestamp(const std::shared_ptr<Store>& store, const StreamId& stream_id) {

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -159,6 +159,12 @@ std::vector<VariantKey> read_incomplete_keys_for_symbol(
         const std::shared_ptr<Store>& store, const StreamId& stream_id, bool via_iteration
 );
 
+// Delete exactly the APPEND_DATA keys named by these stage results.
+// Missing keys are ignored (idempotent).
+void delete_incomplete_keys_for_stage_results(
+        const std::shared_ptr<Store>& store, const std::vector<StageResult>& stage_results
+);
+
 /**
  * Load incomplete segments based on the provided stage results.
  *

--- a/cpp/arcticdb/stream/incompletes.hpp
+++ b/cpp/arcticdb/stream/incompletes.hpp
@@ -159,8 +159,7 @@ std::vector<VariantKey> read_incomplete_keys_for_symbol(
         const std::shared_ptr<Store>& store, const StreamId& stream_id, bool via_iteration
 );
 
-// Delete exactly the APPEND_DATA keys named by these stage results.
-// Missing keys are ignored (idempotent).
+// Delete exactly the APPEND_DATA keys named by these stage results. Missing keys are ignored
 void delete_incomplete_keys_for_stage_results(
         const std::shared_ptr<Store>& store, const std::vector<StageResult>& stage_results
 );

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1203,18 +1203,21 @@ folly::Future<DeleteTreesStats> delete_trees_responsibly(
             .thenValueInline([stats](folly::Unit) { return stats; });
 }
 
-void LocalVersionedEngine::remove_incomplete(const StreamId& stream_id) {
-    remove_incomplete_segments(store_, stream_id);
+void LocalVersionedEngine::remove_incomplete(const std::variant<StreamId, std::vector<StageResult>>& id_or_stage_results
+) {
+    util::variant_match(
+            id_or_stage_results,
+            [this](const StreamId& stream_id) { remove_incomplete_segments(store_, stream_id); },
+            [this](const std::vector<StageResult>& stage_results) {
+                delete_incomplete_keys_for_stage_results(store_, stage_results);
+            }
+    );
 }
 
 void LocalVersionedEngine::remove_incompletes(
         const std::unordered_set<StreamId>& stream_ids, const std::string& common_prefix
 ) {
     remove_incomplete_segments(store_, stream_ids, common_prefix);
-}
-
-void LocalVersionedEngine::remove_incompletes_for_stage_results(const std::vector<StageResult>& stage_results) {
-    delete_incomplete_keys_for_stage_results(store_, stage_results);
 }
 
 std::set<StreamId> LocalVersionedEngine::get_incomplete_symbols() { return ::arcticdb::get_incomplete_symbols(store_); }

--- a/cpp/arcticdb/version/local_versioned_engine.cpp
+++ b/cpp/arcticdb/version/local_versioned_engine.cpp
@@ -1213,6 +1213,10 @@ void LocalVersionedEngine::remove_incompletes(
     remove_incomplete_segments(store_, stream_ids, common_prefix);
 }
 
+void LocalVersionedEngine::remove_incompletes_for_stage_results(const std::vector<StageResult>& stage_results) {
+    delete_incomplete_keys_for_stage_results(store_, stage_results);
+}
+
 std::set<StreamId> LocalVersionedEngine::get_incomplete_symbols() { return ::arcticdb::get_incomplete_symbols(store_); }
 
 std::set<StreamId> LocalVersionedEngine::get_incomplete_refs() { return ::arcticdb::get_incomplete_refs(store_); }

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -141,11 +141,9 @@ class LocalVersionedEngine : public VersionedEngine {
             const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool validate_index
     ) const override;
 
-    void remove_incomplete(const StreamId& stream_id) override;
+    void remove_incomplete(const std::variant<StreamId, std::vector<StageResult>>& id_or_stage_results) override;
 
     void remove_incompletes(const std::unordered_set<StreamId>& sids, const std::string& common_prefix);
-
-    void remove_incompletes_for_stage_results(const std::vector<StageResult>& stage_results);
 
     std::optional<VersionedItem> get_latest_version(const StreamId& stream_id);
 

--- a/cpp/arcticdb/version/local_versioned_engine.hpp
+++ b/cpp/arcticdb/version/local_versioned_engine.hpp
@@ -145,6 +145,8 @@ class LocalVersionedEngine : public VersionedEngine {
 
     void remove_incompletes(const std::unordered_set<StreamId>& sids, const std::string& common_prefix);
 
+    void remove_incompletes_for_stage_results(const std::vector<StageResult>& stage_results);
+
     std::optional<VersionedItem> get_latest_version(const StreamId& stream_id);
 
     std::optional<VersionedItem> get_specific_version(

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -761,6 +761,10 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
                  &PythonVersionStore::remove_incomplete,
                  py::call_guard<SingleThreadMutexHolder>(),
                  "Delete incomplete segments")
+            .def("remove_incompletes_for_stage_results",
+                 &PythonVersionStore::remove_incompletes_for_stage_results,
+                 py::call_guard<SingleThreadMutexHolder>(),
+                 "Delete the APPEND_DATA keys named by the given stage results")
             .def(
                     "remove_incompletes",
                     [&](PythonVersionStore& v,

--- a/cpp/arcticdb/version/python_bindings.cpp
+++ b/cpp/arcticdb/version/python_bindings.cpp
@@ -760,11 +760,7 @@ void register_bindings(py::module& version, py::exception<arcticdb::ArcticExcept
             .def("remove_incomplete",
                  &PythonVersionStore::remove_incomplete,
                  py::call_guard<SingleThreadMutexHolder>(),
-                 "Delete incomplete segments")
-            .def("remove_incompletes_for_stage_results",
-                 &PythonVersionStore::remove_incompletes_for_stage_results,
-                 py::call_guard<SingleThreadMutexHolder>(),
-                 "Delete the APPEND_DATA keys named by the given stage results")
+                 "Delete incomplete segments for a symbol, or the APPEND_DATA keys named by the given stage results")
             .def(
                     "remove_incompletes",
                     [&](PythonVersionStore& v,

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2325,7 +2325,6 @@ DeleteIncompleteKeysOnExit::~DeleteIncompleteKeysOnExit() {
         return;
 
     try {
-        storage::RemoveOpts opts{.ignores_missing_key_ = true};
         if (context_->incompletes_after_) {
             delete_incomplete_keys(*context_, *store_);
         } else {
@@ -2334,6 +2333,7 @@ DeleteIncompleteKeysOnExit::~DeleteIncompleteKeysOnExit() {
             if (stage_results_) {
                 delete_incomplete_keys_for_stage_results(store_, *stage_results_);
             } else {
+                storage::RemoveOpts opts{.ignores_missing_key_ = true};
                 auto keys_to_delete = read_incomplete_keys_for_symbol(store_, context_->stream_id_, via_iteration_);
                 store_->remove_keys(keys_to_delete, opts).get();
             }

--- a/cpp/arcticdb/version/version_core.cpp
+++ b/cpp/arcticdb/version/version_core.cpp
@@ -2331,15 +2331,12 @@ DeleteIncompleteKeysOnExit::~DeleteIncompleteKeysOnExit() {
         } else {
             // If an exception is thrown before read_incompletes_to_pipeline the keys won't be placed inside the
             // context thus they must be read manually.
-            std::vector<VariantKey> keys_to_delete;
             if (stage_results_) {
-                auto keys_to_delete_view =
-                        *stage_results_ | std::views::transform(&StageResult::staged_segments) | std::views::join;
-                keys_to_delete = std::vector<VariantKey>(keys_to_delete_view.begin(), keys_to_delete_view.end());
+                delete_incomplete_keys_for_stage_results(store_, *stage_results_);
             } else {
-                keys_to_delete = read_incomplete_keys_for_symbol(store_, context_->stream_id_, via_iteration_);
+                auto keys_to_delete = read_incomplete_keys_for_symbol(store_, context_->stream_id_, via_iteration_);
+                store_->remove_keys(keys_to_delete, opts).get();
             }
-            store_->remove_keys(keys_to_delete, opts).get();
         }
     } catch (const std::exception& e) {
         // Don't emit exceptions from destructor

--- a/cpp/arcticdb/version/versioned_engine.hpp
+++ b/cpp/arcticdb/version/versioned_engine.hpp
@@ -75,7 +75,7 @@ class VersionedEngine {
 
     virtual void append_incomplete_segment(const StreamId& stream_id, SegmentInMemory&& seg) = 0;
 
-    virtual void remove_incomplete(const StreamId& stream_id) = 0;
+    virtual void remove_incomplete(const std::variant<StreamId, std::vector<StageResult>>& id_or_stage_results) = 0;
 
     virtual StageResult write_parallel_frame(
             const StreamId& stream_id, const std::shared_ptr<InputFrame>& frame, bool validate_index,

--- a/docs/claude/plans/delete-staged-data-by-stage-result/branch-work-log.md
+++ b/docs/claude/plans/delete-staged-data-by-stage-result/branch-work-log.md
@@ -1,0 +1,57 @@
+# Branch: delete-staged-data-by-stage-result
+
+## Goal
+
+Augment the existing staged-data deletion APIs so they accept a `StageResult` or a
+`List[StageResult]` in addition to a `symbol: str`. For the stage-result forms, only the
+`APPEND_DATA` keys named by those receipt(s) are deleted (idempotent); the `str` form is
+unchanged (deletes all incompletes for the symbol).
+
+Motivation (Numeric): they stage from Spark workers and finalize via the listing-based path,
+but retain the `StageResult` receipts. Pre-emption/retries re-stage partitions, creating
+duplicate `APPEND_DATA` bundles; they need to delete precisely the bundles named by specific
+receipts without wiping other workers' good staged data.
+
+## Public API change (V1 and V2)
+
+- V1: `NativeVersionStore.remove_incomplete(symbol: str | StageResult | List[StageResult])`
+- V2: `Library.delete_staged_data(symbol: str | StageResult | List[StageResult])`
+
+Backwards compatible — the `str` form behaves exactly as before.
+
+## What was done
+
+- **C++ helper (reuse, not reinvent):** extracted the flatten-and-remove block from
+  `version_core.cpp:DeleteIncompleteKeysOnExit::~DeleteIncompleteKeysOnExit` into
+  `incompletes.{hpp,cpp}:delete_incomplete_keys_for_stage_results(store, stage_results)` — a
+  single batched `store->remove_keys(keys, RemoveOpts{.ignores_missing_key_ = true})`. The
+  destructor now calls the helper (behaviour-preserving).
+- **Engine:** `LocalVersionedEngine::remove_incompletes_for_stage_results(vector<StageResult>)`
+  delegates to the helper. Inherited by `PythonVersionStore` (no `version_store_api` change
+  needed).
+- **pybind:** added `remove_incompletes_for_stage_results` binding next to `remove_incomplete`.
+- **Python dispatch (single brain in V1):** `NativeVersionStore.remove_incomplete` inspects the
+  argument — `str` → old C++ path; `StageResult` → wrapped in a one-element list; `list` →
+  as-is; both non-str forms call the new binding. V2 `delete_staged_data` stays a thin forwarder
+  to V1. Signatures widened to `Union[str, StageResult, List[StageResult]]` (no `@overload`
+  stubs, per preference).
+- **Design choices:** single batched delete (not a per-receipt loop) to avoid N storage
+  round-trips; idempotent via `ignores_missing_key_`; cross-symbol lists allowed (atom keys are
+  self-describing).
+
+## Tests (`python/tests/unit/arcticdb/version_store/test_parallel.py`)
+
+- `test_delete_staged_data_by_single_stage_result` (V1) — originally the failing/RED test.
+- `test_delete_staged_data_by_list_of_stage_results` (V1)
+- `test_delete_staged_data_by_string_removes_all` (V1 regression)
+- `test_delete_staged_data_by_stage_result_is_idempotent` (V1)
+- `test_delete_staged_data_by_stage_result_cross_symbol` (V1)
+- `test_delete_staged_data_v2_by_stage_result` (V2 entry point)
+
+All pass; full `test_parallel.py` suite green (549 passed, 63 skipped).
+
+## Docs
+
+- `docs/claude/cpp/STREAM.md` — added a "Deletion" subsection (by-symbol vs by-stage-result).
+- `Library.delete_staged_data` docstring — widened, added `Examples` and a `stage` See Also.
+- `NativeVersionStore.remove_incomplete` docstring — widened to describe all three forms.

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2842,11 +2842,13 @@ class NativeVersionStore:
             If a `StageResult` or list of them, removes only the APPEND_DATA keys named by
             those stage result(s). Missing keys are ignored.
         """
-        if isinstance(symbol, str):
-            self.version_store.remove_incomplete(symbol)
+        if isinstance(symbol, StageResult):
+            self.version_store.remove_incompletes_for_stage_results([symbol])
+        elif isinstance(symbol, (list, tuple)):
+            self.version_store.remove_incompletes_for_stage_results(list(symbol))
         else:
-            stage_results = [symbol] if isinstance(symbol, StageResult) else list(symbol)
-            self.version_store.remove_incompletes_for_stage_results(stage_results)
+            # str or numeric StreamId
+            self.version_store.remove_incomplete(symbol)
 
     def compact_incomplete(
         self,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2842,15 +2842,9 @@ class NativeVersionStore:
             If a `StageResult` or list of them, removes only the APPEND_DATA keys named by
             those stage result(s). Missing keys are ignored.
         """
-        if isinstance(symbol, (str, int, list)):
-            self.version_store.remove_incomplete(symbol)
-        elif isinstance(symbol, StageResult):
-            self.version_store.remove_incomplete([symbol])
-        else:
-            raise UserInputException(
-                "remove_incomplete expected a symbol (str), a StageResult, or a list of StageResults, "
-                f"but got {type(symbol).__name__}"
-            )
+        if isinstance(symbol, StageResult):
+            symbol = [symbol]
+        self.version_store.remove_incomplete(symbol)
 
     def compact_incomplete(
         self,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2842,13 +2842,15 @@ class NativeVersionStore:
             If a `StageResult` or list of them, removes only the APPEND_DATA keys named by
             those stage result(s). Missing keys are ignored.
         """
-        if isinstance(symbol, StageResult):
-            self.version_store.remove_incompletes_for_stage_results([symbol])
-        elif isinstance(symbol, (list, tuple)):
-            self.version_store.remove_incompletes_for_stage_results(list(symbol))
-        else:
-            # str or numeric StreamId
+        if isinstance(symbol, (str, int, list)):
             self.version_store.remove_incomplete(symbol)
+        elif isinstance(symbol, StageResult):
+            self.version_store.remove_incomplete([symbol])
+        else:
+            raise UserInputException(
+                "remove_incomplete expected a symbol (str), a StageResult, or a list of StageResults, "
+                f"but got {type(symbol).__name__}"
+            )
 
     def compact_incomplete(
         self,

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2830,17 +2830,23 @@ class NativeVersionStore:
         """
         return list(self.version_store.get_incomplete_symbols())
 
-    def remove_incomplete(self, symbol: str):
+    def remove_incomplete(self, symbol: Union[str, StageResult, List[StageResult]]) -> None:
         """
         Remove previously written un-indexed chunks of data, produced by a tick collector or parallel
         writes/appends.
 
         Parameters
         ----------
-        symbol : `str`
-            Symbol name.
+        symbol : `str`, `StageResult`, or `List[StageResult]`
+            If a symbol name (`str`), removes all incomplete segments for that symbol.
+            If a `StageResult` or list of them, removes only the APPEND_DATA keys named by
+            those stage result(s). Missing keys are ignored.
         """
-        self.version_store.remove_incomplete(symbol)
+        if isinstance(symbol, str):
+            self.version_store.remove_incomplete(symbol)
+        else:
+            stage_results = [symbol] if isinstance(symbol, StageResult) else list(symbol)
+            self.version_store.remove_incompletes_for_stage_results(stage_results)
 
     def compact_incomplete(
         self,

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1741,19 +1741,30 @@ class Library:
         )
         return batch_update_result
 
-    def delete_staged_data(self, symbol: str) -> None:
+    def delete_staged_data(self, symbol: Union[str, StageResult, List[StageResult]]) -> None:
         """
         Removes staged data.
 
         Parameters
         ----------
-        symbol : `str`
-            Symbol to remove staged data for.
+        symbol : `str`, `StageResult`, or `List[StageResult]`
+            If a symbol name (`str`), removes all staged data for that symbol.
+            If a `StageResult` or list of them (as returned by ``stage``), removes only the staged
+            segments named by those stage result(s). Missing keys are ignored.
 
         See Also
         --------
         write
             Documentation on the ``staged`` parameter explains the concept of staged data in more detail.
+        stage
+            Returns the ``StageResult`` receipts accepted by this method.
+
+        Examples
+        --------
+        >>> receipt_1 = lib.stage("symbol", df1)
+        >>> receipt_2 = lib.stage("symbol", df2)
+        >>> lib.delete_staged_data(receipt_1)  # delete only the first batch's staged keys
+        >>> lib.delete_staged_data("symbol")   # delete all remaining staged data for the symbol
         """
         self._nvs.remove_incomplete(symbol)
 

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -1757,14 +1757,14 @@ class Library:
         write
             Documentation on the ``staged`` parameter explains the concept of staged data in more detail.
         stage
-            Returns the ``StageResult`` receipts accepted by this method.
+            Returns the ``StageResult`` objects accepted by this method.
 
         Examples
         --------
-        >>> receipt_1 = lib.stage("symbol", df1)
-        >>> receipt_2 = lib.stage("symbol", df2)
-        >>> lib.delete_staged_data(receipt_1)  # delete only the first batch's staged keys
-        >>> lib.delete_staged_data("symbol")   # delete all remaining staged data for the symbol
+        >>> stage_result_1 = lib.stage("symbol", df1)
+        >>> stage_result_2 = lib.stage("symbol", df2)
+        >>> lib.delete_staged_data(stage_result_1)  # delete only the first batch's staged keys
+        >>> lib.delete_staged_data("symbol")        # delete all remaining staged data for the symbol
         """
         self._nvs.remove_incomplete(symbol)
 

--- a/python/tests/integration/arcticdb/test_arctic.py
+++ b/python/tests/integration/arcticdb/test_arctic.py
@@ -379,6 +379,23 @@ def test_staged_data_bad_mode(arctic_library, sort):
         fn("sym", mode="bad_mode")
 
 
+def test_delete_staged_data_by_stage_result(lmdb_library):
+    lib = lmdb_library
+    sym = "test_delete_staged_data_by_stage_result"
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+
+    stage_result_1 = lib.stage(sym, df1)
+    stage_result_2 = lib.stage(sym, df2)
+
+    lib.delete_staged_data(stage_result_1)
+
+    lib_tool = lib._nvs.library_tool()
+    remaining = {str(k) for k in lib_tool.find_keys_for_symbol(KeyType.APPEND_DATA, sym)}
+    assert remaining == {str(k) for k in stage_result_2.staged_segments}
+
+
 @pytest.mark.parametrize(
     "finalize_method", (StagedDataFinalizeMethod.WRITE, StagedDataFinalizeMethod.APPEND, "write", "wRite")
 )

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -126,6 +126,23 @@ def test_delete_staged_data_by_string_removes_all(lmdb_version_store_v1):
     assert len(get_append_keys(lib, sym)) == 0
 
 
+def test_delete_staged_data_by_numeric_symbol_removes_all(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = 12345  # StreamId is variant<int, str>, so numeric symbols are valid
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+
+    lib.stage(sym, df1)
+    lib.stage(sym, df2)
+    assert sym in lib.list_symbols_with_incomplete_data()
+
+    # Must not be misrouted into the stage-result branch (list(12345) would raise).
+    lib.remove_incomplete(sym)
+
+    assert sym not in lib.list_symbols_with_incomplete_data()
+
+
 def test_delete_staged_data_by_stage_result_is_idempotent(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = "test_delete_staged_data_by_stage_result_is_idempotent"

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -72,6 +72,112 @@ def test_staging_doesnt_write_append_ref(lmdb_version_store_v1):
     assert not len(lib_tool.find_keys_for_symbol(KeyType.APPEND_REF, sym))
 
 
+def test_delete_staged_data_by_single_stage_result(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_delete_staged_data_by_single_stage_result"
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+
+    stage_result_1 = lib.stage(sym, df1)
+    stage_result_2 = lib.stage(sym, df2)
+
+    assert len(get_append_keys(lib, sym)) == len(stage_result_1.staged_segments) + len(stage_result_2.staged_segments)
+
+    # Delete only the first stage result's APPEND_DATA keys, by handing back its receipt.
+    lib.remove_incomplete(stage_result_1)
+
+    remaining = {str(k) for k in get_append_keys(lib, sym)}
+    assert remaining == {str(k) for k in stage_result_2.staged_segments}
+    assert remaining.isdisjoint({str(k) for k in stage_result_1.staged_segments})
+
+
+def test_delete_staged_data_by_list_of_stage_results(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_delete_staged_data_by_list_of_stage_results"
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+    df3 = pd.DataFrame({"col": [4, 5]}, index=pd.date_range("2024-01-05", periods=2))
+
+    stage_result_1 = lib.stage(sym, df1)
+    stage_result_2 = lib.stage(sym, df2)
+    stage_result_3 = lib.stage(sym, df3)
+
+    lib.remove_incomplete([stage_result_1, stage_result_2])
+
+    remaining = {str(k) for k in get_append_keys(lib, sym)}
+    assert remaining == {str(k) for k in stage_result_3.staged_segments}
+
+
+def test_delete_staged_data_by_string_removes_all(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_delete_staged_data_by_string_removes_all"
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+
+    lib.stage(sym, df1)
+    lib.stage(sym, df2)
+    assert len(get_append_keys(lib, sym)) > 0
+
+    lib.remove_incomplete(sym)
+
+    assert len(get_append_keys(lib, sym)) == 0
+
+
+def test_delete_staged_data_by_stage_result_is_idempotent(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym = "test_delete_staged_data_by_stage_result_is_idempotent"
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+
+    stage_result_1 = lib.stage(sym, df1)
+    stage_result_2 = lib.stage(sym, df2)
+
+    lib.remove_incomplete(stage_result_1)
+    # Deleting the same receipt again is a no-op, not an error.
+    lib.remove_incomplete(stage_result_1)
+
+    remaining = {str(k) for k in get_append_keys(lib, sym)}
+    assert remaining == {str(k) for k in stage_result_2.staged_segments}
+
+
+def test_delete_staged_data_by_stage_result_cross_symbol(lmdb_version_store_v1):
+    lib = lmdb_version_store_v1
+    sym_a = "test_delete_staged_data_cross_symbol_a"
+    sym_b = "test_delete_staged_data_cross_symbol_b"
+
+    df = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+
+    stage_result_a = lib.stage(sym_a, df)
+    stage_result_b = lib.stage(sym_b, df)
+    keep_a = lib.stage(sym_a, df)
+
+    lib.remove_incomplete([stage_result_a, stage_result_b])
+
+    remaining_a = {str(k) for k in get_append_keys(lib, sym_a)}
+    assert remaining_a == {str(k) for k in keep_a.staged_segments}
+    assert len(get_append_keys(lib, sym_b)) == 0
+
+
+def test_delete_staged_data_v2_by_stage_result(lmdb_library):
+    lib = lmdb_library
+    sym = "test_delete_staged_data_v2_by_stage_result"
+
+    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
+    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
+
+    stage_result_1 = lib.stage(sym, df1)
+    stage_result_2 = lib.stage(sym, df2)
+
+    lib.delete_staged_data(stage_result_1)
+
+    remaining = {str(k) for k in get_append_keys(lib._nvs, sym)}
+    assert remaining == {str(k) for k in stage_result_2.staged_segments}
+
+
 @pytest.mark.storage
 @pytest.mark.parametrize("batch", (True, False))
 @pytest.mark.parametrize("batch_size", (1000, 7))

--- a/python/tests/unit/arcticdb/version_store/test_parallel.py
+++ b/python/tests/unit/arcticdb/version_store/test_parallel.py
@@ -110,22 +110,6 @@ def test_delete_staged_data_by_list_of_stage_results(lmdb_version_store_v1):
     assert remaining == {str(k) for k in stage_result_3.staged_segments}
 
 
-def test_delete_staged_data_by_string_removes_all(lmdb_version_store_v1):
-    lib = lmdb_version_store_v1
-    sym = "test_delete_staged_data_by_string_removes_all"
-
-    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
-    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
-
-    lib.stage(sym, df1)
-    lib.stage(sym, df2)
-    assert len(get_append_keys(lib, sym)) > 0
-
-    lib.remove_incomplete(sym)
-
-    assert len(get_append_keys(lib, sym)) == 0
-
-
 def test_delete_staged_data_by_numeric_symbol_removes_all(lmdb_version_store_v1):
     lib = lmdb_version_store_v1
     sym = 12345  # StreamId is variant<int, str>, so numeric symbols are valid
@@ -154,7 +138,7 @@ def test_delete_staged_data_by_stage_result_is_idempotent(lmdb_version_store_v1)
     stage_result_2 = lib.stage(sym, df2)
 
     lib.remove_incomplete(stage_result_1)
-    # Deleting the same receipt again is a no-op, not an error.
+    # Deleting the same stage result again is a no-op, not an error.
     lib.remove_incomplete(stage_result_1)
 
     remaining = {str(k) for k in get_append_keys(lib, sym)}
@@ -177,22 +161,6 @@ def test_delete_staged_data_by_stage_result_cross_symbol(lmdb_version_store_v1):
     remaining_a = {str(k) for k in get_append_keys(lib, sym_a)}
     assert remaining_a == {str(k) for k in keep_a.staged_segments}
     assert len(get_append_keys(lib, sym_b)) == 0
-
-
-def test_delete_staged_data_v2_by_stage_result(lmdb_library):
-    lib = lmdb_library
-    sym = "test_delete_staged_data_v2_by_stage_result"
-
-    df1 = pd.DataFrame({"col": [0, 1]}, index=pd.date_range("2024-01-01", periods=2))
-    df2 = pd.DataFrame({"col": [2, 3]}, index=pd.date_range("2024-01-03", periods=2))
-
-    stage_result_1 = lib.stage(sym, df1)
-    stage_result_2 = lib.stage(sym, df2)
-
-    lib.delete_staged_data(stage_result_1)
-
-    remaining = {str(k) for k in get_append_keys(lib._nvs, sym)}
-    assert remaining == {str(k) for k in stage_result_2.staged_segments}
 
 
 @pytest.mark.storage


### PR DESCRIPTION
  Edit the two staged-data deletion APIs so their argument can be a **symbol string**, a
  **single `StageResult`**, or a **`List[StageResult]`**:

  - **V1:** `NativeVersionStore.remove_incomplete(symbol)`
  - **V2:** `Library.delete_staged_data(symbol)`

  | Argument | Behaviour |
  |----------|-----------|
  | `str` | Delete **all** `APPEND_DATA` (incomplete) keys for the symbol — *unchanged* |
  | `StageResult` | Delete **only** the `APPEND_DATA` keys named by that receipt |
  | `List[StageResult]` | Delete **only** the `APPEND_DATA` keys named by those receipts |

  Deleting by stage result(s) is **idempotent** — keys already gone (e.g. already finalized or
  already deleted) are silently ignored.


  ## What was changed

  - Extracted the existing flatten-and-remove logic out of the finalize-failure cleanup
    (`DeleteIncompleteKeysOnExit::~DeleteIncompleteKeysOnExit`) into a shared helper
    `delete_incomplete_keys_for_stage_results` in `incompletes.{hpp,cpp}`. It flattens all
    receipts' keys and issues a **single batched** `remove_keys(..., ignores_missing_key_ = true)`
    call. The destructor now calls this helper (behaviour-preserving).
  - Added `LocalVersionedEngine::remove_incompletes_for_stage_results` and a pybind binding
    (`PythonVersionStore` inherits the engine method, so no `version_store_api` change).
  - Type dispatch lives in **one** place — V1 `remove_incomplete`. `str` keeps the old C++ path;
    a lone `StageResult` is wrapped in a one-element list; both non-`str` forms hit the new
    binding. V2 `delete_staged_data` stays a thin forwarder to V1.
  - A single `StageResult` and a list both funnel to the same batched delete, so ~500 receipts is
    **one** storage round-trip, not 500.

  ## API change (backwards compatible)
  
  Both **V1 and V2 public APIs** widen their parameter from `str` to
  `Union[str, StageResult, List[StageResult]]`. The `str` form is unchanged, so existing callers
  are unaffected.