### PR TITLE
Enhancement 18362804801: Support for round-tripping pyarrow record batches, chunked arrays, and arrays, and polars series

### DIFF
--- a/cpp/arcticdb/processing/schema_combine.cpp
+++ b/cpp/arcticdb/processing/schema_combine.cpp
@@ -707,10 +707,30 @@ NormalizationMetadata accumulate_arrow_and_arrow_norm(
             "Cannot {}: cannot combine indexed arrow data with unindexed arrow data",
             options.name()
     );
+    normalization::check<ErrorCode::E_INCOMPATIBLE_OBJECTS>(
+            accumulated.experimental_arrow().one_dimensional() == other.experimental_arrow().one_dimensional(),
+            "Cannot {}: cannot combine single-array arrow data with multi-array arrow data",
+            options.name()
+    );
+    auto res = accumulated;
+    // This correctly allows an unnamed Polars Series to be combined with [Chunked]Array as well as other unnamed Polars
+    // Series for append/update
+    if (res.experimental_arrow().polars_series_name() != other.experimental_arrow().polars_series_name() &&
+        options.name_mismatch == RequiredNameMismatchPolicy::RECONCILE_TO_UNNAMED) {
+        res.mutable_experimental_arrow()->clear_polars_series_name();
+    } else {
+        schema::check<ErrorCode::E_DESCRIPTOR_MISMATCH>(
+                res.experimental_arrow().polars_series_name() == other.experimental_arrow().polars_series_name(),
+                "Cannot {}: cannot combine single-array arrow data with mismatching names {}",
+                options.name(),
+                names_differ(
+                        res.experimental_arrow().polars_series_name(), other.experimental_arrow().polars_series_name()
+                )
+        );
+    }
     // Per-column metadata is merged rather than taking only the base schema's, so that a column only a later
     // schema has keeps what that schema says about it. Presence is checked per column rather than by comparing
     // map sizes, so that a metadata field a future client adds does not make existing data un-appendable.
