### PR TITLE
Stop the flaky sccache download from failing conda CI, and cache the binary

### DIFF
--- a/.github/workflows/compile_and_test_with_conda.yml
+++ b/.github/workflows/compile_and_test_with_conda.yml
@@ -39,11 +39,20 @@ jobs:
       - name: Initialise lmdb and lmdbxx submodules
         run: git -c core.autocrlf=false submodule update --init cpp/third_party/lmdb cpp/third_party/lmdbxx
 
+      # The release download 5xxs from time to time and the action's own retries are
+      # short (see #3261). Without sccache ARCTICDB_COMPILER_CACHE=AUTO finds no cache
+      # and the build just runs uncached, so degrade to a slow green build, not a red one.
       - name: Configure sccache
+        id: sccache
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.12.0
           disable_annotations: 'true'
+
+      - name: Warn if sccache is unavailable
+        if: steps.sccache.outcome == 'failure'
+        run: echo "::warning title=sccache unavailable::Could not install sccache; building without a compiler cache."
 
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2.0.0
@@ -84,6 +93,7 @@ jobs:
           CMAKE_BUILD_PARALLEL_LEVEL: ${{contains(inputs.platform, 'aarch64') && '3' || ''}}
 
       - name: Show sccache stats
+        if: steps.sccache.outcome == 'success'
         run: ${SCCACHE_PATH} --show-stats || sccache --show-stats
 
       - name: Archive build artifacts
@@ -118,11 +128,18 @@ jobs:
       - name: Initialise lmdb and lmdbxx submodules
         run: git -c core.autocrlf=false submodule update --init cpp/third_party/lmdb cpp/third_party/lmdbxx
 
+      # See the note on the compile job: a failed sccache download must not fail the job.
       - name: Configure sccache
+        id: sccache
+        continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.9
         with:
           version: v0.12.0
           disable_annotations: 'true'
+
+      - name: Warn if sccache is unavailable
+        if: steps.sccache.outcome == 'failure'
+        run: echo "::warning title=sccache unavailable::Could not install sccache; building without a compiler cache."
 
       - name: Free Disk Space
         if: inputs.free_disk_space
@@ -174,6 +191,7 @@ jobs:
           ARCTICDB_USING_CONDA: 1
 
       - name: Show sccache stats
+        if: steps.sccache.outcome == 'success'
         run: ${SCCACHE_PATH} --show-stats || sccache --show-stats
 
       - name: Run C++ Tests
@@ -195,8 +213,6 @@ jobs:
     env:
       ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
       ACTIONS_ALLOW_UNSECURE_COMMANDS: true
-      SCCACHE_GHA_VERSION: ${{vars.SCCACHE_GHA_VERSION || 1}}
-      SCCACHE_GHA_ENABLED: "true"
     defaults:
       run:
         shell: bash -l {0}
@@ -214,11 +230,9 @@ jobs:
       - name: Initialise lmdb and lmdbxx submodules
         run: git -c core.autocrlf=false submodule update --init cpp/third_party/lmdb cpp/third_party/lmdbxx
 
-      - name: Configure sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
-        with:
-          version: v0.12.0
-          disable_annotations: 'true'
+      # No sccache here on purpose: this job installs the artifacts built by `compile`
+      # and never invokes a compiler, so downloading sccache only added a network hop
+      # that could (and did) fail the job.
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/compile_and_test_with_conda.yml
+++ b/.github/workflows/compile_and_test_with_conda.yml
@@ -53,9 +53,10 @@ jobs:
           path: ${{runner.tool_cache}}/sccache
           key: sccache-tool-${{runner.os}}-${{runner.arch}}-${{env.SCCACHE_VERSION}}
 
-      # And if the tool cache misses and the download fails anyway: without sccache
-      # ARCTICDB_COMPILER_CACHE=AUTO finds no cache and the build just runs uncached,
-      # so degrade to a slow green build rather than a red one.
+      # And if the tool cache misses and the download fails anyway, don't fail the job.
+      # The conda presets pin ARCTICDB_COMPILER_CACHE=sccache (cpp/CMakePresets.json,
+      # common_conda) and environment-dev.yml ships an sccache, so the build still gets
+      # a compiler cache - but only a local one, see the unset below.
       - name: Configure sccache
         id: sccache
         continue-on-error: true
@@ -66,7 +67,7 @@ jobs:
 
       - name: Warn if sccache is unavailable
         if: steps.sccache.outcome == 'failure'
-        run: echo "::warning title=sccache unavailable::Could not install sccache; building without a compiler cache."
+        run: echo "::warning title=sccache unavailable::Could not install sccache; building with a local disk cache only."
 
       - name: Get number of CPU cores
         uses: SimenB/github-actions-cpu-cores@v2.0.0
@@ -100,6 +101,17 @@ jobs:
 
       - name: Build ArcticDB with conda
         run: |
