### PR TITLE
Scan Arrow validity bitmaps a word at a time when building the sparse map

### DIFF
--- a/cpp/arcticdb/pipeline/write_frame.cpp
+++ b/cpp/arcticdb/pipeline/write_frame.cpp
@@ -15,6 +15,7 @@
 #include <arcticdb/stream/stream_sink.hpp>
 #include <arcticdb/entity/performance_tracing.hpp>
 #include <arcticdb/stream/aggregator.hpp>
+#include <arcticdb/util/bitset.hpp>
 #include <arcticdb/util/variant.hpp>
 #include <arcticdb/pipeline/frame_utils.hpp>
 #include <arcticdb/pipeline/write_frame.hpp>
@@ -168,13 +169,13 @@ util::BitSet construct_sparse_map(const std::vector<ArrowInputContiguousSlice>& 
     auto dest_pos = 0u;
     for (const auto& slice : slices) {
         if (slice.bitmap_block.has_value()) {
-            for (auto i = 0u; i < slice.size; ++i) {
-                auto pos_in_bitmap_block = slice.bitmap_block.value()->shift() + slice.start_pos + i;
-                auto is_set = get_bit_at(slice.bitmap_block.value()->data(), pos_in_bitmap_block);
-                if (!is_set) {
-                    inserter = dest_pos + i;
-                }
-            }
+            const auto* bitmap_block = slice.bitmap_block.value();
+            for_each_unset_bit(
+                    bitmap_block->data(),
+                    bitmap_block->shift() + slice.start_pos,
+                    slice.size,
+                    [&] ARCTICDB_LAMBDA_INLINE(size_t i) { inserter = bv_size(dest_pos + i); }
+            );
         }
         dest_pos += slice.size;
     }

--- a/cpp/arcticdb/util/bitset.cpp
+++ b/cpp/arcticdb/util/bitset.cpp
@@ -78,21 +78,6 @@ void bools_to_packed_bits(const bool* src, size_t num_bools, uint8_t* dest) {
     }
 }
 
