### PR TITLE
Col stats: Unify NaN and Null stats in to one statistic

### DIFF
--- a/cpp/arcticdb/pipeline/column_stats.cpp
+++ b/cpp/arcticdb/pipeline/column_stats.cpp
@@ -36,9 +36,7 @@ struct StatKeyHash {
     }
 };
 
-bool is_count_stat(ColumnStatTypeInternal type) {
-    return type == ColumnStatTypeInternal::NAN_COUNT_V1 || type == ColumnStatTypeInternal::NULL_COUNT_V1;
-}
+bool is_count_stat(ColumnStatTypeInternal type) { return type == ColumnStatTypeInternal::ISNULL_COUNT_V1; }
 
 std::vector<StatColumn> collect_stat_columns(
         const std::vector<ColumnStatsRow>& column_stats_rows, const StreamDescriptor& descriptor,
@@ -183,10 +181,8 @@ std::string type_to_operator_string(ColumnStatTypeInternal type) {
         return "v1_MIN";
     case ColumnStatTypeInternal::MAX_V1:
         return "v1_MAX";
-    case ColumnStatTypeInternal::NAN_COUNT_V1:
-        return "v1_NAN_COUNT";
-    case ColumnStatTypeInternal::NULL_COUNT_V1:
-        return "v1_NULL_COUNT";
+    case ColumnStatTypeInternal::ISNULL_COUNT_V1:
+        return "v1_ISNULL_COUNT";
     default:
         internal::raise<ErrorCode::E_ASSERTION_FAILURE>("Unknown column stat type requested");
     }
@@ -314,9 +310,8 @@ ColumnStats::ColumnStats(
             switch (entry.type()) {
             case MIN_V1:
             case MAX_V1:
-            case NAN_COUNT_V1:
-            case NULL_COUNT_V1:
-                external_type = ColumnStatType::MINMAX; // null and nan are calculated inline with minmax
+            case ISNULL_COUNT_V1:
+                external_type = ColumnStatType::MINMAX; // isnull count is calculated inline with minmax
                 break;
             case UNKNOWN:
             default:

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.cpp
@@ -43,7 +43,7 @@ StatsComparison stats_membership_comparator(const ColumnStatsValues& stats, Valu
         return StatsComparison::NONE_MATCH;
     }
 
-    if (stats.only_nulls()) {
+    if (stats.all_isnull()) {
         // Every row is null: a null is never in the set, so isin matches none and isnotin matches all.
         return is_isin ? StatsComparison::NONE_MATCH : StatsComparison::ALL_MATCH;
     }
@@ -145,10 +145,11 @@ StatsComparison stats_membership_comparator(const ColumnStatsValues& stats, Valu
                 }
 
                 // Same idea as `adjust_for_missing` in column_stats_dispatch.hpp:
-                // when the segment has NaN/NaT/sparse-gap rows, an `isin` ALL_MATCH may overstate
-                // (NaN never matches isin), so the corresponding `isnotin` NONE_MATCH (after the
-                // flip below) would also be wrong. Downgrade before the flip so both paths agree.
-                if ((stats.nan_count + stats.null_count) > 0 && isin_result == StatsComparison::ALL_MATCH) {
+                // when the segment has isnull rows (NaN/NaT/sparse-gap), an `isin` ALL_MATCH may
+                // overstate (NaN never matches isin), so the corresponding `isnotin` NONE_MATCH
+                // (after the flip below) would also be wrong. Downgrade before the flip so both
+                // paths agree.
+                if (stats.isnull_count > 0 && isin_result == StatsComparison::ALL_MATCH) {
                     isin_result = StatsComparison::UNKNOWN;
                 }
 

--- a/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_dispatch.hpp
@@ -131,7 +131,7 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value
     if (stats_lhs.column_absent) {
         return StatsComparison::NONE_MATCH;
     }
-    if (stats_lhs.only_nulls()) {
+    if (stats_lhs.all_isnull()) {
         // Every row is null: `!=` matches all of them, every other comparison matches none.
         return std::is_same_v<std::remove_cvref_t<Func>, NotEqualsOperator> ? StatsComparison::ALL_MATCH
                                                                             : StatsComparison::NONE_MATCH;
@@ -179,7 +179,7 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Value
             return StatsComparison::UNKNOWN;
         });
     });
-    return adjust_for_missing<Func>(result, stats_lhs.nan_count + stats_lhs.null_count);
+    return adjust_for_missing<Func>(result, stats_lhs.isnull_count);
 }
 
 template<typename Func>
@@ -230,9 +230,7 @@ StatsComparison stats_comparator(const ColumnStatsValues& stats_lhs, const Colum
             return StatsComparison::UNKNOWN;
         });
     });
-    return adjust_for_missing<Func>(
-            result, stats_lhs.nan_count + stats_lhs.null_count + stats_rhs.nan_count + stats_rhs.null_count
-    );
+    return adjust_for_missing<Func>(result, stats_lhs.isnull_count + stats_rhs.isnull_count);
 }
 
 template<typename Func>