-    auto res = accumulated;
     auto& res_columns = *res.mutable_experimental_arrow()->mutable_columns();
     util::for_each_key_union(
             accumulated.experimental_arrow().columns(),

--- a/cpp/arcticdb/processing/test/test_schema_combine.cpp
+++ b/cpp/arcticdb/processing/test/test_schema_combine.cpp
@@ -127,6 +127,22 @@ OutputSchema rowcount_df(const std::vector<ColumnSpec>& columns, const std::stri
     return {std::move(desc), std::move(norm)};
 }
 
+OutputSchema arrow_1d_array(
+        DataType data_type, bool has_index = false, const std::optional<std::string>& opt_series_name = std::nullopt
+) {
+    auto index_desc = has_index ? IndexDescriptorImpl{IndexDescriptor::Type::TIMESTAMP, 1}
+                                : IndexDescriptorImpl{IndexDescriptor::Type::ROWCOUNT, 0};
+    StreamDescriptor desc{StreamId{}, index_desc};
+    // __array__ is hard-coded as the name of the singular column in 1D Arrow structures in _normalization.py
+    desc.add_scalar_field(data_type, "__array__");
+    NormalizationMetadata norm;
+    norm.mutable_experimental_arrow()->set_one_dimensional(true);
+    if (opt_series_name.has_value()) {
+        norm.mutable_experimental_arrow()->set_polars_series_name(*opt_series_name);
+    }
+    return {std::move(desc), std::move(norm)};
+}
+
 // Helper to take an `std::vector` so we can pass in an initializer_list like `combine({a, b}, options)`
 OutputSchema combine(std::vector<OutputSchema> schemas, const SchemaCombineOptions& options) {
     return combine_schema(schemas, options);
@@ -595,4 +611,117 @@ TEST(CombineSchema, ThreeSchemasKeepFirstSeenColumnOrder) {
             ColumnSpec{"d", DataType::FLOAT64}
     };
     ASSERT_THAT(columns_of(combined), ElementsAreArray(expected));
+}
+
+TEST(CombineSchema1dArrow, IndexMismatch) {
+    auto array_with_index = arrow_1d_array(DataType::NANOSECONDS_UTC64, true);
+    auto array_without_index = arrow_1d_array(DataType::NANOSECONDS_UTC64, false);
+    for (auto index_first : std::vector<bool>{true, false}) {
+        for (const auto& options : std::vector<SchemaCombineOptions>{
+                     append_options(true),
+                     append_options(false),
+                     update_options(true),
+                     update_options(false),
+                     concat_options(JoinType::OUTER),
+                     concat_options(JoinType::INNER)
+             }) {
+            ASSERT_THROW(
+                    combine({index_first ? array_with_index : array_without_index,
+                             index_first ? array_without_index : array_with_index},
+                            options),
+                    NormalizationException
+            );
+        }
+    }
+}
+
+TEST(CombineSchema1dArrow, UnnamedSeries) {
+    auto array_without_name = arrow_1d_array(DataType::INT64);
+    auto array_with_empty_name = arrow_1d_array(DataType::INT64, false, "");
+    for (auto empty_name_first : std::vector<bool>{true, false}) {
+        for (const auto& options : std::vector<SchemaCombineOptions>{
+                     append_options(true),
+                     append_options(false),
+                     update_options(true),
+                     update_options(false),
+                     concat_options(JoinType::OUTER),
+                     concat_options(JoinType::INNER)
+             }) {
+            auto combined =
+                    combine({empty_name_first ? array_with_empty_name : array_without_name,
+                             empty_name_first ? array_without_name : array_with_empty_name},
+                            options);
+            const std::array expected{ColumnSpec{"__array__", DataType::INT64}};
+            ASSERT_THAT(columns_of(combined), ElementsAreArray(expected));
+            ASSERT_TRUE(combined.norm_metadata_.has_experimental_arrow());
+            ASSERT_TRUE(combined.norm_metadata_.experimental_arrow().one_dimensional());
+            // Can either be from the optional not being populated, or being populated with an empty string. Both are
+            // handled the same
+            ASSERT_EQ(combined.norm_metadata_.experimental_arrow().polars_series_name(), "");
+        }
+    }
+}
+
+TEST(CombineSchema1dArrow, SeriesNameMismatchAppendUpdate) {
+    auto array_without_name = arrow_1d_array(DataType::INT64);
+    auto array_with_empty_name = arrow_1d_array(DataType::INT64, false, "");
+    auto array_with_name_1 = arrow_1d_array(DataType::INT64, false, "name_1");
+    auto array_with_name_2 = arrow_1d_array(DataType::INT64, false, "name_2");
+    for (auto schemas : std::vector<std::vector<OutputSchema>>{
+                 {array_without_name, array_with_name_1},
+                 {array_with_name_1, array_without_name},
+                 {array_with_empty_name, array_with_name_1},
+                 {array_with_name_1, array_with_empty_name},
+                 {array_with_name_1, array_with_name_2}
+         }) {
+        for (const auto& options : std::vector<SchemaCombineOptions>{
+                     append_options(true), append_options(false), update_options(true), update_options(false)
+             }) {
+            ASSERT_THROW(combine(schemas, options), SchemaException);
+        }
+    }
+}
+
+TEST(CombineSchema1dArrow, SeriesNameMismatchConcat) {
+    auto array_without_name = arrow_1d_array(DataType::INT64);
+    auto array_with_empty_name = arrow_1d_array(DataType::INT64, false, "");
+    auto array_with_name_1 = arrow_1d_array(DataType::INT64, false, "name_1");
+    auto array_with_name_2 = arrow_1d_array(DataType::INT64, false, "name_2");
+    std::vector<OutputSchema> schemas{array_without_name, array_with_empty_name, array_with_name_1, array_with_name_2};
+    for (const auto& first_schema : schemas) {
+        for (const auto& second_schema : schemas) {
+            for (const auto& options :
+                 std::vector<SchemaCombineOptions>{concat_options(JoinType::OUTER), concat_options(JoinType::INNER)}) {
+                auto combined = combine({first_schema, second_schema}, options);
+                if (&first_schema == &schemas[2] && &second_schema == &schemas[2]) {
+                    ASSERT_EQ(combined.norm_metadata_.experimental_arrow().polars_series_name(), "name_1");
+                } else if (&first_schema == &schemas[3] && &second_schema == &schemas[3]) {
+                    ASSERT_EQ(combined.norm_metadata_.experimental_arrow().polars_series_name(), "name_2");
+                } else {
+                    ASSERT_EQ(combined.norm_metadata_.experimental_arrow().polars_series_name(), "");
+                }
+            }
+        }
+    }
+}
+
+TEST(CombineSchema1dArrow, CombineWithTable) {
+    auto array_1d = arrow_1d_array(DataType::INT64);
+    auto table = arrow_1d_array(DataType::INT64);
+    table.norm_metadata_.mutable_experimental_arrow()->set_one_dimensional(false);
+    for (auto table_first : std::vector<bool>{true, false}) {
+        for (const auto& options : std::vector<SchemaCombineOptions>{
+                     append_options(true),
+                     append_options(false),
+                     update_options(true),
+                     update_options(false),
+                     concat_options(JoinType::OUTER),
+                     concat_options(JoinType::INNER)
+             }) {
+            ASSERT_THROW(
+                    combine({table_first ? table : array_1d, table_first ? array_1d : table}, options),
+                    NormalizationException
+            );
+        }
+    }
 }

--- a/cpp/proto/arcticc/pb2/descriptors.proto
+++ b/cpp/proto/arcticc/pb2/descriptors.proto
@@ -240,6 +240,11 @@ message NormalizationMetadata {
 
         bool has_index = 1;
         map<string, ColumnMeta> columns = 2;
+        // True for Polars series, and PyArrow chunked arrays and arrays. False for Polars dataframes, and PyArrow
+        // tables and record batches
+        bool one_dimensional = 3;
+        // Set only when data written is a Polars Series
+        optional string polars_series_name = 4;
     }
 
     oneof input_type {

--- a/python/arcticdb/util/arrow.py
+++ b/python/arcticdb/util/arrow.py
@@ -49,8 +49,8 @@ def convert_arrow_to_pandas_for_tests(table):
 
 
 def to_pyarrow_table(
-    arrow_structure: Union[pa.Table, pa.RecordBatch, pa.ChunkedArray, pa.Array, pl.DataFrame, pl.Series],
-) -> pa.Table:
+    arrow_structure: "Union[pa.Table, pa.RecordBatch, pa.ChunkedArray, pa.Array, pl.DataFrame, pl.Series]",
+) -> "pa.Table":
     if isinstance(arrow_structure, NORMALIZABLE_POLARS_TYPES):
         if not _PYARROW_AVAILABLE:
             raise ModuleNotFoundError(

--- a/python/arcticdb/util/arrow.py
+++ b/python/arcticdb/util/arrow.py
@@ -1,4 +1,10 @@
-from arcticdb.dependencies import pyarrow as pa
+from typing import Union
+
+from arcticdb.dependencies import _PYARROW_AVAILABLE, _POLARS_AVAILABLE, pyarrow as pa, polars as pl
+from arcticdb.exceptions import ArcticUnsupportedDataTypeException
+
+NORMALIZABLE_PYARROW_TYPES = (pa.Table, pa.RecordBatch, pa.ChunkedArray, pa.Array) if _PYARROW_AVAILABLE else tuple()
+NORMALIZABLE_POLARS_TYPES = (pl.DataFrame, pl.Series) if _POLARS_AVAILABLE else tuple()
 
 
 def cast_string_columns(table, string_type=None):
@@ -40,3 +46,27 @@ def convert_arrow_to_pandas_for_tests(table):
             new_col = new_table.column(i).fill_null(False)
             new_table = new_table.set_column(i, name, new_col)
     return new_table.to_pandas()
+
+
+def to_pyarrow_table(
+    arrow_structure: Union[pa.Table, pa.RecordBatch, pa.ChunkedArray, pa.Array, pl.DataFrame, pl.Series],
+) -> pa.Table:
+    if isinstance(arrow_structure, NORMALIZABLE_POLARS_TYPES):
+        if not _PYARROW_AVAILABLE:
+            raise ModuleNotFoundError(
+                "ArcticDB's pyarrow optional dependency is missing and is required for working with polars DataFrames."
+            )
+        if isinstance(arrow_structure, pl.Series):
+            # For some reason to_arrow() on a pl.DataFrame maintains the chunking and so is zero-copy, but on a
+            # pl.Series it copies into a pa.Array if the Series was chunked
+            arrow_structure = arrow_structure.to_frame().to_arrow().column(0)
+        else:  # pl.DataFrame
+            arrow_structure = arrow_structure.to_arrow()
+    if isinstance(arrow_structure, (pa.ChunkedArray, pa.Array)):
+        arrow_structure = pa.Table.from_arrays([arrow_structure], names=["__array__"])
+    elif isinstance(arrow_structure, pa.RecordBatch):
+        arrow_structure = pa.Table.from_batches([arrow_structure])
+    elif not isinstance(arrow_structure, pa.Table):
+        # Should be unreachable due to checks in get_normalizer_for_type
+        raise ArcticUnsupportedDataTypeException(f"Unsupported Arrow type: {type(arrow_structure)}")
+    return arrow_structure

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -763,9 +763,9 @@ class ArrowTableNormalizer(Normalizer):
 
     def normalize(self, arrow_structure, **kwargs):
         norm_metadata = NormalizationMetadata()
-        norm_metadata.experimental_arrow.one_dimensional = isinstance(
-            arrow_structure, (pa.ChunkedArray, pa.Array, pl.Series)
-        )
+        norm_metadata.experimental_arrow.one_dimensional = (
+            _PYARROW_AVAILABLE and isinstance(arrow_structure, (pa.ChunkedArray, pa.Array))
+        ) or (_POLARS_AVAILABLE and isinstance(arrow_structure, pl.Series))
         if _POLARS_AVAILABLE and isinstance(arrow_structure, pl.Series):
             norm_metadata.experimental_arrow.polars_series_name = arrow_structure.name
         arrow_structure = to_pyarrow_table(arrow_structure)

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -766,7 +766,7 @@ class ArrowTableNormalizer(Normalizer):
         norm_metadata.experimental_arrow.one_dimensional = isinstance(
             arrow_structure, (pa.ChunkedArray, pa.Array, pl.Series)
         )
-        if isinstance(arrow_structure, pl.Series):
+        if _POLARS_AVAILABLE and isinstance(arrow_structure, pl.Series):
             norm_metadata.experimental_arrow.polars_series_name = arrow_structure.name
         arrow_structure = to_pyarrow_table(arrow_structure)
         if arrow_structure.num_rows == 0:
@@ -1916,7 +1916,7 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
     elif isinstance(data, NORMALIZABLE_PYARROW_TYPES + NORMALIZABLE_POLARS_TYPES):
         check(index_column, "Cannot update with pyarrow Table without specifying index_column=True")
         original_type = type(data)
-        original_name = data.name if original_type == pl.Series else None
+        original_name = data.name if _POLARS_AVAILABLE and original_type == pl.Series else None
         # PyArrow binary search + slice is benchmarked faster than polars native filtering
         # (filter/is_between with set_sorted), which materializes a boolean mask over the
         # entire column. The result is a zero-copy pa.Table view.

--- a/python/arcticdb/version_store/_normalization.py
+++ b/python/arcticdb/version_store/_normalization.py
@@ -43,10 +43,12 @@ from collections import Counter
 from arcticdb.exceptions import (
     ArcticNativeException,
     ArcticDbNotYetImplemented,
+    ArcticUnsupportedDataTypeException,
     NormalizationException,
     UnsortedDataException,
 )
 from arcticdb.supported_types import DateRangeInput, time_types as supported_time_types
+from arcticdb.util.arrow import NORMALIZABLE_PYARROW_TYPES, NORMALIZABLE_POLARS_TYPES, to_pyarrow_table
 from arcticdb.util._versions import IS_PANDAS_TWO, IS_PANDAS_ZERO
 from arcticdb_ext.version_store import PandasData, RecordBatchData, SortedValue as _SortedValue
 from pandas.core.internals import make_block
@@ -101,7 +103,6 @@ def _tz_error_context():
 
 
 NormalizedInput = NamedTuple("NormalizedInput", [("item", PandasData), ("metadata", NormalizationMetadata)])
-
 
 _PICKLED_METADATA_LOGLEVEL = None  # set lazily with function below
 
@@ -760,29 +761,30 @@ class ArrowTableNormalizer(Normalizer):
             new_columns, schema=pa.schema(new_fields).with_metadata({b"pandas": json.dumps(pandas_metadata)})
         )
 
-    def normalize(self, table, **kwargs):
-        if _POLARS_AVAILABLE and isinstance(table, pl.DataFrame):
-            if not _PYARROW_AVAILABLE:
-                raise ModuleNotFoundError(
-                    "ArcticDB's pyarrow optional dependency is missing and is required for working with polars DataFrames."
-                )
-            table = table.to_arrow()
-        if table.num_rows == 0:
+    def normalize(self, arrow_structure, **kwargs):
+        norm_metadata = NormalizationMetadata()
+        norm_metadata.experimental_arrow.one_dimensional = isinstance(
+            arrow_structure, (pa.ChunkedArray, pa.Array, pl.Series)
+        )
+        if isinstance(arrow_structure, pl.Series):
+            norm_metadata.experimental_arrow.polars_series_name = arrow_structure.name
+        arrow_structure = to_pyarrow_table(arrow_structure)
+        if arrow_structure.num_rows == 0:
             # to_batches has a bug https://github.com/apache/arrow/issues/49309 so that it returns an empty list when
             # the table has zero rows, losing the schema information
             pa_record_batches = [
                 pa.RecordBatch.from_arrays(
-                    [chunked_array.chunk(0) for chunked_array in table.itercolumns()], schema=table.schema
+                    [chunked_array.chunk(0) for chunked_array in arrow_structure.itercolumns()],
+                    schema=arrow_structure.schema,
                 )
             ]
         else:
-            pa_record_batches = table.to_batches()
+            pa_record_batches = arrow_structure.to_batches()
         arcticdb_record_batches = []
         for pa_record_batch in pa_record_batches:
             arcticdb_record_batch = RecordBatchData()
             pa_record_batch._export_to_c(arcticdb_record_batch.array(), arcticdb_record_batch.schema())
             arcticdb_record_batches.append(arcticdb_record_batch)
-        norm_metadata = NormalizationMetadata()
         norm_metadata.experimental_arrow.has_index = kwargs.get("index_column", False)
         return arcticdb_record_batches, norm_metadata
 
@@ -836,7 +838,14 @@ class ArrowTableNormalizer(Normalizer):
             # For pandas series we always return a dataframe (to not lose the index information).
             pandas_meta = norm_meta.series.common
         elif input_type == "experimental_arrow":
-            return item
+            if norm_meta.experimental_arrow.one_dimensional:
+                check(
+                    item.num_columns == 1,
+                    f"Unexpected {item.num_columns} column Arrow table read for single-array output",
+                )
+                return item.column(0)
+            else:
+                return item
         else:
             raise ArcticNativeException(f"Expected dataframe or series input, actual: {input_type}")
 
@@ -1656,9 +1665,9 @@ class CompositeNormalizer(Normalizer):
             return self.np.normalize
 
         if allow_arrow_input:
-            if _PYARROW_AVAILABLE and isinstance(item, pa.Table):
+            if isinstance(item, NORMALIZABLE_PYARROW_TYPES):
                 return self.pa.normalize
-            if _POLARS_AVAILABLE and isinstance(item, pl.DataFrame):
+            if isinstance(item, NORMALIZABLE_POLARS_TYPES):
                 return self.pa.normalize
 
         if self.fallback_normalizer is not None:
@@ -1904,18 +1913,14 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
             # of duplicating exception messages.
             raise UnsortedDataException("E_UNSORTED_DATA When calling update, the input data must be sorted.")
         data = data.loc[pd.to_datetime(start) : pd.to_datetime(end)]
-    elif _PYARROW_AVAILABLE and isinstance(data, pa.Table) or _POLARS_AVAILABLE and isinstance(data, pl.DataFrame):
-        if _POLARS_AVAILABLE and isinstance(data, pl.DataFrame):
-            if not _PYARROW_AVAILABLE:
-                raise ModuleNotFoundError(
-                    "ArcticDB's pyarrow optional dependency is missing and is required for working with polars DataFrames."
-                )
-            # PyArrow binary search + slice is benchmarked faster than polars native filtering
-            # (filter/is_between with set_sorted), which materializes a boolean mask over the
-            # entire column. The result is a zero-copy pa.Table view which the caller's
-            # normalizer accepts directly, avoiding a needless round-trip back to polars.
-            data = data.to_arrow()
+    elif isinstance(data, NORMALIZABLE_PYARROW_TYPES + NORMALIZABLE_POLARS_TYPES):
         check(index_column, "Cannot update with pyarrow Table without specifying index_column=True")
+        original_type = type(data)
+        original_name = data.name if original_type == pl.Series else None
+        # PyArrow binary search + slice is benchmarked faster than polars native filtering
+        # (filter/is_between with set_sorted), which materializes a boolean mask over the
+        # entire column. The result is a zero-copy pa.Table view.
+        data = to_pyarrow_table(data)
         col_name = data.column_names[0]
         if not data.column(col_name).type.tz:
             # Matches pandas behavior to strip the timezone if index column is timezone naive.
@@ -1926,6 +1931,13 @@ def restrict_data_to_date_range_only(data: T, *, start: Timestamp, end: Timestam
         # TODO: Decide on a consistent way to deal with unsorted index column. E.g. a flag `validate_index`
         # which will enable the index sortedness check. (monday ref: 11668250872)
         data = _filter_pyarrow_table_to_date_range(data, col_name, start, end)
+        if issubclass(original_type, NORMALIZABLE_POLARS_TYPES):
+            data = pl.from_arrow(data, rechunk=False)
+            if issubclass(original_type, pl.Series):
+                data = data.to_series(0).rename(original_name)
+        else:  # issubclass(original_type, NORMALIZABLE_PYARROW_TYPES)
+            if issubclass(original_type, (pa.ChunkedArray, pa.Array)):
+                data = data.column(0)
     else:  # non-Pandas, try to slice it anyway
         if not getattr(data, "timezone", None):
             start, end = _strip_tz(start, end)

--- a/python/arcticdb/version_store/_store.py
+++ b/python/arcticdb/version_store/_store.py
@@ -2966,6 +2966,8 @@ class NativeVersionStore:
                 and not norm.WhichOneof("input_type") == "msg_pack_frame"
             ):
                 data = pl.from_arrow(data, rechunk=False)
+                if isinstance(data, pl.Series) and norm.WhichOneof("input_type") == "experimental_arrow":
+                    data = data.rename(norm.experimental_arrow.polars_series_name)
                 data = self._apply_polars_sorted_flag_to_index(data, sort_order, norm)
         else:
             data = self._normalizer.denormalize(frame_data, norm)
@@ -2981,11 +2983,16 @@ class NativeVersionStore:
         # safely tell Polars the column is sorted.
         if sort_order not in (SortedValue.ASCENDING, SortedValue.DESCENDING):
             return data
-        if not _has_physically_stored_index(norm) or len(data.columns) == 0:
+        if not _has_physically_stored_index(norm):
             return data
-        # The index column is always the first column.
-        index_col = data.columns[0]
-        return data.with_columns(pl.col(index_col).set_sorted(descending=(sort_order == SortedValue.DESCENDING)))
+        if isinstance(data, pl.DataFrame):
+            if len(data.columns) == 0:
+                return data
+            # The index column is always the first column.
+            index_col = data.columns[0]
+            return data.with_columns(pl.col(index_col).set_sorted(descending=(sort_order == SortedValue.DESCENDING)))
+        else:  # Series
+            return data.set_sorted(descending=(sort_order == SortedValue.DESCENDING))
 
     def _adapt_read_res(self, read_result: ReadResult, output_format: OutputFormat) -> VersionedItem:
         data = self._adapt_frame_data(read_result.frame_data, read_result.norm, output_format, read_result.sort_order)
@@ -3885,6 +3892,10 @@ class NativeVersionStore:
                 columns = pd.RangeIndex(0, len(columns))
         elif input_type == "experimental_arrow":
             arrow_meta = timeseries_descriptor.normalization.experimental_arrow
+            if arrow_meta.one_dimensional:
+                # This correctly gives an empty string for Array/ChunkedArray written data as well as Series with empty
+                # names
+                columns[0] = arrow_meta.polars_series_name
             if arrow_meta.has_index:
                 index = [columns.pop(0)]
                 index_dtype = [dtypes.pop(0)]
@@ -3919,8 +3930,16 @@ class NativeVersionStore:
         read_query = self._get_read_query(date_range=None, row_range=None, columns=columns, query_builder=query_builder)
         record_batch, norm = _modify_schema(preloaded_index, read_query, read_options)
         record_batch = pa.RecordBatch._import_from_c(record_batch.array(), record_batch.schema())
-        data = self._normalizer.denormalize(pa.Table.from_batches([record_batch]), norm)
-        return pl.Schema(data.schema)
+        data = pl.from_arrow(self._normalizer.denormalize(pa.Table.from_batches([record_batch]), norm))
+        if isinstance(data, pl.DataFrame):
+            return data.schema
+        else:  # Series
+            name = (
+                norm.experimental_arrow.polars_series_name
+                if norm.WhichOneof("input_type") == "experimental_arrow"
+                else ""
+            )
+            return pl.Schema({name: data.dtype})
 
     def _get_info(self, symbol: str, version: Optional[VersionQueryInput] = None, **kwargs):
         version_query = self._get_version_query(version, **kwargs)

--- a/python/arcticdb/version_store/library.py
+++ b/python/arcticdb/version_store/library.py
@@ -30,6 +30,7 @@ from arcticdb.options import LibraryOptions, EnterpriseLibraryOptions, OutputFor
 from arcticc.pb2.descriptors_pb2 import TypeDescriptor
 from arcticdb.preconditions import check
 from arcticdb.supported_types import Timestamp
+from arcticdb.util.arrow import NORMALIZABLE_PYARROW_TYPES, NORMALIZABLE_POLARS_TYPES
 from arcticdb.util._versions import IS_PANDAS_TWO
 
 from arcticdb.version_store.processing import ExpressionNode, QueryBuilder
@@ -924,9 +925,9 @@ class Library:
         if isinstance(data, NORMALIZABLE_TYPES):
             return True
         if self._nvs._allow_arrow_input:
-            if _PYARROW_AVAILABLE and isinstance(data, pa.Table):
+            if isinstance(data, NORMALIZABLE_PYARROW_TYPES):
                 return True
-            if _POLARS_AVAILABLE and isinstance(data, pl.DataFrame):
+            if isinstance(data, NORMALIZABLE_POLARS_TYPES):
                 return True
         return False
 

--- a/python/tests/unit/arcticdb/test_arrow_api.py
+++ b/python/tests/unit/arcticdb/test_arrow_api.py
@@ -3,6 +3,7 @@ import pandas as pd
 import pyarrow as pa
 import pyarrow.compute as pc
 import polars as pl
+from polars.testing import assert_series_equal as polars_assert_series_equal
 import pytest
 
 from arcticdb import LazyDataFrame, DataError, concat
@@ -10,7 +11,8 @@ from arcticdb.exceptions import ArcticNativeException, ArcticUnsupportedDataType
 from arcticdb.options import OutputFormat, ArrowOutputStringFormat, LibraryOptions
 from arcticdb.util.test import assert_frame_equal_with_arrow, sample_dataframe
 
-from arcticdb.version_store.library import WritePayload, UpdatePayload, ReadRequest
+from arcticdb.version_store.library import ArcticUnsupportedDataTypeException, WritePayload, UpdatePayload, ReadRequest
+from tests.util.arrow import create_1d_arrow_structure
 
 all_output_format_args = [
     None,
@@ -486,3 +488,63 @@ def test_arrow_written_data_get_info_timeseries(mem_library, table, tz, has_inde
         assert desc.sorted == "ASCENDING"
     else:
         assert desc.sorted == "UNKNOWN"
+
+
+# See test with the same name in test_arrow_read.py for V1 API equivalent
+@pytest.mark.parametrize("timeseries", [False, True])
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_arrow_written_1d_data_get_info(mem_library, timeseries, input_type):
+    lib = mem_library
+    sym = "test_arrow_written_1d_data_get_info"
+    lib._nvs._set_allow_arrow_input()
+    data = (
+        pa.Array.from_pandas(pd.date_range("2026-01-01", periods=10), type=pa.timestamp("ns"))
+        if timeseries
+        else pa.array(np.arange(10), pa.int64())
+    )
+    input = create_1d_arrow_structure(input_type, data)
+    lib.write(sym, input, index_column=timeseries)
+    desc = lib.get_description(sym)
+    assert len(desc.columns) == (0 if timeseries else 1)
+    if not timeseries:
+        assert desc.columns[0].name == ("series_name" if input_type == "NamedSeries" else "")
+    assert len(desc.index) == (1 if timeseries else 0)
+    if timeseries:
+        assert desc.index[0].name == ("series_name" if input_type == "NamedSeries" else "")
+    if timeseries:
+        assert "NANOSECONDS_UTC64" in str(desc.index[0].dtype)
+    else:
+        assert "INT64" in str(desc.columns[0].dtype)
+    if timeseries:
+        assert desc.date_range == (data.to_pandas()[0], data.to_pandas()[9])
+    else:
+        assert np.isnat(desc.date_range[0]) and np.isnat(desc.date_range[1])
+    assert desc.index_type == "NA"
+    assert desc.row_count == 10
+    assert desc.sorted == ("ASCENDING" if timeseries else "UNKNOWN")
+
+
+# Main tests for this are in test_arrow_writes.py, this is mainly to test that the additional type validation present in
+# the V2 API allows these structures through
+@pytest.mark.parametrize(
+    "input_output",
+    [
+        (pa.array([0], pa.int64()), pa.chunked_array([[0]], pa.int64())),
+        (pa.chunked_array([[0], [1]], pa.int64()), pa.chunked_array([[0, 1]], pa.int64())),
+        (pa.record_batch({"col": pa.array([0], pa.int64())}), pa.table({"col": pa.array([0], pa.int64())})),
+        (pl.Series(values=[0], dtype=pl.Int64), pl.Series(values=[0], dtype=pl.Int64)),
+    ],
+)
+def test_roundtrip_lower_level_arrow_primitives(mem_library, input_output):
+    input, output = input_output
+    lib = mem_library
+    sym = "test_roundtrip_lower_level_arrow_primitives"
+    lib._nvs._set_allow_arrow_input()
+    lib.write(sym, input)
+    assert not lib._nvs.is_symbol_pickled(sym)
+    if isinstance(input, pl.Series):
+        received = lib.read(sym, output_format="polars").data
+        polars_assert_series_equal(received, output)
+    else:
+        received = lib.read(sym, output_format="pyarrow").data
+        assert received.equals(output)

--- a/python/tests/unit/arcticdb/test_arrow_api.py
+++ b/python/tests/unit/arcticdb/test_arrow_api.py
@@ -11,7 +11,7 @@ from arcticdb.exceptions import ArcticNativeException, ArcticUnsupportedDataType
 from arcticdb.options import OutputFormat, ArrowOutputStringFormat, LibraryOptions
 from arcticdb.util.test import assert_frame_equal_with_arrow, sample_dataframe
 
-from arcticdb.version_store.library import ArcticUnsupportedDataTypeException, WritePayload, UpdatePayload, ReadRequest
+from arcticdb.version_store.library import WritePayload, UpdatePayload, ReadRequest
 from tests.util.arrow import create_1d_arrow_structure
 
 all_output_format_args = [

--- a/python/tests/unit/arcticdb/version_store/test_arrow_pandas_interop.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_pandas_interop.py
@@ -601,9 +601,6 @@ def test_write_arrow_chunked_array_read_pandas(in_memory_version_store_arrow):
     assert_series_equal(pd.Series(np.arange(1, 4, dtype=np.int64)), received)
 
 
-@pytest.mark.xfail(
-    reason="pyarrow RecordBatch input should read back as a pandas DataFrame, not be pickled", strict=True
-)
 def test_write_arrow_record_batch_read_pandas(in_memory_version_store_arrow):
     lib = in_memory_version_store_arrow
     sym = "test_write_arrow_record_batch_read_pandas"

--- a/python/tests/unit/arcticdb/version_store/test_arrow_read.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_read.py
@@ -25,7 +25,7 @@ from arcticdb.util.test import get_sample_dataframe, make_dynamic
 from arcticdb.util._versions import IS_PANDAS_ONE
 from arcticdb_ext.storage import KeyType
 from tests.util.mark import WINDOWS
-from tests.util.arrow import arrow_output_string_format_to_pa_type
+from tests.util.arrow import arrow_output_string_format_to_pa_type, create_1d_arrow_structure
 
 
 def test_basic(lmdb_version_store_arrow):
@@ -1413,3 +1413,36 @@ def test_arrow_written_data_get_info_timeseries(in_memory_version_store_arrow, t
         assert info["sorted"] == "ASCENDING"
     else:
         assert info["sorted"] == "UNKNOWN"
+
+
+# See test with the same name in test_arrow_api.py for V2 API equivalent
+@pytest.mark.parametrize("timeseries", [False, True])
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_arrow_written_1d_data_get_info(in_memory_version_store_arrow, timeseries, input_type):
+    lib = in_memory_version_store_arrow
+    sym = "test_arrow_written_1d_data_get_info"
+    data = (
+        pa.Array.from_pandas(pd.date_range("2026-01-01", periods=10), type=pa.timestamp("ns"))
+        if timeseries
+        else pa.array(np.arange(10), pa.int64())
+    )
+    input = create_1d_arrow_structure(input_type, data)
+    lib.write(sym, input, validate_index=True, index_column=timeseries)
+    info = lib.get_info(sym)
+    assert info["col_names"]["columns"] == (
+        [] if timeseries else ["series_name" if input_type == "NamedSeries" else ""]
+    )
+    assert len(info["dtype"]) == (0 if timeseries else 1)
+    if not timeseries:
+        assert "INT64" in str(info["dtype"][0])
+    assert len(info["col_names"]["index"]) == (1 if timeseries else 0)
+    assert len(info["col_names"]["index_dtype"]) == (1 if timeseries else 0)
+    assert info["rows"] == 10
+    assert info["input_type"] == "experimental_arrow"
+    assert info["index_type"] == "NA"
+    assert info["type"] == "arrow"
+    if timeseries:
+        assert info["date_range"] == (data.to_pandas()[0], data.to_pandas()[9])
+    else:
+        assert np.isnat(info["date_range"][0]) and np.isnat(info["date_range"][1])
+    assert info["sorted"] == ("ASCENDING" if timeseries else "UNKNOWN")

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -1292,14 +1292,14 @@ def test_update_with_date_range_wider_than_data_1d(in_memory_version_store_arrow
         pytest.param((pd.Timestamp("2025-01-04"), pd.Timestamp("2025-01-03")), id="start_gt_end"),
         pytest.param(
             (
-                pd.Timestamp("2025-01-03 12:00:00", tz="US/Eastern"),
-                pd.Timestamp("2025-01-04 12:00:00", tz="US/Eastern"),
+                pd.Timestamp("2025-01-03 12:00:00", tz="America/New_York"),
+                pd.Timestamp("2025-01-04 12:00:00", tz="America/New_York"),
             ),
             id="tz_aware_date_range",
         ),
     ],
 )
-@pytest.mark.parametrize("index_tz", [None, "UTC", "US/Eastern"])
+@pytest.mark.parametrize("index_tz", [None, "UTC", "America/New_York"])
 def test_update_with_date_range_narrower_than_data(
     in_memory_version_store_arrow, date_range, index_tz, arrow_output_format
 ):

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -1299,7 +1299,7 @@ def test_update_with_date_range_wider_than_data_1d(in_memory_version_store_arrow
         ),
     ],
 )
-@pytest.mark.parametrize("index_tz", [None, "UTC", "America/New_York"])
+@pytest.mark.parametrize("index_tz", [None, "Etc/UTC", "America/New_York"])
 def test_update_with_date_range_narrower_than_data(
     in_memory_version_store_arrow, date_range, index_tz, arrow_output_format
 ):

--- a/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
+++ b/python/tests/unit/arcticdb/version_store/test_arrow_writes.py
@@ -13,10 +13,13 @@ import hypothesis.strategies as st
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import pyarrow.compute as pc
 import polars as pl
+from polars.testing import assert_series_equal as polars_assert_series_equal
 import pytest
 from arcticdb import DataError
 from arcticdb.exceptions import (
+    NormalizationException,
     SchemaException,
     StreamDescriptorMismatch,
     UserInputException,
@@ -36,6 +39,7 @@ from arcticdb_ext.storage import KeyType
 from tests.util.arrow import (
     arrow_output_string_format_to_pa_type,
     assert_arrow_equal,
+    create_1d_arrow_structure,
     deep_copy,
     to_format,
     undictionarify_table,
@@ -50,6 +54,299 @@ def assert_inputs_not_modified(*inputs):
     yield
     for inp, original in zip(inputs, originals):
         assert_arrow_equal(original, inp)
+
+
+# A RecordBatch is converted to a Table with 1 row-slice early on during normalization, and follows the exact same code
+# path as reading Table/DataFrame on read, so minimal testing is required for this
+@pytest.mark.parametrize("index_column", [False, True])
+@pytest.mark.parametrize("num_rows", [0, 2, 4])  # Empty/unsliced/sliced on disk
+def test_roundtrip_record_batch(in_memory_version_store_tiny_segment_arrow, index_column, num_rows):
+    lib = in_memory_version_store_tiny_segment_arrow
+    sym = "test_roundtrip_record_batch"
+    rb = pa.record_batch(
+        {
+            "ts": pa.Array.from_pandas(pd.date_range("2026-01-01", periods=num_rows), type=pa.timestamp("ns")),
+            "col": pa.array(np.arange(num_rows), type=pa.int64()),
+        }
+    )
+    lib.write(sym, rb, index_column=index_column)
+    assert not lib.is_symbol_pickled(sym)
+    assert lib.get_info(sym)["col_names"]["index"] == (["ts"] if index_column else [])
+    received = lib.read(sym).data
+    expected = pa.Table.from_batches([rb])
+    assert received.equals(expected)
+
+
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize("input_rows", [0, 2, 10])
+def test_roundtrip_1d_arrow_structures(in_memory_version_store_tiny_segment_arrow, input_type, input_rows):
+    lib = in_memory_version_store_tiny_segment_arrow
+    sym = "test_roundtrip_1d_arrow_structures"
+    data = pa.array(np.arange(input_rows), pa.int64())
+    input = create_1d_arrow_structure(input_type, data)
+    lib.write(sym, input)
+    assert not lib.is_symbol_pickled(sym)
+
+    received_pa = lib.read(sym).data
+    assert isinstance(received_pa, pa.ChunkedArray)
+    assert received_pa.num_chunks == (1 if input_rows == 0 else input_rows // 2)
+    expected_pa = create_1d_arrow_structure("ChunkedArray", data)
+    assert received_pa.equals(expected_pa)
+
+    received_pl = lib.read(sym, output_format="polars").data
+    assert isinstance(received_pl, pl.Series)
+    assert received_pl.n_chunks() == (1 if input_rows == 0 else input_rows // 2)
+    expected_pl = create_1d_arrow_structure("NamedSeries" if input_type == "NamedSeries" else "UnnamedSeries", data)
+    polars_assert_series_equal(received_pl, expected_pl)
+
+
+def test_write_chunked_series(in_memory_version_store_arrow):
+    lib = in_memory_version_store_arrow
+    sym = "test_write_chunked_series"
+    series = pl.concat([pl.Series(values=[0]), pl.Series(values=[1])], rechunk=False)
+    assert series.n_chunks() == 2
+    lib.write(sym, series)
+    assert not lib.is_symbol_pickled(sym)
+    received = lib.read(sym, output_format="polars").data
+    assert received.n_chunks() == 1
+    polars_assert_series_equal(received, series)
+
+
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize(
+    "data",
+    [
+        pa.array(np.arange(4), pa.int64()),
+        pa.Array.from_pandas(pd.date_range("2026-01-01", periods=4), type=pa.timestamp("ns")),
+    ],
+)
+def test_1d_arrow_structures_index_column(in_memory_version_store_tiny_segment_arrow, input_type, data):
+    lib = in_memory_version_store_tiny_segment_arrow
+    sym = "test_roundtrip_1d_arrow_structures"
+    input = create_1d_arrow_structure(input_type, data)
+    if data.type == pa.int64():
+        with pytest.raises(UserInputException):
+            lib.write(sym, input, index_column=True)
+    else:  # Time-type, writing just an index is allowed
+        # Validate index sets the sort order on the output
+        lib.write(sym, input, validate_index=True, index_column=True)
+        assert not lib.is_symbol_pickled(sym)
+        # Read as Polars as this preserves the series name if it was present
+        received = lib.read(sym, output_format="polars").data
+        expected = create_1d_arrow_structure("NamedSeries" if input_type == "NamedSeries" else "UnnamedSeries", data)
+        polars_assert_series_equal(received, expected)
+        assert received.flags["SORTED_ASC"]
+
+
+@pytest.mark.parametrize("dynamic_schema", [False, True])
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize("index_column", [False, True])
+def test_1d_arrow_structures_timezones(in_memory_store_factory, dynamic_schema, input_type, index_column):
+    lib = in_memory_store_factory(dynamic_schema=dynamic_schema)
+    lib._set_allow_arrow_input()
+    # Read as Polars as this preserves the series name if it was present
+    lib.set_output_format("polars")
+    sym = "test_1d_arrow_structures_column_metadata"
+    write_date_range = pd.date_range("2026-01-01", periods=4, tz="America/New_York")
+    write_data = pa.Array.from_pandas(write_date_range, type=pa.timestamp("ns", tz="America/New_York"))
+    write_input = create_1d_arrow_structure(input_type, write_data)
+    lib.write(sym, write_input, index_column=index_column)
+    assert not lib.is_symbol_pickled(sym)
+    received = lib.read(sym).data
+    expected = create_1d_arrow_structure("NamedSeries" if input_type == "NamedSeries" else "UnnamedSeries", write_data)
+    polars_assert_series_equal(received, expected)
+    assert received.dtype.time_zone == "America/New_York"
+
+    append_date_range = pd.date_range("2026-01-05", periods=4, tz="Europe/Brussels")
+    append_data = pa.Array.from_pandas(append_date_range, type=pa.timestamp("ns", tz="Europe/Brussels"))
+    append_input = create_1d_arrow_structure(input_type, append_data)
+    if dynamic_schema:
+        lib.append(sym, append_input, index_column=index_column)
+        received = lib.read(sym).data
+        expected_date_range = write_date_range.tz_convert(None).append(append_date_range.tz_convert(None))
+        expected_data = pa.Array.from_pandas(expected_date_range, type=pa.timestamp("ns"))
+        expected = create_1d_arrow_structure(
+            "NamedSeries" if input_type == "NamedSeries" else "UnnamedSeries", expected_data
+        )
+        polars_assert_series_equal(received, expected)
+        assert received.dtype.time_zone is None
+    else:
+        with pytest.raises(StreamDescriptorMismatch):
+            lib.append(sym, append_input, index_column=index_column)
+
+
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_1d_arrow_structures_string_format(in_memory_version_store_arrow, input_type):
+    lib = in_memory_version_store_arrow
+    sym = "test_1d_arrow_structures_string_format"
+    # Read as Polars as this preserves the series name if it was present
+    lib.set_output_format("polars")
+    write_data = pc.dictionary_encode(pa.array(["hi", "hello", "gday", "ciao"], type=pa.large_string()))
+    write_input = create_1d_arrow_structure(input_type, write_data)
+    lib.write(sym, write_input)
+    assert not lib.is_symbol_pickled(sym)
+    received = lib.read(sym).data
+    expected = create_1d_arrow_structure("NamedSeries" if input_type == "NamedSeries" else "UnnamedSeries", write_data)
+    polars_assert_series_equal(received, expected)
+    assert received.dtype == pl.Categorical
+
+    append_data = pa.array(["hi", "hello", "gday", "ciao"], type=pa.string())
+    append_input = create_1d_arrow_structure(input_type, append_data)
+    lib.append(sym, append_input)
+    received = lib.read(sym).data
+    expected_data = pa.array(["hi", "hello", "gday", "ciao", "hi", "hello", "gday", "ciao"], type=pa.large_string())
+    expected = create_1d_arrow_structure(
+        "NamedSeries" if input_type == "NamedSeries" else "UnnamedSeries", expected_data
+    )
+    polars_assert_series_equal(received, expected)
+    assert received.dtype == pl.String
+
+
+@pytest.mark.parametrize("method", ["append", "update"])
+@pytest.mark.parametrize("first_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize("second_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_1d_arrow_structures_append_update(in_memory_version_store_arrow, method, first_type, second_type):
+    lib = in_memory_version_store_arrow
+    sym = "test_1d_arrow_structures_append"
+    # Read as Polars as this preserves the series name if it was present
+    lib.set_output_format("polars")
+    data = (
+        pa.array(np.arange(8), pa.int64())
+        if method == "append"
+        else pa.Array.from_pandas(pd.date_range("2026-01-01", periods=8), type=pa.timestamp("ns"))
+    )
+    first_input = create_1d_arrow_structure(first_type, data[:4])
+    second_input = create_1d_arrow_structure(second_type, data[4:])
+    lib.write(sym, first_input, index_column=method == "update")
+    assert not lib.is_symbol_pickled(sym)
+
+    # All combinations are permissible except named series with everything else
+    if (first_type == "NamedSeries" and second_type != "NamedSeries") or (
+        first_type != "NamedSeries" and second_type == "NamedSeries"
+    ):
+        with pytest.raises(StreamDescriptorMismatch):
+            getattr(lib, method)(sym, second_input, index_column=method == "update")
+    else:
+        getattr(lib, method)(sym, second_input, index_column=method == "update")
+        received = lib.read(sym).data
+        expected = create_1d_arrow_structure("NamedSeries" if first_type == "NamedSeries" else "UnnamedSeries", data)
+        polars_assert_series_equal(received, expected)
+
+
+@pytest.mark.parametrize("dynamic_schema", [False, True])
+@pytest.mark.parametrize("first_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize("second_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_1d_arrow_structures_append_type_promotion(in_memory_store_factory, dynamic_schema, first_type, second_type):
+    lib = in_memory_store_factory(dynamic_schema=dynamic_schema)
+    lib._set_allow_arrow_input()
+    # Read as Polars as this preserves the series name if it was present
+    lib.set_output_format("polars")
+    sym = "test_1d_arrow_structures_append_type_promotion"
+    data = pa.array(np.arange(8), pa.int8())
+    first_input = create_1d_arrow_structure(first_type, data[:4])
+    # Change the type
+    data = data.cast(pa.int16())
+    second_input = create_1d_arrow_structure(second_type, data[4:])
+    lib.write(sym, first_input)
+    assert not lib.is_symbol_pickled(sym)
+
+    # All combinations are permissible with dynamic schema except named series with everything else
+    if (
+        not dynamic_schema
+        or (first_type == "NamedSeries" and second_type != "NamedSeries")
+        or (first_type != "NamedSeries" and second_type == "NamedSeries")
+    ):
+        with pytest.raises(StreamDescriptorMismatch):
+            lib.append(sym, second_input)
+    else:
+        lib.append(sym, second_input)
+        received = lib.read(sym).data
+        expected = create_1d_arrow_structure("NamedSeries" if first_type == "NamedSeries" else "UnnamedSeries", data)
+        polars_assert_series_equal(received, expected)
+
+
+@pytest.mark.parametrize("join", ["inner", "outer"])
+@pytest.mark.parametrize("first_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize("second_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_1d_arrow_structures_concat(in_memory_version_store_arrow, join, first_type, second_type):
+    lib = in_memory_version_store_arrow
+    first_sym = "test_1d_arrow_structures_append_0"
+    second_sym = "test_1d_arrow_structures_append_1"
+    # Read as Polars as this preserves the series name if it was present
+    lib.set_output_format("polars")
+    data = pa.array(np.arange(8), pa.int64())
+    first_input = create_1d_arrow_structure(first_type, data[:4])
+    second_input = create_1d_arrow_structure(second_type, data[4:])
+    lib.write(first_sym, first_input)
+    lib.write(second_sym, second_input)
+    assert not lib.is_symbol_pickled(first_sym)
+    assert not lib.is_symbol_pickled(second_sym)
+
+    # All combinations are permissible with concat. Named/unnamed combinations become unnamed
+    received = lib.batch_read_and_join([first_sym, second_sym], QueryBuilder().concat(join)).data
+    expected = create_1d_arrow_structure(
+        "NamedSeries" if first_type == "NamedSeries" and second_type == "NamedSeries" else "UnnamedSeries", data
+    )
+    polars_assert_series_equal(received, expected)
+
+
+# Use __array__ as the column name in the 2D structures as this is the placeholder we use for 1D structures, and so is
+# the most likely to accidentally be allowed
+@pytest.mark.parametrize("type_1d", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+@pytest.mark.parametrize(
+    "data_2d",
+    [
+        pa.table({"__array__": pa.array([2], type=pa.int64())}),
+        pl.DataFrame({"__array__": pl.Series(values=[2], dtype=pl.Int64)}),
+        pa.record_batch({"__array__": pa.array([2], type=pa.int64())}),
+    ],
+)
+@pytest.mark.parametrize("first_1d", [False, True])
+def test_combine_1d_arrow_structures_with_multi_column(in_memory_version_store_arrow, type_1d, data_2d, first_1d):
+    lib = in_memory_version_store_arrow
+    first_sym = "test_combine_1d_arrow_structures_with_multi_column_0"
+    second_sym = "test_combine_1d_arrow_structures_with_multi_column_1"
+    data_1d = pa.array([0, 1], type=pa.int64())
+    data_1d = create_1d_arrow_structure(type_1d, data_1d)
+    first_data = data_1d if first_1d else data_2d
+    second_data = data_2d if first_1d else data_1d
+    lib.write(first_sym, first_data)
+    assert not lib.is_symbol_pickled(first_sym)
+    with pytest.raises(NormalizationException):
+        lib.append(first_sym, second_data)
+    lib.write(second_sym, second_data)
+    with pytest.raises(NormalizationException):
+        lib.batch_read_and_join([first_sym, second_sym], QueryBuilder().concat("inner"))
+    with pytest.raises(NormalizationException):
+        lib.batch_read_and_join([first_sym, second_sym], QueryBuilder().concat("outer"))
+
+
+@pytest.mark.parametrize("dynamic_schema", [False, True])
+@pytest.mark.parametrize("first_name", [None, "name_1", "name_2"])
+@pytest.mark.parametrize("second_name", [None, "name_1", "name_2"])
+def test_combine_polars_named_series(in_memory_store_factory, dynamic_schema, first_name, second_name):
+    lib = in_memory_store_factory(dynamic_schema=dynamic_schema)
+    lib.set_output_format("polars")
+    lib._set_allow_arrow_input()
+    first_sym = "test_combine_polars_named_series_0"
+    second_sym = "test_combine_polars_named_series_1"
+    first_df = pl.Series(first_name, [0], dtype=pl.Int64)
+    second_df = pl.Series(second_name, [1], dtype=pl.Int64)
+    lib.write(first_sym, first_df)
+    assert not lib.is_symbol_pickled(first_sym)
+    lib.write(second_sym, second_df)
+    assert not lib.is_symbol_pickled(second_sym)
+    # All combinations are permissible with concat. Mismatched names become an empty string
+    received = lib.batch_read_and_join([first_sym, second_sym], QueryBuilder().concat()).data
+    expected = pl.Series(first_name if first_name == second_name else "", [0, 1], pl.Int64)
+    polars_assert_series_equal(received, expected)
+    if first_name == second_name:
+        lib.append(first_sym, second_df)
+        received = lib.read(first_sym).data
+        polars_assert_series_equal(received, pl.concat([first_df, second_df]))
+    else:
+        with pytest.raises(StreamDescriptorMismatch):
+            lib.append(first_sym, second_df)
 
 
 def test_record_batches_roundtrip():
@@ -207,6 +504,19 @@ def test_write_with_index(in_memory_version_store_arrow, arrow_output_format):
     assert_arrow_equal(table, received)
 
 
+def test_write_with_only_index(in_memory_version_store_arrow, arrow_output_format):
+    lib = in_memory_version_store_arrow
+    sym = "test_write_with_only_index"
+    table = pa.table(
+        {
+            "ts": pa.Array.from_pandas(pd.date_range("2025-01-01", periods=2), type=pa.timestamp("ns")),
+        }
+    )
+    lib.write(sym, to_format(table, arrow_output_format), index_column=True)
+    received = lib.read(sym, output_format=arrow_output_format).data
+    assert_arrow_equal(table, received)
+
+
 def test_write_multiple_record_batches_indexed(in_memory_version_store_arrow):
     lib = in_memory_version_store_arrow
     sym = "test_write_multiple_record_batches_indexed"
@@ -337,7 +647,7 @@ def test_many_record_batches_many_slices(in_memory_store_factory, rows_per_slice
                     "bool": pa.array(rng.choice([True, False], length), pa.bool_()),
                     "string": pa.array([f"{i}" for i in range(length)], pa.string()),
                     # Few distinct values so the dictionary genuinely encodes repeats
-                    "categorical": pa.compute.dictionary_encode(
+                    "categorical": pc.dictionary_encode(
                         pa.array([f"{i % 3}" for i in range(length)], pa.large_string())
                     ),
                 }
@@ -720,7 +1030,7 @@ def test_write_categorical_strings(in_memory_version_store_arrow, format, sparse
     )
     if format == "pyarrow":
         # pyarrow's dictionary_encode produces int32 keys
-        data = pa.table({"col": pa.compute.dictionary_encode(pa.array(values, pa.large_string()))})
+        data = pa.table({"col": pc.dictionary_encode(pa.array(values, pa.large_string()))})
         assert pa.types.is_dictionary(data.column(0).type)
     else:
         # polars' Categorical produces uint32 keys
@@ -938,6 +1248,36 @@ def test_update_with_date_range_wider_than_data(in_memory_version_store_arrow, d
     assert_frame_equal(expected, received)
 
 
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_update_with_date_range_wider_than_data_1d(in_memory_version_store_arrow, input_type):
+    lib = in_memory_version_store_arrow
+    sym = "test_update_with_date_range_wider_than_data_1d"
+    write_date_range = pd.date_range("2025-01-01", periods=6)
+    write_array = pa.Array.from_pandas(write_date_range, type=pa.timestamp("ns"))
+    write_data = create_1d_arrow_structure(input_type, write_array)
+    lib.write(sym, write_data, index_column=True)
+
+    # Use an offset date range, otherwise the result will be indistinguishable from the update not occurring
+    update_date_range = pd.date_range("2025-01-03 12:00:00", periods=1)
+    update_array = pa.Array.from_pandas(update_date_range, type=pa.timestamp("ns"))
+    update_data = create_1d_arrow_structure(input_type, update_array)
+
+    date_range = (pd.Timestamp("2025-01-03"), pd.Timestamp("2025-01-04"))
+    lib.update(sym, update_data, date_range=date_range, index_column=True)
+    received = lib.read(sym).data
+    expected = pa.Array.from_pandas(
+        [
+            pd.Timestamp("2025-01-01"),
+            pd.Timestamp("2025-01-02"),
+            pd.Timestamp("2025-01-03 12:00:00"),
+            pd.Timestamp("2025-01-05"),
+            pd.Timestamp("2025-01-06"),
+        ],
+        type=pa.timestamp("ns"),
+    )
+    assert received.equals(pa.chunked_array([expected]))
+
+
 @pytest.mark.parametrize(
     "date_range",
     [
@@ -959,22 +1299,7 @@ def test_update_with_date_range_wider_than_data(in_memory_version_store_arrow, d
         ),
     ],
 )
-@pytest.mark.parametrize(
-    "index_tz",
-    [
-        pytest.param(None, id="naive"),
-        pytest.param(
-            "UTC",
-            id="UTC",
-            marks=pytest.mark.xfail(reason="Tz-aware arrow writes not yet supported (monday ref: 9929831600)"),
-        ),
-        pytest.param(
-            "US/Eastern",
-            id="US_Eastern",
-            marks=pytest.mark.xfail(reason="Tz-aware arrow writes not yet supported (monday ref: 9929831600)"),
-        ),
-    ],
-)
+@pytest.mark.parametrize("index_tz", [None, "UTC", "US/Eastern"])
 def test_update_with_date_range_narrower_than_data(
     in_memory_version_store_arrow, date_range, index_tz, arrow_output_format
 ):
@@ -1005,6 +1330,37 @@ def test_update_with_date_range_narrower_than_data(
     expected = lib.read(reference_sym, output_format="pandas").data
     received = lib.read(sym).data.to_pandas().set_index("ts")
     assert_frame_equal(expected, received)
+
+
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_update_with_date_range_narrower_than_data_1d(in_memory_version_store_arrow, input_type):
+    lib = in_memory_version_store_arrow
+    sym = "test_update_with_date_range_narrower_than_data_1d"
+    write_date_range = pd.date_range("2025-01-01", periods=6)
+    write_array = pa.Array.from_pandas(write_date_range, type=pa.timestamp("ns"))
+    write_data = create_1d_arrow_structure(input_type, write_array)
+    lib.write(sym, write_data, index_column=True)
+
+    # Use an offset date range, otherwise the result will be indistinguishable from the update not occurring
+    update_date_range = pd.date_range("2025-01-01 12:00:00", periods=6)
+    update_array = pa.Array.from_pandas(update_date_range, type=pa.timestamp("ns"))
+    update_data = create_1d_arrow_structure(input_type, update_array)
+
+    # Picks out only 2025-01-03 12:00:00 from update_data, and drops index values 2025-01-03 and 2025-01-04
+    date_range = (pd.Timestamp("2025-01-03"), pd.Timestamp("2025-01-04"))
+    lib.update(sym, update_data, date_range=date_range, index_column=True)
+    received = lib.read(sym).data
+    expected = pa.Array.from_pandas(
+        [
+            pd.Timestamp("2025-01-01"),
+            pd.Timestamp("2025-01-02"),
+            pd.Timestamp("2025-01-03 12:00:00"),
+            pd.Timestamp("2025-01-05"),
+            pd.Timestamp("2025-01-06"),
+        ],
+        type=pa.timestamp("ns"),
+    )
+    assert received.equals(pa.chunked_array([expected]))
 
 
 @pytest.mark.parametrize("method", ["write_parallel", "write_incomplete", "append", "stage"])
@@ -1761,7 +2117,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
         }
         table = pa.table(data)
         lib.write(sym, table)
@@ -1808,7 +2164,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
         }
         table = pa.table(data)
         lib.write(sym, table)
@@ -1826,7 +2182,7 @@ class TestStringFormatRoundtrip:
             "ts": pa.Array.from_pandas(pd.date_range("2026-01-01", periods=len(values)), type=pa.timestamp("ns")),
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
         }
         table = pa.table(data)
         lib.write(sym, table, index_column=True)
@@ -1856,9 +2212,9 @@ class TestStringFormatRoundtrip:
             "large_to_small": pa.array(write_values, pa.large_string()),
             "large_to_large": pa.array(write_values, pa.large_string()),
             "large_to_dict": pa.array(write_values, pa.large_string()),
-            "dict_to_small": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
-            "dict_to_large": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
-            "dict_to_dict": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_to_small": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_to_large": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_to_dict": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
         }
         write_table = pa.table(write_data)
         lib.write(sym, write_table, index_column=True)
@@ -1869,13 +2225,13 @@ class TestStringFormatRoundtrip:
             ),
             "small_to_small": pa.array(modify_values, pa.string()),
             "small_to_large": pa.array(modify_values, pa.large_string()),
-            "small_to_dict": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "small_to_dict": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
             "large_to_small": pa.array(modify_values, pa.string()),
             "large_to_large": pa.array(modify_values, pa.large_string()),
-            "large_to_dict": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "large_to_dict": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
             "dict_to_small": pa.array(modify_values, pa.string()),
             "dict_to_large": pa.array(modify_values, pa.large_string()),
-            "dict_to_dict": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "dict_to_dict": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
         }
         modify_table = pa.table(modify_data)
         getattr(lib, method)(sym, modify_table, index_column=True)
@@ -1904,7 +2260,7 @@ class TestStringFormatRoundtrip:
             "large_to_dict": pa.array(expected_values, pa.large_string()),
             "dict_to_small": pa.array(expected_values, pa.large_string()),
             "dict_to_large": pa.array(expected_values, pa.large_string()),
-            "dict_to_dict": pa.compute.dictionary_encode(pa.array(expected_values, pa.large_string())),
+            "dict_to_dict": pc.dictionary_encode(pa.array(expected_values, pa.large_string())),
         }
         # assert_arrow_equal requires the exact dict-encoding to match. We have already checked the schema was correct on
         # read above, so just check the values here
@@ -1924,7 +2280,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
         }
         table = pa.table(data)
         lib.write(sym, table)
@@ -1949,7 +2305,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
             "not_overridden": pa.array(values, pa.string()),
         }
         table = pa.table(data)
@@ -1982,7 +2338,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
             "overridden_by_read_level_default": pa.array(values, pa.string()),
             "explicitly_set_to_stored_type": pa.array(values, pa.string()),
         }
@@ -2082,7 +2438,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
         }
         table = pa.table(data)
         lib.write(sym, table)
@@ -2102,7 +2458,7 @@ class TestStringFormatRoundtrip:
         data = {
             "small_string": pa.array(values, pa.string()),
             "large_string": pa.array(values, pa.large_string()),
-            "dict_encoded": pa.compute.dictionary_encode(pa.array(values, pa.large_string())),
+            "dict_encoded": pc.dictionary_encode(pa.array(values, pa.large_string())),
         }
         table = pa.table(data)
         lib.write(sym, table)
@@ -2122,9 +2478,7 @@ class TestStringFormatRoundtrip:
         assert received.schema.field(1).type == pa.dictionary(pa.int32(), pa.large_string())
         assert received.schema.field(2).type == pa.string()
         assert received.schema.field(3).type == pa.dictionary(pa.int32(), pa.large_string())
-        table = table.add_column(
-            3, "new", pa.compute.dictionary_encode(pa.array(len(values) * ["value"], pa.large_string()))
-        )
+        table = table.add_column(3, "new", pc.dictionary_encode(pa.array(len(values) * ["value"], pa.large_string())))
         table = table.set_column(0, "small_string", table.column(0).cast(pa.large_string()))
         table = table.set_column(1, "large_string", table.column(1).cast(pa.dictionary(pa.int32(), pa.large_string())))
         table = table.set_column(2, "dict_encoded", table.column(2).cast(pa.string()))
@@ -2145,12 +2499,12 @@ class TestStringFormatRoundtrip:
             "large_to_small": pa.array(write_values, pa.large_string()),
             "large_to_large": pa.array(write_values, pa.large_string()),
             "large_to_dict": pa.array(write_values, pa.large_string()),
-            "dict_to_small": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
-            "dict_to_large": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
-            "dict_to_dict": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_to_small": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_to_large": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_to_dict": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
             "small_first_only": pa.array(write_values, pa.string()),
             "large_first_only": pa.array(write_values, pa.large_string()),
-            "dict_first_only": pa.compute.dictionary_encode(pa.array(write_values, pa.large_string())),
+            "dict_first_only": pc.dictionary_encode(pa.array(write_values, pa.large_string())),
         }
         write_table = pa.table(write_data)
         lib.write(sym, write_table)
@@ -2159,12 +2513,12 @@ class TestStringFormatRoundtrip:
             "small_second_only": pa.array(modify_values, pa.string()),
             "dict_to_large": pa.array(modify_values, pa.large_string()),
             "large_second_only": pa.array(modify_values, pa.large_string()),
-            "dict_second_only": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
-            "dict_to_dict": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "dict_second_only": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "dict_to_dict": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
             "small_to_large": pa.array(modify_values, pa.large_string()),
-            "small_to_dict": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "small_to_dict": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
             "large_to_large": pa.array(modify_values, pa.large_string()),
-            "large_to_dict": pa.compute.dictionary_encode(pa.array(modify_values, pa.large_string())),
+            "large_to_dict": pc.dictionary_encode(pa.array(modify_values, pa.large_string())),
             "dict_to_small": pa.array(modify_values, pa.string()),
             "large_to_small": pa.array(modify_values, pa.string()),
             "small_to_small": pa.array(modify_values, pa.string()),
@@ -2199,10 +2553,10 @@ def test_roundtrip_string_types_batch(in_memory_version_store_arrow):
     data_0 = {
         "col_0": pa.array(values_0, pa.string()),
         "col_1": pa.array(values_0, pa.large_string()),
-        "col_2": pa.compute.dictionary_encode(pa.array(values_0, pa.large_string())),
+        "col_2": pc.dictionary_encode(pa.array(values_0, pa.large_string())),
     }
     data_1 = {
-        "col_1": pa.compute.dictionary_encode(pa.array(values_1, pa.large_string())),
+        "col_1": pc.dictionary_encode(pa.array(values_1, pa.large_string())),
         "col_2": pa.array(values_1, pa.large_string()),
         "col_3": pa.array(values_1, pa.string()),
     }
@@ -2267,12 +2621,12 @@ def test_symbol_concat_arrow_string_types(in_memory_version_store_arrow):
         "large_to_small": pa.array(values_0, pa.large_string()),
         "large_to_large": pa.array(values_0, pa.large_string()),
         "large_to_dict": pa.array(values_0, pa.large_string()),
-        "dict_to_small": pa.compute.dictionary_encode(pa.array(values_0, pa.large_string())),
-        "dict_to_large": pa.compute.dictionary_encode(pa.array(values_0, pa.large_string())),
-        "dict_to_dict": pa.compute.dictionary_encode(pa.array(values_0, pa.large_string())),
+        "dict_to_small": pc.dictionary_encode(pa.array(values_0, pa.large_string())),
+        "dict_to_large": pc.dictionary_encode(pa.array(values_0, pa.large_string())),
+        "dict_to_dict": pc.dictionary_encode(pa.array(values_0, pa.large_string())),
         "small_first_only": pa.array(values_0, pa.string()),
         "large_first_only": pa.array(values_0, pa.large_string()),
-        "dict_first_only": pa.compute.dictionary_encode(pa.array(values_0, pa.large_string())),
+        "dict_first_only": pc.dictionary_encode(pa.array(values_0, pa.large_string())),
     }
     table_0 = pa.table(data_0)
     lib.write(sym_0, table_0)