+          # If `Configure sccache` failed we have no GHA cache credentials
+          # (ACTIONS_RESULTS_URL/ACTIONS_RUNTIME_TOKEN are exported by that action and
+          # nothing else), and sccache treats a configured-but-unusable GHA backend as
+          # fatal: storage_from_config returns early on the GHA arm and server.rs aborts
+          # startup, so every compiler invocation fails. Both variables have to be unset
+          # rather than set to false - SCCACHE_GHA_VERSION alone enables the backend, and
+          # sccache checks it first (src/config.rs, "======= GHA =======").
+          # With them gone the conda sccache falls back to its local disk cache.
+          if [[ "${{steps.sccache.outcome}}" != "success" ]]; then
+            unset SCCACHE_GHA_VERSION SCCACHE_GHA_ENABLED
+          fi
           python -m pip install --no-build-isolation --no-deps --retries 3 --timeout 400 -v -e .
         env:
           ARCTICDB_USING_CONDA: 1
@@ -143,7 +155,7 @@ jobs:
         run: git -c core.autocrlf=false submodule update --init cpp/third_party/lmdb cpp/third_party/lmdbxx
 
       # See the notes on the compile job: seed the tool cache to avoid the release CDN,
-      # and treat a failed download as "build uncached" rather than as a job failure.
+      # and on a failed download fall back to a local disk cache rather than failing.
       - name: Restore sccache binary
         uses: actions/cache@v4
         with:
@@ -160,7 +172,7 @@ jobs:
 
       - name: Warn if sccache is unavailable
         if: steps.sccache.outcome == 'failure'
-        run: echo "::warning title=sccache unavailable::Could not install sccache; building without a compiler cache."
+        run: echo "::warning title=sccache unavailable::Could not install sccache; building with a local disk cache only."
 
       - name: Free Disk Space
         if: inputs.free_disk_space
@@ -193,6 +205,12 @@ jobs:
 
       - name: Configure C++ Tests
         run: |
+          # See the compile job: without the action's credentials a configured GHA
+          # backend stops the sccache server from starting at all, and SCCACHE_GHA_VERSION
+          # enables it on its own, so drop both and use the local disk cache.
+          if [[ "${{steps.sccache.outcome}}" != "success" ]]; then
+            unset SCCACHE_GHA_VERSION SCCACHE_GHA_ENABLED
+          fi
           cd cpp
           if [ -f out/${{inputs.preset}}-build/CMakeCache.txt ] && grep -q "TEST:BOOL=ON" out/${{inputs.preset}}-build/CMakeCache.txt; then
             echo "CMake cache already has TEST=ON, skipping reconfiguration"
@@ -204,6 +222,9 @@ jobs:
 
       - name: Build C++ Tests
         run: |
+          if [[ "${{steps.sccache.outcome}}" != "success" ]]; then
+            unset SCCACHE_GHA_VERSION SCCACHE_GHA_ENABLED
+          fi
           cd cpp
           CMAKE_JOBS=${{contains(inputs.platform, 'linux') && '3' || steps.cpu-cores.outputs.count}}
           cmake --build --preset ${{inputs.preset}} --target arcticdb_rapidcheck_tests -j $CMAKE_JOBS

--- a/.github/workflows/compile_and_test_with_conda.yml
+++ b/.github/workflows/compile_and_test_with_conda.yml
@@ -20,6 +20,10 @@ on:
       run_commandline:           {required: false, type: string,  default: '',    description: Custom commandline to run before tests}
       run_custom_pytest_command: {required: false, type: string,  default: '',    description: Custom pytest command or additional arguments}
 
+env:
+  # Single source of truth: feeds both the sccache-action input and the tool cache key.
+  SCCACHE_VERSION: v0.12.0
+
 jobs:
   # ==================== JOB 1: COMPILE ====================
   compile:
@@ -39,15 +43,25 @@ jobs:
       - name: Initialise lmdb and lmdbxx submodules
         run: git -c core.autocrlf=false submodule update --init cpp/third_party/lmdb cpp/third_party/lmdbxx
 
-      # The release download 5xxs from time to time and the action's own retries are
-      # short (see #3261). Without sccache ARCTICDB_COMPILER_CACHE=AUTO finds no cache
-      # and the build just runs uncached, so degrade to a slow green build, not a red one.
+      # sccache-action looks in the runner tool cache before it downloads, so seeding
+      # the tool cache keeps the GitHub release CDN - which 5xxs from time to time,
+      # see #3261 - off the critical path. The action still runs on a hit, so it still
+      # exports SCCACHE_PATH and the GHA cache backend credentials.
+      - name: Restore sccache binary
+        uses: actions/cache@v4
+        with:
+          path: ${{runner.tool_cache}}/sccache
+          key: sccache-tool-${{runner.os}}-${{runner.arch}}-${{env.SCCACHE_VERSION}}
+
+      # And if the tool cache misses and the download fails anyway: without sccache
+      # ARCTICDB_COMPILER_CACHE=AUTO finds no cache and the build just runs uncached,
+      # so degrade to a slow green build rather than a red one.
       - name: Configure sccache
         id: sccache
         continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: v0.12.0