--- a/cpp/arcticdb/pipeline/column_stats_filter.cpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.cpp
@@ -141,8 +141,7 @@ std::vector<StatsMetadataForColumn> calculate_stats_metadata(
             const auto entry_type = entry.type();
             const bool is_min_max = entry_type == arcticc::pb2::column_stats_pb2::MIN_V1 ||
                                     entry_type == arcticc::pb2::column_stats_pb2::MAX_V1;
-            const bool is_count = entry_type == arcticc::pb2::column_stats_pb2::NAN_COUNT_V1 ||
-                                  entry_type == arcticc::pb2::column_stats_pb2::NULL_COUNT_V1;
+            const bool is_count = entry_type == arcticc::pb2::column_stats_pb2::ISNULL_COUNT_V1;
             if (!is_min_max && !is_count) {
                 log::version().warn(
                         "Unknown column stats type {} for column {}, skipping",
@@ -157,7 +156,7 @@ std::vector<StatsMetadataForColumn> calculate_stats_metadata(
                 // Column was filtered out at decode time, or never present in this segment.
                 continue;
             }
-            // NAN_COUNT/NULL_COUNT are always UINT64 and tracked separately; only MIN/MAX define the
+            // ISNULL_COUNT is always UINT64 and tracked separately; only MIN/MAX define the
             // column's value data type.
             if (is_min_max) {
                 const auto entry_data_type = fields.at(*col_index).type().data_type();
@@ -190,11 +189,10 @@ std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
         StatsForColumn stats_for_column;
         stats_for_column.mins.resize(num_rows);
         stats_for_column.maxes.resize(num_rows);
-        stats_for_column.nan_counts.resize(num_rows, 0);
-        stats_for_column.null_counts.resize(num_rows, 0);
+        stats_for_column.isnull_counts.resize(num_rows, 0);
 
         // data_type stays UNKNOWN when every row-slice this column's stats were computed over was
-        // entirely null, leaving only NAN_COUNT/NULL_COUNT
+        // entirely null, leaving only ISNULL_COUNT
         // entries below - nothing to decode here, mins/maxes stay all-absent.
         if (stats_metadata_for_column.data_type != DataType::UNKNOWN) {
             details::visit_type(stats_metadata_for_column.data_type, [&]<typename T>(T) {
@@ -222,18 +220,17 @@ std::unordered_map<std::string, StatsForColumn> load_stats_by_column(
             });
         }
 
-        // NaN/NaT and null (sparse-gap) counts are stored inline with min/max as dense UINT64 columns.
+        // The isnull count is stored inline with min/max as a dense UINT64 column.
         using CountTDT = ScalarTagType<DataTypeTag<DataType::UINT64>>;
         for (const auto& entry : stats_metadata_for_column.entries) {
-            if (entry.stat_type != NAN_COUNT_V1 && entry.stat_type != NULL_COUNT_V1) {
+            if (entry.stat_type != ISNULL_COUNT_V1) {
                 continue;
             }
-            auto& dest = entry.stat_type == NAN_COUNT_V1 ? stats_for_column.nan_counts : stats_for_column.null_counts;
             const auto& column = segment.column(static_cast<position_t>(entry.segment_col_idx));
             for_each_enumerated<CountTDT>(column, [&](const ColumnData::Enumeration<uint64_t>& enumerating_it) {
                 auto idx = static_cast<size_t>(enumerating_it.idx());
                 if (idx >= first_kept && idx < last_kept_excl) {
-                    dest.at(idx - first_kept) = enumerating_it.value();
+                    stats_for_column.isnull_counts.at(idx - first_kept) = enumerating_it.value();
                 }
             });
         }
@@ -367,11 +364,9 @@ std::vector<ColumnStatsValues> ColumnStatsData::values_for_column(
         if (min_set) {
             result_entry.min = stats.mins.at(r);
             result_entry.max = stats.maxes.at(r);
-            result_entry.nan_count = stats.nan_counts.at(r);
-            result_entry.null_count = stats.null_counts.at(r);
-        } else if (stats.nan_counts.at(r) > 0 || stats.null_counts.at(r) > 0) {
-            result_entry.nan_count = stats.nan_counts.at(r);
-            result_entry.null_count = stats.null_counts.at(r);
+            result_entry.isnull_count = stats.isnull_counts.at(r);
+        } else if (stats.isnull_counts.at(r) > 0) {
+            result_entry.isnull_count = stats.isnull_counts.at(r);
         } else {
             result_entry.column_absent = true;
         }

--- a/cpp/arcticdb/pipeline/column_stats_filter.hpp
+++ b/cpp/arcticdb/pipeline/column_stats_filter.hpp
@@ -28,10 +28,10 @@ namespace arcticdb {
 struct ColumnStatsValues {
     std::optional<Value> min;
     std::optional<Value> max;
-    // In-band sentinels (NaN for floats, NaT for time types) counted during write-time aggregation.
-    uint64_t nan_count = 0;
-    // Sparse-map gaps (rows genuinely absent from the data segment) counted during write-time aggregation.
-    uint64_t null_count = 0;
+    // Rows for which ArcticDB's ISNULL would be true, counted during write-time aggregation:
+    // sparse-map gaps (rows genuinely absent from the data segment) plus in-band sentinel values
+    // (NaN for floats, NaT for time types).
+    uint64_t isnull_count = 0;
     bool column_absent = false;
 
     ColumnStatsValues() = default;
@@ -40,7 +40,7 @@ struct ColumnStatsValues {
         util::check(min.has_value() == max.has_value(), "min and max should either both be present or both be absent");
     };
 
-    bool only_nulls() const { return !min.has_value() && (nan_count + null_count) > 0; }
+    bool all_isnull() const { return !min.has_value() && isnull_count > 0; }
 };
 
 struct StatsIndexAndType {
@@ -57,8 +57,7 @@ struct StatsMetadataForColumn {
 struct StatsForColumn {
     std::vector<std::optional<Value>> mins;  // size == num_rows_
     std::vector<std::optional<Value>> maxes; // size == num_rows_
-    std::vector<uint64_t> nan_counts;        // size == num_rows_, default 0
-    std::vector<uint64_t> null_counts;       // size == num_rows_, default 0
+    std::vector<uint64_t> isnull_counts;     // size == num_rows_, default 0
 };
 
 /**

--- a/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
+++ b/cpp/arcticdb/pipeline/test/test_column_stats_data.cpp
@@ -359,9 +359,9 @@ TEST(ColumnStatsDataTest, SparseColumnAbsentMarkedCorrectly) {
     ASSERT_TRUE(v1.column_absent);
 }
 
-// A wholly-null row-slice has NAN_COUNT/NULL_COUNT entries but no MIN/MAX (no real value to
-// min/max over). values_for_column must propagate the counts and leave column_absent false, so
-// downstream comparators fall through to UNKNOWN rather than pruning the slice
+// A wholly-null row-slice has an ISNULL_COUNT entry but no MIN/MAX (no real value to min/max
+// over). values_for_column must propagate the count and leave column_absent false, so downstream
+// comparators fall through to UNKNOWN rather than pruning the slice
 TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     using namespace arcticc::pb2::column_stats_pb2;
 
@@ -370,34 +370,30 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     //   col 1: end_row
     //   col 2: v1_MIN(price)
     //   col 3: v1_MAX(price)
-    //   col 4: v1_NAN_COUNT(price)
-    //   col 5: v1_NULL_COUNT(price)
+    //   col 4: v1_ISNULL_COUNT(price)
     //
     // Row 0: price=[10,20]            (real values)
-    // Row 1: price all null           (no MIN/MAX, null_count=3)
+    // Row 1: price all null           (no MIN/MAX, isnull_count=3)
 
     auto start_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
     auto end_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
     auto min_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
     auto max_price_col = std::make_shared<Column>(make_scalar_type(DataType::INT64), Sparsity::PERMITTED);
-    auto nan_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
-    auto null_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
+    auto isnull_count_col = std::make_shared<Column>(make_scalar_type(DataType::UINT64), Sparsity::PERMITTED);
 
     // Row 0: real values present, no nulls
     start_col->push_back<uint64_t>(100);
     end_col->push_back<uint64_t>(200);
     min_price_col->push_back<int64_t>(10);
     max_price_col->push_back<int64_t>(20);
-    nan_count_col->push_back<uint64_t>(0);
-    null_count_col->push_back<uint64_t>(0);
+    isnull_count_col->push_back<uint64_t>(0);
 
-    // Row 1: all null - min/max absent, counts present
+    // Row 1: all null - min/max absent, count present
     start_col->push_back<uint64_t>(300);
     end_col->push_back<uint64_t>(400);
     min_price_col->mark_absent_rows(1);
     max_price_col->mark_absent_rows(1);
-    nan_count_col->push_back<uint64_t>(0);
-    null_count_col->push_back<uint64_t>(3);
+    isnull_count_col->push_back<uint64_t>(3);
 
     ssize_t last_row = 1;
     SegmentInMemory seg;
@@ -406,8 +402,7 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     seg.add_column(scalar_field(DataType::UINT64, end_row_column_name), end_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MIN(price)"), min_price_col);
     seg.add_column(scalar_field(DataType::INT64, "v1_MAX(price)"), max_price_col);
-    seg.add_column(scalar_field(DataType::UINT64, "v1_NAN_COUNT(price)"), nan_count_col);
-    seg.add_column(scalar_field(DataType::UINT64, "v1_NULL_COUNT(price)"), null_count_col);
+    seg.add_column(scalar_field(DataType::UINT64, "v1_ISNULL_COUNT(price)"), isnull_count_col);
     seg.set_row_data(last_row);
 
     ColumnStatsHeader header;
@@ -419,12 +414,9 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     auto* p_max = price_entries.add_entries();
     p_max->set_stats_seg_offset(3);
     p_max->set_type(MAX_V1);
-    auto* p_nan = price_entries.add_entries();
-    p_nan->set_stats_seg_offset(4);
-    p_nan->set_type(NAN_COUNT_V1);
-    auto* p_null = price_entries.add_entries();
-    p_null->set_stats_seg_offset(5);
-    p_null->set_type(NULL_COUNT_V1);
+    auto* p_isnull = price_entries.add_entries();
+    p_isnull->set_stats_seg_offset(4);
+    p_isnull->set_type(ISNULL_COUNT_V1);
 
     google::protobuf::Any any;
     any.PackFrom(header);
@@ -448,7 +440,6 @@ TEST(ColumnStatsDataTest, AllNullSliceKeepsCountsAndNotAbsent) {
     ASSERT_FALSE(v1.min.has_value());
     ASSERT_FALSE(v1.max.has_value());
     ASSERT_FALSE(v1.column_absent); // present-but-all-null, not absent
-    ASSERT_EQ(v1.nan_count, 0u);
-    ASSERT_EQ(v1.null_count, 3u);
+    ASSERT_EQ(v1.isnull_count, 3u);
 }
 } // namespace arcticdb

--- a/cpp/arcticdb/processing/unsorted_aggregation.cpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.cpp
@@ -25,12 +25,10 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
         using type_info = ScalarTypeInfo<decltype(col_tag)>;
         using RawType = typename type_info::RawType;
         if constexpr (!is_sequence_type(type_info::data_type)) {
-            // null_count_ tracks rows that are genuinely absent (sparse-map gaps from Arrow
-            // validity bitmaps). nan_count_ tracks in-band sentinel values found while iterating
-            // the dense values (NaN for floats, NaT for time types) - see the for_each below.
+            // isnull_count_ counts every row for which ArcticDB's ISNULL is true
             if (input_column.column_->is_sparse()) {
                 const auto sparse_gap_count = input_column.column_->last_row() + 1 - input_column.column_->row_count();
-                null_count_ += static_cast<uint64_t>(sparse_gap_count);
+                isnull_count_ += static_cast<uint64_t>(sparse_gap_count);
             }
             auto is_nat_or_nan = []([[maybe_unused]] RawType v) {
                 if constexpr (is_floating_point_type(type_info::data_type)) {
@@ -56,7 +54,7 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
                 // min/max update so those reflect only real values.
                 if constexpr (is_floating_point_type(type_info::data_type) || is_time_type(type_info::data_type)) {
                     if (is_nat_or_nan(value)) {
-                        ++nan_count_;
+                        ++isnull_count_;
                         any_nan = true;
                         return;
                     }
@@ -87,18 +85,15 @@ void MinMaxAggregatorData::aggregate(const ColumnWithStrings& input_column) {
 std::vector<ColumnStatValue> MinMaxAggregatorData::finalize() const {
     std::vector<ColumnStatValue> res;
     if (min_.has_value()) {
-        res.reserve(4);
+        res.reserve(3);
         res.emplace_back(ColumnStatValue{ColumnStatTypeInternal::MIN_V1, data_col_offset_, *min_});
         res.emplace_back(ColumnStatValue{ColumnStatTypeInternal::MAX_V1, data_col_offset_, *max_});
-    } else if (null_count_ == 0) {
+    } else if (isnull_count_ == 0) {
         // The column is absent from this slice entirely, so there is nothing to record
         return res;
     }
-    res.emplace_back(
-            ColumnStatValue{ColumnStatTypeInternal::NAN_COUNT_V1, data_col_offset_, Value{nan_count_, DataType::UINT64}}
-    );
     res.emplace_back(ColumnStatValue{
-            ColumnStatTypeInternal::NULL_COUNT_V1, data_col_offset_, Value{null_count_, DataType::UINT64}
+            ColumnStatTypeInternal::ISNULL_COUNT_V1, data_col_offset_, Value{isnull_count_, DataType::UINT64}
     });
     return res;
 }

--- a/cpp/arcticdb/processing/unsorted_aggregation.hpp
+++ b/cpp/arcticdb/processing/unsorted_aggregation.hpp
@@ -25,8 +25,7 @@ class MinMaxAggregatorData {
   private:
     std::optional<Value> min_;
     std::optional<Value> max_;
-    uint64_t nan_count_{0};
-    uint64_t null_count_{0};
+    uint64_t isnull_count_{0};
     size_t data_col_offset_;
 };
 

--- a/cpp/proto/arcticc/pb2/column_stats.proto
+++ b/cpp/proto/arcticc/pb2/column_stats.proto
@@ -23,8 +23,8 @@ enum ColumnStatsType {
     // misinterpret the new statistics format.
     MIN_V1 = 1;
     MAX_V1 = 2;
-    NAN_COUNT_V1 = 3;
-    NULL_COUNT_V1 = 4;
+    // Counts rows for which ArcticDB's ISNULL is true
+    ISNULL_COUNT_V1 = 3;
 }
 
 message StatEntry {

--- a/docs/claude/cpp/PIPELINE.md
+++ b/docs/claude/cpp/PIPELINE.md
@@ -152,9 +152,8 @@ Key types:
 | Type | Location | Purpose |
 |------|----------|---------|
 | `ColumnStatsData` | `column_stats_filter.hpp` | Parsed stats segment, indexed by `RowRange` |
-| `ColumnStatsRow` | `column_stats_filter.hpp` | Stats for a single row-slice: start/end row + per-column min/max |
-| `ColumnStatsValues` | `column_stats_filter.hpp` | Min/max `Value` pair for one column in one row-slice, plus `column_absent` flag marking segments where the column was not present |
-| `ColumnStatElement` | `column_stats.hpp` | `MIN` or `MAX` — the individual stat within a `MINMAX` stat type |
+| `ColumnStatsRow` | `column_stats_types.hpp` | Stats for a single row-slice: start/end row + per-column min/max |
+| `ColumnStatsValues` | `column_stats_filter.hpp` | Min/max `Value` pair for one column in one row-slice, plus `isnull_count` (rows where `ISNULL` is true — sparse-map gaps or in-band NaN/NaT) and `column_absent` flag marking segments where the column was not present |
 
 `StatsVariantData` is a `std::variant` over `std::vector<StatsComparison>`, `std::shared_ptr<Value>`, `std::vector<ColumnStatsValues>`, and `std::shared_ptr<ValueSet>`. The `ValueSet` alternative is used by `isin`/`isnotin` expressions.
 

--- a/python/tests/unit/arcticdb/test_column_stats_creation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_creation.py
@@ -76,8 +76,8 @@ def assert_stats_equal(received, expected, check_dtypes=False):
     assert isinstance(received, pa.Table)
     assert isinstance(expected, pl.DataFrame)
     received_pl = pl.from_arrow(received)
-    # The C++ aggregator always emits v1_NAN_COUNT and v1_NULL_COUNT columns alongside MIN/MAX.
-    # Tests that aren't exercising the count behaviour omit those columns from `expected`;
+    # The C++ aggregator always emits a v1_ISNULL_COUNT column alongside MIN/MAX.
+    # Tests that aren't exercising the count behaviour omit that column from `expected`;
     # subselect `received` down to the expected columns so the comparison stays focused.
     missing = set(expected.columns) - set(received_pl.columns)
     assert not missing, f"Expected columns missing from received: {missing}"
@@ -249,13 +249,13 @@ def test_column_stats_nat_values(in_memory_store_factory, lib_name, encoding_ver
     assert raw_stats["v1_MAX(col_1)"].values.view("int64")[3] == nat_sentinel
 
 
-def test_column_stats_nan_and_null_counts(in_memory_store_factory, lib_name, encoding_version, any_output_format):
+def test_column_stats_isnull_count_nan_and_nat(in_memory_store_factory, lib_name, encoding_version, any_output_format):
     lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
     lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_nan_and_null_counts"
+    sym = "test_column_stats_isnull_count_nan_and_nat"
 
     # Each write/append produces a separate segment, so we get one row per dataframe in the stats.
-    # Both NaN (float) and NaT (timestamp) are in-band sentinels and count toward v1_NAN_COUNT.
+    # Both NaN (float) and NaT (timestamp) are in-band sentinels and count toward v1_ISNULL_COUNT.
     df0 = pd.DataFrame(
         {"float_col": [1.0, 2.0], "ts_col": [pd.Timestamp("2020-01-01"), pd.Timestamp("2020-06-01")]},
         index=pd.date_range("2000-01-01", periods=2),
@@ -282,8 +282,7 @@ def test_column_stats_nan_and_null_counts(in_memory_store_factory, lib_name, enc
     expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series("v1_MIN(float_col)", [1.0, 5.0, np.nan, 1.0]),
         pl.Series("v1_MAX(float_col)", [2.0, 5.0, np.nan, 2.0]),
-        pl.Series("v1_NAN_COUNT(float_col)", [0, 1, 2, 1], dtype=pl.UInt64),
-        pl.Series("v1_NULL_COUNT(float_col)", [0, 0, 0, 0], dtype=pl.UInt64),
+        pl.Series("v1_ISNULL_COUNT(float_col)", [0, 1, 2, 1], dtype=pl.UInt64),
         pl.Series(
             "v1_MIN(ts_col)",
             [
@@ -304,49 +303,23 @@ def test_column_stats_nan_and_null_counts(in_memory_store_factory, lib_name, enc
             ],
             dtype=pl.Int64,
         ).cast(pl.Datetime("ns")),
-        pl.Series("v1_NAN_COUNT(ts_col)", [0, 1, 2, 1], dtype=pl.UInt64),
-        pl.Series("v1_NULL_COUNT(ts_col)", [0, 0, 0, 0], dtype=pl.UInt64),
+        pl.Series("v1_ISNULL_COUNT(ts_col)", [0, 1, 2, 1], dtype=pl.UInt64),
     )
 
     column_stats = lib.read_column_stats_experimental(sym)
     assert_stats_equal(column_stats, expected_column_stats)
 
 
-def test_column_stats_nan_count_single_segment(in_memory_store_factory, lib_name, encoding_version, any_output_format):
-    """In-band sentinels (NaN in a float column, NaT in a timestamp column) count towards
-    v1_NAN_COUNT. v1_NULL_COUNT is reserved for genuinely-missing rows (sparse-map gaps)."""
-    lib = in_memory_store_factory(encoding_version=int(encoding_version), name=lib_name)
-    lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_nan_count_single_segment"
-    df = pd.DataFrame(
-        {
-            "float_col": [1.0, np.nan, 2.0, np.nan, np.nan],
-            "ts_col": [
-                pd.Timestamp("2020-01-01"),
-                pd.NaT,
-                pd.Timestamp("2020-06-01"),
-                pd.NaT,
-                pd.Timestamp("2020-12-01"),
-            ],
-        },
-        index=pd.date_range("2000-01-01", periods=5),
-    )
-    lib.write(sym, df)
-    lib.create_column_stats_experimental(sym)
+def test_column_stats_isnull_count_invariant_to_sparsify(
+    in_memory_store_factory, lib_name, encoding_version, any_output_format
+):
+    """v1_ISNULL_COUNT counts rows for which ISNULL is true, regardless of whether the storage
+    layer represents that as an in-band NaN or a sparse-map gap. Writing the same NaN-containing
+    frame with and without sparsify_floats=True must therefore produce an identical isnull count,
+    equal to the NaN count.
 
-    cs = pl.from_arrow(lib.read_column_stats_experimental(sym))
-    assert cs["v1_NAN_COUNT(float_col)"].to_list() == [3]
-    assert cs["v1_NULL_COUNT(float_col)"].to_list() == [0]
-    assert cs["v1_NAN_COUNT(ts_col)"].to_list() == [2]
-    assert cs["v1_NULL_COUNT(ts_col)"].to_list() == [0]
-
-
-def test_column_stats_null_count_sparse_floats(in_memory_store_factory, lib_name, encoding_version, any_output_format):
-    """sparsify_floats=True stores NaN floats as sparse-map gaps rather than dense NaN values.
-    Those gaps are counted as nulls (v1_NULL_COUNT), not NaNs (v1_NAN_COUNT).
-
-    The 6 rows span multiple segments (segment_row_size=3) with a different null count in each,
-    so the per-segment null calculation is exercised rather than a single-segment case."""
+    The 6 rows span multiple segments (segment_row_size=3) with a different count in each, so the
+    per-segment calculation is exercised rather than a single-segment case."""
     lib = in_memory_store_factory(
         column_group_size=2,
         segment_row_size=3,
@@ -354,18 +327,53 @@ def test_column_stats_null_count_sparse_floats(in_memory_store_factory, lib_name
         name=lib_name + f"_{encoding_version.name}",
     )
     lib._set_output_format_for_pipeline_tests(any_output_format)
-    sym = "test_column_stats_null_count_sparse_floats"
-    # Segment 0 (rows 0-2): [1.0, nan, 2.0] -> 1 null, min 1.0, max 2.0
-    # Segment 1 (rows 3-5): [nan, nan, 4.0] -> 2 nulls, min 4.0, max 4.0
+    # Segment 0 (rows 0-2): [1.0, nan, 2.0] -> isnull_count 1, min 1.0, max 2.0
+    # Segment 1 (rows 3-5): [nan, nan, 4.0] -> isnull_count 2, min 4.0, max 4.0
     df = pd.DataFrame({"col_1": [1.0, np.nan, 2.0, np.nan, np.nan, 4.0]}, index=pd.date_range("2000-01-01", periods=6))
-    lib.write(sym, df, sparsify_floats=True)
-    lib.create_column_stats_experimental(sym)
+    expected_isnull_count = [1, 2]
+    expected_min = [1.0, 4.0]
+    expected_max = [2.0, 4.0]
 
+    sym_dense = "test_column_stats_isnull_count_invariant_to_sparsify_dense"
+    lib.write(sym_dense, df)
+    lib.create_column_stats_experimental(sym_dense)
+    dense_stats = pl.from_arrow(lib.read_column_stats_experimental(sym_dense)).sort("start_row")
+
+    sym_sparse = "test_column_stats_isnull_count_invariant_to_sparsify_sparse"
+    lib.write(sym_sparse, df, sparsify_floats=True)
+    lib.create_column_stats_experimental(sym_sparse)
+    sparse_stats = pl.from_arrow(lib.read_column_stats_experimental(sym_sparse)).sort("start_row")
+
+    assert dense_stats["v1_ISNULL_COUNT(col_1)"].to_list() == expected_isnull_count
+    assert sparse_stats["v1_ISNULL_COUNT(col_1)"].to_list() == expected_isnull_count
+    assert dense_stats["v1_MIN(col_1)"].to_list() == expected_min
+    assert dense_stats["v1_MAX(col_1)"].to_list() == expected_max
+    assert sparse_stats["v1_MIN(col_1)"].to_list() == expected_min
+    assert sparse_stats["v1_MAX(col_1)"].to_list() == expected_max
+
+
+def test_column_stats_isnull_count_nat_and_sparse_gap(in_memory_version_store_arrow):
+    """v1_ISNULL_COUNT counts both mechanisms that produce a null timestamp: an in-band NaT
+    value and a genuine sparse-map gap (an Arrow null), regardless of which produced it."""
+    lib = in_memory_version_store_arrow
+    lib._cfg.write_options.segment_row_size = 100
+    sym = "test_column_stats_isnull_count_nat_and_sparse_gap"
+    nat_sentinel = np.iinfo(np.int64).min
+
+    def ts_table(int64_values):
+        return pa.table({"ts": pa.array(int64_values, pa.int64()).cast(pa.timestamp("ns"))})
+
+    # segment 0: one in-band NaT and one sparse gap in the same column -> isnull_count = 2
+    lib.write(sym, ts_table([1_000_000_000, nat_sentinel, None, 2_000_000_000]))
+    # segment 1: in-band NaT only -> isnull_count = 1
+    lib.append(sym, ts_table([nat_sentinel, 3_000_000_000]))
+    # segment 2: sparse gap only -> isnull_count = 1
+    lib.append(sym, ts_table([None, 4_000_000_000]))
+
+    lib.create_column_stats_experimental(sym)
     cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_row")
-    assert cs["v1_NULL_COUNT(col_1)"].to_list() == [1, 2]
-    assert cs["v1_NAN_COUNT(col_1)"].to_list() == [0, 0]
-    assert cs["v1_MIN(col_1)"].to_list() == [1.0, 4.0]
-    assert cs["v1_MAX(col_1)"].to_list() == [2.0, 4.0]
+
+    assert cs["v1_ISNULL_COUNT(ts)"].to_list() == [2, 1, 1]
 
 
 def test_column_stats_arrow_nan_and_null_same_column(in_memory_version_store_arrow):
@@ -376,16 +384,15 @@ def test_column_stats_arrow_nan_and_null_same_column(in_memory_version_store_arr
     def table(values):
         return pa.table({"f": pa.array(values, pa.float64())})
 
-    lib.write(sym, table([1.0, np.nan, None, 2.0]))  # nan=1, null=1, min=1, max=2
-    lib.append(sym, table([np.nan, np.nan, None]))  # nan=2, null=1, all stored values are NaN
-    lib.append(sym, table([None, None]))  # all null: nan=0, null=2, no min/max
-    lib.append(sym, table([3.0, None, np.nan, 4.0, None]))  # nan=1, null=2, min=3, max=4
+    lib.write(sym, table([1.0, np.nan, None, 2.0]))  # nan=1, null=1, isnull=2, min=1, max=2
+    lib.append(sym, table([np.nan, np.nan, None]))  # nan=2, null=1, isnull=3, all stored values are NaN
+    lib.append(sym, table([None, None]))  # all null: isnull=2, no min/max
+    lib.append(sym, table([3.0, None, np.nan, 4.0, None]))  # nan=1, null=2, isnull=3, min=3, max=4
 
     lib.create_column_stats_experimental(sym)
     cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_row")
 
-    assert cs["v1_NAN_COUNT(f)"].to_list() == [1, 2, 0, 1]
-    assert cs["v1_NULL_COUNT(f)"].to_list() == [1, 1, 2, 2]
+    assert cs["v1_ISNULL_COUNT(f)"].to_list() == [2, 3, 2, 3]
 
     mins = cs["v1_MIN(f)"].to_list()
     maxs = cs["v1_MAX(f)"].to_list()
@@ -407,11 +414,11 @@ def _segment_values():
 @use_of_function_scoped_fixtures_in_hypothesis_checked
 @settings(deadline=None)
 @given(segments=st.lists(_segment_values(), min_size=1, max_size=6))
-def test_column_stats_arrow_nan_null_counts_hypothesis(in_memory_version_store_arrow, segments):
+def test_column_stats_arrow_isnull_count_hypothesis(in_memory_version_store_arrow, segments):
     lib = in_memory_version_store_arrow
     lib._cfg.write_options.segment_row_size = 100
     lib.version_store.clear()
-    sym = "test_column_stats_arrow_nan_null_counts_hypothesis"
+    sym = "test_column_stats_arrow_isnull_count_hypothesis"
 
     lib.write(sym, pa.table({"f": pa.array(segments[0], pa.float64())}))
     for seg in segments[1:]:
@@ -421,11 +428,9 @@ def test_column_stats_arrow_nan_null_counts_hypothesis(in_memory_version_store_a
     cs = pl.from_arrow(lib.read_column_stats_experimental(sym)).sort("start_row")
 
     # Each write/append is its own row-slice, so column stats rows line up with segments in index order.
-    expected_nan = [sum(1 for v in seg if v is not None and np.isnan(v)) for seg in segments]
-    expected_null = [sum(1 for v in seg if v is None) for seg in segments]
+    expected_isnull = [sum(1 for v in seg if v is None or np.isnan(v)) for seg in segments]
 
-    assert cs["v1_NAN_COUNT(f)"].to_list() == expected_nan
-    assert cs["v1_NULL_COUNT(f)"].to_list() == expected_null
+    assert cs["v1_ISNULL_COUNT(f)"].to_list() == expected_isnull
 
 
 def test_column_stats_as_of(in_memory_store_factory, lib_name, encoding_version, any_output_format):
@@ -580,9 +585,9 @@ def test_column_stats_dynamic_schema_missing_data(
 
     # Slices that are missing the column come back as null via the validity bitmap. df4["col_2"] is
     # all-NaN but the column is present so the stat is computed and stored as NaN, not null.
-    # The count columns follow the same rule: a fully-missing column has no aggregator run for that
-    # slice, so its NAN_COUNT/NULL_COUNT are null (not 0). Present columns count their NaNs in
-    # NAN_COUNT and leave NULL_COUNT at 0 (NaN floats are stored densely here, not as sparse gaps).
+    # The count column follows the same rule: a fully-missing column has no aggregator run for that
+    # slice, so its ISNULL_COUNT is null (not 0). Present columns count their NaNs in ISNULL_COUNT
+    # (NaN floats are stored densely here, not as sparse gaps).
     expected_column_stats = row_range_columns_to_pl(lib, sym).with_columns(
         pl.Series(
             "v1_MIN(col_1)",
@@ -592,8 +597,7 @@ def test_column_stats_dynamic_schema_missing_data(
             "v1_MAX(col_1)",
             [df0["col_1"].max(), None, df2["col_1"].max(), None, df4["col_1"].max(), None],
         ),
-        pl.Series("v1_NAN_COUNT(col_1)", [0, None, 0, None, 1, None], dtype=pl.UInt64),
-        pl.Series("v1_NULL_COUNT(col_1)", [0, None, 0, None, 0, None], dtype=pl.UInt64),
+        pl.Series("v1_ISNULL_COUNT(col_1)", [0, None, 0, None, 1, None], dtype=pl.UInt64),
         pl.Series(
             "v1_MIN(col_2)",
             [df0["col_2"].min(), df1["col_2"].min(), None, None, df4["col_2"].min(), None],
@@ -602,12 +606,10 @@ def test_column_stats_dynamic_schema_missing_data(
             "v1_MAX(col_2)",
             [df0["col_2"].max(), df1["col_2"].max(), None, None, df4["col_2"].max(), None],
         ),
-        pl.Series("v1_NAN_COUNT(col_2)", [0, 0, None, None, 2, None], dtype=pl.UInt64),
-        pl.Series("v1_NULL_COUNT(col_2)", [0, 0, None, None, 0, None], dtype=pl.UInt64),
+        pl.Series("v1_ISNULL_COUNT(col_2)", [0, 0, None, None, 2, None], dtype=pl.UInt64),
         pl.Series("v1_MIN(col_5)", [None, None, None, None, None, df5["col_5"].min()], dtype=pl.Int64),
         pl.Series("v1_MAX(col_5)", [None, None, None, None, None, df5["col_5"].max()], dtype=pl.Int64),
-        pl.Series("v1_NAN_COUNT(col_5)", [None, None, None, None, None, 0], dtype=pl.UInt64),
-        pl.Series("v1_NULL_COUNT(col_5)", [None, None, None, None, None, 0], dtype=pl.UInt64),
+        pl.Series("v1_ISNULL_COUNT(col_5)", [None, None, None, None, None, 0], dtype=pl.UInt64),
     )
     lib.create_column_stats_experimental(sym)
     assert lib.get_column_stats_info_experimental(sym) == {
@@ -932,8 +934,7 @@ def assert_header_offsets_match_field_names(lib, sym, header):
     field_name_by_type = {
         ColumnStatsType.MIN_V1: "v1_MIN",
         ColumnStatsType.MAX_V1: "v1_MAX",
-        ColumnStatsType.NAN_COUNT_V1: "v1_NAN_COUNT",
-        ColumnStatsType.NULL_COUNT_V1: "v1_NULL_COUNT",
+        ColumnStatsType.ISNULL_COUNT_V1: "v1_ISNULL_COUNT",
     }
     lib_tool = lib.library_tool()
     index_key = lib_tool.find_keys_for_symbol(KeyType.TABLE_INDEX, sym)[0]
@@ -958,12 +959,11 @@ def test_column_stats_header_metadata(in_memory_store_factory, lib_name, encodin
 
     # Auto-discovery creates stats for all eligible columns: the index at offset 0, col_1 at offset 2
     # and col_2 at offset 3. col_0 at offset 1 is a string, so it is ineligible.
-    # MINMAX emits 4 stat entries per column: MIN, MAX, NAN_COUNT, NULL_COUNT.
+    # MINMAX emits 3 stat entries per column: MIN, MAX, ISNULL_COUNT.
     minmax_types = {
         ColumnStatsType.MIN_V1,
         ColumnStatsType.MAX_V1,
-        ColumnStatsType.NAN_COUNT_V1,
-        ColumnStatsType.NULL_COUNT_V1,
+        ColumnStatsType.ISNULL_COUNT_V1,
     }
     lib.create_column_stats_experimental(sym)
     header = read_column_stats_header(lib, sym)
@@ -971,10 +971,10 @@ def test_column_stats_header_metadata(in_memory_store_factory, lib_name, encodin
     assert header.version == 1
     # if you change the structure, consider whether you need to change header.version too
     assert len(header.ListFields()) == 2
-    assert header_stat_count(header) == 12
+    assert header_stat_count(header) == 9
     assert header_stat_pairs(header) == {(offset, t) for offset in (0, 2, 3) for t in minmax_types}
     offsets = [entry.stats_seg_offset for _, entry in header_all_entries(header)]
-    assert len(set(offsets)) == 12
+    assert len(set(offsets)) == 9
 
     # Verify descriptor field names match the offsets
     assert_header_offsets_match_field_names(lib, sym, header)
@@ -998,8 +998,8 @@ def test_column_stats_create_twice_is_idempotent(in_memory_store_factory, lib_na
 
     assert header_offset_by_stat(second_header) == header_offset_by_stat(first_header)
     assert second_header.version == first_header.version
-    assert header_stat_count(second_header) == 12
-    assert len({entry.stats_seg_offset for _, entry in header_all_entries(second_header)}) == 12
+    assert header_stat_count(second_header) == 9
+    assert len({entry.stats_seg_offset for _, entry in header_all_entries(second_header)}) == 9
     assert_header_offsets_match_field_names(lib, sym, second_header)
     assert lib.get_column_stats_info_experimental(sym) == {
         "index": {"MINMAX"},
@@ -1564,9 +1564,8 @@ def expected_row_range_stats(df, expected_slices):
             [int(values.isna().sum()) for values in values_by_slice],
         )
 
-    col_1_min, col_1_max, col_1_nan = slice_stats("col_1")
-    col_2_min, col_2_max, col_2_nan = slice_stats("col_2")
-    null_counts = [0] * len(expected_slices)
+    col_1_min, col_1_max, col_1_isnull = slice_stats("col_1")
+    col_2_min, col_2_max, col_2_isnull = slice_stats("col_2")
     index_by_slice = [df.index[s:e] for s, e in expected_slices]
     zero_counts = pl.Series([0] * len(expected_slices), dtype=pl.UInt64)
 
@@ -1576,16 +1575,13 @@ def expected_row_range_stats(df, expected_slices):
             "end_row": pl.Series([e for _, e in expected_slices], dtype=pl.UInt64),
             "v1_MIN(index)": pl.Series([idx.min() for idx in index_by_slice], dtype=pl.Datetime("ns")),
             "v1_MAX(index)": pl.Series([idx.max() for idx in index_by_slice], dtype=pl.Datetime("ns")),
-            "v1_NAN_COUNT(index)": zero_counts,
-            "v1_NULL_COUNT(index)": zero_counts,
+            "v1_ISNULL_COUNT(index)": zero_counts,
             "v1_MIN(col_1)": pl.Series([int(v) for v in col_1_min], dtype=pl.Int64),
             "v1_MAX(col_1)": pl.Series([int(v) for v in col_1_max], dtype=pl.Int64),
-            "v1_NAN_COUNT(col_1)": pl.Series(col_1_nan, dtype=pl.UInt64),
-            "v1_NULL_COUNT(col_1)": pl.Series(null_counts, dtype=pl.UInt64),
+            "v1_ISNULL_COUNT(col_1)": pl.Series(col_1_isnull, dtype=pl.UInt64),
             "v1_MIN(col_2)": pl.Series(col_2_min, dtype=pl.Float64),
             "v1_MAX(col_2)": pl.Series(col_2_max, dtype=pl.Float64),
-            "v1_NAN_COUNT(col_2)": pl.Series(col_2_nan, dtype=pl.UInt64),
-            "v1_NULL_COUNT(col_2)": pl.Series(null_counts, dtype=pl.UInt64),
+            "v1_ISNULL_COUNT(col_2)": pl.Series(col_2_isnull, dtype=pl.UInt64),
         }
     )
 
@@ -1817,12 +1813,10 @@ def test_column_stats_create_dynamic_schema_preserves_stats_for_column_outside_t
             "end_row": pl.Series([3, 6], dtype=pl.UInt64),
             "v1_MIN(col_1)": pl.Series([1, None], dtype=pl.Int64),
             "v1_MAX(col_1)": pl.Series([3, None], dtype=pl.Int64),
-            "v1_NAN_COUNT(col_1)": pl.Series([0, None], dtype=pl.UInt64),
-            "v1_NULL_COUNT(col_1)": pl.Series([0, None], dtype=pl.UInt64),
+            "v1_ISNULL_COUNT(col_1)": pl.Series([0, None], dtype=pl.UInt64),
             "v1_MIN(col_2)": pl.Series([None, 4], dtype=pl.Int64),
             "v1_MAX(col_2)": pl.Series([None, 6], dtype=pl.Int64),
-            "v1_NAN_COUNT(col_2)": pl.Series([None, 0], dtype=pl.UInt64),
-            "v1_NULL_COUNT(col_2)": pl.Series([None, 0], dtype=pl.UInt64),
+            "v1_ISNULL_COUNT(col_2)": pl.Series([None, 0], dtype=pl.UInt64),
         }
     )
 

--- a/python/tests/unit/arcticdb/test_column_stats_optimisation.py
+++ b/python/tests/unit/arcticdb/test_column_stats_optimisation.py
@@ -708,11 +708,11 @@ def test_column_stats_comparison_operators(
 def test_column_stats_all_null_slice_pruning(
     in_memory_store_factory, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr, expected_reads
 ):
-    """A wholly-null row-slice has no MIN/MAX, only NAN_COUNT/NULL_COUNT. It must be kept for
+    """A wholly-null row-slice has no MIN/MAX, only ISNULL_COUNT. It must be kept for
     `!=`/`isnotin` (every null row matches) and pruned for `==`/`isin` (no null row matches).
     Regression test for the slice being marked column_absent and always pruned to NONE_MATCH."""
     # segment_row_size=2 splits into 3 row-slices: [1,2], [NaN,NaN], [5,6]. sparsify_floats stores the
-    # NaNs as sparse-map gaps, so the middle slice is wholly null with no MIN/MAX (only NAN/NULL counts).
+    # NaNs as sparse-map gaps, so the middle slice is wholly null with no MIN/MAX (only ISNULL_COUNT).
     lib = in_memory_store_factory(column_group_size=2, segment_row_size=2)
     df = pd.DataFrame({"col_1": [1.0, 2.0, np.nan, np.nan, 5.0, 6.0]}, index=pd.date_range("2000-01-01", periods=6))
     lib.write(sym, df, sparsify_floats=True)
@@ -742,7 +742,7 @@ def test_column_stats_column_null_in_every_slice_prunes(
 
     stats = lib.read_column_stats_experimental(sym)
     assert "v1_MIN(f)" not in stats.column_names
-    assert stats.column("v1_NULL_COUNT(f)").to_pylist() == [2, 2, 2, 2]
+    assert stats.column("v1_ISNULL_COUNT(f)").to_pylist() == [2, 2, 2, 2]
 
     qs.enable()
     q = QueryBuilder()
@@ -2341,7 +2341,7 @@ NE_FLOAT_EXPRS = [
 def test_column_stats_no_prune_when_in_band_nan(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
 ):
-    """[3.0, NaN, NaN, 3.0] in one segment: min=max=3, nan_count=2.
+    """[3.0, NaN, NaN, 3.0] in one segment: min=max=3, isnull_count=2.
     Filters that would normally prune the segment must include the NaN rows."""
     lib = in_memory_version_store
 
@@ -2388,7 +2388,7 @@ NE_TS_EXPRS = [
 def test_column_stats_no_prune_ne_when_nat(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
 ):
-    """Time-type analogue of the in-band NaN case: min=max=ts, nan_count=2."""
+    """Time-type analogue of the in-band NaN case: min=max=ts, isnull_count=2."""
     lib = in_memory_version_store
 
     df = pd.DataFrame(
@@ -2414,8 +2414,8 @@ def test_column_stats_no_prune_ne_when_nat(
 def test_column_stats_no_prune_ne_when_sparse_null(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
 ):
-    """sparsify_floats stores NaN floats as sparse-map gaps -> null_count > 0, nan_count = 0.
-    The downgrade must still fire."""
+    """sparsify_floats stores NaN floats as sparse-map gaps -> isnull_count > 0 via the gap rather
+    than an in-band NaN. The downgrade must still fire."""
     lib = in_memory_version_store
 
     df = pd.DataFrame({"a": [3.0, np.nan, np.nan, 3.0]}, index=pd.date_range("2000-01-01", periods=4))
@@ -2449,7 +2449,7 @@ def test_column_stats_still_prunes_when_nan_does_not_save_row(
     in_memory_version_store, clear_query_stats, column_stats_filtering_enabled, query_expr, pandas_expr
 ):
     """Negative control: NaN rows do NOT satisfy a magnitude comparison, so NONE_MATCH must
-    stay NONE_MATCH and the segments must still be pruned even though nan_count > 0."""
+    stay NONE_MATCH and the segments must still be pruned even though isnull_count > 0."""
     lib = in_memory_version_store
 
     df0 = pd.DataFrame({"a": [3.0, np.nan, np.nan, 3.0]}, index=pd.date_range("2000-01-01", periods=4))

--- a/python/tests/unit/arcticdb/version_store/test_filtering.py
+++ b/python/tests/unit/arcticdb/version_store/test_filtering.py
@@ -1167,9 +1167,7 @@ def test_filter_on_multi_index_primary_level(
     }
     stats_columns = set(lib.read_column_stats_experimental(symbol).column_names)
     assert stats_columns == {"start_row", "end_row"} | {
-        f"v1_{stat}({col})"
-        for col in ("datetime", "__idx__level", "a")
-        for stat in ("MIN", "MAX", "NAN_COUNT", "NULL_COUNT")
+        f"v1_{stat}({col})" for col in ("datetime", "__idx__level", "a") for stat in ("MIN", "MAX", "ISNULL_COUNT")
     }
 
     threshold = pd.Timestamp("2000-01-01")


### PR DESCRIPTION
Since we only use their sum, so keeping them separate is wasting space in the column stats segment.

The only place where keeping them separate could help is for Arrow semantics where

```
isnull(NaN) == False
```

We haven't implemented these semantics anywhere, and handling that edge case neatly doesn't seem worth the space amplification of the separate NaN and null columns.

A subsequent change will start to use the for the `IsNullOperator` pruning.