@@ -2281,12 +2635,12 @@ def test_symbol_concat_arrow_string_types(in_memory_version_store_arrow):
         "small_second_only": pa.array(values_1, pa.string()),
         "dict_to_large": pa.array(values_1, pa.large_string()),
         "large_second_only": pa.array(values_1, pa.large_string()),
-        "dict_second_only": pa.compute.dictionary_encode(pa.array(values_1, pa.large_string())),
-        "dict_to_dict": pa.compute.dictionary_encode(pa.array(values_1, pa.large_string())),
+        "dict_second_only": pc.dictionary_encode(pa.array(values_1, pa.large_string())),
+        "dict_to_dict": pc.dictionary_encode(pa.array(values_1, pa.large_string())),
         "small_to_large": pa.array(values_1, pa.large_string()),
-        "small_to_dict": pa.compute.dictionary_encode(pa.array(values_1, pa.large_string())),
+        "small_to_dict": pc.dictionary_encode(pa.array(values_1, pa.large_string())),
         "large_to_large": pa.array(values_1, pa.large_string()),
-        "large_to_dict": pa.compute.dictionary_encode(pa.array(values_1, pa.large_string())),
+        "large_to_dict": pc.dictionary_encode(pa.array(values_1, pa.large_string())),
         "dict_to_small": pa.array(values_1, pa.string()),
         "large_to_small": pa.array(values_1, pa.string()),
         "small_to_small": pa.array(values_1, pa.string()),

