### PR TITLE
Benchmarks: stabilise the compact_data suite

### DIFF
--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2434,6 +2434,7 @@
             ]
         ],
         "setup_cache_key": "compact_data:427",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "ba4165befb708b8f7f58643cda9872d9cb793aad070c02999d2cc7114fa42ec9"
@@ -2466,6 +2467,7 @@
         "rounds": 1,
         "sample_time": 0.01,
         "setup_cache_key": "compact_data:427",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "213d83968732a37caeb4a6199db291b7ff4720e1ba81da9b8f9d335bf863e675",
@@ -2495,6 +2497,7 @@
             ]
         ],
         "setup_cache_key": "compact_data:329",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "1581bf5cf4f523b1dba5029cd77944e091eb35ea35bb67e679bda577d5e5ace3"
@@ -2528,6 +2531,7 @@
         "rounds": 1,
         "sample_time": 0.01,
         "setup_cache_key": "compact_data:329",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "fec1a6b2e52e6380a99b1666c49b3461b4fb24f28221b495f60e1be274bb9023",
@@ -2557,6 +2561,7 @@
             ]
         ],
         "setup_cache_key": "compact_data:378",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "7a58c10ef4b2a352df474a8f1904d021f721652d3837e10680d47d47c3d275b6"
@@ -2590,6 +2595,7 @@
         "rounds": 1,
         "sample_time": 0.01,
         "setup_cache_key": "compact_data:378",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "8665815997d55eb8deeb5b37f5eafc228bc6aed867aee9a5f0e5171296cbbd26",
@@ -2613,6 +2619,7 @@
             ]
         ],
         "setup_cache_key": "compact_data:219",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "c15da0bab109a8a3ef408294394b0b4492de87510ce03ef817a72ddba0572700"
@@ -2640,6 +2647,7 @@
         "rounds": 1,
         "sample_time": 0.01,
         "setup_cache_key": "compact_data:219",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "1a7929bda8b3b10dd3e652f070e4ccc125a28aae4caf0e7ebe539f86bc24f897",
@@ -2669,6 +2677,7 @@
             ]
         ],
         "setup_cache_key": "compact_data:109",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "37d8aadd1f1639c8702ca70ab8299d2d64e6b9e634862531b424ebde718e1275"
@@ -2702,6 +2711,7 @@
         "rounds": 1,
         "sample_time": 0.01,
         "setup_cache_key": "compact_data:109",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "1adb81796aa15ebb66f2b9cfa6d803ffb9687ea074115073d9e0ff49fd342d73",
@@ -2736,6 +2746,7 @@
             ]
         ],
         "setup_cache_key": "compact_data:165",
+        "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
         "version": "c0318b30706b143ac685ec9a5c549702a5d82b8f0bbe7e4587e0ceb96620e91d"
@@ -2774,6 +2785,7 @@
         "rounds": 1,
         "sample_time": 0.01,
         "setup_cache_key": "compact_data:165",
+        "timeout": 600,
         "type": "time",
         "unit": "seconds",
         "version": "dd1b297e52b126a9abb2023c06bfd999045e847f37e7ab00a34e7e842b39a305",

--- a/python/.asv/results/benchmarks.json
+++ b/python/.asv/results/benchmarks.json
@@ -2433,7 +2433,7 @@
                 "1000"
             ]
         ],
-        "setup_cache_key": "compact_data:427",
+        "setup_cache_key": "compact_data:436",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2466,7 +2466,7 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:427",
+        "setup_cache_key": "compact_data:436",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -2496,7 +2496,7 @@
                 "1000000"
             ]
         ],
-        "setup_cache_key": "compact_data:329",
+        "setup_cache_key": "compact_data:338",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2530,7 +2530,7 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:329",
+        "setup_cache_key": "compact_data:338",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -2560,7 +2560,7 @@
                 "1000000"
             ]
         ],
-        "setup_cache_key": "compact_data:378",
+        "setup_cache_key": "compact_data:387",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2594,7 +2594,7 @@
         "repeat": 7,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:378",
