### PR TITLE
Single-hash insert for StringPool

### DIFF
--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -104,32 +104,32 @@ void StringPool::set_allow_sparse(Sparsity) {
 
 size_t StringPool::num_blocks() const { return block_.num_blocks(); }
 
+// try_emplace hashes and probes once for both the lookup and the insertion, where find followed by
+// insert hashes the same string twice on the miss path. The key it stores is the caller's view, which
+// need not outlive this pool, so it is rebound to the block-backed copy. The two compare equal, so the
+// bucket the key was placed in remains the right one.
+// Invariant: a key is only left in the map once the block holds a copy of it, hence the erase if the
+// block insert throws.
 OffsetString StringPool::get(std::string_view s, bool deduplicate) {
-    if (deduplicate) {
-        if (auto it = map_.find(s); it != map_.end())
-            return OffsetString(it->second, this);
+    if (!deduplicate)
+        return OffsetString(block_.insert(s.data(), s.size()), this);
+
+    auto [it, inserted] = map_.try_emplace(s, offset_t{0});
+    if (inserted) {
+        try {
+            const auto offset = block_.insert(s.data(), s.size());
+            it->first = block_.at(offset);
+            it->second = offset;
+        } catch (...) {
+            map_.erase(it);
+            throw;
+        }
     }
-
-    OffsetString str(block_.insert(s.data(), s.size()), this);
-
-    if (deduplicate)
-        map_.insert(std::make_pair(block_.at(str.offset()), str.offset()));
-
-    return str;
+    return OffsetString(it->second, this);
 }
 
 OffsetString StringPool::get(const char* data, size_t size, bool deduplicate) {
-    StringType s(data, size);
-    if (deduplicate) {
-        if (auto it = map_.find(s); it != map_.end())
-            return OffsetString(it->second, this);
-    }
-
-    OffsetString str(block_.insert(s.data(), s.size()), this);
-    if (deduplicate)
-        map_.insert(std::make_pair(StringType(str), str.offset()));
-
-    return str;
+    return get(StringType(data, size), deduplicate);
 }
 
 const ChunkedBuffer& StringPool::data() const { return block_.buffer(); }

--- a/cpp/arcticdb/util/test/test_string_pool.cpp
+++ b/cpp/arcticdb/util/test/test_string_pool.cpp
@@ -8,6 +8,7 @@
 
 #include <gtest/gtest.h> // googletest header file
 #include <unordered_map>
+#include <fmt/format.h>
 
 #include <arcticdb/column_store/string_pool.hpp>
 #include <arcticdb/util/offset_string.hpp>
@@ -45,6 +46,65 @@ TEST(StringPool, MultipleReadWrite) {
         StringPool::StringType fs(view.data(), view.size());
         ASSERT_EQ(fs, comp_fs);
     }
+}
+
+// The pool stores its keys as views. They must be rebound to the copies it owns, or a later lookup
+// reads freed memory. Enough strings to span several blocks and force many rehashes.
+TEST(StringPool, KeysDoNotAliasCallerBuffers) {
+    StringPool pool;
+
+    const size_t num_strings = 20000;
+    std::vector<position_t> offsets;
+    offsets.reserve(num_strings);
+    for (size_t idx = 0; idx < num_strings; ++idx) {
+        const std::string transient = fmt::format("string_number_{}", idx);
+        offsets.emplace_back(pool.get(std::string_view(transient)).offset());
+    }
+    ASSERT_GT(pool.num_blocks(), 1);
+
+    for (size_t idx = 0; idx < num_strings; ++idx) {
+        const std::string expected = fmt::format("string_number_{}", idx);
+        ASSERT_EQ(pool.get_view(offsets[idx]), expected);
+        ASSERT_EQ(pool.get(std::string_view(expected)).offset(), offsets[idx]);
+        ASSERT_EQ(pool.get(expected.data(), expected.size()).offset(), offsets[idx]);
+    }
+}
+
+TEST(StringPool, DeduplicationEdgeCases) {
+    StringPool pool;
+
+    const auto empty = pool.get(std::string_view(""));
+    ASSERT_EQ(pool.get(std::string_view("")).offset(), empty.offset());
+    ASSERT_EQ(pool.get_view(empty.offset()), "");
+
+    // Longer than the inline StringHead, and a prefix of it, so neither can be confused for the other
+    const std::string long_string(1000, 'x');
+    const auto long_offset = pool.get(std::string_view(long_string)).offset();
+    const auto prefix_offset = pool.get(std::string_view(long_string).substr(0, 999)).offset();
+    ASSERT_NE(long_offset, prefix_offset);
+    ASSERT_EQ(pool.get_view(long_offset).size(), 1000);
+    ASSERT_EQ(pool.get_view(prefix_offset).size(), 999);
+
+    // Embedded nulls are part of the string
+    const std::string_view with_null("a\0b", 3);
+    const auto null_offset = pool.get(with_null).offset();
+    ASSERT_NE(null_offset, pool.get(std::string_view("a")).offset());
+    ASSERT_EQ(pool.get_view(null_offset), with_null);
+}
+
+TEST(StringPool, WithoutDeduplication) {
+    StringPool pool;
+
+    const auto first = pool.get(std::string_view("abc"), false);
+    const auto second = pool.get(std::string_view("abc"), false);
+    ASSERT_NE(first.offset(), second.offset());
+    ASSERT_EQ(pool.get_view(first.offset()), "abc");
+    ASSERT_EQ(pool.get_view(second.offset()), "abc");
+
+    // Deduplicated inserts of the same string are still stable with one another
+    const auto deduplicated = pool.get(std::string_view("abc"));
+    ASSERT_EQ(pool.get(std::string_view("abc")).offset(), deduplicated.offset());
+    ASSERT_EQ(pool.get_view(deduplicated.offset()), "abc");
 }
 
 TEST(StringPool, StressTest) {


### PR DESCRIPTION
`StringPool::get` hashed every string twice on the miss path: once for the `find` that established it was absent, and again for the `insert` of the same string.

The motivation is measured, from a CI flame graph of compaction on high-cardinality string columns: 2.02s of self time in `do_find`'s bucket probing under `StringPool::get`. Nothing about this is specific to compaction — every write path interns its strings through this function.

`try_emplace` gives the lookup and the insertion a single hash and probe. The key it stores is the caller's `string_view`, which need not outlive the pool, so it is rebound to the block-backed copy once the block holds one; the two compare equal, so the bucket the key was placed in stays correct.

**Exception safety.** `try_emplace` puts the key in the map *before* `block_.insert` runs, a window the old find-then-insert did not have: if the block insert threw, the map would be left holding a key that points into the caller's buffer. The block insert is wrapped so the entry is erased before the exception propagates, restoring the invariant — stated in a comment above the function — that a key is only in the map once the block owns a copy of it. This is not covered by a test: there is no seam to inject an allocation failure at, and a throwing allocator for this one call site was not worth the machinery.

Part 1 of a stack. Part 2 of the stack adds a `StringPool::reserve` capacity API and calls it from the reslicer, where capacity is known a priori.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGB2G1euu3wVQczjRbrsJv