--- a/python/tests/unit/arcticdb/version_store/test_collect_schema.py
+++ b/python/tests/unit/arcticdb/version_store/test_collect_schema.py
@@ -16,6 +16,7 @@ from arcticdb.exceptions import SchemaException, KeyNotFoundException
 from arcticdb.options import ArrowOutputStringFormat, OutputFormat
 import arcticdb.toolbox.query_stats as qs
 from arcticdb.util.test import assert_frame_equal_with_arrow, config_context, query_stats_operation_count
+from tests.util.arrow import create_1d_arrow_structure
 
 
 @pytest.mark.parametrize("num_rows", [0, 1])
@@ -416,3 +417,16 @@ def test_collect_schema_pickled_symbol(lmdb_library):
     lib.write_pickle(sym, "blah")
     with pytest.raises(SchemaException):
         lib.read(sym, lazy=True)._collect_schema()
+
+
+@pytest.mark.parametrize("input_type", ["Array", "ChunkedArray", "UnnamedSeries", "NamedSeries"])
+def test_collect_schema_1d(mem_library, input_type):
+    lib = mem_library
+    sym = "test_collect_schema_1d"
+    lib._nvs._set_allow_arrow_input()
+    data = pa.array([0], pa.int64())
+    input = create_1d_arrow_structure(input_type, data)
+    lib.write(sym, input)
+    schema = lib.read(sym, lazy=True)._collect_schema()
+    expected_name = "series_name" if input_type == "NamedSeries" else ""
+    assert schema == pl.Schema({expected_name: pl.Int64})

