### PR TITLE
Bump ec2-github-runner to v2.6.1: GitHub now refuses runners below 2.329.0

### DIFF
--- a/.github/workflows/ec2_runner_jobs.yml
+++ b/.github/workflows/ec2_runner_jobs.yml
@@ -32,7 +32,7 @@ jobs:
           aws-region: "eu-west-1"
       - name: Start EC2 runner
         id: start-ec2-runner
-        uses: machulav/ec2-github-runner@v2.3.3
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: start
           github-token: ${{ secrets.ARCTICDB_TEST_PAT }}
@@ -63,7 +63,7 @@ jobs:
           aws-secret-access-key: "${{ secrets.AWS_S3_SECRET_KEY }}"
           aws-region: "eu-west-1"
       - name: Stop EC2 runner
-        uses: machulav/ec2-github-runner@v2.3.3
+        uses: machulav/ec2-github-runner@v2.6.1
         with:
           mode: stop
           github-token: ${{ secrets.ARCTICDB_TEST_PAT }}


### PR DESCRIPTION
Bumps `machulav/ec2-github-runner` from v2.3.3 to v2.6.1 in `ec2_runner_jobs.yml` 

GitHub's [minimum runner version enforcement](https://github.blog/changelog/2026-02-05-github-actions-self-hosted-runner-minimum-version-enforcement-extended) requires (≥ 2.329.0). v2.3.3's user-data downloads a pinned, older runner on every boot, so every EC2 runner start now fails.
The job log only shows `Checking...` until the timeout; the actual error is in the instance's serial console (`aws ec2 get-console-output`):

```
ERROR: Your runner version is out of date and can no longer register with GitHub.
The minimum runner version required to register with GitHub Actions is now 2.329.0.
```

Since v2.4.3 the action fetches the **latest** runner release at boot instead of a pin.