+        "setup_cache_key": "compact_data:387",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -2618,7 +2618,7 @@
                 "10000"
             ]
         ],
-        "setup_cache_key": "compact_data:219",
+        "setup_cache_key": "compact_data:233",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2646,7 +2646,7 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:219",
+        "setup_cache_key": "compact_data:233",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -2676,7 +2676,7 @@
                 "True"
             ]
         ],
-        "setup_cache_key": "compact_data:109",
+        "setup_cache_key": "compact_data:123",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2710,7 +2710,7 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:109",
+        "setup_cache_key": "compact_data:123",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",
@@ -2745,7 +2745,7 @@
                 "100000"
             ]
         ],
-        "setup_cache_key": "compact_data:165",
+        "setup_cache_key": "compact_data:179",
         "timeout": 600,
         "type": "peakmemory",
         "unit": "bytes",
@@ -2784,7 +2784,7 @@
         "repeat": 15,
         "rounds": 1,
         "sample_time": 0.01,
-        "setup_cache_key": "compact_data:165",
+        "setup_cache_key": "compact_data:179",
         "timeout": 600,
         "type": "time",
         "unit": "seconds",

--- a/python/benchmarks/compact_data.py
+++ b/python/benchmarks/compact_data.py
@@ -25,7 +25,30 @@ random.seed(42)
 rng = np.random.default_rng(42)
 
 
-class CompactDataBase:
+class CompactDataLmdbBase:
+    # asv applies this to setup_cache as well, which has been measured at 36s on the nightly runners, too close to the
+    # 60s default to survive a slow disk day without NaN-ing the whole class
+    timeout = 600
+
+    def _setup_lmdb_dir(self, lib_name):
+        # Drop both references before recreating the directory. self.lib keeps the previous iteration's LMDB
+        # environment open on this path, LMDB does not support opening it twice, and reclaiming the old 400GiB
+        # mapping would otherwise land inside the next timed call
+        self.lib = None
+        self.ac = None
+        # ignore_errors, so a directory left behind by a killed process does not cascade FileExistsError through every
+        # remaining parameter combination of the class
+        shutil.rmtree(self.LMDB_DIR, ignore_errors=True)
+        os.mkdir(self.LMDB_DIR)
+        # Copy the config database and the relevant library database for these benchmark parameters to the actual
+        # LMDB directory where compaction will happen
+        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
+        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
+        self.ac = Arctic(self.CONNECTION_STRING)
+        self.lib = self.ac.get_library(lib_name)
+
+
+class CompactDataBase(CompactDataLmdbBase):
     def __init__(self):
         self.logger = get_logger()
         self.SYM = "sym"
@@ -37,9 +60,6 @@ class CompactDataBase:
         self.warmup_time = 0
         # Each derived benchmark class takes less than 2 minutes total locally on an SSD
         self.repeat = 15