-bool get_bit_at(const uint8_t* packed_bits, size_t bit_pos) {
-    auto dv = std::div(bit_pos, 8);
-    size_t byte_idx = dv.quot;
-    size_t bit_idx = dv.rem;
-    return (packed_bits[byte_idx] >> bit_idx) & 1;
-}
-
-void set_bit_at(uint8_t* packed_bits, size_t bit_pos, bool value) {
-    auto dv = std::div(bit_pos, 8);
-    size_t byte_idx = dv.quot;
-    size_t bit_idx = dv.rem;
-    packed_bits[byte_idx] &= ~(1 << bit_idx);                        // Unset bit
-    packed_bits[byte_idx] |= static_cast<uint8_t>(value) << bit_idx; // Set bit
-}
-
 void copy_packed_bits(const uint8_t* src, size_t src_bit_offset, size_t num_bits, uint8_t* dest) {
     if (src_bit_offset % 8 == 0) {
         memcpy(dest, src + src_bit_offset / 8, bitset_packed_size_bytes(num_bits));

--- a/cpp/arcticdb/util/bitset.hpp
+++ b/cpp/arcticdb/util/bitset.hpp
@@ -13,6 +13,10 @@
 #include <bitmagic/bm.h>
 #include <bitmagic/bmalgo.h>
 
+#include <algorithm>
+#include <bit>
+#include <cstring>
+
 namespace arcticdb {
 
 namespace util {
@@ -60,9 +64,51 @@ void packed_bits_to_buffer(const uint8_t* packed_bits, size_t num_bits, size_t o
 
 void bools_to_packed_bits(const bool* src, size_t num_bools, uint8_t* dest);
 
-bool get_bit_at(const uint8_t* packed_bits, size_t bit_pos);
+inline bool get_bit_at(const uint8_t* packed_bits, size_t bit_pos) {
+    return (packed_bits[bit_pos >> 3] >> (bit_pos & 7)) & 1;
+}
 
-void set_bit_at(uint8_t* packed_bits, size_t bit_pos, bool value);
+inline void set_bit_at(uint8_t* packed_bits, size_t bit_pos, bool value) {
+    const size_t byte_idx = bit_pos >> 3;
+    const auto bit_idx = static_cast<unsigned>(bit_pos & 7);
+    packed_bits[byte_idx] &= static_cast<uint8_t>(~(1u << bit_idx));                        // Unset bit
+    packed_bits[byte_idx] |= static_cast<uint8_t>(static_cast<unsigned>(value) << bit_idx); // Set bit
+}
+
+// Calls f(i) for every i in [0, num_bits) whose bit (bit_offset + i) of packed_bits is unset, in ascending order.
+// Scans 64 bits at a time so the cost is proportional to the number of unset bits rather than to num_bits.
+// Only the bytes holding bits [bit_offset, bit_offset + num_bits) are read, so the caller need only guarantee that
+// range is in bounds.
+template<typename functor>
+requires std::is_invocable_r_v<void, functor, size_t>
+void for_each_unset_bit(const uint8_t* packed_bits, size_t bit_offset, size_t num_bits, functor&& f) {
+    static_assert(std::endian::native == std::endian::little, "Word-at-a-time bit scan assumes a little-endian host");
+    if (num_bits == 0) {
+        return;
+    }
+    const uint8_t* const base = packed_bits + (bit_offset >> 3);
+    // Logical bit i is bit (shift + i) of the bit stream starting at *base, so shift < 8 is the only misalignment
+    const size_t shift = bit_offset & 7;
+    const size_t total_bits = shift + num_bits;
+    const size_t total_bytes = bitset_packed_size_bytes(total_bits);
+    for (size_t word_start = 0; word_start < total_bits; word_start += 64) {
+        const size_t byte_idx = word_start >> 3;
+        const size_t available_bytes = std::min(size_t{8}, total_bytes - byte_idx);
+        uint64_t word = 0;
+        std::memcpy(&word, base + byte_idx, available_bytes);
+        // Bits [lo, hi) of this word map to a logical bit. lo is only non-zero for the first word, hi only clips the
+        // last one. Bits outside [lo, hi) are masked off, which also discards the zero-padding of a partial load.
+        const size_t lo = word_start == 0 ? shift : 0;
+        const size_t hi = std::min(size_t{64}, total_bits - word_start);
+        const uint64_t mask = (hi == 64 ? ~uint64_t{0} : ((uint64_t{1} << hi) - 1)) & (~uint64_t{0} << lo);
+        uint64_t unset = ~word & mask;
+        while (unset != 0) {
+            const auto bit = static_cast<size_t>(std::countr_zero(unset));
+            f(word_start + bit - shift);
+            unset &= unset - 1;
+        }
+    }
+}
 
 void copy_packed_bits(const uint8_t* src, size_t src_bit_offset, size_t num_bits, uint8_t* dest);
 

--- a/cpp/arcticdb/util/test/benchmark_bitset.cpp
+++ b/cpp/arcticdb/util/test/benchmark_bitset.cpp
@@ -63,3 +63,28 @@ static void BM_bools_to_packed_bits(benchmark::State& state) {
 }
 
 BENCHMARK(BM_bools_to_packed_bits)->Args({100'000})->Args({1'000'000})->Args({10'000'000});
+
+// Args are {num_bits, percentage of unset bits, starting bit offset}. A non-zero offset covers the byte-unaligned
+// case, which is what the Arrow validity bitmap of a sliced array looks like.
+static void BM_for_each_unset_bit(benchmark::State& state) {
+    const auto num_bits = static_cast<size_t>(state.range(0));
+    const auto unset_percent = static_cast<size_t>(state.range(1));
+    const auto bit_offset = static_cast<size_t>(state.range(2));
+    std::vector<uint8_t> packed(bitset_packed_size_bytes(bit_offset + num_bits), 0);
+    std::uniform_int_distribution<size_t> dis(0, 99);
+    for (size_t i = 0; i < bit_offset + num_bits; ++i) {
+        set_bit_at(packed.data(), i, dis(gen) >= unset_percent);
+    }
+    for (auto _ : state) {
+        size_t total = 0;
+        for_each_unset_bit(packed.data(), bit_offset, num_bits, [&](size_t pos) { total += pos; });
+        benchmark::DoNotOptimize(total);
+    }
+}
+
+BENCHMARK(BM_for_each_unset_bit)
+        ->Args({10'000'000, 0, 0})
+        ->Args({10'000'000, 10, 0})
+        ->Args({10'000'000, 10, 5})
+        ->Args({10'000'000, 50, 0})
+        ->Args({10'000'000, 90, 0});

--- a/cpp/arcticdb/util/test/test_bitset.cpp
+++ b/cpp/arcticdb/util/test/test_bitset.cpp
@@ -10,6 +10,9 @@
 
 #include <arcticdb/util/bitset.hpp>
 
+#include <random>
+#include <vector>
+
 using namespace arcticdb;
 
 TEST(BoolsToPacked, StandardValues) {
@@ -57,4 +60,98 @@ TEST(BoolsToPacked, NonAligned) {
     uint8_t dest[1];
     bools_to_packed_bits(src, 3, dest);
     EXPECT_EQ(dest[0] % 8, 0b101);
+}
+
+namespace {
+
+// The buffer is sized to exactly the bytes holding [bit_offset, bit_offset + num_bits), so a scan that reads past
+// the last relevant byte is a heap overflow that sanitizer builds will catch.
+std::vector<uint8_t> packed_from_bools(const std::vector<bool>& bits) {
+    std::vector<uint8_t> packed(bitset_packed_size_bytes(bits.size()), 0);
+    for (size_t i = 0; i < bits.size(); ++i) {
+        set_bit_at(packed.data(), i, bits[i]);
+    }
+    return packed;
+}
+
+std::vector<size_t> unset_positions_naive(const std::vector<uint8_t>& packed, size_t bit_offset, size_t num_bits) {
+    std::vector<size_t> positions;
+    for (size_t i = 0; i < num_bits; ++i) {
+        if (!get_bit_at(packed.data(), bit_offset + i)) {
+            positions.push_back(i);
+        }
+    }
+    return positions;
+}
+
+std::vector<size_t> unset_positions_scan(const std::vector<uint8_t>& packed, size_t bit_offset, size_t num_bits) {
+    std::vector<size_t> positions;
+    for_each_unset_bit(packed.data(), bit_offset, num_bits, [&](size_t i) { positions.push_back(i); });
+    return positions;
+}
+
+void check_matches_naive(const std::vector<bool>& bits, size_t bit_offset, size_t num_bits) {
+    const auto packed = packed_from_bools(bits);
+    ASSERT_EQ(unset_positions_scan(packed, bit_offset, num_bits), unset_positions_naive(packed, bit_offset, num_bits))
+            << "bit_offset=" << bit_offset << " num_bits=" << num_bits;
+}
+
+} // namespace
+
+TEST(ForEachUnsetBit, Empty) {
+    const std::vector<uint8_t> packed{0x00, 0xFF};
+    size_t calls = 0;
+    for_each_unset_bit(packed.data(), 3, 0, [&](size_t) { ++calls; });
+    EXPECT_EQ(calls, 0u);
+}
+
+TEST(ForEachUnsetBit, KnownValues) {
+    // 0b10110100, 0b00001111 -> set positions 2, 4, 5, 7, 8, 9, 10, 11
+    const std::vector<uint8_t> packed{0b10110100, 0b00001111};
+    EXPECT_EQ(unset_positions_scan(packed, 0, 16), (std::vector<size_t>{0, 1, 3, 6, 12, 13, 14, 15}));
+    // Starting at bit 3 shifts every position down by 3 and drops those before it
+    EXPECT_EQ(unset_positions_scan(packed, 3, 13), (std::vector<size_t>{0, 3, 9, 10, 11, 12}));
+    EXPECT_EQ(unset_positions_scan(packed, 6, 2), (std::vector<size_t>{0}));
+}
+
+// Exhaustive over every length up to two words and every start bit spanning nine bytes, so every combination of
+// head shift, whole-word body and partial tail is covered for each pattern.
+TEST(ForEachUnsetBit, ExhaustiveAgainstNaive) {
+    constexpr size_t max_num_bits = 130;
+    constexpr size_t max_bit_offset = 71;
+    std::mt19937 rng(42);
+    for (size_t bit_offset = 0; bit_offset <= max_bit_offset; ++bit_offset) {
+        for (size_t num_bits = 0; num_bits <= max_num_bits; ++num_bits) {
+            const size_t total = bit_offset + num_bits;
+            std::vector<bool> all_set(total, true);
+            std::vector<bool> all_unset(total, false);
+            std::vector<bool> alternating(total);
+            std::vector<bool> random_bits(total);
+            for (size_t i = 0; i < total; ++i) {
+                alternating[i] = (i % 2) == 0;
+                random_bits[i] = (rng() & 1) != 0;
+            }
+            check_matches_naive(all_set, bit_offset, num_bits);
+            check_matches_naive(all_unset, bit_offset, num_bits);
+            check_matches_naive(alternating, bit_offset, num_bits);
+            check_matches_naive(random_bits, bit_offset, num_bits);
+        }
+    }
+}
+
+// Sparse patterns at sizes well past the exhaustive range, matching the shapes seen in Arrow validity bitmaps.
+TEST(ForEachUnsetBit, RandomLargeAgainstNaive) {
+    std::mt19937 rng(1337);
+    for (const size_t num_bits : {1u, 63u, 64u, 65u, 127u, 128u, 1000u, 4096u, 10'007u}) {
+        for (const double set_probability : {0.0, 0.01, 0.5, 0.99, 1.0}) {
+            for (size_t bit_offset = 0; bit_offset < 8; ++bit_offset) {
+                std::bernoulli_distribution dist(set_probability);
+                std::vector<bool> bits(bit_offset + num_bits);
+                for (size_t i = 0; i < bits.size(); ++i) {
+                    bits[i] = dist(rng);
+                }
+                check_matches_naive(bits, bit_offset, num_bits);
+            }
+        }
+    }
 }


### PR DESCRIPTION
`get_bit_at` resolved every bit with an out-of-line `std::div` call — `div@plt` shows up as its own frame in a CI flame graph of `arrow.ArrowBools.time_write`, where `get_bit_at` + `construct_sparse_map` account for 56% of native CPU. `construct_sparse_map` walked Arrow validity bitmaps one bit (and one `div`) per row.

Two layers:

- `get_bit_at`/`set_bit_at` become inline shift/mask in the header (~4× on their own).
- `construct_sparse_map` scans the bitmap through a new `for_each_unset_bit`: 64 bits per load, complement, `std::countr_zero` — O(unset bits) instead of O(rows × div). Head shift (Arrow slices can start mid-byte) and tail are handled by per-word masks; the scan provably touches exactly the bytes the per-bit loop did.

The bool merge-path caller already iterates set positions and keeps its structure; it gets the inlining for free.

**Measured** (10M rows × 9 columns, interleaved A/B with both extensions side by side, medians of 9): this is a **CPU-time** win — the write is parallel and storage-bound, so wall clock barely moves on a many-core box.

| benchmark (sparsity) | CPU before | CPU after | Δ |
|---|---|---|---|
| ArrowBools.time_write (0.0, control: no validity buffer) | 0.146 s | 0.144 s | −1% |
| ArrowBools.time_write (0.1) | 0.725 s | 0.381 s | **−47%** |
| ArrowBools.time_write (0.5) | 0.923 s | 0.328 s | **−64%** |
| ArrowBools.time_write (0.9) | 0.560 s | 0.348 s | **−38%** |
| ArrowSparseNumeric.time_write (0.1 / 0.5 / 0.9) | | | −26% / −49% / −35% |
| ArrowBools.time_read (0.1 / 0.5), wall | | | −18% / −22% |

The sparsity-0.0 row is the attribution argument: pyarrow emits no validity buffer there, so the changed code never runs.

**Correctness:** exhaustive gtest comparison against a naive per-bit reference — every length 0–130 × every start offset 0–71 × {all-set, all-unset, alternating, random} (37,728 cases), with buffers sized to exactly `bitset_packed_size_bytes` so any over-read is a heap overflow; the same logic green standalone under ASan+UBSan; full C++ suite 1,819 passing; Python readback across null patterns, sliced tables at real Arrow offsets, and byte-unaligned row ranges. Little-endianness is `static_assert`ed (the file already relied on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGB2G1euu3wVQczjRbrsJv