--- a/python/tests/util/arrow.py
+++ b/python/tests/util/arrow.py
@@ -59,3 +59,17 @@ def arrow_output_string_format_to_pa_type(arrow_output_string_format):
         ArrowOutputStringFormat.DICTIONARY_ENCODED,
     ]:
         return pa.dictionary(pa.int32(), pa.large_string())
+
+
+def create_1d_arrow_structure(input_type: str, data: pa.Array) -> Union[pa.Array, pa.ChunkedArray, pl.Series]:
+    if input_type == "Array":
+        input = data
+    elif input_type == "ChunkedArray":
+        input = pa.chunked_array([pa.array(data[: len(data) // 2]), pa.array(data[len(data) // 2 :])])
+    elif input_type in ["UnnamedSeries", "NamedSeries"]:
+        input = pl.Series(values=data)
+        if input_type == "NamedSeries":
+            input = input.rename("series_name")
+    else:
+        assert False, f"Unexpected input_type '{input_type}' in create_1d_arrow_structure"
+    return input


### PR DESCRIPTION
#### Reference Issues/PRs
[9360502457](https://man312219.monday.com/boards/7852509418/pulses/9360502457)

#### What does this implement or fix?
Adds support for writing `pyarrow.RecordBatch/ChunkedArray/Array` and `polars.Series`. Due to our on-disk slicing, `RecordBatch` always reads back as a `Table`, and `Array` always reads back as a `ChunkedArray`, even if they only have 1 chunk per column.