### PR TITLE
Vectorize timestamp conversion in NativeVersionStore.list_versions

### DIFF
--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -26,7 +26,7 @@ import difflib
 from datetime import datetime
 
 from numpy import datetime64
-from pandas import Timestamp, to_datetime, Timedelta
+from pandas import Timestamp, Timedelta
 from typing import Any, Optional, Union, List, Sequence, Tuple, Dict, Set, NamedTuple
 from contextlib import contextmanager
 import time
@@ -3100,15 +3100,23 @@ class NativeVersionStore:
             NativeVersionStore._warned_about_list_version_latest_only_and_snapshot = True
 
         result = self.version_store.list_versions(symbol, snapshot, latest_only, skip_snapshots)
+        # Scalar pd.to_datetime builds a throwaway one-element DatetimeIndex per call, so convert the whole
+        # column of epoch-nanosecond creation timestamps in one go instead of once per version.
+        dates = pd.DatetimeIndex(
+            np.fromiter((version_result[2] for version_result in result), dtype=np.int64, count=len(result)).view(
+                "M8[ns]"
+            ),
+            tz="UTC",
+        )
         return [
             {
                 "symbol": version_result[0],
                 "version": version_result[1],
-                "date": to_datetime(version_result[2], unit="ns", utc=True),
+                "date": date,
                 "deleted": version_result[4],
                 "snapshots": version_result[3],
             }
-            for version_result in result
+            for version_result, date in zip(result, dates)
         ]
 
     def list_symbols(

--- a/python/tests/unit/arcticdb/version_store/test_list_versions.py
+++ b/python/tests/unit/arcticdb/version_store/test_list_versions.py
@@ -6,9 +6,13 @@ Use of this software is governed by the Business Source License 1.1 included in 
 As of the Change Date specified in that file, in accordance with the Business Source License, use of this software will be governed by the Apache License, version 2.0.
 """
 
+import datetime
+
+import pandas as pd
 import pytest
 
 import arcticdb.toolbox.query_stats as qs
+from arcticdb.util._versions import IS_PANDAS_TWO
 from arcticdb.util.test import config_context, query_stats_operation_count
 from arcticdb_ext.exceptions import InternalException, KeyNotFoundException
 from arcticdb_ext.storage import KeyType, NoDataFoundException
@@ -500,3 +504,34 @@ def test_list_versions_with_snapshot_deleted_always_false(lmdb_version_store_v1,
 
     res = lib.list_versions(snapshot="snap")
     assert res[0]["deleted"] == False
+
+
+def test_list_versions_date_is_utc_nanosecond_timestamp(lmdb_version_store_v1):
+    """The `date` field is dropped by assert_versions_equal, so pin its type, precision and timezone here."""
+    lib = lmdb_version_store_v1
+    lib.write("sym", 1)
+    lib.write("sym", 2)
+    lib.write("other", 3)
+    lib.snapshot("snap")
+
+    def assert_dates_ok(versions):
+        for version in versions:
+            date = version["date"]
+            assert isinstance(date, pd.Timestamp)
+            if IS_PANDAS_TWO:
+                assert date.unit == "ns"
+            assert date.tz is not None
+            assert date.utcoffset() == datetime.timedelta(0)
+
+    all_versions = lib.list_versions()
+    assert len(all_versions) == 3
+    assert_dates_ok(all_versions)
+
+    # Timestamps must be per-version, not all collapsed on to one value
+    assert len({version["date"] for version in all_versions}) == 3
+
+    # Single row, filtered, and empty results go down the same path
+    assert_dates_ok(lib.list_versions("other"))
+    assert_dates_ok(lib.list_versions(latest_only=True))
+    assert_dates_ok(lib.list_versions(snapshot="snap"))
+    assert lib.list_versions("non_existent_sym") == []


### PR DESCRIPTION
#### Reference Issues/PRs

None. Found while profiling the existing `python/benchmarks/list_versions.py` ASV benchmark.

#### What does this implement or fix?

`NativeVersionStore.list_versions` called `pandas.to_datetime` on a **scalar** epoch-nanosecond `int` once per returned version:

```python
"date": to_datetime(version_result[2], unit="ns", utc=True),
```

pandas' scalar branch (`pandas/core/tools/datetimes.py:1106`) is not a fast path. For every single call it allocates a throwaway one-element numpy array, constructs a full `DatetimeIndex`, tz-localizes it (a second `DatetimeArray._simple_new`), and then unboxes element `[0]`. That is create a lot of overhead and it scales lenearly with the number of versions.

This replaces the per-row scalar call with a single columnar conversion: gather the `creation_ts` values into an `int64` buffer, view it as `M8[ns]`, and build one `DatetimeIndex` with `tz="UTC"`, then zip it against the rows.

```python
result = self.version_store.list_versions(symbol, snapshot, latest_only, skip_snapshots)
dates = pd.DatetimeIndex(
    np.fromiter((version_result[2] for version_result in result), dtype=np.int64, count=len(result)).view("M8[ns]"),
    tz="UTC",
)
return [
    {
        "symbol": version_result[0],
        "version": version_result[1],
        "date": date,
        ...
    }
    for version_result, date in zip(result, dates)
]
```

**Micro-benchmark** of the returning comprehension in isolation (pandas 2.3.3), best-of-5:

| rows | before | after | speedup |
|-----:|-------:|------:|--------:|
| 1 | 11.9 µs | 6.2 µs | 1.9× |
| 10 | 118.0 µs | 8.4 µs | 14.0× |
| 100 | 1182 µs | 29 µs | 40.8× |
| 1,000 | 11.8 ms | 0.26 ms | 45.1× |
| 10,000 | 118.6 ms | 3.2 ms | 40.8× |

It is faster at **every** size, including a single row, so there is no length threshold or guard to tune.

and here are the results from the ASV benchmarks:

| Change   | Before [46c5ecdd]    | After [232d7b50]    |   Ratio | Benchmark (Parameter)                                                                                         |
|----------|----------------------|---------------------|---------|---------------------------------------------------------------------------------------------------------------|
| -        | 111±2μs              | 84.2±0.5μs          |    0.76 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, '0_sym', None, False, False)       |
| -        | 105±1μs              | 78.4±0.5μs          |    0.75 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, '0_sym', None, False, True)        |
| -        | 103±0.9μs            | 77.7±0.7μs          |    0.76 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, '0_sym', None, True, False)        |
| -        | 96.3±0.5μs           | 70.0±2μs            |    0.73 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, '0_sym', None, True, True)         |
| -        | 755±3μs              | 229±2μs             |    0.3  | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, None, None, False, False)          |
| -        | 751±4μs              | 230±1μs             |    0.31 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, None, None, False, True)           |
| -        | 728±4μs              | 194±3μs             |    0.27 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, None, None, True, False)           |
| -        | 718±3μs              | 185±3μs             |    0.26 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 0, None, None, True, True)            |
| -        | 102±1μs              | 76.2±1μs            |    0.75 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, '0_sym', '0_snap', False, True)  |
| -        | 104±2μs              | 77.0±0.6μs          |    0.74 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, '0_sym', None, False, True)      |
| -        | 96.0±2μs             | 70.9±1μs            |    0.74 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, '0_sym', None, True, True)       |
| -        | 1.47±0.01ms          | 938±10μs            |    0.64 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, None, '0_snap', False, False)    |
| -        | 627±0.9μs            | 94.2±2μs            |    0.15 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, None, '0_snap', False, True)     |
| -        | 1.59±0.01ms          | 1.06±0.01ms         |    0.67 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, None, None, False, False)        |
| -        | 766±4μs              | 224±4μs             |    0.29 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, None, None, False, True)         |
| -        | 1.55±0.01ms          | 1.03±0.02ms         |    0.66 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, None, None, True, False)         |
| -        | 730±4μs              | 186±0.9μs           |    0.25 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 1, 100, None, None, True, True)          |
| -        | 631±2μs              | 106±1μs             |    0.17 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, '0_sym', None, False, False)      |
| -        | 618±2μs              | 95.7±1μs            |    0.15 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, '0_sym', None, False, True)       |
| -        | 102±1μs              | 75.8±0.6μs          |    0.75 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, '0_sym', None, True, False)       |
| -        | 94.8±0.3μs           | 72.3±0.5μs          |    0.76 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, '0_sym', None, True, True)        |
| -        | 5.80±0.01ms          | 375±3μs             |    0.06 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, None, None, False, False)         |
| -        | 5.85±0.01ms          | 367±3μs             |    0.06 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, None, None, False, True)          |
| -        | 720±6μs              | 188±2μs             |    0.26 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, None, None, True, False)          |
| -        | 718±5μs              | 196±3μs             |    0.27 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 0, None, None, True, True)           |
| -        | 102±0.3μs            | 75.9±0.3μs          |    0.74 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, '0_sym', '0_snap', False, True) |
| -        | 1.30±0.01ms          | 755±8μs             |    0.58 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, '0_sym', None, False, False)    |
| -        | 620±3μs              | 95.6±1μs            |    0.15 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, '0_sym', None, False, True)     |
| -        | 96.5±0.8μs           | 70.8±0.6μs          |    0.73 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, '0_sym', None, True, True)      |
| -        | 1.47±0.01ms          | 940±7μs             |    0.64 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, None, '0_snap', False, False)   |
| -        | 617±2μs              | 93.9±0.6μs          |    0.15 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, None, '0_snap', False, True)    |
| -        | 6.61±0.01ms          | 1.26±0.01ms         |    0.19 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, None, None, False, False)       |
| -        | 5.80±0.01ms          | 356±1μs             |    0.06 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, None, None, False, True)        |
| -        | 1.56±0.01ms          | 1.05±0.01ms         |    0.67 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, None, None, True, False)        |
| -        | 719±3μs              | 190±3μs             |    0.26 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 10, 10, 100, None, None, True, True)         |
| -        | 6.69±0.02ms          | 1.23±0.01ms         |    0.18 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 0, None, None, False, False)         |
| -        | 6.63±0.01ms          | 1.23±0ms            |    0.18 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 0, None, None, False, True)          |
| -        | 6.13±0.02ms          | 703±7μs             |    0.11 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 0, None, None, True, False)          |
| -        | 6.09±0.02ms          | 695±20μs            |    0.11 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 0, None, None, True, True)           |
| -        | 8.43±0.01ms          | 2.98±0.02ms         |    0.35 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 100, None, '0_snap', False, False)   |
| -        | 5.68±0.01ms          | 265±2μs             |    0.05 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 100, None, '0_snap', False, True)    |
| -        | 9.58±0.01ms          | 4.22±0.04ms         |    0.44 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 100, None, None, False, False)       |
| -        | 6.63±0.02ms          | 1.22±0.01ms         |    0.18 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 100, None, None, False, True)        |
| -        | 9.03±0.02ms          | 3.60±0.02ms         |    0.4  | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 100, None, None, True, False)        |
| -        | 6.29±0.01ms          | 704±8μs             |    0.11 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 1, 100, None, None, True, True)         |
| -        | 56.8±0.08ms          | 2.61±0.02ms         |    0.05 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 0, None, None, False, False)        |
| -        | 57.4±0.07ms          | 2.62±0.02ms         |    0.05 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 0, None, None, False, True)         |
| -        | 6.21±0.02ms          | 703±10μs            |    0.11 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 0, None, None, True, False)         |
| -        | 6.16±0.01ms          | 701±20μs            |    0.11 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 0, None, None, True, True)          |
| -        | 8.49±0.01ms          | 3.13±0.02ms         |    0.37 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 100, None, '0_snap', False, False)  |
| -        | 5.69±0.01ms          | 266±0.9μs           |    0.05 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 100, None, '0_snap', False, True)   |
| -        | 60.2±0.08ms          | 6.00±0.04ms         |    0.1  | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 100, None, None, False, False)      |
| -        | 57.1±0.1ms           | 2.63±0.02ms         |    0.05 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 100, None, None, False, True)       |
| -        | 9.00±0.02ms          | 3.69±0.02ms         |    0.41 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 100, None, None, True, False)       |
| -        | 6.10±0.01ms          | 690±9μs             |    0.11 | list_versions.ListVersions.time_list_versions(<Storage.LMDB: 2>, 100, 10, 100, None, None, True, True)        |