### PR TITLE
Keep the LMDB environment alive for the whole storage call

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1142,6 +1142,7 @@ if(${TEST})
             processing/test/test_merge_update.cpp
             storage/test/test_lmdb_cve.cpp
             processing/test/test_structure_by_time_slice.cpp
+            storage/test/test_lmdb_storage_concurrency.cpp
             storage/test/test_local_storages.cpp
             storage/test/test_memory_storage.cpp
             storage/test/test_s3_storage.cpp

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -56,29 +56,29 @@ static void raise_lmdb_exception(const ::lmdb::error& e, const std::string& obje
     raise<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(fmt::format("Unexpected LMDB Error: {}", error_message_suffix));
 }
 
-::lmdb::env& LmdbStorage::env() {
+std::shared_ptr<LmdbInstance> LmdbStorage::instance() const {
+    std::shared_ptr<LmdbInstance> instance;
+    {
+        std::shared_lock<std::shared_mutex> lock{*instance_mutex_};
+        instance = lmdb_instance_;
+    }
     storage::check<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(
-            lmdb_instance_,
+            instance,
             "Unexpected LMDB Error: Invalid operation: LMDB environment has been removed. Possibly because the library "
             "has been deleted"
     );
-    return lmdb_instance_->env_;
+    return instance;
 }
 
-::lmdb::dbi& LmdbStorage::get_dbi(const std::string& db_name) {
-    storage::check<ErrorCode::E_UNEXPECTED_LMDB_ERROR>(
-            lmdb_instance_,
-            "Unexpected LMDB Error: Invalid operation: LMDB environment has been removed. Possibly because the library "
-            "has been deleted"
-    );
-    return *(lmdb_instance_->dbi_by_key_type_.at(db_name));
+::lmdb::dbi& LmdbStorage::get_dbi(const LmdbInstance& instance, const std::string& db_name) {
+    return *(instance.dbi_by_key_type_.at(db_name));
 }
 
-void LmdbStorage::do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn) {
+void LmdbStorage::do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn, const LmdbInstance& instance) {
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
 
     auto db_name = fmt::format(FMT_COMPILE("{}"), key_seg.key_type());
-    ::lmdb::dbi& dbi = get_dbi(db_name);
+    ::lmdb::dbi& dbi = get_dbi(instance, db_name);
 
     ARCTICDB_SUBSAMPLE(LmdbStorageWriteValues, 0)
     ARCTICDB_DEBUG(log::storage(), "Lmdb storage writing segment with key {}", key_seg.key_view());
@@ -99,9 +99,10 @@ std::string LmdbStorage::name() const { return fmt::format("lmdb_storage-{}", li
 void LmdbStorage::do_write(KeySegmentPair& key_seg) {
     ARCTICDB_SAMPLE(LmdbStorageWrite, 0)
     std::lock_guard<std::mutex> lock{*write_mutex_};
-    auto txn = ::lmdb::txn::begin(env()); // scoped abort on exception, so no partial writes
+    auto instance = this->instance();
+    auto txn = ::lmdb::txn::begin(instance->env_); // scoped abort on exception, so no partial writes
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
-    do_write_internal(key_seg, txn);
+    do_write_internal(key_seg, txn, *instance);
     ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
     txn.commit();
 }
@@ -109,14 +110,15 @@ void LmdbStorage::do_write(KeySegmentPair& key_seg) {
 void LmdbStorage::do_update(KeySegmentPair& key_seg, UpdateOpts opts) {
     ARCTICDB_SAMPLE(LmdbStorageUpdate, 0)
     std::lock_guard<std::mutex> lock{*write_mutex_};
-    auto txn = ::lmdb::txn::begin(env());
+    auto instance = this->instance();
+    auto txn = ::lmdb::txn::begin(instance->env_);
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
     auto key = key_seg.variant_key();
     // Deleting keys (no error is thrown if the keys already exist)
     RemoveOpts remove_opts;
     remove_opts.ignores_missing_key_ = opts.upsert_;
     std::array<VariantKey, 1> arr{std::move(key)};
-    auto failed_deletes = do_remove_internal(std::span(arr), txn, remove_opts);
+    auto failed_deletes = do_remove_internal(std::span(arr), txn, *instance, remove_opts);
     if (!failed_deletes.empty()) {
         ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
         txn.commit();
@@ -124,7 +126,7 @@ void LmdbStorage::do_update(KeySegmentPair& key_seg, UpdateOpts opts) {
                 fmt::format("do_update called with upsert=false on non-existent key(s): {}", failed_deletes);
         throw KeyNotFoundException(failed_deletes, err_message);
     }
-    do_write_internal(key_seg, txn);
+    do_write_internal(key_seg, txn, *instance);
     ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
     txn.commit();
 }
@@ -132,18 +134,19 @@ void LmdbStorage::do_update(KeySegmentPair& key_seg, UpdateOpts opts) {
 KeySegmentPair LmdbStorage::do_read(VariantKey&& variant_key, ReadKeyOpts) {
     ARCTICDB_SAMPLE(LmdbStorageReadReturn, 0)
     std::optional<VariantKey> failed_read;
+    auto instance = this->instance();
     auto db_name = fmt::format(FMT_COMPILE("{}"), variant_key_type(variant_key));
-    ::lmdb::dbi& dbi = get_dbi(db_name);
+    ::lmdb::dbi& dbi = get_dbi(*instance, db_name);
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
     auto stored_key = to_serialized_key(variant_key);
     try {
-        auto txn = std::make_shared<::lmdb::txn>(::lmdb::txn::begin(env(), nullptr, MDB_RDONLY));
+        auto txn = std::make_shared<::lmdb::txn>(::lmdb::txn::begin(instance->env_, nullptr, MDB_RDONLY));
         ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
         auto segment = lmdb_client_->read(db_name, stored_key, *txn, dbi);
 
         if (segment.has_value()) {
             ARCTICDB_SUBSAMPLE(LmdbStorageVisitSegment, 0)
-            segment->set_keepalive(std::any{LmdbKeepalive{lmdb_instance_, std::move(txn)}});
+            segment->set_keepalive(std::any{LmdbKeepalive{instance, std::move(txn)}});
             ARCTICDB_DEBUG(
                     log::storage(),
                     "Read key {}: {}, with {} bytes of data",
@@ -168,18 +171,19 @@ KeySegmentPair LmdbStorage::do_read(VariantKey&& variant_key, ReadKeyOpts) {
 void LmdbStorage::do_read(VariantKey&& key, const ReadVisitor& visitor, storage::ReadKeyOpts) {
     ARCTICDB_SAMPLE(LmdbStorageRead, 0)
     std::optional<VariantKey> failed_read;
+    auto instance = this->instance();
     auto db_name = fmt::format(FMT_COMPILE("{}"), variant_key_type(key));
-    ::lmdb::dbi& dbi = get_dbi(db_name);
+    ::lmdb::dbi& dbi = get_dbi(*instance, db_name);
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
     auto stored_key = to_serialized_key(key);
     try {
-        auto txn = std::make_shared<::lmdb::txn>(::lmdb::txn::begin(env(), nullptr, MDB_RDONLY));
+        auto txn = std::make_shared<::lmdb::txn>(::lmdb::txn::begin(instance->env_, nullptr, MDB_RDONLY));
         ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
         auto segment = lmdb_client_->read(db_name, stored_key, *txn, dbi);
 
         if (segment.has_value()) {
             ARCTICDB_SUBSAMPLE(LmdbStorageVisitSegment, 0)
-            segment->set_keepalive(std::any{LmdbKeepalive{lmdb_instance_, std::move(txn)}});
+            segment->set_keepalive(std::any{LmdbKeepalive{instance, std::move(txn)}});
             ARCTICDB_DEBUG(
                     log::storage(),
                     "Read key {}: {}, with {} bytes of data",
@@ -205,14 +209,15 @@ void LmdbStorage::do_read(VariantKey&& key, const ReadVisitor& visitor, storage:
 
 bool LmdbStorage::do_key_exists(const VariantKey& key) {
     ARCTICDB_SAMPLE(LmdbStorageKeyExists, 0)
-    auto txn = ::lmdb::txn::begin(env(), nullptr, MDB_RDONLY);
+    auto instance = this->instance();
+    auto txn = ::lmdb::txn::begin(instance->env_, nullptr, MDB_RDONLY);
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
     ARCTICDB_DEBUG_THROW(5)
     auto db_name = fmt::format("{}", variant_key_type(key));
     ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
     auto stored_key = to_serialized_key(key);
     try {
-        ::lmdb::dbi& dbi = get_dbi(db_name);
+        ::lmdb::dbi& dbi = get_dbi(*instance, db_name);
         return lmdb_client_->exists(db_name, stored_key, txn, dbi);
     } catch ([[maybe_unused]] const ::lmdb::not_found_error& ex) {
         ARCTICDB_DEBUG(log::storage(), "Caught lmdb not found error: {}", ex.what());
@@ -223,7 +228,7 @@ bool LmdbStorage::do_key_exists(const VariantKey& key) {
 }
 
 boost::container::small_vector<VariantKey, 1> LmdbStorage::do_remove_internal(
-        std::span<VariantKey> variant_keys, ::lmdb::txn& txn, RemoveOpts opts
+        std::span<VariantKey> variant_keys, ::lmdb::txn& txn, const LmdbInstance& instance, RemoveOpts opts
 ) {
     boost::container::small_vector<VariantKey, 1> failed_deletes;
 
@@ -232,7 +237,7 @@ boost::container::small_vector<VariantKey, 1> LmdbStorage::do_remove_internal(
         auto db_name = fmt::format("{}", variant_key_type(key));
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
         try {
-            ::lmdb::dbi& dbi = get_dbi(db_name);
+            ::lmdb::dbi& dbi = get_dbi(instance, db_name);
             auto stored_key = to_serialized_key(key);
 
             try {
@@ -262,10 +267,11 @@ boost::container::small_vector<VariantKey, 1> LmdbStorage::do_remove_internal(
 void LmdbStorage::do_remove(VariantKey&& variant_key, RemoveOpts opts) {
     ARCTICDB_SAMPLE(LmdbStorageRemove, 0)
     std::lock_guard<std::mutex> lock{*write_mutex_};
-    auto txn = ::lmdb::txn::begin(env());
+    auto instance = this->instance();
+    auto txn = ::lmdb::txn::begin(instance->env_);
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
     std::array<VariantKey, 1> arr{std::move(variant_key)};
-    auto failed_deletes = do_remove_internal(std::span{arr}, txn, opts);
+    auto failed_deletes = do_remove_internal(std::span{arr}, txn, *instance, opts);
     ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
     txn.commit();
 
@@ -276,9 +282,10 @@ void LmdbStorage::do_remove(VariantKey&& variant_key, RemoveOpts opts) {
 void LmdbStorage::do_remove(std::span<VariantKey> variant_keys, RemoveOpts opts) {
     ARCTICDB_SAMPLE(LmdbStorageRemoveMultiple, 0)
     std::lock_guard<std::mutex> lock{*write_mutex_};
-    auto txn = ::lmdb::txn::begin(env());
+    auto instance = this->instance();
+    auto txn = ::lmdb::txn::begin(instance->env_);
     ARCTICDB_SUBSAMPLE(LmdbStorageInTransaction, 0)
-    auto failed_deletes = do_remove_internal(variant_keys, txn, opts);
+    auto failed_deletes = do_remove_internal(variant_keys, txn, *instance, opts);
     ARCTICDB_SUBSAMPLE(LmdbStorageCommit, 0)
     txn.commit();
 
@@ -290,7 +297,8 @@ bool LmdbStorage::do_fast_delete() {
     std::lock_guard<std::mutex> lock{*write_mutex_};
     // bool is probably not the best return type here but it does help prevent the insane boilerplate for
     // an additional function that checks whether this is supported (like the prefix matching)
-    auto dtxn = ::lmdb::txn::begin(env());
+    auto instance = this->instance();
+    auto dtxn = ::lmdb::txn::begin(instance->env_);
     foreach_key_type([&](KeyType key_type) {
         if (key_type == KeyType::TOMBSTONE) {
             // TOMBSTONE and LOCK both format to code 'x' - do not try to drop both
@@ -299,7 +307,7 @@ bool LmdbStorage::do_fast_delete() {
         auto db_name = fmt::format("{}", key_type);
         ARCTICDB_SUBSAMPLE(LmdbStorageOpenDb, 0)
         ARCTICDB_TRACE(log::storage(), "LMDB storage dropping keytype {}", db_name);
-        ::lmdb::dbi& dbi = get_dbi(db_name);
+        ::lmdb::dbi& dbi = get_dbi(*instance, db_name);
         try {
             ::lmdb::dbi_drop(dtxn, dbi);
         } catch (const ::lmdb::error& ex) {
@@ -315,9 +323,10 @@ bool LmdbStorage::do_iterate_type_until_match(
         KeyType key_type, const IterateTypePredicate& visitor, const std::string& prefix
 ) {
     ARCTICDB_SAMPLE(LmdbStorageItType, 0)
-    auto txn = ::lmdb::txn::begin(env(), nullptr, MDB_RDONLY); // scoped abort on
+    auto instance = this->instance();
+    auto txn = ::lmdb::txn::begin(instance->env_, nullptr, MDB_RDONLY); // scoped abort on
     std::string type_db = fmt::format("{}", key_type);
-    ::lmdb::dbi& dbi = get_dbi(type_db);
+    ::lmdb::dbi& dbi = get_dbi(*instance, type_db);
 
     try {
         auto keys = lmdb_client_->list(type_db, prefix, txn, dbi, key_type);
@@ -394,7 +403,19 @@ void remove_db_files(const fs::path& lib_path) {
 }
 
 void LmdbStorage::cleanup() {
-    lmdb_instance_.reset();
+    // Dropping the storage's reference does not necessarily close the environment: any call already in flight on
+    // another thread holds its own reference (see LmdbStorage::instance) and the environment stays open until the last
+    // one goes away. On POSIX, unlinking the files underneath a live mapping is safe, whereas unmapping them
+    // underneath one is not - so remove_db_files() below can run while a writer still holds the environment.
+    // Windows refuses to delete a mapped file, so there remove_db_files() raises instead of racing: a cleanup()
+    // concurrent with an in-flight write reports an error rather than corrupting memory.
+    std::shared_ptr<LmdbInstance> instance;
+    {
+        std::unique_lock<std::shared_mutex> lock{*instance_mutex_};
+        instance = std::move(lmdb_instance_);
+    }
+    // Released outside the lock: this is where the environment is actually closed, if nobody else is still using it.
+    instance.reset();
     remove_db_files(lib_dir_);
 }
 
@@ -417,7 +438,10 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
     lib_dir_ = root_path / lib_path_str;
 
     write_mutex_ = std::make_unique<std::mutex>();
-    lmdb_instance_ = std::make_shared<LmdbInstance>(LmdbInstance{::lmdb::env::create(conf.flags()), {}});
+    instance_mutex_ = std::make_unique<std::shared_mutex>();
+    // Built locally and only published to lmdb_instance_ once it is fully open, so no other thread can ever observe a
+    // half-constructed environment.
+    auto instance = std::make_shared<LmdbInstance>(LmdbInstance{::lmdb::env::create(conf.flags()), {}});
 
     warn_if_lmdb_already_open();
 
@@ -453,24 +477,29 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
     constexpr uint64_t default_map_size = 400ULL * (1ULL << 30); /* 400 GiB */
 #endif
     auto mapsize = or_else(static_cast<uint64_t>(conf.map_size()), default_map_size);
-    env().set_mapsize(mapsize);
-    env().set_max_dbs(or_else(static_cast<unsigned int>(conf.max_dbs()), 1024U));
-    env().set_max_readers(or_else(conf.max_readers(), 1024U));
-    env().open(lib_dir_.generic_string().c_str(), MDB_NOTLS);
+    instance->env_.set_mapsize(mapsize);
+    instance->env_.set_max_dbs(or_else(static_cast<unsigned int>(conf.max_dbs()), 1024U));
+    instance->env_.set_max_readers(or_else(conf.max_readers(), 1024U));
+    instance->env_.open(lib_dir_.generic_string().c_str(), MDB_NOTLS);
 
-    auto txn = ::lmdb::txn::begin(env());
+    auto txn = ::lmdb::txn::begin(instance->env_);
 
     try {
-        arcticdb::entity::foreach_key_type([&txn, this](KeyType&& key_type) {
+        arcticdb::entity::foreach_key_type([&txn, &instance](KeyType&& key_type) {
             std::string db_name = fmt::format("{}", key_type);
             ::lmdb::dbi dbi = ::lmdb::dbi::open(txn, db_name.data(), MDB_CREATE);
-            lmdb_instance_->dbi_by_key_type_.emplace(std::move(db_name), std::make_unique<::lmdb::dbi>(std::move(dbi)));
+            instance->dbi_by_key_type_.emplace(std::move(db_name), std::make_unique<::lmdb::dbi>(std::move(dbi)));
         });
     } catch (const ::lmdb::error& ex) {
         raise_lmdb_exception(ex, "dbi creation");
     }
 
     txn.commit();
+
+    {
+        std::unique_lock<std::shared_mutex> lock{*instance_mutex_};
+        lmdb_instance_ = std::move(instance);
+    }
 
     ARCTICDB_DEBUG(
             log::storage(), "Opened lmdb storage at {} with map size {}", lib_dir_.string(), format_bytes(mapsize)
@@ -480,7 +509,13 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
 void LmdbStorage::warn_if_lmdb_already_open() const {
     const std::string warn_setting =
             util::to_lower(ConfigsMap::instance()->get_string("LMDBStorage.WarnIfOpened", "config"));
-    const uint64_t& count_for_pid = ++times_path_opened[lib_dir_.string()];
+    // Taken by value under the lock rather than as a reference into the map: another thread constructing a storage
+    // over a different path can rehash it, which would invalidate the reference.
+    uint64_t count_for_pid;
+    {
+        std::lock_guard<std::mutex> lock{times_path_opened_mutex};
+        count_for_pid = ++times_path_opened[lib_dir_.string()];
+    }
     if (warn_setting == "none") {
         return;
     }
@@ -522,6 +557,7 @@ void LmdbStorage::print_warning_if_lmdb_already_open() const {
 LmdbStorage::LmdbStorage(LmdbStorage&& other) noexcept :
     Storage(std::move(static_cast<Storage&>(other))),
     write_mutex_(std::move(other.write_mutex_)),
+    instance_mutex_(std::move(other.instance_mutex_)),
     lmdb_instance_(std::move(other.lmdb_instance_)),
     lib_dir_(std::move(other.lib_dir_)) {
     other.lib_dir_ = "";
@@ -530,10 +566,14 @@ LmdbStorage::LmdbStorage(LmdbStorage&& other) noexcept :
 
 LmdbStorage::~LmdbStorage() {
     if (!lib_dir_.empty()) {
+        std::lock_guard<std::mutex> lock{times_path_opened_mutex};
         --times_path_opened[lib_dir_.string()];
     }
 }
 
-void LmdbStorage::reset_warning_counter() { times_path_opened = std::unordered_map<std::string, uint64_t>{}; }
+void LmdbStorage::reset_warning_counter() {
+    std::lock_guard<std::mutex> lock{times_path_opened_mutex};
+    times_path_opened = std::unordered_map<std::string, uint64_t>{};
+}
 
 } // namespace arcticdb::storage::lmdb

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -403,24 +403,16 @@ void remove_db_files(const fs::path& lib_path) {
 }
 
 void LmdbStorage::cleanup() {
-    // Dropping the storage's reference does not necessarily close the environment: any call already in flight on
-    // another thread holds its own reference (see LmdbStorage::instance) and the environment stays open until the last
-    // one goes away. On POSIX, unlinking the files underneath a live mapping is safe, whereas unmapping them
-    // underneath one is not - so remove_db_files() below can run while a writer still holds the environment.
-    // Windows refuses to delete a mapped file, so there remove_db_files() raises instead of racing: a cleanup()
-    // concurrent with an in-flight write reports an error rather than corrupting memory.
+    // Dropping the storage's reference does not necessarily close the environment: a call in flight on another
+    // thread holds its own. On POSIX unlinking a mapped file is safe, so remove_db_files() below can run regardless;
+    // Windows refuses to delete one, so it raises there rather than racing.
     std::shared_ptr<LmdbInstance> instance;
     {
         std::unique_lock<std::shared_mutex> lock{*instance_mutex_};
         instance = std::move(lmdb_instance_);
     }
-    // Diagnostic only, and deliberately not used for control flow: use_count() is a snapshot another thread can
-    // invalidate before it is even read, so it is a lower bound on a moving number rather than an answer. A count
-    // above one means somebody was still inside a storage call, or still held a segment whose buffer points into this
-    // mapping, at the moment the library was deleted. That is survivable - the environment closes later instead of
-    // now - but it is the shape of a caller bug, and it is otherwise invisible: nothing is logged and no exception is
-    // raised, so the consequences surface later as a failed delete on Windows or as an unexplained retention of the
-    // files. Logging it here is what turns "some unrelated operation misbehaved" into a named cause.
+    // Diagnostic only, never control flow: use_count() is a snapshot another thread can invalidate, hence "at
+    // least". A count above one means a storage call or an unreleased read segment overlapped the deletion.
     if (instance) {
         if (const auto holders = instance.use_count(); holders > 1) {
             log::storage().warn(
@@ -458,8 +450,7 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
 
     write_mutex_ = std::make_unique<std::mutex>();
     instance_mutex_ = std::make_unique<std::shared_mutex>();
-    // Built locally and only published to lmdb_instance_ once it is fully open, so no other thread can ever observe a
-    // half-constructed environment.
+    // Published only once fully open, so no other thread can observe a half-constructed environment.
     auto instance = std::make_shared<LmdbInstance>(LmdbInstance{::lmdb::env::create(conf.flags()), {}});
 
     warn_if_lmdb_already_open();
@@ -528,8 +519,7 @@ LmdbStorage::LmdbStorage(const LibraryPath& library_path, OpenMode mode, const C
 void LmdbStorage::warn_if_lmdb_already_open() const {
     const std::string warn_setting =
             util::to_lower(ConfigsMap::instance()->get_string("LMDBStorage.WarnIfOpened", "config"));
-    // Taken by value under the lock rather than as a reference into the map: another thread constructing a storage
-    // over a different path can rehash it, which would invalidate the reference.
+    // By value, not a reference into the map: another thread's construction can rehash it.
     uint64_t count_for_pid;
     {
         std::lock_guard<std::mutex> lock{times_path_opened_mutex};

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.cpp
@@ -414,6 +414,25 @@ void LmdbStorage::cleanup() {
         std::unique_lock<std::shared_mutex> lock{*instance_mutex_};
         instance = std::move(lmdb_instance_);
     }
+    // Diagnostic only, and deliberately not used for control flow: use_count() is a snapshot another thread can
+    // invalidate before it is even read, so it is a lower bound on a moving number rather than an answer. A count
+    // above one means somebody was still inside a storage call, or still held a segment whose buffer points into this
+    // mapping, at the moment the library was deleted. That is survivable - the environment closes later instead of
+    // now - but it is the shape of a caller bug, and it is otherwise invisible: nothing is logged and no exception is
+    // raised, so the consequences surface later as a failed delete on Windows or as an unexplained retention of the
+    // files. Logging it here is what turns "some unrelated operation misbehaved" into a named cause.
+    if (instance) {
+        if (const auto holders = instance.use_count(); holders > 1) {
+            log::storage().warn(
+                    "LMDB library at {} deleted while at least {} other reference(s) to its environment are still "
+                    "live; it will stay open until they are released. A storage call or an unreleased read segment "
+                    "overlapped the deletion.",
+                    lib_dir_.string(),
+                    holders - 1
+            );
+        }
+    }
+
     // Released outside the lock: this is where the environment is actually closed, if nobody else is still using it.
     instance.reset();
     remove_db_files(lib_dir_);

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -13,6 +13,9 @@
 #include <arcticdb/storage/lmdb/lmdb_client_interface.hpp>
 #include <arcticdb/storage/lmdb/lmdb.hpp>
 #include <filesystem>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
 
 namespace fs = std::filesystem;
 
@@ -69,9 +72,12 @@ class LmdbStorage final : public Storage {
 
     std::optional<char> do_verify_library_suffix(std::string_view path) const final;
 
-    ::lmdb::env& env();
+    // Returns a strong reference to the instance, which the caller must hold for as long as it touches the LMDB
+    // environment or any dbi. cleanup() can run concurrently on another thread and drop the storage's own reference;
+    // holding one here is what stops the MDB_env being closed (and lock.mdb unmapped) mid-transaction.
+    std::shared_ptr<LmdbInstance> instance() const;
 
-    ::lmdb::dbi& get_dbi(const std::string& db_name);
+    static ::lmdb::dbi& get_dbi(const LmdbInstance& instance, const std::string& db_name);
 
     std::string do_key_path(const VariantKey&) const final { return {}; };
 
@@ -83,11 +89,17 @@ class LmdbStorage final : public Storage {
     void print_warning_if_lmdb_already_open() const;
 
     // _internal methods assume the write mutex is already held
-    void do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn);
+    void do_write_internal(KeySegmentPair& key_seg, ::lmdb::txn& txn, const LmdbInstance& instance);
     boost::container::small_vector<VariantKey, 1> do_remove_internal(
-            std::span<VariantKey> variant_key, ::lmdb::txn& txn, RemoveOpts opts
+            std::span<VariantKey> variant_key, ::lmdb::txn& txn, const LmdbInstance& instance, RemoveOpts opts
     );
     std::unique_ptr<std::mutex> write_mutex_;
+
+    // Guards lmdb_instance_ itself, not the environment it points at. Only ever held for the length of a shared_ptr
+    // copy or reset. Shared because instance() is on the path of every storage call, including the reads the IO pool
+    // runs in parallel - an exclusive mutex there serialises them and costs more than the bug being fixed. The pointer
+    // is written exactly twice, when the constructor publishes it and when cleanup() drops it.
+    std::unique_ptr<std::shared_mutex> instance_mutex_;
     std::shared_ptr<LmdbInstance> lmdb_instance_;
 
     std::filesystem::path lib_dir_;
@@ -97,6 +109,8 @@ class LmdbStorage final : public Storage {
     // For log warning only
     // Number of times an LMDB path has been opened. See also reinit_lmdb_warning.
     // Opening an LMDB env over the same path twice in the same process is unsafe, so we warn the user about it.
+    // Storages over different paths are constructed and destroyed from arbitrary threads, so all access is guarded.
+    inline static std::mutex times_path_opened_mutex;
     inline static std::unordered_map<std::string, uint64_t> times_path_opened;
 };
 

--- a/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
+++ b/cpp/arcticdb/storage/lmdb/lmdb_storage.hpp
@@ -72,9 +72,8 @@ class LmdbStorage final : public Storage {
 
     std::optional<char> do_verify_library_suffix(std::string_view path) const final;
 
-    // Returns a strong reference to the instance, which the caller must hold for as long as it touches the LMDB
-    // environment or any dbi. cleanup() can run concurrently on another thread and drop the storage's own reference;
-    // holding one here is what stops the MDB_env being closed (and lock.mdb unmapped) mid-transaction.
+    // Returns a strong reference the caller must hold while it touches the environment or any dbi: cleanup() can
+    // drop the storage's own reference concurrently.
     std::shared_ptr<LmdbInstance> instance() const;
 
     static ::lmdb::dbi& get_dbi(const LmdbInstance& instance, const std::string& db_name);
@@ -95,10 +94,8 @@ class LmdbStorage final : public Storage {
     );
     std::unique_ptr<std::mutex> write_mutex_;
 
-    // Guards lmdb_instance_ itself, not the environment it points at. Only ever held for the length of a shared_ptr
-    // copy or reset. Shared because instance() is on the path of every storage call, including the reads the IO pool
-    // runs in parallel - an exclusive mutex there serialises them and costs more than the bug being fixed. The pointer
-    // is written exactly twice, when the constructor publishes it and when cleanup() drops it.
+    // Guards lmdb_instance_ itself, not the environment it points at. Shared because instance() is on the path of
+    // every storage call, including the reads the IO pool runs in parallel.
     std::unique_ptr<std::shared_mutex> instance_mutex_;
     std::shared_ptr<LmdbInstance> lmdb_instance_;
 

--- a/cpp/arcticdb/storage/test/test_lmdb_storage_concurrency.cpp
+++ b/cpp/arcticdb/storage/test/test_lmdb_storage_concurrency.cpp
@@ -28,9 +28,8 @@ namespace {
 
 const fs::path CONCURRENCY_TEST_PATH = "./test_databases_concurrency";
 
-// Returns the storage by its base type on purpose. cleanup() is public on Storage but overridden privately by
-// LmdbStorage, so it is only reachable through a Storage handle - which is also how production gets there, via
-// Library::cleanup() -> Storages::cleanup() -> primary().cleanup().
+// Returned as the base type on purpose: cleanup() is private on LmdbStorage and reachable only through a Storage
+// handle, which is also how production reaches it (Library::cleanup() -> Storages::cleanup()).
 std::unique_ptr<Storage> make_lmdb_storage(const std::string& lib_name) {
     arcticdb::proto::lmdb_storage::Config cfg;
     cfg.set_path(CONCURRENCY_TEST_PATH.generic_string());
@@ -73,11 +72,8 @@ class LmdbStorageConcurrencyTest : public ::testing::Test {
  */
 TEST_F(LmdbStorageConcurrencyTest, WriteDuringCleanup) {
 #if defined(_WIN32)
-    // cleanup() removes lock.mdb and data.mdb immediately after dropping the storage's reference to the environment.
-    // Once the environment is kept alive for the duration of each call, a writer can still be holding it open at that
-    // moment - and Windows refuses to delete a mapped file, so cleanup() raises E_UNEXPECTED_LMDB_ERROR rather than
-    // racing. Both the defect this test targets and the POSIX unlink-while-mapped semantics the fix leans on are
-    // therefore unreproducible here.
+    // Windows refuses to delete a mapped file, so cleanup() raises rather than racing. Both the defect and the POSIX
+    // unlink-while-mapped semantics the fix relies on are unreproducible here.
     GTEST_SKIP() << "relies on POSIX unlink-while-mapped semantics";
 #else
     constexpr int num_rounds = 20;
@@ -91,9 +87,8 @@ TEST_F(LmdbStorageConcurrencyTest, WriteDuringCleanup) {
         std::vector<std::thread> writers;
         writers.reserve(num_writers);
 
-        // Stops and joins the writers however this scope is left. cleanup() can throw, and destroying a joinable
-        // std::thread calls std::terminate - which takes down the whole test binary with no report at all. Declared
-        // after the threads it owns so it runs before they are destroyed, and before storage is.
+        // cleanup() can throw, and destroying a joinable std::thread calls std::terminate. Declared after the
+        // threads so it runs before they are destroyed.
         struct StopWriters {
             std::atomic<bool>& stop;
             std::vector<std::thread>& writers;
@@ -114,8 +109,7 @@ TEST_F(LmdbStorageConcurrencyTest, WriteDuringCleanup) {
                         write_in_store(*storage, fmt::format("sym_{}_{}", t, n));
                         writes_started.fetch_add(1, std::memory_order_relaxed);
                     } catch (const std::exception&) {
-                        // Expected once cleanup() has removed the environment; an escaping exception would
-                        // std::terminate the test rather than report anything useful.
+                        // Expected once cleanup() has removed the environment; escaping would std::terminate.
                     }
                 }
             });
@@ -161,8 +155,7 @@ TEST_F(LmdbStorageConcurrencyTest, ConcurrentOpenAndClose) {
     for (int t = 0; t < num_threads; ++t) {
         threads.emplace_back([t, &failures]() {
             for (int i = 0; i < num_iterations; ++i) {
-                // An exception escaping a std::thread callable calls std::terminate, which kills the binary with no
-                // report. Record it and let the test body assert on it instead.
+                // Escaping a std::thread callable calls std::terminate; record and assert in the test body instead.
                 try {
                     auto storage = make_lmdb_storage(fmt::format("open_close_{}_{}", t, i));
                     write_in_store(*storage, "sym");

--- a/cpp/arcticdb/storage/test/test_lmdb_storage_concurrency.cpp
+++ b/cpp/arcticdb/storage/test/test_lmdb_storage_concurrency.cpp
@@ -1,0 +1,188 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+
+#include <arcticdb/storage/lmdb/lmdb_storage.hpp>
+#include <arcticdb/storage/storage_exceptions.hpp>
+#include <arcticdb/storage/test/common.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace arcticdb;
+using namespace arcticdb::storage;
+
+namespace {
+
+const fs::path CONCURRENCY_TEST_PATH = "./test_databases_concurrency";
+
+// Returns the storage by its base type on purpose. cleanup() is public on Storage but overridden privately by
+// LmdbStorage, so it is only reachable through a Storage handle - which is also how production gets there, via
+// Library::cleanup() -> Storages::cleanup() -> primary().cleanup().
+std::unique_ptr<Storage> make_lmdb_storage(const std::string& lib_name) {
+    arcticdb::proto::lmdb_storage::Config cfg;
+    cfg.set_path(CONCURRENCY_TEST_PATH.generic_string());
+    cfg.set_map_size(64ULL * (1ULL << 20));
+    cfg.set_recreate_if_exists(true);
+    LibraryPath library_path(lib_name, '/');
+    return std::make_unique<arcticdb::storage::lmdb::LmdbStorage>(library_path, OpenMode::DELETE, cfg);
+}
+
+class LmdbStorageConcurrencyTest : public ::testing::Test {
+  protected:
+    void SetUp() override {
+        if (!fs::exists(CONCURRENCY_TEST_PATH)) {
+            fs::create_directories(CONCURRENCY_TEST_PATH);
+        }
+    }
+
+    void TearDown() override {
+        if (fs::exists(CONCURRENCY_TEST_PATH)) {
+            fs::remove_all(CONCURRENCY_TEST_PATH);
+        }
+    }
+};
+
+} // namespace
+
+/*
+ * Reproduction for the LmdbStorage environment-lifetime defect.
+ *
+ * Storage::write runs on folly IO pool threads (see async::WriteSegmentTask), while cleanup() runs on whichever thread
+ * called Arctic.delete_library. Before the fix, LmdbStorage::env() and LmdbStorage::get_dbi() returned raw references
+ * into lmdb_instance_ and kept no ownership for the duration of the call, so cleanup() could drop the last reference
+ * and close the MDB_env - unmapping lock.mdb - while a writer was inside mdb_txn_begin, which is exactly the CI
+ * segfault (pthread_mutex_lock on env->me_txns->mti_wmutex). Reading and resetting the shared_ptr member from
+ * different threads with no synchronisation is separately a data race.
+ *
+ * This test does not fail deterministically on a non-instrumented build: a use-after-free of a just-freed MDB_env
+ * usually reads plausible garbage rather than crashing. Run it under AddressSanitizer (heap-use-after-free inside
+ * mdb_txn_begin / mdb_txn_commit) or ThreadSanitizer (data race on lmdb_instance_) to see it fail before the fix.
+ */
+TEST_F(LmdbStorageConcurrencyTest, WriteDuringCleanup) {
+#if defined(_WIN32)
+    // cleanup() removes lock.mdb and data.mdb immediately after dropping the storage's reference to the environment.
+    // Once the environment is kept alive for the duration of each call, a writer can still be holding it open at that
+    // moment - and Windows refuses to delete a mapped file, so cleanup() raises E_UNEXPECTED_LMDB_ERROR rather than
+    // racing. Both the defect this test targets and the POSIX unlink-while-mapped semantics the fix leans on are
+    // therefore unreproducible here.
+    GTEST_SKIP() << "relies on POSIX unlink-while-mapped semantics";
+#else
+    constexpr int num_rounds = 20;
+    constexpr int num_writers = 4;
+
+    for (int round = 0; round < num_rounds; ++round) {
+        auto storage = make_lmdb_storage(fmt::format("cleanup_race_{}", round));
+
+        std::atomic<bool> stop{false};
+        std::atomic<int> writes_started{0};
+        std::vector<std::thread> writers;
+        writers.reserve(num_writers);
+
+        // Stops and joins the writers however this scope is left. cleanup() can throw, and destroying a joinable
+        // std::thread calls std::terminate - which takes down the whole test binary with no report at all. Declared
+        // after the threads it owns so it runs before they are destroyed, and before storage is.
+        struct StopWriters {
+            std::atomic<bool>& stop;
+            std::vector<std::thread>& writers;
+            ~StopWriters() {
+                stop.store(true, std::memory_order_relaxed);
+                for (auto& writer : writers) {
+                    if (writer.joinable()) {
+                        writer.join();
+                    }
+                }
+            }
+        } stop_writers{stop, writers};
+
+        for (int t = 0; t < num_writers; ++t) {
+            writers.emplace_back([&, t]() {
+                for (int n = 0; !stop.load(std::memory_order_relaxed); ++n) {
+                    try {
+                        write_in_store(*storage, fmt::format("sym_{}_{}", t, n));
+                        writes_started.fetch_add(1, std::memory_order_relaxed);
+                    } catch (const std::exception&) {
+                        // Expected once cleanup() has removed the environment; an escaping exception would
+                        // std::terminate the test rather than report anything useful.
+                    }
+                }
+            });
+        }
+
+        // Let the writers get going so that cleanup lands in the middle of an in-flight transaction.
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        storage->cleanup();
+        stop.store(true, std::memory_order_relaxed);
+        for (auto& writer : writers) {
+            writer.join();
+        }
+
+        ASSERT_GT(writes_started.load(), 0) << "writers never got going, the race window was never opened";
+        // After cleanup every subsequent call must report the environment is gone rather than touch freed memory.
+        ASSERT_THROW({ write_in_store(*storage, "after_cleanup"); }, UnexpectedLMDBErrorException);
+    }
+#endif
+}
+
+/*
+ * LmdbStorage::times_path_opened is a process-wide static std::unordered_map mutated from the constructor
+ * (warn_if_lmdb_already_open), the destructor and reset_warning_counter. Storages over different paths are constructed
+ * and destroyed from arbitrary threads (pybind11 holders are released on whichever thread drops the last Python
+ * reference), so before the fix this was unsynchronised mutation of a std::unordered_map - a plausible source of the
+ * heap corruption seen in the second CI signature.
+ *
+ * Like the test above this needs ThreadSanitizer (or a lot of luck) to fail on a pre-fix build.
+ */
+TEST_F(LmdbStorageConcurrencyTest, ConcurrentOpenAndClose) {
+    constexpr int num_threads = 8;
+    constexpr int num_iterations = 25;
+
+    arcticdb::storage::lmdb::LmdbStorage::reset_warning_counter();
+
+    struct Failures {
+        std::mutex mutex;
+        std::vector<std::string> messages;
+    } failures;
+
+    std::vector<std::thread> threads;
+    threads.reserve(num_threads);
+    for (int t = 0; t < num_threads; ++t) {
+        threads.emplace_back([t, &failures]() {
+            for (int i = 0; i < num_iterations; ++i) {
+                // An exception escaping a std::thread callable calls std::terminate, which kills the binary with no
+                // report. Record it and let the test body assert on it instead.
+                try {
+                    auto storage = make_lmdb_storage(fmt::format("open_close_{}_{}", t, i));
+                    write_in_store(*storage, "sym");
+                } catch (const std::exception& e) {
+                    std::lock_guard<std::mutex> lock{failures.mutex};
+                    failures.messages.emplace_back(e.what());
+                }
+            }
+        });
+    }
+    for (auto& thread : threads) {
+        thread.join();
+    }
+
+    {
+        std::lock_guard<std::mutex> lock{failures.mutex};
+        EXPECT_TRUE(failures.messages.empty())
+                << failures.messages.size() << " of " << (num_threads * num_iterations)
+                << " open/write/close cycles failed, first: " << failures.messages.front();
+    }
+
+    arcticdb::storage::lmdb::LmdbStorage::reset_warning_counter();
+}


### PR DESCRIPTION
### Problem

`LmdbStorage::env()` and `get_dbi()` checked `lmdb_instance_` and then returned a **raw reference into it**, keeping no ownership for the call:

```cpp
::lmdb::env& LmdbStorage::env() {
    storage::check<...>(lmdb_instance_, "...LMDB environment has been removed...");
    return lmdb_instance_->env_;   // caller holds nothing
}
```

`cleanup()` drops that `shared_ptr`, closing the `MDB_env` and unmapping `lock.mdb`. Storage calls run on folly IO pool threads while `cleanup()` runs on whichever thread called `delete_library`, so a writer could be mid-transaction when the mapping went away. Reading and `reset()`ing the member from different threads was separately a plain data race.

Every entry point was exposed: `do_write`, `do_update`, both `do_read`, `do_key_exists`, `do_remove`, `do_fast_delete`, `do_iterate_type_until_match`.

Separately, `times_path_opened` is a process-wide `static std::unordered_map` mutated from the constructor, destructor and `reset_warning_counter()` on arbitrary threads, unsynchronised.

### Fix

`instance()` replaces both accessors, returning the `shared_ptr` by value so every entry point holds the environment open for as long as it touches it. `get_dbi` becomes a static taking the instance the caller already owns, so a `dbi` cannot be reached without holding the environment.

`cleanup()` moves the pointer out under the lock and releases it outside — dropping the storage's reference no longer necessarily closes the environment, since a call in flight holds its own. It also now warns when it finds other live references, which names the overlap instead of leaving it silent.

The lock is a `std::shared_mutex` because `instance()` is on the path of every storage call, including reads the IO pool runs in parallel. The constructor publishes the instance only once fully open.

`times_path_opened` is guarded by a static mutex at all three sites.

### Relationship to earlier work

**#1879 "Extend LMDB instance lifetime"** (`8669ceee`) introduced `LmdbInstance`, the `shared_ptr`, and `LmdbKeepalive` so a `Segment` returned from `do_read` keeps the environment alive — its buffer points into the mmap. That covered the returned segment but not the in-flight call, which kept using raw references. This applies #1879's own mechanism to the case it left open; nothing from it is reverted.

**#1437 "Remove lmdb files when `delete_library` is called"** (`7d57f21f`, fixes #1266) is why `cleanup()` closes the environment before deleting: Windows will not delete a file that is still mapped. See below.

**"Refactor storages to async"** (`32341ae7c`) moved storage calls onto the async path, which is what makes a concurrent `cleanup()` reachable.

### Behaviour change on Windows

Previously `cleanup()` always closed the environment before `remove_db_files()`, so files were never mapped at deletion. Now an in-flight call can hold it open past that point. On POSIX that is the intent — unlinking a mapped file is safe. On Windows deletion is refused, so `remove_db_files()` raises `E_UNEXPECTED_LMDB_ERROR`. A `delete_library` racing an in-flight write reports an error where it previously closed the environment out from under the writer.

#1437's actual scenario is unaffected: single-threaded create/use/delete holds the only reference at `cleanup()`, so the environment still closes eagerly. Keepalives do not survive the read pipeline either — `Segment::force_own_buffer()` copies the buffer and drops them. `test_delete_library` and the Windows C++ suite pass.

`WriteDuringCleanup` is skipped on Windows for the same reason.

### Testing

**These tests need a sanitizer to fail on a pre-fix build** — uninstrumented, a use-after-free of a just-closed `MDB_env` usually reads plausible garbage rather than crashing. Verified in CI both ways:

- **Positive control** (this branch): ASan job passes.
- **Negative control** (`lmdb_storage.{hpp,cpp}` reverted to master, test kept): ASan fails with `heap-use-after-free`, `READ of size 8` in `mdb_env_write_meta` <- `_mdb_txn_commit` <- `lmdb::txn::commit()` on a writer thread, freed by `LmdbStorage::cleanup()` at `lmdb_storage.cpp:397` — the exact line this PR replaces.

`ConcurrentOpenAndClose` is weaker: it targets a data race, which needs TSan, and that job is commented out in `analysis_workflow.yml`. Treat it as documentation plus a smoke test, not a regression gate.

### The failing benchmark job is not this branch

The step measures only HEAD (`asv run --bench $SUITE HEAD^!`) and takes the "Before" column from the results bucket. The stored `fd61ffb6` record reads `17.7±0.2ms` for `time_compact_data((100000, 100000, 10000), 2, False, 2)`; every branch based on it measures ~44ms fresh:

| Branch | After | Ratio |
|---|---|---|
| `quality/12966372853/remove-unused-arguments-related-to-staging` | 43.6±0.2ms | 2.46 |
| `delete-staged-data-by-stage-result` | 45.9±1ms | 2.59 |
| this branch | 44.2±0.2ms | 2.49 |

Neither of the first two touches LMDB. The stored baseline looks stale.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVPtQqQ8NUgBt67kUAMsZ5
