### PR TITLE
Benchmarks: build the arrow fixtures without boxing every value

### DIFF
--- a/python/benchmarks/arrow.py
+++ b/python/benchmarks/arrow.py
@@ -117,7 +117,7 @@ class ArrowSparseNumeric:
         columns = {}
         for i in range(self.num_cols):
             vals = np.arange(i * num_rows, (i + 1) * num_rows, dtype=np.int64)
-            columns[f"col{i}"] = pa.array(np.where(mask, None, vals), pa_type)
+            columns[f"col{i}"] = pa.array(vals, pa_type, mask=mask)
         return pa.table(columns)
 
     def setup_cache(self):
@@ -201,7 +201,7 @@ class ArrowBools:
         vals = rng.random(num_rows) < 0.5
         if sparsity > 0.0:
             null_mask = rng.random(num_rows) < sparsity
-            columns = {f"col{i}": pa.array(np.where(null_mask, None, vals), pa.bool_()) for i in range(self.num_cols)}
+            columns = {f"col{i}": pa.array(vals, pa.bool_(), mask=null_mask) for i in range(self.num_cols)}
         else:
             columns = {f"col{i}": pa.array(vals, pa.bool_()) for i in range(self.num_cols)}
         return pa.table(columns)


### PR DESCRIPTION
Two lines in the arrow benchmark fixtures build their sparse arrays as `pa.array(np.where(mask, None, vals), type)` — which boxes every one of 10M values into a Python object and unboxes them one `PyObject` at a time inside pyarrow. `pa.array(vals, type, mask=mask)` builds the identical array from the native buffers.

**Measured in CI** (this PR's run 34335554816 against the previous master run of the same job): `<setup_cache arrow:123>` 34.5 → **10.3 s** (−70%) and `<setup_cache arrow:209>` 11.8–12.3 → **4.97 s** (−58%). asv re-runs `setup` between repeats, so the saving is paid many times per benchmark run.

**Nothing measured changes.** `Array.equals()` verified byte-identical output for int64 and bool at sparsity 0.1/0.5/0.9 (pyarrow 25.0.1 / numpy 2.4.6), and the CI run reported no benchmark value changes. `_generate_table` is a helper, not one of the sources asv hashes, so version hashes and the committed `benchmarks.json` are untouched — every series continues uninterrupted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGB2G1euu3wVQczjRbrsJv