-        # The same timeout also bounds setup_cache, which has been measured at 36s on the nightly runners, too close to
-        # the 60s asv default to survive a slow disk day without NaN-ing the whole class
-        self.timeout = 600
         self.ac = None
         self.lib = None
         self.base_param_names = [
@@ -69,21 +89,7 @@ class CompactDataBase:
             lib.append(self.SYM, df)
 
     def _setup(self, lib_name, target_rows_per_segment):
-        # Drop both references first, otherwise we keep holding the previous iteration's .mdb files and its LMDB
-        # environment is still open on this path when the next Arctic instance opens it. LMDB does not support that,
-        # and reclaiming the old 400GiB mapping then lands inside the next timed call
-        self.lib = None
-        self.ac = None
-        # A directory left behind by a killed process would otherwise cascade FileExistsError through every remaining
-        # parameter combination of this class
-        shutil.rmtree(self.LMDB_DIR, ignore_errors=True)
-        os.mkdir(self.LMDB_DIR)
-        # Copy the config database and the relevant library database for these benchmark parameters to the actual
-        # LMDB directory where compaction will happen
-        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
-        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
-        self.ac = Arctic(self.CONNECTION_STRING)
-        self.lib = self.ac.get_library(lib_name)
+        self._setup_lmdb_dir(lib_name)
         # Check the compaction will actually do something!
         assert self.lib.compact_data_explain_plan(self.SYM, rows_per_segment=target_rows_per_segment).will_do_work
         # read the symbol to warm up the cache
@@ -263,7 +269,7 @@ class CompactDataNumericDynamicSchema(CompactDataBase):
         self.compact_data(row_params[2])
 
 
-class AppendCompactDataBase:
+class AppendCompactDataBase(CompactDataLmdbBase):
     def __init__(self):
         self.logger = get_logger()
         # Do not interleave benchmarks as they are using the same LMDB directory for actually running the benchmarks
@@ -274,9 +280,6 @@ class AppendCompactDataBase:
         self.warmup_time = 0
         # Total runtime of the 3 derived benchmark classes is ~10m locally on an SSD
         self.repeat = 7
-        # The same timeout also bounds setup_cache, which has been measured at 36s on the nightly runners, too close to
-        # the 60s asv default to survive a slow disk day without NaN-ing the whole class
-        self.timeout = 600
         self.ac = None
         self.lib = None
         self.base_param_names = ["num_symbols", "existing_data_fragmented", "append_rows"]
@@ -296,21 +299,7 @@ class AppendCompactDataBase:
             lib.append_batch([WritePayload(sym, df) for sym in self.SYMS])
 
     def _setup(self, lib_name):
-        # Drop both references first, otherwise we keep holding the previous iteration's .mdb files and its LMDB
-        # environment is still open on this path when the next Arctic instance opens it. LMDB does not support that,
-        # and reclaiming the old 400GiB mapping then lands inside the next timed call
-        self.lib = None
-        self.ac = None
-        # A directory left behind by a killed process would otherwise cascade FileExistsError through every remaining
-        # parameter combination of this class
-        shutil.rmtree(self.LMDB_DIR, ignore_errors=True)
-        os.mkdir(self.LMDB_DIR)
-        # Copy the config database and the relevant library database for these benchmark parameters to the actual
-        # LMDB directory where compaction will happen
-        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
-        shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
-        self.ac = Arctic(self.CONNECTION_STRING)
-        self.lib = self.ac.get_library(lib_name)
+        self._setup_lmdb_dir(lib_name)
         # Read one symbol to warm up the cache. All of the symbols hold identical data written in a single batch, and
         # reading all of them here would dominate the setup time of the slowest classes in this file
         self.lib.read(self.SYMS[0])

--- a/python/benchmarks/compact_data.py
+++ b/python/benchmarks/compact_data.py
@@ -37,6 +37,9 @@ class CompactDataBase:
         self.warmup_time = 0
         # Each derived benchmark class takes less than 2 minutes total locally on an SSD
         self.repeat = 15
+        # The same timeout also bounds setup_cache, which has been measured at 36s on the nightly runners, too close to
+        # the 60s asv default to survive a slow disk day without NaN-ing the whole class
+        self.timeout = 600
         self.ac = None
         self.lib = None
         self.base_param_names = [
@@ -66,14 +69,19 @@ class CompactDataBase:
             lib.append(self.SYM, df)
 
     def _setup(self, lib_name, target_rows_per_segment):
+        # Drop both references first, otherwise we keep holding the previous iteration's .mdb files and its LMDB
+        # environment is still open on this path when the next Arctic instance opens it. LMDB does not support that,
+        # and reclaiming the old 400GiB mapping then lands inside the next timed call
+        self.lib = None
+        self.ac = None
+        # A directory left behind by a killed process would otherwise cascade FileExistsError through every remaining
+        # parameter combination of this class
+        shutil.rmtree(self.LMDB_DIR, ignore_errors=True)
         os.mkdir(self.LMDB_DIR)
         # Copy the config database and the relevant library database for these benchmark parameters to the actual
         # LMDB directory where compaction will happen
         shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
         shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
-        # Create a new Arctic instance, otherwise we will be holding a reference to the previous iteration's .mdb files
-        # and the deletion and recreation won't be noticed by Arctic
-        del self.ac
         self.ac = Arctic(self.CONNECTION_STRING)
         self.lib = self.ac.get_library(lib_name)
         # Check the compaction will actually do something!
@@ -266,6 +274,9 @@ class AppendCompactDataBase:
         self.warmup_time = 0
         # Total runtime of the 3 derived benchmark classes is ~10m locally on an SSD
         self.repeat = 7
+        # The same timeout also bounds setup_cache, which has been measured at 36s on the nightly runners, too close to
+        # the 60s asv default to survive a slow disk day without NaN-ing the whole class
+        self.timeout = 600
         self.ac = None
         self.lib = None
         self.base_param_names = ["num_symbols", "existing_data_fragmented", "append_rows"]
@@ -285,16 +296,24 @@ class AppendCompactDataBase:
             lib.append_batch([WritePayload(sym, df) for sym in self.SYMS])
 
     def _setup(self, lib_name):
+        # Drop both references first, otherwise we keep holding the previous iteration's .mdb files and its LMDB
+        # environment is still open on this path when the next Arctic instance opens it. LMDB does not support that,
+        # and reclaiming the old 400GiB mapping then lands inside the next timed call
+        self.lib = None
+        self.ac = None
+        # A directory left behind by a killed process would otherwise cascade FileExistsError through every remaining
+        # parameter combination of this class
+        shutil.rmtree(self.LMDB_DIR, ignore_errors=True)
         os.mkdir(self.LMDB_DIR)
         # Copy the config database and the relevant library database for these benchmark parameters to the actual
         # LMDB directory where compaction will happen
         shutil.copytree(os.path.join(self.LMDB_BASE_DIR, "_arctic_cfg"), os.path.join(self.LMDB_DIR, "_arctic_cfg"))
         shutil.copytree(os.path.join(self.LMDB_BASE_DIR, lib_name), os.path.join(self.LMDB_DIR, lib_name))
-        # Create a new Arctic instance, otherwise we will be holding a reference to the previous iteration's .mdb files
-        # and the deletion and recreation won't be noticed by Arctic
-        del self.ac
         self.ac = Arctic(self.CONNECTION_STRING)
         self.lib = self.ac.get_library(lib_name)
+        # Read one symbol to warm up the cache. All of the symbols hold identical data written in a single batch, and
+        # reading all of them here would dominate the setup time of the slowest classes in this file
+        self.lib.read(self.SYMS[0])
 
     def _teardown(self):
         shutil.rmtree(self.LMDB_DIR)

--- a/python/benchmarks/compact_data.py
+++ b/python/benchmarks/compact_data.py
@@ -300,9 +300,10 @@ class AppendCompactDataBase(CompactDataLmdbBase):
 
     def _setup(self, lib_name):
         self._setup_lmdb_dir(lib_name)
-        # Read one symbol to warm up the cache. All of the symbols hold identical data written in a single batch, and
-        # reading all of them here would dominate the setup time of the slowest classes in this file
-        self.lib.read(self.SYMS[0])
+        # Warm up the cache, but read a single row rather than the whole symbol. peakmem_* is a process high-water
+        # mark, so a full read here would become the reported peak for the parameter combinations whose append
+        # allocates less than the symbol. One row still pays the cold cost, which is the version and index keys
+        self.lib.read(self.SYMS[0], row_range=(0, 1))
 
     def _teardown(self):
         shutil.rmtree(self.LMDB_DIR)


### PR DESCRIPTION
The `compact_data` benchmarks are noisy enough that they cannot currently gate a regression. Across three asv runs of the **same commit**, the median run-to-run ratio on identical code is **1.28x**; **82% of the 39 parameter combinations exceed the 1.15x** threshold we would want to gate on, and the worst combination moves by **3.04x**. All of that is setup noise rather than anything the timed calls do.

Four causes, each addressed below.

### 1. The previous iteration's LMDB environment is still open

`_setup` did `del self.ac` but left `self.lib` bound, and `self.lib` transitively keeps the library's `LmdbStorage` alive. The old environment was therefore still open on the LMDB path when the next `Arctic()` opened the same path. LMDB does not support opening a path twice in one process, and with the default 400GiB mapsize the two mappings coexist, leaving kernel page reclaim to land inside the next timed call.

Clearing **both** references (`self.lib = None; self.ac = None`) at the top of `_setup` destructs the old storage and drops the LMDB refcount before the directory is recreated and the new environment opened. Verified locally: with `LMDBStorage.WarnIfOpened=all`, the old pattern (drop `ac`, hold `lib`) emits `LMDB path at ... has already been opened in this process` on the reopen, and the new pattern does not. Doing this first, rather than immediately before `Arctic()`, also moves the old mapping's teardown ahead of the `copytree` instead of into the measurement.

### 2. No `timeout`, so asv's 60s default applied

The same `timeout` value also bounds `setup_cache`, which has been measured at 36s on the nightly runners. That is close enough to 60s that one slow disk day fails `setup_cache` and NaNs every benchmark in the class, which shows up as a hole in the series rather than as a result. Set to `600`, matching `ModificationFunctions` in `modification_functions.py`.

### 3. `FileExistsError` cascade from a bare `os.mkdir`

`_setup` called `os.mkdir` on a fixed directory name. `teardown` removes it, but if a process is killed between the two, the directory survives and every subsequent parameter combination of that class fails in setup, not just the one that was interrupted. An `shutil.rmtree(..., ignore_errors=True)` before the `mkdir` makes setup idempotent. Confirmed against the unpatched file: a pre-existing directory raises `FileExistsError: append_compact_data_numeric_static_schema`, and does not after the change.

### 4. `AppendCompactData*` ran cold

`CompactDataBase._setup` gained a `lib.read(...)` warm-up in #3217; `AppendCompactDataBase._setup` never got one, and its three classes are the slowest and coldest benchmarks in the file. Added the equivalent warm-up read.

Two deliberate deviations there:

- The warm-up reads `self.SYMS[0]` only, not all ten symbols. Every symbol is written identical data by a single `append_batch` in `setup_cache`, so one read exercises the same paths, and reading all ten would dominate setup time for exactly the classes this is meant to help.
- **No `will_do_work` assertion.** `CompactDataBase` can assert `compact_data_explain_plan(...).will_do_work` because the timed call is `compact_data` itself. The append classes time `append(..., compact_data=True)`, where compaction runs *after* the append, so an explain plan taken in `_setup` describes the pre-append state and not the work the timed call will do. It would also be wrong for the `existing_data_fragmented=False` half of the parameter matrix, where the cheap no-op compaction path is the thing being measured. Skipped rather than asserted on something misleading.

### Series comparability

None of these edits touch a `setup`, `setup_cache`, `teardown`, or `time_*`/`peakmem_*` body — they are confined to `__init__` and the `_setup` helpers. asv derives a benchmark's version hash from the source of the timed function plus `setup`/`setup_cache`/`teardown` only, so the version hashes are unchanged and the existing history stays comparable rather than being split into a new series. Checked mechanically: all 12 asv-hashed methods in the file (6 classes × `time_`/`peakmem_`) hash identically before and after.

Unchanged version hashes keep the *identity* of each series, not its values. Both the LMDB lifetime fix and the warm-up read change what is measured, so a one-off step will land inside the existing series and register as a regression or improvement rather than starting a fresh one. That is the intended trade for `time_*`: the step is the noise going away, and keeping the pre-fix history visible next to it is more useful than discarding it. For `peakmem_*` it would not have been an acceptable trade, which is why the append warm-up is scoped to a single row instead of materialising the symbol.

### Related

#3217 is where `CompactDataBase._setup` got its warm-up read (fix 4 here is the missing counterpart in `AppendCompactDataBase`); #3280 is where these benchmarks were added; #2882 is the closest prior art for this kind of change.

### Testing

Ran both edited `_setup` paths end to end against a shrunk parameter set (three `setup`/timed-call/`teardown` cycles each, for `AppendCompactDataNumericStaticSchema` and `CompactDataNumericStaticSchema`), including the leftover-directory case, which fails on `master` and passes here. The full asv suite was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGB2G1euu3wVQczjRbrsJv

