### PR TITLE
CI: print sccache stats at the end of every compile job

### DIFF
--- a/.github/workflows/build_steps.yml
+++ b/.github/workflows/build_steps.yml
@@ -500,6 +500,15 @@ jobs:
           name: wheel-${{env.CIBW_BUILD}}
           path: wheelhouse/*.whl
 
+      - name: sccache stats
+        # disable_annotations on the sccache action also returns before its post-job
+        # --show-stats call, so without this step no job reports whether the cache
+        # is hitting at all. Linux wheels compile inside the cibuildwheel container
+        # against the container's own sccache server, so this prints zero requests
+        # there; every other lane compiles against this server.
+        if: always()
+        run: ${SCCACHE_PATH:-sccache} --show-stats || true
+
       - name: Discover test directory names
         if: inputs.job_type == 'build-python-wheels'
         # We only run the compat tests on for newer python versions.


### PR DESCRIPTION
Follow-up to #3376, from investigating why its Windows C++ Tests job looked slow (run 34212169212): the answer was a cold cache — #3378 had just landed touching widely-included headers, and the master run at the same base went equally cold — but reaching that answer took comparing per-object compile times across eight runs, because **no job anywhere prints sccache stats**.

## Why nothing prints them today

`build_steps.yml` passes `disable_annotations: 'true'` to `mozilla-actions/sccache-action` to keep its report out of the summary page. In v0.0.9 the post-job step (`src/show_stats.ts`) checks that flag **first and returns before running `--show-stats` at all**, so suppressing the annotation also suppressed the numbers everywhere: no hit rate, no error count, nothing. A cold cache and a silently broken cache (dead S3 auth, non-cacheable MSVC flags, launcher not applied) currently look identical.

## The change

One fail-soft step after the last compile work in the `compile` job, all lanes, `if: always()`:

```yaml
- name: sccache stats
  if: always()
  run: ${SCCACHE_PATH:-sccache} --show-stats || true
```

`disable_annotations` stays — the summary page remains clean; the stats land in the job log where they are one click away when a build time looks wrong.

Known blind spot, noted in a comment next to the step: Linux wheels compile inside the cibuildwheel container against the container's own sccache server, so the step prints zero requests on that lane. Windows/macOS wheels and all cpp-tests lanes compile against the host server the step queries.

## Not included

While timing the runs: `CMAKE_BUILD_PARALLEL_LEVEL=3` (from `CpuCount.cmake`'s RAM cap) costs ~35% on warm-cache Windows C++ compile steps once #3376 makes the variable take effect — warm builds are S3-latency-bound, not CPU-bound, so the cap only hurts when almost nothing compiles. The workflow already honours the `CMAKE_BUILD_PARALLEL_LEVEL` repo variable, so that is a settings change, not a workflow change, and is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGB2G1euu3wVQczjRbrsJv
