### PR TITLE
Create only one AwsEventLoop thread rather than num cores

### DIFF
--- a/cpp/arcticdb/CMakeLists.txt
+++ b/cpp/arcticdb/CMakeLists.txt
@@ -1143,6 +1143,7 @@ if(${TEST})
             storage/test/test_local_storages.cpp
             storage/test/test_memory_storage.cpp
             storage/test/test_s3_storage.cpp
+            storage/test/test_s3_api.cpp
             storage/test/test_storage_factory.cpp
             storage/test/common.hpp
             storage/test/test_storage_exceptions.cpp

--- a/cpp/arcticdb/storage/s3/s3_api.cpp
+++ b/cpp/arcticdb/storage/s3/s3_api.cpp
@@ -12,7 +12,9 @@
 #include <arcticdb/util/configs_map.hpp>
 #include <arcticdb/log/log.hpp>
 #include <arcticdb/storage/s3/ec2_utils.hpp>
+#include <algorithm>
 #include <cstdarg>
+#include <limits>
 #include <vector>
 #ifndef WIN32
 #include <aws/core/http/standard/StandardHttpRequest.h>
@@ -23,6 +25,8 @@
 namespace arcticdb::storage::s3 {
 
 namespace {
+constexpr const char* EventLoopAllocationTag = "ArcticDBS3EventLoop";
+
 spdlog::level::level_enum to_spdlog_level(Aws::Utils::Logging::LogLevel log_level) {
     switch (log_level) {
     case Aws::Utils::Logging::LogLevel::Fatal:
@@ -134,12 +138,35 @@ void ArcticCurlHttpClientFactory::CleanupStaticState() {
 }
 #endif // WIN32
 
-S3ApiInstance::S3ApiInstance(Aws::Utils::Logging::LogLevel log_level, bool log_to_file) :
+uint16_t event_loop_thread_count_from_config() {
+    const auto configured = ConfigsMap::instance()->get_int("AWS.EventLoopThreads", 1);
+    return static_cast<uint16_t>(std::clamp<int64_t>(configured, 0, std::numeric_limits<uint16_t>::max()));
+}
+
+ClientBootstrapFactory make_client_bootstrap_factory(uint16_t event_loop_thread_count) {
+    // Mirrors Aws::InitAPI's own default construction, apart from the explicit thread count.
+    return [event_loop_thread_count]() {
+        Aws::Crt::Io::EventLoopGroup event_loop_group(event_loop_thread_count);
+        Aws::Crt::Io::DefaultHostResolver host_resolver(event_loop_group, 8, 30);
+        auto client_bootstrap =
+                Aws::MakeShared<Aws::Crt::Io::ClientBootstrap>(EventLoopAllocationTag, event_loop_group, host_resolver);
+        client_bootstrap->EnableBlockingShutdown();
+        return client_bootstrap;
+    };
+}
+
+S3ApiInstance::S3ApiInstance(
+        Aws::Utils::Logging::LogLevel log_level, bool log_to_file, uint16_t event_loop_thread_count
+) :
     log_level_(log_level),
     options_() {
     // Use correct URI encoding rather than legacy compat one in AWS SDK. PURE S3 needs this to handle symbol names
     // that have special characters (eg ':').
     options_.httpOptions.compliantRfc3986Encoding = true;
+
+    // Left unset, Aws::InitAPI builds a ClientBootstrap with one AWS CRT event-loop thread per two logical
+    // processors, which ArcticDB's S3Client has no use for - its HTTP transport is never CRT-backed.
+    options_.ioOptions.clientBootstrap_create_fn = make_client_bootstrap_factory(event_loop_thread_count);
 
     if (log_level_ > Aws::Utils::Logging::LogLevel::Off) {
         if (log_to_file) {
@@ -185,7 +212,9 @@ S3ApiInstance::~S3ApiInstance() {
 void S3ApiInstance::init() {
     auto log_level = ConfigsMap::instance()->get_int("AWS.LogLevel", 0);
     auto log_to_file = ConfigsMap::instance()->get_int("AWS.LogToFile", 0) != 0;
-    S3ApiInstance::instance_ = std::make_shared<S3ApiInstance>(Aws::Utils::Logging::LogLevel(log_level), log_to_file);
+    S3ApiInstance::instance_ = std::make_shared<S3ApiInstance>(
+            Aws::Utils::Logging::LogLevel(log_level), log_to_file, event_loop_thread_count_from_config()
+    );
 }
 
 std::shared_ptr<S3ApiInstance> S3ApiInstance::instance() {

--- a/cpp/arcticdb/storage/s3/s3_api.hpp
+++ b/cpp/arcticdb/storage/s3/s3_api.hpp
@@ -15,6 +15,8 @@
 #include <aws/core/http/curl/CurlHttpClient.h>
 #endif
 #include <atomic>
+#include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -79,12 +81,23 @@ class ArcticCurlHttpClientFactory : public Aws::Http::HttpClientFactory {
 };
 #endif // WIN32
 
+using ClientBootstrapFactory = std::function<std::shared_ptr<Aws::Crt::Io::ClientBootstrap>()>;
+
+// A count of 0 means one event loop thread per two logical processors, which is what the AWS SDK does when left to
+// itself.
+uint16_t event_loop_thread_count_from_config();
+
+ClientBootstrapFactory make_client_bootstrap_factory(uint16_t event_loop_thread_count);
+
 class S3ApiInstance {
   public:
     S3ApiInstance(
-            Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Off, bool log_to_file = false
+            Aws::Utils::Logging::LogLevel log_level = Aws::Utils::Logging::LogLevel::Off, bool log_to_file = false,
+            uint16_t event_loop_thread_count = 1
     );
     ~S3ApiInstance();
+
+    const Aws::SDKOptions& options() const { return options_; }
 
     static std::shared_ptr<S3ApiInstance> instance_;
     static std::once_flag init_flag_;

--- a/cpp/arcticdb/storage/test/test_s3_api.cpp
+++ b/cpp/arcticdb/storage/test/test_s3_api.cpp
@@ -1,0 +1,55 @@
+/* Copyright 2026 Man Group Operations Limited
+ *
+ * Use of this software is governed by the Business Source License 1.1 included in the file licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source License, use of this software
+ * will be governed by the Apache License, version 2.0.
+ */
+
+#include <gtest/gtest.h>
+#include <arcticdb/storage/s3/s3_api.hpp>
+#include <arcticdb/util/configs_map.hpp>
+
+#include <limits>
+#include <optional>
+
+namespace arcticdb::storage::s3 {
+
+TEST(S3ApiEventLoopThreads, DefaultsToOneThread) {
+    ScopedConfig unset({{"AWS.EventLoopThreads", std::nullopt}});
+    ASSERT_EQ(event_loop_thread_count_from_config(), 1);
+}
+
+TEST(S3ApiEventLoopThreads, ReadsConfiguredValue) {
+    ScopedConfig config("AWS.EventLoopThreads", 4);
+    ASSERT_EQ(event_loop_thread_count_from_config(), 4);
+}
+
+TEST(S3ApiEventLoopThreads, ZeroSelectsTheSdkDefault) {
+    ScopedConfig config("AWS.EventLoopThreads", 0);
+    ASSERT_EQ(event_loop_thread_count_from_config(), 0);
+}
+
+TEST(S3ApiEventLoopThreads, NegativeValuesSelectTheSdkDefault) {
+    ScopedConfig config("AWS.EventLoopThreads", -1);
+    ASSERT_EQ(event_loop_thread_count_from_config(), 0);
+}
+
+TEST(S3ApiEventLoopThreads, SaturatesAtTheMaximumEventLoopGroupSize) {
+    ScopedConfig config("AWS.EventLoopThreads", 1'000'000);
+    ASSERT_EQ(event_loop_thread_count_from_config(), std::numeric_limits<uint16_t>::max());
+}
+
+TEST(S3ApiEventLoopThreads, ApiInstanceOverridesTheSdkClientBootstrap) {
+    const auto& io_options = S3ApiInstance::instance()->options().ioOptions;
+    ASSERT_TRUE(static_cast<bool>(io_options.clientBootstrap_create_fn));
+}
+
+TEST(S3ApiEventLoopThreads, FactoryProducesAValidClientBootstrap) {
+    S3ApiInstance::instance();
+    auto client_bootstrap = make_client_bootstrap_factory(1)();
+    ASSERT_TRUE(client_bootstrap);
+    ASSERT_TRUE(static_cast<bool>(*client_bootstrap));
+}
+
+} // namespace arcticdb::storage::s3


### PR DESCRIPTION
Create only one AwsEventLoop thread. These are only used for data transfer by the CRT client, whereas we use the cUrl client, so they are just wasting threads on the host machine. This is especially true when running on cgroup'd platforms like k8s where the host machine may have hundreds of cores - the AWS SDK's calculation is not cgroup aware - it uses the number of cores on the machine divided by two.

We do use these threads for auth interactions - looking up creds from a profile, or STS credentials refresh. A single thread should be plenty for these.

Testing on PURE and VAST:

## Method

| | |
|---|---|
| Dataset | 100 symbols x 100,000 rows x 5 float64 columns, 400 MB per batch read |
| Read with | `read_batch` of 100 `ReadRequest`s |
| Concurrency | ArcticDB defaults: ~192 IO threads and `S3Storage.MaxConnections` 192 on a 128-thread host |
| Repetitions | 5 per backend per configuration, A/B interleaved within each repetition |
| Per process | two `read_batch` passes, the first on a cold connection pool and the second warm |

## Results

These show no difference on the read timings, and something like a 15% improvement in the time taken to create the `Arctic()` instance.

Median with [min-max] across the 5 repetitions. Times in seconds.

| backend / config | `AwsEventLoop` threads | `Arctic()` construct | read pass 0 (cold) | read pass 1 (warm) | RSS MB |
|---|---|---|---|---|---|
| PURE / pinned (1) | 1 | **0.213** [0.213-0.214] | 0.280 [0.248-0.352] | 0.149 [0.141-0.175] | 1677 |
| PURE / SDK default (0) | 64 | 0.244 [0.235-0.263] | 0.335 [0.238-0.383] | 0.185 [0.146-0.195] | 1679 |
| VAST / pinned (1) | 1 | **0.214** [0.214-0.214] | 0.319 [0.301-0.578] | 0.218 [0.185-0.493] | 1696 |
| VAST / SDK default (0) | 64 | 0.247 [0.236-0.269] | 0.326 [0.278-0.497] | 0.226 [0.189-0.365] | 1719 |

Throughput at the median: PURE 1429 MB/s cold and 2685 MB/s warm when pinned, against 1194 and
2162 at the SDK default. VAST 1254 and 1835 when pinned, against 1227 and 1770.

