### PR TITLE
Raise the Resample benchmarks' timeout so setup_cache fits hosted runners

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -5046,7 +5046,8 @@
                 "'count'"
             ]
         ],
-        "setup_cache_key": "resample:53",
+        "setup_cache_key": "resample:57",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "e0d4d4d70e841616329b33431eb4753443e3143e7d7c458daa965b15278c1015"
@@ -5092,7 +5093,8 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "resample:53",
+        "setup_cache_key": "resample:57",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "19cf418c76226bff4b3c6f56f5a8e84707551066a9b995c8f83f5876c869714b",
@@ -5103,7 +5105,7 @@
         "name": "resample.ResampleWide.peakmem_resample_wide",
         "param_names": [],
         "params": [],
-        "setup_cache_key": "resample:127",
+        "setup_cache_key": "resample:131",
         "type": "peakmemory",
         "unit": "bytes",
         "version": "93455e3ea01b28c847b53f4ed1ecbf6ea0faa06d1b08631f863399fe9a9ee8b3"
@@ -5118,7 +5120,7 @@
         "repeat": 0,
         "rounds": 2,
         "sample_time": 0.01,
-        "setup_cache_key": "resample:127",
+        "setup_cache_key": "resample:131",
         "type": "time",
         "unit": "seconds",
         "version": "b91bf134b20358ef57d42d66f4578d48c3908d31422ab5ecba4fc0dccf3c5427",

--- a/python/benchmarks/resample.py
+++ b/python/benchmarks/resample.py
@@ -23,6 +23,10 @@ from asv_runner.benchmarks.mark import skip_for_params
 
 class Resample:
     number = 5
+    # setup_cache takes right around asv's 60s default timeout on a shared
+    # windows-latest box, so it flakes on the slower draws; 600 matches the
+    # timeout the other heavy suites in this directory already declare.
+    timeout = 600
 
     LIB_NAME = "resample"
     CONNECTION_STRING = "lmdb://resample"


### PR DESCRIPTION
#### Reference Issues/PRs

No linked issue. Evidence is a benchmarking run on this repo:
[run 33889446573](https://github.com/man-group/ArcticDB/actions/runs/33889446573),
job `bench windows_pilot 6.24.0` (2026-09-04).

#### What does this implement or fix?

`resample.Resample.setup_cache` builds the benchmark datasets (five column
types x 100 segments of 100k rows each) and runs under asv's default 60s
budget, which it now sits right on top of. On a hosted `windows-latest`
runner it goes over and asv kills it:

```
[11.11%] ··· Setting up resample:53                    failed
[11.11%] ···· asv: setup_cache failed (exit status -256)
[11.11%] ··· resample.Resample.time_resample skipped (setup_cache failed)
...
                    <setup_cache resample:53>          1.00m
                    <setup_cache resample:127>         9.99s
```

`resample:53` is `Resample.setup_cache`, killed at exactly the 60s deadline
(`-256` is asv's timeout exit code); `resample:127` is
`ResampleWide.setup_cache`, which finishes in ~10s. Losing the cache skips
every `Resample` time and peakmem benchmark for that job. This is variance,
not a regression: nine sibling jobs on the same hardware in the same run
came in just under the limit.

This sets `timeout = 600` on the `Resample` class, matching the value
`basic_functions`, `query_builder`, `column_stats`, `arrow` and
`modification_functions` already declare for their heavy suites.

#### Any other comments?

A note on why `timeout` is the right knob, since asv's handling of
`setup_cache` is not obvious:

- `asv_runner` only reads a `timeout` attribute off the `setup_cache`
  *function object* (`benchmarks/_base.py`:
  `setup_cache_timeout = _get_first_attr([self._setup_cache], "timeout", None)`).
- When that is absent, asv falls back to the benchmark's own timeout
  (`asv/runner.py`: `benchmark.get('setup_cache_timeout', benchmark['timeout'])`),
  which *is* resolved from the class. So a class-level `timeout` does govern
  `setup_cache` here.
- A class-level `setup_cache_timeout` attribute would be silently ignored —
  it never reaches the benchmark JSON.

Verified against asv 0.6.6 / asv_runner 0.3.1 by running the discovery and
budget-resolution code paths directly: no timeout -> 60s, class
`timeout = 600` -> 600s, class `setup_cache_timeout = 600` -> 60s.

`Resample` sets no `repeat`, so `asv_runner`'s timing loop takes the
`repeat == 0` branch with its own `max_time = 20.0` and never consults
`timeout`. Raising it therefore changes only the kill deadline, not how the
benchmarks are sampled. `ResampleWide` is left alone.

#### Checklist

<details>
  <summary>
   Checklist for code changes...
  </summary>
 
 - [x] Have you updated the relevant docstrings, documentation and copyright notice? — n/a, benchmark configuration only; the change carries an explanatory comment.
 - [x] Is this contribution tested against [all ArcticDB's features](../docs/mkdocs/docs/technical/contributing.md)? — n/a, no library code is touched.
 - [x] Do all exceptions introduced raise appropriate [error messages](https://docs.arcticdb.io/error_messages/)? — n/a, no exceptions introduced.
 - [x] Are API changes highlighted in the PR description? — n/a, no API changes.
 - [x] Is the PR labelled as enhancement or bug so it appears in autogenerated release notes? — labelled `patch` / `no-release-notes`, matching prior benchmark-only PRs (#3217, #3215, #3016).
</details>
