### PR TITLE
Remap tables instead of per-row re-interning in the segment reslicer

### DIFF
--- a/cpp/arcticdb/column_store/column_reslicer.cpp
+++ b/cpp/arcticdb/column_store/column_reslicer.cpp
@@ -76,13 +76,15 @@ void ColumnReslicer::push_back(size_t row_count) {
     sparse_ = true;
 }
 
-std::vector<Column> ColumnReslicer::reslice_columns(std::vector<StringPool>& string_pools) {
+std::vector<Column> ColumnReslicer::reslice_columns(
+        std::vector<StringPool>& string_pools, std::vector<StringOffsetRemap>& remaps
+) {
     util::check(type_.has_value(), "ColumnReslicer::reslice_columns called without any calls to push_back");
-    auto res = [this, &string_pools]() {
+    auto res = [this, &string_pools, &remaps]() {
         if (!is_sequence_type(type_->data_type()) && numeric_types_all_same_) {
             return reslice_by_memcpy();
         } else {
-            return reslice_by_iteration(string_pools);
+            return reslice_by_iteration(string_pools, remaps);
         }
     }();
     for (auto&& [idx, col] : folly::enumerate(res)) {
@@ -162,7 +164,9 @@ std::vector<Column> ColumnReslicer::reslice_by_memcpy() {
     return output_columns;
 }
 
-std::vector<Column> ColumnReslicer::reslice_by_iteration(std::vector<StringPool>& string_pools) {
+std::vector<Column> ColumnReslicer::reslice_by_iteration(
+        std::vector<StringPool>& string_pools, std::vector<StringOffsetRemap>& remaps
+) {
     auto output_columns = initialise_output_columns();
     util::check(
             output_columns.size() == string_pools.size(),
@@ -170,6 +174,12 @@ std::vector<Column> ColumnReslicer::reslice_by_iteration(std::vector<StringPool>
             "{} != {}",
             output_columns.size(),
             string_pools.size()
+    );
+    util::check(
+            cols_or_row_counts_.size() == remaps.size(),
+            "ColumnReslicer::reslice_by_iteration number of input slices does not match number of remaps {} != {}",
+            cols_or_row_counts_.size(),
+            remaps.size()
     );
     auto output_col = output_columns.begin();
     auto string_pool = string_pools.begin();
@@ -190,13 +200,32 @@ std::vector<Column> ColumnReslicer::reslice_by_iteration(std::vector<StringPool>
         using output_type_info = ScalarTypeInfo<decltype(output_tag)>;
         auto output_it = output_data.begin<typename output_type_info::TDT>();
         auto output_end_it = output_data.end<typename output_type_info::TDT>();
-        for (auto& col_or_row_count : cols_or_row_counts_) {
+        // An index loop rather than folly::enumerate: the nested generic lambdas below
+        // refer to the loop variables, and a structured binding referred to from a
+        // generic lambda makes GCC treat everything derived from it as dependent,
+        // rejecting the member-template calls this file compiles with today.
+        for (size_t input_idx = 0; input_idx < cols_or_row_counts_.size(); ++input_idx) {
+            auto& col_or_row_count = cols_or_row_counts_[input_idx];
             if (auto* col_with_strings = std::get_if<ColumnWithStrings>(&col_or_row_count)) {
                 details::visit_type(col_with_strings->column_->type().data_type(), [&](auto input_tag) {
                     // Maps offsets in the input string pool to offsets in the output string pool
                     // Provides a small speed boost for low cardinality string columns
                     ankerl::unordered_dense::map<StringPool::offset_t, StringPool::offset_t> offsets_map;
                     using input_type_info = ScalarTypeInfo<decltype(input_tag)>;
+                    // Fixed-width strings are transformed before being interned, so the offsets in the input pool do
+                    // not identify the strings that end up in the output pool, and the remap shared with the other
+                    // columns of this input segment cannot be used
+                    StringOffsetRemap* remap = nullptr;
+                    if constexpr (is_sequence_type(output_type_info::data_type) &&
+                                  !is_fixed_string_type(input_type_info::data_type)) {
+                        if (col_with_strings->string_pool_) {
+                            remap = &remaps[input_idx];
+                            remap->set_output_pool(
+                                    static_cast<size_t>(std::distance(output_columns.begin(), output_col)),
+                                    col_with_strings->string_pool_->size()
+                            );
+                        }
+                    }
                     auto input_data = col_with_strings->column_->data();
                     auto input_end_it = input_data.cend<typename input_type_info::TDT>();
                     for (auto input_it = input_data.cbegin<typename input_type_info::TDT>(); input_it != input_end_it;
@@ -210,9 +239,37 @@ std::vector<Column> ColumnReslicer::reslice_by_iteration(std::vector<StringPool>
                                 output_data = output_col->data();
                                 output_it = output_data.begin<typename output_type_info::TDT>();
                                 output_end_it = output_data.end<typename output_type_info::TDT>();
+                                if (remap != nullptr) {
+                                    remap->set_output_pool(
+                                            static_cast<size_t>(std::distance(output_columns.begin(), output_col)),
+                                            col_with_strings->string_pool_->size()
+                                    );
+                                }
                             }
                         }
                         if constexpr (is_sequence_type(output_type_info::data_type)) {
+                            if (remap != nullptr) {
+                                if (const auto mapped = remap->lookup(*input_it);
+                                    mapped != StringOffsetRemap::unmapped) {
+                                    *output_it = mapped;
+                                } else if (auto opt_str = col_with_strings->string_at_offset(*input_it);
+                                           opt_str.has_value()) {
+                                    *output_it = string_pool->get(*opt_str).offset();
+                                    remap->insert(*input_it, *output_it);
+                                } else {
+                                    // This is only possible if the input column has a dynamic string type, and so
+                                    // *input_it will represent either None or NaN. Those offsets are out of range of
+                                    // the remap, so they are never given an entry in it
+                                    ARCTICDB_DEBUG_CHECK(
+                                            ErrorCode::E_ASSERTION_FAILURE,
+                                            !is_a_string(*input_it),
+                                            "Invalid non-string offset {}",
+                                            *input_it
+                                    );
+                                    *output_it = *input_it;
+                                }
+                                continue;
+                            }
                             if (auto offsets_map_it = offsets_map.find(*input_it);
                                 offsets_map_it != offsets_map.end()) {
                                 *output_it = offsets_map_it->second;

--- a/cpp/arcticdb/column_store/column_reslicer.hpp
+++ b/cpp/arcticdb/column_store/column_reslicer.hpp
@@ -80,6 +80,43 @@ class ReslicingInfo {
     uint64_t num_exact_segments;
 };
 
+// Maps offsets in one input segment's string pool to offsets in an output segment's string pool, so
+// that reslicing a string column costs a table lookup per row rather than a string pool insertion.
+// Shared by every column of that input segment and populated on demand, so a string used by several
+// columns is only interned into the output pool once.
+// Offsets are byte offsets, and no string occupies fewer than StringPool::min_string_bytes() bytes,
+// so dividing by that gives a dense index without collisions.
+class StringOffsetRemap {
+  public:
+    static constexpr StringPool::offset_t unmapped = -1;
+
+    // Discards any offsets mapped into a different output string pool
+    void set_output_pool(size_t output_idx, size_t input_pool_bytes) {
+        const auto required = input_pool_bytes / StringPool::min_string_bytes() + 1;
+        if (offsets_.size() != required) {
+            offsets_.assign(required, unmapped);
+        } else if (output_idx_ != output_idx) {
+            std::fill(offsets_.begin(), offsets_.end(), unmapped);
+        }
+        output_idx_ = output_idx;
+    }
+
+    // Returns unmapped for offsets not yet seen, and for the None and NaN sentinels, which are out of
+    // range of any string pool
+    [[nodiscard]] StringPool::offset_t lookup(StringPool::offset_t input_offset) const {
+        const auto idx = static_cast<size_t>(input_offset) / StringPool::min_string_bytes();
+        return idx < offsets_.size() ? offsets_[idx] : unmapped;
+    }
+
+    void insert(StringPool::offset_t input_offset, StringPool::offset_t output_offset) {
+        offsets_[static_cast<size_t>(input_offset) / StringPool::min_string_bytes()] = output_offset;
+    }
+
+  private:
+    std::vector<StringPool::offset_t> offsets_;
+    size_t output_idx_{0};
+};
+
 // Given a maximum number of rows per slice, reslices a set of columns into a new shape, with at most
 // max_rows_per_slice_ rows in each one.
 // This is used in SegmentReslicer to simultaneously combine and split data segments into appropriate sizes with the
@@ -99,8 +136,10 @@ class ColumnReslicer {
     void push_back(std::shared_ptr<Column> column, std::shared_ptr<StringPool> string_pool);
     void push_back(size_t row_count);
     // There should be as many provided string pools as there will be output columns as these are for the output
-    // segments
-    std::vector<Column> reslice_columns(std::vector<StringPool>& string_pools);
+    // segments, and as many remaps as there are input slices, one per input segment's string pool. Callers reslicing
+    // more than one column of the same input segments should pass the same remaps to each of them, so that a string
+    // used by several of those columns is only interned into the output pool once.
+    std::vector<Column> reslice_columns(std::vector<StringPool>& string_pools, std::vector<StringOffsetRemap>& remaps);
     // Public only for benchmarking
     std::vector<Column> initialise_output_columns() const;
 
@@ -109,7 +148,9 @@ class ColumnReslicer {
     // Once the output buffers have been allocated, dense and sparse inputs and outputs work in the same way, as every
     // value from the input must be copied to an element of the output.
     std::vector<Column> reslice_by_memcpy();
-    std::vector<Column> reslice_by_iteration(std::vector<StringPool>& string_pools);
+    std::vector<Column> reslice_by_iteration(
+            std::vector<StringPool>& string_pools, std::vector<StringOffsetRemap>& remaps
+    );
 
     ReslicingInfo reslicing_info_;
     // Holds either a column along with its string pool, or the number of skipped rows if a row-slice was missing with

--- a/cpp/arcticdb/column_store/segment_reslicer.cpp
+++ b/cpp/arcticdb/column_store/segment_reslicer.cpp
@@ -34,12 +34,23 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
             [](uint64_t n, const SegmentInMemory& segment) { return n + segment.row_count(); }
     );
     ReslicingInfo reslicing_info{total_rows, max_rows_per_segment_};
+    const auto num_input_slices = segments.size();
+    // Used to size the output string pools. There can be no more strings in an output pool than there are in all of
+    // the input pools, or than there are string values in the output row-slice.
+    uint64_t total_string_pool_bytes{0};
+    uint64_t max_string_columns{0};
     for (const auto& segment : segments) {
+        if (segment.has_string_pool()) {
+            total_string_pool_bytes += segment.string_pool_ptr()->size();
+        }
+        uint64_t string_columns{0};
         for (const auto& field : segment.descriptor().fields()) {
+            string_columns += is_sequence_type(field.type().data_type()) ? 1 : 0;
             if (column_map.emplace(field.name(), ColumnReslicer(segments.size(), reslicing_info)).second) {
                 col_names_in_order.emplace_back(field.name());
             }
         }
+        max_string_columns = std::max(max_string_columns, string_columns);
     }
     std::vector<SegmentInMemory> res(reslicing_info.num_segments());
     const auto& desc = segments.front().descriptor();
@@ -64,19 +75,19 @@ std::vector<SegmentInMemory> SegmentReslicer::reslice_segments(std::vector<Segme
     // copied into the result column, and so the memory is freed as early as possible
     segments.clear();
     std::vector<StringPool> string_pools(reslicing_info.num_segments());
+    const auto max_input_strings = total_string_pool_bytes / StringPool::min_string_bytes();
+    for (size_t idx = 0; idx < reslicing_info.num_segments(); ++idx) {
+        string_pools[idx].reserve(std::min(max_input_strings, reslicing_info.rows_in_slice(idx) * max_string_columns));
+    }
+    // One per input segment, shared by all of that segment's columns so that a string used by more than one of them is
+    // only interned into the output pool once
+    std::vector<StringOffsetRemap> remaps(num_input_slices);
     // We can use string_view keys here as they point to the keys in column_map, which are still live while this
     // variable is in use
     ankerl::unordered_dense::map<std::string_view, std::vector<Column>, util::TransparentStringHash, std::equal_to<>>
             resliced_column_map;
-    // There is a possible optimisation here in the fairly common case where we are merging all of the input segments
-    // into a single output segment. Namely, to pre-populate the output stringpool with the union of the input string
-    // pools, as we know a priori that is how it will end up. While doing this, we could generate one map for each
-    // input segment from their stringpool offsets to the stringpool offsets in the output string pool, and pass these
-    // maps into the reslice_columns call instead of the string pools. It is not clear that this would provide much
-    // benefit though, as the introduction of the offsets_map in ColumnReslicer::reslice_by_iteration only had a small
-    // impact even with extremely low cardinality string columns.
     for (auto&& [col_name, column_reslicer] : column_map) {
-        resliced_column_map.emplace(col_name, column_reslicer.reslice_columns(string_pools));
+        resliced_column_map.emplace(col_name, column_reslicer.reslice_columns(string_pools, remaps));
     }
     for (const auto& col_name : col_names_in_order) {
         auto& sliced_cols = resliced_column_map.at(col_name);

--- a/cpp/arcticdb/column_store/string_pool.cpp
+++ b/cpp/arcticdb/column_store/string_pool.cpp
@@ -132,6 +132,8 @@ OffsetString StringPool::get(const char* data, size_t size, bool deduplicate) {
     return get(StringType(data, size), deduplicate);
 }
 
+void StringPool::reserve(size_t num_strings) { map_.reserve(num_strings); }
+
 const ChunkedBuffer& StringPool::data() const { return block_.buffer(); }
 
 std::string_view StringPool::get_view(offset_t o) { return block_.at(o); }

--- a/cpp/arcticdb/column_store/string_pool.hpp
+++ b/cpp/arcticdb/column_store/string_pool.hpp
@@ -101,6 +101,10 @@ class StringBlock {
 
     [[nodiscard]] size_t num_blocks() { return data_.buffer().num_blocks(); }
 
+    // The fewest bytes any string occupies in the block, so consecutive strings are at least this far
+    // apart and offset / min_entry_bytes() is a dense injective index over them
+    static constexpr size_t min_entry_bytes() { return sizeof(StringHead); }
+
     StringHead* head_at(position_t pos) {
         auto data = data_.buffer().ptr_cast<uint8_t>(pos, sizeof(StringHead));
         return reinterpret_cast<StringHead*>(data);
@@ -153,6 +157,12 @@ class StringPool {
 
     OffsetString get(std::string_view s, bool deduplicate = true);
     OffsetString get(const char* data, size_t size, bool deduplicate = true);
+
+    // Hint that at least num_strings distinct strings will be added, so that they can be inserted
+    // without repeated rehashing
+    void reserve(size_t num_strings);
+
+    static constexpr size_t min_string_bytes() { return StringBlock::min_entry_bytes(); }
 
     const ChunkedBuffer& data() const;
 

--- a/cpp/arcticdb/column_store/test/benchmark_column_reslicer.cpp
+++ b/cpp/arcticdb/column_store/test/benchmark_column_reslicer.cpp
@@ -41,8 +41,9 @@ static void BM_column_reslicer_combine_dense_numeric_same_type(benchmark::State&
         for (auto& column : columns) {
             reslicer.push_back(column, string_pool);
         }
+        std::vector<StringOffsetRemap> remaps(static_cast<size_t>(num_input_columns));
         state.ResumeTiming();
-        reslicer.reslice_columns(string_pools);
+        reslicer.reslice_columns(string_pools, remaps);
     }
 }
 
@@ -77,8 +78,9 @@ static void BM_column_reslicer_combine_dense_numeric_same_type_small_appends(ben
         for (auto& column : columns) {
             reslicer.push_back(column, string_pool);
         }
+        std::vector<StringOffsetRemap> remaps(static_cast<size_t>(num_input_columns));
         state.ResumeTiming();
-        reslicer.reslice_columns(string_pools);
+        reslicer.reslice_columns(string_pools, remaps);
     }
 }
 
@@ -112,8 +114,9 @@ static void BM_column_reslicer_combine_dense_numeric_type_promotion(benchmark::S
         for (auto& column : columns) {
             reslicer.push_back(column, string_pool);
         }
+        std::vector<StringOffsetRemap> remaps(static_cast<size_t>(num_input_columns));
         state.ResumeTiming();
-        reslicer.reslice_columns(string_pools);
+        reslicer.reslice_columns(string_pools, remaps);
     }
 }
 
@@ -136,8 +139,9 @@ static void BM_column_reslicer_split_dense_numeric_same_type(benchmark::State& s
         state.PauseTiming();
         ColumnReslicer reslicer(1, ReslicingInfo{num_input_rows, num_input_rows / num_output_columns});
         reslicer.push_back(column, string_pool);
+        std::vector<StringOffsetRemap> remaps(1);
         state.ResumeTiming();
-        reslicer.reslice_columns(string_pools);
+        reslicer.reslice_columns(string_pools, remaps);
     }
 }
 
@@ -179,8 +183,9 @@ static void BM_column_reslicer_combine_dense_strings(benchmark::State& state) {
             reslicer.push_back(columns.at(idx), input_string_pools.at(idx));
         }
         std::vector<StringPool> output_string_pools(1);
+        std::vector<StringOffsetRemap> remaps(static_cast<size_t>(num_input_columns));
         state.ResumeTiming();
-        reslicer.reslice_columns(output_string_pools);
+        reslicer.reslice_columns(output_string_pools, remaps);
     }
 }
 
@@ -209,8 +214,9 @@ static void BM_column_reslicer_split_dense_strings(benchmark::State& state) {
         ColumnReslicer reslicer(1, ReslicingInfo{num_input_rows, num_input_rows / num_output_columns});
         reslicer.push_back(column, input_string_pool);
         std::vector<StringPool> output_string_pools(10);
+        std::vector<StringOffsetRemap> remaps(1);
         state.ResumeTiming();
-        reslicer.reslice_columns(output_string_pools);
+        reslicer.reslice_columns(output_string_pools, remaps);
     }
 }
 

--- a/cpp/arcticdb/column_store/test/test_column_reslicer.cpp
+++ b/cpp/arcticdb/column_store/test/test_column_reslicer.cpp
@@ -9,6 +9,7 @@
 #include <gtest/gtest.h>
 #include <arcticdb/column_store/column_reslicer.hpp>
 #include <arcticdb/column_store/string_pool.hpp>
+#include <arcticdb/util/offset_string.hpp>
 #include <arcticdb/util/string_utils.hpp>
 
 using namespace arcticdb;
@@ -43,7 +44,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, CombineIntoOneStatic) {
         }
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.row_count(), total_rows);
@@ -103,7 +105,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, CombineIntoOneDynamicMissi
         reslicer.push_back(std::make_shared<Column>(std::move(col)), std::shared_ptr<StringPool>{});
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.row_count(), value_count);
@@ -176,7 +179,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, CombineIntoOneDynamicMissi
         reslicer.push_back(std::make_shared<Column>(std::move(col)), std::shared_ptr<StringPool>{});
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.row_count(), value_count);
@@ -240,7 +244,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, CombineIntoOneDynamicMissi
         reslicer.push_back(std::make_shared<Column>(std::move(col)), std::shared_ptr<StringPool>{});
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(4);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.row_count(), value_count);
@@ -328,7 +333,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, CombineIntoOneDynamicMissi
         reslicer.push_back(5);
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.row_count(), value_count);
@@ -384,7 +390,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, SplitInTwoStatic) {
     }
     reslicer.push_back(std::make_shared<Column>(std::move(input_col)), std::shared_ptr<StringPool>{});
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(1);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
 
     uint64_t rows_in_first_slice{total_rows - max_rows_per_slice};
     ASSERT_EQ(res.size(), 2);
@@ -447,7 +454,8 @@ TYPED_TEST(ColumnReslicerDenseNumericSameTypeFixture, CombineThreeIntoTwoStatic)
         }
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
 
     ASSERT_EQ(res.size(), 2);
     auto& col_0 = res.front();
@@ -509,7 +517,8 @@ TEST(ColumnReslicerDenseNumericStaticSchema, MultiBlockColumns) {
     reslicer.push_back(std::make_shared<Column>(std::move(input_columns.at(1))), std::shared_ptr<StringPool>{});
     reslicer.push_back(std::make_shared<Column>(std::move(input_columns.at(2))), std::shared_ptr<StringPool>{});
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
 
     ASSERT_EQ(res.size(), 2);
     auto& col_0 = res.front();
@@ -576,7 +585,8 @@ TYPED_TEST(ColumnReslicerSparseNumericSameTypeFixture, CombineIntoOneStatic) {
         }
     }
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(3);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.row_count(), total_values);
@@ -663,7 +673,8 @@ TYPED_TEST(ColumnReslicerSparseNumericSameTypeFixture, SplitInThreeStatic) {
     col.set_row_data(total_rows - 1);
     reslicer.push_back(std::make_shared<Column>(std::move(col)), std::shared_ptr<StringPool>{});
     std::vector<StringPool> string_pools; // Unused with numeric data
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(1);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 3);
     auto& col_0 = res.front();
     auto& col_1 = res.at(1);
@@ -759,7 +770,8 @@ TEST_F(ColumnReslicerDenseStringStaticSchema, CombineIntoOne) {
     input_columns.clear(); // In debug builds there are checks that the reslicer has the last reference to input columns
 
     std::vector<StringPool> string_pools(1);
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(4);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 1);
     auto& col = res.front();
     ASSERT_EQ(col.type(), utf8_td);
@@ -822,7 +834,8 @@ TEST_P(ColumnReslicerDenseStringStaticSchemaSplit, SplitInTwoTest) {
     col_with_strings.reset();
 
     std::vector<StringPool> string_pools(2);
-    auto res = reslicer.reslice_columns(string_pools);
+    std::vector<StringOffsetRemap> remaps(1);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
     ASSERT_EQ(res.size(), 2);
     auto& col_0 = res.front();
     auto& col_1 = res.back();
@@ -861,3 +874,90 @@ INSTANTIATE_TEST_SUITE_P(
                 DataType::ASCII_FIXED64, DataType::ASCII_DYNAMIC64, DataType::UTF_FIXED64, DataType::UTF_DYNAMIC64
         )
 );
+
+// Two columns of the same input segment share that segment's string pool, and so share a remap. A string that both
+// columns use should be interned into the output pool exactly once, and both should reference it at the same offset.
+TEST_F(ColumnReslicerDenseStringStaticSchema, RemapSharedBetweenColumnsOfOneSegment) {
+    using RawType = StringPool::offset_t;
+    auto input_string_pool = std::make_shared<StringPool>();
+    auto column_over_shared_pool = [&](const std::vector<std::string>& strings) {
+        Column col{utf8_td, Sparsity::NOT_PERMITTED};
+        for (const auto& str : strings) {
+            col.push_back(input_string_pool->get(str).offset());
+        }
+        return std::make_shared<Column>(std::move(col));
+    };
+    // "shared" is in both columns, the others in only one of them
+    const std::vector<std::string> left_strings{"shared", "left", "shared"};
+    const std::vector<std::string> right_strings{"right", "shared", "right"};
+    ReslicingInfo reslicing_info{left_strings.size(), left_strings.size()};
+
+    ColumnReslicer left_reslicer{1, reslicing_info};
+    left_reslicer.push_back(column_over_shared_pool(left_strings), input_string_pool);
+    ColumnReslicer right_reslicer{1, reslicing_info};
+    right_reslicer.push_back(column_over_shared_pool(right_strings), input_string_pool);
+
+    std::vector<StringPool> string_pools(1);
+    std::vector<StringOffsetRemap> remaps(1);
+    auto left_res = left_reslicer.reslice_columns(string_pools, remaps);
+    auto right_res = right_reslicer.reslice_columns(string_pools, remaps);
+    ASSERT_EQ(left_res.size(), 1);
+    ASSERT_EQ(right_res.size(), 1);
+    const auto& string_pool = string_pools.front();
+
+    for (size_t idx = 0; idx < left_strings.size(); ++idx) {
+        auto left_val = left_res.front().scalar_at<RawType>(idx);
+        auto right_val = right_res.front().scalar_at<RawType>(idx);
+        ASSERT_TRUE(left_val.has_value());
+        ASSERT_TRUE(right_val.has_value());
+        ASSERT_EQ(string_pool.get_const_view(*left_val), left_strings.at(idx));
+        ASSERT_EQ(string_pool.get_const_view(*right_val), right_strings.at(idx));
+    }
+    // "shared" is at the same offset in both output columns, and the pool holds it once
+    ASSERT_EQ(*left_res.front().scalar_at<RawType>(0), *right_res.front().scalar_at<RawType>(1));
+    std::unordered_set<RawType> distinct_offsets;
+    for (size_t idx = 0; idx < left_strings.size(); ++idx) {
+        distinct_offsets.insert(*left_res.front().scalar_at<RawType>(idx));
+        distinct_offsets.insert(*right_res.front().scalar_at<RawType>(idx));
+    }
+    ASSERT_EQ(distinct_offsets.size(), 3);
+}
+
+// None and NaN are represented by offsets outside the range of any string pool, so they must miss the remap and be
+// copied through untouched
+TEST_F(ColumnReslicerDenseStringStaticSchema, NoneAndNanPassThroughRemap) {
+    using RawType = StringPool::offset_t;
+    auto input_string_pool = std::make_shared<StringPool>();
+    Column col{utf8_td, Sparsity::NOT_PERMITTED};
+    const auto hello = input_string_pool->get(std::string_view("hello")).offset();
+    const auto world = input_string_pool->get(std::string_view("world")).offset();
+    const std::vector<RawType> input_offsets{
+            hello, not_a_string(), world, nan_placeholder(), hello, not_a_string(), world
+    };
+    for (const auto offset : input_offsets) {
+        col.push_back(offset);
+    }
+    uint64_t total_rows{input_offsets.size()};
+    // Two output slices, so the remap is also cleared part way through
+    ReslicingInfo reslicing_info{total_rows, 4};
+    ColumnReslicer reslicer{1, reslicing_info};
+    reslicer.push_back(std::make_shared<Column>(std::move(col)), input_string_pool);
+
+    std::vector<StringPool> string_pools(2);
+    std::vector<StringOffsetRemap> remaps(1);
+    auto res = reslicer.reslice_columns(string_pools, remaps);
+    ASSERT_EQ(res.size(), 2);
+    const auto rows_in_first_slice = static_cast<size_t>(res.front().row_count());
+    for (size_t idx = 0; idx < total_rows; ++idx) {
+        const bool in_first = idx < rows_in_first_slice;
+        auto opt_val = in_first ? res.front().scalar_at<RawType>(idx)
+                                : res.back().scalar_at<RawType>(idx - rows_in_first_slice);
+        ASSERT_TRUE(opt_val.has_value());
+        const auto& pool = in_first ? string_pools.front() : string_pools.back();
+        if (is_a_string(input_offsets.at(idx))) {
+            ASSERT_EQ(pool.get_const_view(*opt_val), input_string_pool->get_const_view(input_offsets.at(idx)));
+        } else {
+            ASSERT_EQ(*opt_val, input_offsets.at(idx));
+        }
+    }
+}

--- a/cpp/arcticdb/util/test/test_string_pool.cpp
+++ b/cpp/arcticdb/util/test/test_string_pool.cpp
@@ -107,6 +107,28 @@ TEST(StringPool, WithoutDeduplication) {
     ASSERT_EQ(pool.get_view(deduplicated.offset()), "abc");
 }
 
+TEST(StringPool, Reserve) {
+    StringPool pool;
+    pool.reserve(1024);
+
+    const auto alpha = pool.get(std::string_view("alpha")).offset();
+    const auto beta = pool.get(std::string_view("beta")).offset();
+    ASSERT_NE(alpha, beta);
+
+    // Reserving again, including for fewer strings than are already present, keeps the pool intact
+    pool.reserve(1 << 16);
+    pool.reserve(1);
+    ASSERT_EQ(pool.get(std::string_view("alpha")).offset(), alpha);
+    ASSERT_EQ(pool.get(std::string_view("beta")).offset(), beta);
+    ASSERT_EQ(pool.get_view(alpha), "alpha");
+    ASSERT_EQ(pool.get_view(beta), "beta");
+
+    const auto gamma = pool.get(std::string_view("gamma")).offset();
+    ASSERT_NE(gamma, alpha);
+    ASSERT_NE(gamma, beta);
+    ASSERT_EQ(pool.get_view(gamma), "gamma");
+}
+
 TEST(StringPool, StressTest) {
     StringPool pool;
 


### PR DESCRIPTION
At 100k unique strings, per-row `StringPool::get` was 62% of the compaction body's CPU in a CI flame graph. `reslice_by_iteration` reached it once per distinct offset per column per output row-slice: its `offsets_map` memo was per column, and it was cleared whenever the output segment changed.

Give each *input segment* a dense offset-to-offset table instead, shared by every column of that segment, so a string used by several columns is interned into an output pool at most once. Offsets are byte offsets and no string occupies fewer than `sizeof(StringHead)` bytes, so dividing by that indexes a vector without collisions. The table is filled lazily and clears itself when the output segment changes. Two cases keep the existing per-row path untouched: fixed-width string columns, whose strings are transformed before interning so their input offsets do not identify what lands in the output pool, and the None/NaN sentinels, which are out of range of any pool and so never get an entry.

This also adds a `StringPool::reserve` capacity API alongside the remap, and sizes each output pool with it at the `SegmentReslicer` call site: an output pool holds no more strings than all of the input pools do, and no more than the output row-slice has string values. Without it a pool that ends up with 100k strings rehashes its way there through every intermediate power of two.

Measured on the isolated reslicer benchmarks, this branch against a `master` benchmark binary, interleaved A/B, median of 5 rounds each:

| `BM_column_reslicer_...` | master | this branch | |
|---|---|---|---|
| `combine_dense_strings/10/10000/1` | 1.69 ms | 0.89 ms | **−47%** |
| `combine_dense_strings/10/10000/100000` | 5.94 ms | 4.13 ms | **−30%** |
| `split_dense_strings/100000/10/1` | 256 µs | 184 µs | **−28%** |

The single-unique case gains most because the old memo still cost a hash and a probe per row even when it hit. End-to-end `compact_data` was −29% at 10 columns and −8% at 2 when this was prototyped on a laptop; peak RSS unchanged.

**Why lazy, rather than pre-populating the output pool from the input pools** — which is what the comment this change deletes suggested. A decoded string pool is a single buffer that still contains the writer's block-boundary zero padding, so a linear walk over `StringHead` records desyncs from the real string starts. Enumerating an input pool's strings is not safe as the format stands; only the offsets a column actually references are known good, and those are exactly the ones the lazy table fills.

`reslice_columns` takes the remaps as a required parameter rather than gaining an overload: the signature already makes the caller own the output string pools and share them across a segment's columns, and the remaps are the exact analogue, where an overload that manufactured a private remap per column would compile and silently forgo the sharing that is the point.

Correctness: C++ unit suite green (1805 passed), Python unit suite green (18644 passed), with new tests covering the shared remap across two columns of one input segment and None/NaN passing through it across an output-slice boundary.

Stacked on #3408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CGB2G1euu3wVQczjRbrsJv