+          version: ${{env.SCCACHE_VERSION}}
           disable_annotations: 'true'
 
       - name: Warn if sccache is unavailable
@@ -128,13 +142,20 @@ jobs:
       - name: Initialise lmdb and lmdbxx submodules
         run: git -c core.autocrlf=false submodule update --init cpp/third_party/lmdb cpp/third_party/lmdbxx
 
-      # See the note on the compile job: a failed sccache download must not fail the job.
+      # See the notes on the compile job: seed the tool cache to avoid the release CDN,
+      # and treat a failed download as "build uncached" rather than as a job failure.
+      - name: Restore sccache binary
+        uses: actions/cache@v4
+        with:
+          path: ${{runner.tool_cache}}/sccache
+          key: sccache-tool-${{runner.os}}-${{runner.arch}}-${{env.SCCACHE_VERSION}}
+
       - name: Configure sccache
         id: sccache
         continue-on-error: true
         uses: mozilla-actions/sccache-action@v0.0.9
         with:
-          version: v0.12.0
+          version: ${{env.SCCACHE_VERSION}}
           disable_annotations: 'true'
 
       - name: Warn if sccache is unavailable


### PR DESCRIPTION
Fixes #3261.

Both recorded failures are transient 5xx responses from the GitHub release CDN while `mozilla-actions/sccache-action` downloads the binary, outlasting the action's ~35s of retries. Every failure hit `python_tests`, which never compiles (`ARCTIC_CMAKE_PRESET=skip`) — the step was pure network exposure there.

Three commits in `compile_and_test_with_conda.yml`:

1. `python_tests` drops the sccache step entirely. In `compile`/`cpp_tests` the step becomes `continue-on-error` with a warning annotation.
2. `actions/cache` seeds `${{runner.tool_cache}}/sccache` — the action checks the tool cache before downloading (`find('sccache', version)`, `src/setup.ts:45`), so a hit skips the CDN entirely after we have cached it once. `SCCACHE_VERSION` at workflow level feeds both the action input and the cache key so they can't drift.
3. Makes the degraded path in (1) actually work.

On (3): the first commit's message claimed `compiler_cache.cmake` defaults to `AUTO`, so a failed download would mean an uncached build. That was wrong, and thanks to the review for catching it. Every preset this workflow is called with inherits `common_conda`, which pins `ARCTICDB_COMPILER_CACHE=sccache` (`cpp/CMakePresets.json`), and `environment-dev.yml` ships an `sccache` — so CMake takes the non-`AUTO` branch, finds the conda binary, and uses it as the compiler launcher.

The real problem was what that sccache was pointed at. `sccache-action` is the only thing that exports `ACTIONS_RESULTS_URL`/`ACTIONS_RUNTIME_TOKEN`, and on failure it returns before doing so (`src/setup.ts:48-50`), while the job-level GHA settings survive. sccache treats a configured-but-unusable backend as fatal — `storage_from_config` returns on the GHA arm without reaching the disk fallback, and `server.rs` aborts startup — so every compiler invocation fails. So `continue-on-error` alone would have converted a fast, clear step failure into an opaque server-startup failure minutes into the build.

The compiling steps now unset the GHA settings when the sccache step didn't succeed. Both have to go, not just `SCCACHE_GHA_ENABLED`: `SCCACHE_GHA_VERSION` is checked first and enables the backend on its own (`src/config.rs`, `======= GHA =======`), and blanking either isn't enough because v0.12.0 reads them with `env::var`, where an empty string still counts as set.

```
$ env -u ACTIONS_RUNTIME_TOKEN -u ACTIONS_RESULTS_URL -u ACTIONS_CACHE_URL \
    SCCACHE_GHA_ENABLED=false SCCACHE_GHA_VERSION=1 sccache cc -c t.c -o t.o
sccache: error: Server startup failed: create gha cache failed: ConfigInvalid (permanent) at  => cache url for ghac not found, maybe not in github action environment?
$ echo $?
2
```

With both unset the same command exits 0 and falls back to the local disk cache — a cold cache, so a slower green build, which is what the warning annotation now says. The successful path is unchanged.

Deliberately untouched: `build_steps.yml`, `benchmark_commits.yml` and `analysis_workflow.yml`. They set `CMAKE_C_COMPILER_LAUNCHER: sccache` explicitly rather than going through the presets, and none has been observed failing this way.

Known limitations: `continue-on-error` can mask a bad version pin as a permanently uncached slow build — the warning annotation is the signal for that. Caches are branch-scoped with default-branch fallback, and the entries are ~30MB each against the shared 10GB budget.
